### PR TITLE
internal/v1: return more info in API response.

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -113,6 +113,10 @@ type EnvironmentResponse struct {
 	// UUID holds the UUID of the environment.
 	UUID string `json:"uuid"`
 
+	// ServerUUID holds the UUID of the state server
+	// environment containing this environment.
+	ServerUUID  string `json:"server-uuid"`
+
 	// CACert holds the CA certificate that will be used
 	// to validate the state server's certificate, in PEM format.
 	CACert string `json:"ca-cert"`


### PR DESCRIPTION
Also create the juju user based on the JEM name, not the authorized
user name.

We want the extra info because it seems to be required as part
of a .jenv file.
