### PR TITLE
cmd/juju-jem: new command (no logic)

### DIFF
--- a/cmd/juju-jem/jemcmd/add-server.go
+++ b/cmd/juju-jem/jemcmd/add-server.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"github.com/juju/cmd"
+	"launchpad.net/gnuflag"
+)
+
+type addServerCommand struct {
+	cmd.CommandBase
+}
+
+var addServerDoc = `
+The add-server command ... TODO.
+`
+
+func (c *addServerCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "add-server",
+		Args:    "TODO",
+		Purpose: "TODO",
+		Doc:     addServerDoc,
+	}
+}
+
+func (c *addServerCommand) SetFlags(f *gnuflag.FlagSet) {
+	// f.StringVar(&c.value, "flagname", "default", "description")
+}
+
+func (c *addServerCommand) Init(args []string) error {
+	// TODO
+	return nil
+}
+
+func (c *addServerCommand) Run(ctxt *cmd.Context) error {
+	// TODO
+	return nil
+}

--- a/cmd/juju-jem/jemcmd/add-server_test.go
+++ b/cmd/juju-jem/jemcmd/add-server_test.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	gc "gopkg.in/check.v1"
+)
+
+type addServerSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&addServerSuite{})
+
+// TODO tests

--- a/cmd/juju-jem/jemcmd/cmd.go
+++ b/cmd/juju-jem/jemcmd/cmd.go
@@ -1,0 +1,34 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"os"
+
+	"github.com/juju/cmd"
+)
+
+// jujuLoggingConfigEnvKey matches osenv.JujuLoggingConfigEnvKey
+// in the Juju project.
+const jujuLoggingConfigEnvKey = "JUJU_LOGGING_CONFIG"
+
+var cmdDoc = `
+The juju jem command provides ... TODO.
+`
+
+// New returns a command that can execute juju-jem
+// commands.
+func New() cmd.Command {
+	supercmd := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "jem",
+		UsagePrefix: "juju",
+		Doc:         cmdDoc,
+		Purpose:     "TODO",
+		Log: &cmd.Log{
+			DefaultConfig: os.Getenv(jujuLoggingConfigEnvKey),
+		},
+	})
+	supercmd.Register(&addServerCommand{})
+
+	return supercmd
+}

--- a/cmd/juju-jem/jemcmd/cmd_test.go
+++ b/cmd/juju-jem/jemcmd/cmd_test.go
@@ -1,0 +1,48 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+	"launchpad.net/loggo"
+
+	"github.com/CanonicalLtd/jem/cmd/juju-jem/jemcmd"
+)
+
+// run runs a jem plugin subcommand with the given arguments,
+// its context directory set to dir. It returns the output of the command
+// and its exit code.
+func run(dir string, args ...string) (stdout, stderr string, exitCode int) {
+	// Remove the warning writer usually registered by cmd.Log.Start, so that
+	// it is possible to run multiple commands in the same test.
+	// We are not interested in possible errors here.
+	defer loggo.RemoveWriter("warning")
+	var stdoutBuf, stderrBuf bytes.Buffer
+	ctxt := &cmd.Context{
+		Dir:    dir,
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	}
+	exitCode = cmd.Main(jemcmd.New(), ctxt, args)
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}
+
+type commonSuite struct {
+	testing.IsolatedMgoSuite
+}
+
+func (s *commonSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	// TODO delete this method if there's nothing else here.
+}
+
+func (s *commonSuite) TearDownTest(c *gc.C) {
+	// TODO delete this method if there's nothing else here.
+	s.IsolatedMgoSuite.TearDownTest(c)
+}

--- a/cmd/juju-jem/jemcmd/package_test.go
+++ b/cmd/juju-jem/jemcmd/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/cmd/juju-jem/main.go
+++ b/cmd/juju-jem/main.go
@@ -1,0 +1,20 @@
+// Copyright 2015 Canonical Ltd.
+package main
+
+import (
+	"os"
+
+	"github.com/juju/cmd"
+
+	"github.com/CanonicalLtd/jem/cmd/juju-jem/jemcmd"
+)
+
+func main() {
+	ctxt := &cmd.Context{
+		Dir:    ".",
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Stdin:  os.Stdin,
+	}
+	os.Exit(cmd.Main(jemcmd.New(), ctxt, os.Args[1:]))
+}


### PR DESCRIPTION
This entire commit has been automatically generated by
running:

```
newjujuplugin github.com/CanonicalLtd/jem/cmd/juju-jem add-server
```

The source to that command is at github.com/rogpeppe/misc/cmd/newjujuplugin.

Actual logic for the new commands will follow in a separate PR - this
just establishes the skeleton of the plugin.
