### PR TITLE
internal/v1: use JEM connection cache

### DIFF
--- a/internal/apiconn/cache.go
+++ b/internal/apiconn/cache.go
@@ -52,6 +52,16 @@ func (c *Cache) Close() error {
 	return nil
 }
 
+// EvictAll clears the entire cache. This can be useful for testing.
+func (cache *Cache) EvictAll() {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	for uuid, conn := range cache.conns {
+		conn.Close()
+		delete(cache.conns, uuid)
+	}
+}
+
 // OpenAPI dials the API server at the environment with the given UUID.
 // If a connection is not currently available, the dial
 // function will be called to connect to it and its returned

--- a/internal/jem/export_test.go
+++ b/internal/jem/export_test.go
@@ -1,3 +1,0 @@
-package jem
-
-var APIOpenTimeout = &apiOpenTimeout

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -35,7 +35,7 @@ func (s *jemAPIConnSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	s.pool = pool
 	s.store = s.pool.JEM()
-	s.PatchValue(jem.APIOpenTimeout, time.Duration(0))
+	s.PatchValue(&jem.APIOpenTimeout, time.Duration(0))
 }
 
 func (s *jemAPIConnSuite) TearDownTest(c *gc.C) {

--- a/internal/v1/export_test.go
+++ b/internal/v1/export_test.go
@@ -3,7 +3,6 @@
 package v1
 
 var (
-	DialTimeout  = &dialTimeout
 	UsernameAttr = usernameAttr
 	GroupsAttr   = groupsAttr
 )

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/mgo.v2"
 
@@ -50,5 +51,9 @@ type HandleCloser interface {
 // be closed after use (first ensuring that all outstanding requests have
 // completed).
 func NewServer(config ServerParams) (HandleCloser, error) {
-	return jem.NewServer(jem.ServerParams(config), versions)
+	srv, err := jem.NewServer(jem.ServerParams(config), versions)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return srv, nil
 }


### PR DESCRIPTION
This changes the internal/v1 package to use the API connection cache
we implemented in the previous PRs.
