### PR TITLE
jem: make top level handler into a Closer

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -31,7 +31,7 @@ func NewAPIHandler(jp *jem.Pool, sp jem.ServerParams) ([]httprequest.Handler, er
 		}
 		auth, err := h.checkRequest(p.Request)
 		if err != nil {
-			h.jem.Close()
+			h.Close()
 			return nil, errgo.Mask(err, errgo.Any)
 		}
 		h.auth = auth
@@ -39,6 +39,8 @@ func NewAPIHandler(jp *jem.Pool, sp jem.ServerParams) ([]httprequest.Handler, er
 	}), nil
 }
 
+// Close implements io.Closer and is called by httprequest
+// when the request is complete.
 func (h *Handler) Close() error {
 	h.jem.Close()
 	h.jem = nil

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@
 package jem
 
 import (
+	"io"
 	"net/http"
 
 	"gopkg.in/macaroon-bakery.v1/bakery"
@@ -35,8 +36,19 @@ type ServerParams struct {
 	PublicKeyLocator bakery.PublicKeyLocator
 }
 
+// HandleCloser represents an HTTP handler that can
+// be closed to free resources associated with the
+// handler. The Close method should not be called
+// until all requests on the handler have completed.
+type HandleCloser interface {
+	http.Handler
+	io.Closer
+}
+
 // NewServer returns a new handler that handles charm store requests and stores
-// its data in the given database.
-func NewServer(config ServerParams) (http.Handler, error) {
+// its data in the given database. The returned handler should
+// be closed after use (first ensuring that all outstanding requests have
+// completed).
+func NewServer(config ServerParams) (HandleCloser, error) {
 	return jem.NewServer(jem.ServerParams(config), versions)
 }


### PR DESCRIPTION
This will enable us to keep a cache of connections shared between
all clients  - we need to be able to close things down in an orderly fashion
when testing.
