### PR TITLE
internal/v1: implement environment get endpoint

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -10,7 +10,7 @@ import (
 type StateServer struct {
 	// Id holds the primary key for a state server.
 	// It's actually in the form user/name.
-	Id   string `bson:"_id"` // Actually user/name.
+	Id string `bson:"_id"` // Actually user/name.
 
 	// User holds the user name containing the state server.
 	User params.User

--- a/params/params.go
+++ b/params/params.go
@@ -5,11 +5,12 @@ import "github.com/juju/httprequest"
 // AddJES holds the parameters for adding a new state server.
 type AddJES struct {
 	httprequest.Route `httprequest:"PUT /v1/u/:User/server/:Name"`
-	User              User       `httprequest:",path"`
-	Name              Name       `httprequest:",path"`
-	Info              ServerInfo `httprequest:",body"`
+	EntityPath
+	Info ServerInfo `httprequest:",body"`
 }
 
+// ServerInfo holds information specifying how
+// to connect to an existing state server.
 type ServerInfo struct {
 	// HostPorts holds host/port pairs (in host:port form)
 	// of the state server API endpoints.
@@ -26,7 +27,34 @@ type ServerInfo struct {
 	// Password holds the password for the user.
 	Password string `json:"password"`
 
-	// EnvironUUID holds the environ tag for the environment we are
+	// EnvironUUID holds the environ UUID of the environment we are
 	// trying to connect to.
 	EnvironUUID string `json:"environ-uuid"`
+}
+
+// EntityPath holds the path parameters for specifying
+// an entity in the API.
+type EntityPath struct {
+	User User `httprequest:",path"`
+	Name Name `httprequest:",path"`
+}
+
+// GetEnvironment holds parameters for retrieving
+// an environment.
+type GetEnvironment struct {
+	httprequest.Route `httprequest:"GET /v1/u/:User/env/:Name"`
+	EntityPath
+}
+
+type EnvironmentResponse struct {
+	// UUID holds the UUID of the environment.
+	UUID string `json:"uuid"`
+
+	// CACert holds the CA certificate that will be used
+	// to validate the state server's certificate, in PEM format.
+	CACert string `json:"ca-cert"`
+
+	// HostPorts holds host/port pairs (in host:port form)
+	// of the state server API endpoints.
+	HostPorts []string `json:"host-ports"`
 }


### PR DESCRIPTION
This allows a user to retrieve details of a JEM environment.
We do not return the user name or password, as we expect
the client to be responsible for authenticating itself
(with macaroons eventually).
