### PR TITLE
internal/v1: create environment entry

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -86,3 +86,7 @@ func (db Database) Macaroons() *mgo.Collection {
 func (db Database) StateServers() *mgo.Collection {
 	return db.C("stateservers")
 }
+
+func (db Database) Environments() *mgo.Collection {
+	return db.C("environments")
+}

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -5,9 +5,50 @@ import (
 )
 
 // StateServer holds information on a given state server.
+// Each state server also has an entry in the environments
+// collection with the same id.
 type StateServer struct {
+	// Id holds the primary key for a state server.
+	// It's actually in the form user/name.
 	Id   string `bson:"_id"` // Actually user/name.
-	User string
-	Name string
-	Info params.ServerInfo
+
+	// User holds the user name containing the state server.
+	User params.User
+
+	// Name holds the local name given to the state
+	// server. It is unique within a given user.
+	Name params.Name
+
+	// CACert holds the CA certificate of the server.
+	CACert string
+
+	// HostPorts holds the most recently known set
+	// of host-port addresses for the API servers,
+	// with the most-recently-dialed address at the start.
+	HostPorts []string
+}
+
+type Environment struct {
+	Id string `bson:"_id"` // Actually user/name.
+
+	// User holds the user name containing the environment.
+	User params.User
+
+	// Name holds the local name given to the environment.
+	// It is unique within a given user.
+	Name params.Name
+
+	// UUID holds the UUID of the environment.
+	UUID string
+
+	// AdminUser holds the user name to use
+	// when connecting to the state server.
+	AdminUser string
+
+	// AdminPassword holds the password for the admin user.
+	AdminPassword string
+
+	// StateServer holds the id of the environment's
+	// state server.
+	StateServer string
 }

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1,11 +1,15 @@
 package v1
 
 import (
+	"time"
+
 	"github.com/juju/httprequest"
 	"github.com/juju/juju/api"
 	"github.com/juju/names"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
+
+	"github.com/juju/juju/network"
 
 	"github.com/CanonicalLtd/jem/internal/jem"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
@@ -17,6 +21,8 @@ type Handler struct {
 	config jem.ServerParams
 	auth   authorization
 }
+
+var dialTimeout = 15 * time.Second
 
 func NewAPIHandler(jp *jem.Pool, sp jem.ServerParams) ([]httprequest.Handler, error) {
 	return errorMapper.Handlers(func(p httprequest.Params) (*Handler, error) {
@@ -57,35 +63,84 @@ func (h *Handler) AddJES(arg *params.AddJES) error {
 	if !names.IsValidEnvironment(arg.Info.EnvironUUID) {
 		return badRequestf(nil, "bad environment UUID in request")
 	}
+	id := string(arg.User) + "/" + string(arg.Name)
+	env := &mongodoc.Environment{
+		Id:            id,
+		User:          arg.User,
+		Name:          arg.Name,
+		AdminUser:     arg.Info.User,
+		AdminPassword: arg.Info.Password,
+		StateServer:   id,
+	}
+	srv := &mongodoc.StateServer{
+		Id:        id,
+		User:      arg.User,
+		Name:      arg.Name,
+		CACert:    arg.Info.CACert,
+		HostPorts: arg.Info.HostPorts,
+	}
 	// Attempt to connect to the environment before accepting it.
-	state, err := api.Open(&api.Info{
-		Addrs:      arg.Info.HostPorts,
-		CACert:     arg.Info.CACert,
-		Tag:        names.NewUserTag(arg.Info.User),
-		Password:   arg.Info.Password,
-		EnvironTag: names.NewEnvironTag(arg.Info.EnvironUUID),
-	}, api.DialOpts{})
+	state, err := dialEnvironment(env, srv)
 	if err != nil {
 		return badRequestf(err, "cannot connect to environment")
 	}
 	state.Close()
-	err = h.jem.DB.StateServers().Insert(mongodoc.StateServer{
-		Id:   string(arg.User) + "/" + string(arg.Name),
-		User: string(arg.User),
-		Name: string(arg.Name),
-		Info: arg.Info,
-	})
+
+	// Update addresses from latest known in state server.
+	// Note that state.APIHostPorts is always guaranteed
+	// to include the actual address we succeeded in
+	// connecting to.
+	srv.HostPorts = collapseHostPorts(state.APIHostPorts())
+
+	// Insert the environment before inserting the state server
+	// to avoid races with other clients creating non-state-server
+	// environments.
+	err = h.jem.DB.Environments().Insert(env)
 	if mgo.IsDup(err) {
 		return errgo.WithCausef(nil, params.ErrAlreadyExists, "")
 	}
+	if err != nil {
+		return errgo.Notef(err, "cannot insert state server environment")
+	}
+	err = h.jem.DB.StateServers().Insert(srv)
 	if err != nil {
 		return errgo.Notef(err, "cannot insert state server")
 	}
 	return nil
 }
 
+func dialEnvironment(
+	env *mongodoc.Environment,
+	srv *mongodoc.StateServer,
+) (*api.State, error) {
+	return api.Open(&api.Info{
+		Addrs:      srv.HostPorts,
+		CACert:     srv.CACert,
+		Tag:        names.NewUserTag(env.AdminUser),
+		Password:   env.AdminPassword,
+		EnvironTag: names.NewEnvironTag(env.UUID),
+	}, api.DialOpts{
+		Timeout:    dialTimeout,
+		RetryDelay: 500 * time.Millisecond,
+	})
+}
+
 func badRequestf(underlying error, f string, a ...interface{}) error {
 	err := errgo.WithCausef(underlying, params.ErrBadRequest, f, a...)
 	err.(*errgo.Err).SetLocation(1)
 	return err
+}
+
+// collapseHostPorts collapses a list of host-port lists
+// into a single list suitable for passing to api.Open.
+// It preserves ordering because api.State.APIHostPorts
+// makes sure to return the first-connected address
+// first in the slice.
+// See juju.PrepareEndpointsForCaching for a more
+// comprehensive version of this function.
+func collapseHostPorts(hpss [][]network.HostPort) []string {
+	hps := network.CollapseHostPorts(hpss)
+	hps = network.FilterUnusableHostPorts(hps)
+	hps = network.DropDuplicatedHostPorts(hps)
+	return network.HostPortsToStrings(hps)
 }

--- a/internal/v1/api_test.go
+++ b/internal/v1/api_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	corejujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/testing/httptesting"
@@ -35,6 +36,7 @@ var _ = gc.Suite(&APISuite{})
 
 func (s *APISuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
+	s.PatchValue(v1.DialTimeout, time.Duration(0))
 	s.srv, s.jem, s.discharger = s.newServer(c, s.Session)
 	s.username = "testuser"
 }

--- a/internal/v1/export_test.go
+++ b/internal/v1/export_test.go
@@ -3,6 +3,7 @@
 package v1
 
 var (
+	DialTimeout  = &dialTimeout
 	UsernameAttr = usernameAttr
 	GroupsAttr   = groupsAttr
 )

--- a/params/params.go
+++ b/params/params.go
@@ -2,6 +2,7 @@ package params
 
 import "github.com/juju/httprequest"
 
+// AddJES holds the parameters for adding a new state server.
 type AddJES struct {
 	httprequest.Route `httprequest:"PUT /v1/u/:User/server/:Name"`
 	User              User       `httprequest:",path"`


### PR DESCRIPTION
Every state server also has an environment
entry because every state server _is_ an environment as well as being
a state server for other environments.
