### PR TITLE
cmd/juju-jem/jemcmd: new create command

### DIFF
--- a/cmd/juju-jem/jemcmd/add-server_test.go
+++ b/cmd/juju-jem/jemcmd/add-server_test.go
@@ -53,19 +53,9 @@ var addServerErrorTests = []struct {
 	expectStderr: "got 3 arguments, want 1",
 	expectCode:   2,
 }, {
-	about:        "only one part in server id",
+	about:        "invalid server name",
 	args:         []string{"a"},
-	expectStderr: `invalid JEM environment name \(needs to be <user>/<name>\)`,
-	expectCode:   2,
-}, {
-	about:        "too many parts in server id",
-	args:         []string{"a/b/c"},
-	expectStderr: `invalid JEM environment name \(needs to be <user>/<name>\)`,
-	expectCode:   2,
-}, {
-	about:        "empty server id",
-	args:         []string{""},
-	expectStderr: `invalid JEM environment name \(needs to be <user>/<name>\)`,
+	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
 	expectCode:   2,
 }, {
 	about:        "invalid name checked by server",

--- a/cmd/juju-jem/jemcmd/cmd.go
+++ b/cmd/juju-jem/jemcmd/cmd.go
@@ -5,6 +5,7 @@ package jemcmd
 import (
 	"os"
 	"path"
+	"strings"
 
 	"github.com/juju/cmd"
 	"github.com/juju/juju/cmd/envcmd"
@@ -18,6 +19,7 @@ import (
 	"launchpad.net/gnuflag"
 
 	"github.com/CanonicalLtd/jem/jemclient"
+	"github.com/CanonicalLtd/jem/params"
 )
 
 var logger = loggo.GetLogger("jem")
@@ -61,6 +63,7 @@ func New() cmd.Command {
 		},
 	})
 	supercmd.Register(&addServerCommand{})
+	supercmd.Register(&createCommand{})
 
 	return supercmd
 }
@@ -164,3 +167,24 @@ func cookieFile() string {
 	}
 	return path.Join(utils.Home(), ".go-cookies")
 }
+
+// entityPathValue holds an EntityPath that
+// can be used as a flag value.
+type entityPathValue struct {
+	params.EntityPath
+}
+
+// Set implements gnuflag.Value.Set, enabling entityPathValue
+// to be used as a custom flag value.
+// The String method is implemented by EntityPath itself.
+func (v *entityPathValue) Set(p string) error {
+	parts := strings.Split(p, "/")
+	if len(parts) != 2 {
+		return errgo.Newf("invalid JEM name %q (needs to be <user>/<name>)", p)
+	}
+	v.User = params.User(parts[0])
+	v.Name = params.Name(parts[1])
+	return nil
+}
+
+var _ gnuflag.Value = (*entityPathValue)(nil)

--- a/cmd/juju-jem/jemcmd/common_test.go
+++ b/cmd/juju-jem/jemcmd/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/cmd"
 	jujufeature "github.com/juju/juju/feature"
 	corejujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/loggo"
 	"github.com/juju/utils/featureflag"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
@@ -19,7 +20,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakerytest"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/mgo.v2"
-	"launchpad.net/loggo"
 
 	"github.com/CanonicalLtd/jem"
 	"github.com/CanonicalLtd/jem/cmd/juju-jem/jemcmd"
@@ -60,7 +60,6 @@ type commonSuite struct {
 
 func (s *commonSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	c.Logf("done jujuconnsuite SetUpTest")
 	s.jemSrv, s.discharger = s.newServer(c, s.Session)
 	s.httpSrv = httptest.NewServer(s.jemSrv)
 	s.username = "testuser"
@@ -107,3 +106,5 @@ func (s *commonSuite) newServer(c *gc.C, session *mgo.Session) (jem.HandleCloser
 	c.Assert(err, gc.IsNil)
 	return srv, discharger
 }
+
+const fakeSSHKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCcEHVJtQyjN0eaNMAQIwhwknKj+8uZCqmzeA6EfnUEsrOHisoKjRVzb3bIRVgbK3SJ2/1yHPpL2WYynt3LtToKgp0Xo7LCsspL2cmUIWNYCbcgNOsT5rFeDsIDr9yQito8A3y31Mf7Ka7Rc0EHtCW4zC5yl/WZjgmMmw930+V1rDa5GjkqivftHE5AvLyRGvZJPOLH8IoO+sl02NjZ7dRhniBO9O5UIwxSkuGA5wvfLV7dyT/LH56gex7C2fkeBkZ7YGqTdssTX6DvFTHjEbBAsdWd8/rqXWtB6Xdi8sb3+aMpg9DRomZfb69Y+JuqWTUaq+q30qG2CTiqFRbgwRpp bob@somewhere"

--- a/cmd/juju-jem/jemcmd/create.go
+++ b/cmd/juju-jem/jemcmd/create.go
@@ -1,0 +1,289 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/cmd"
+	"github.com/juju/errors"
+	jujuconfig "github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/configstore"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/utils"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/environschema.v1"
+	"gopkg.in/yaml.v1"
+	"launchpad.net/gnuflag"
+
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type createCommand struct {
+	commandBase
+
+	srvPath    entityPathValue
+	envPath    entityPathValue
+	configFile string
+	localName  string
+}
+
+var createDoc = `
+The create command creates a new environment inside the specified state
+server. Its argument specifies the JEM name of the new environment.
+`
+
+func (c *createCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "create",
+		Args:    "<user>/<envname>",
+		Purpose: "Create a new environment in JEM",
+		Doc:     createDoc,
+	}
+}
+
+func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.commandBase.SetFlags(f)
+	f.Var(&c.srvPath, "state-server", "state server to create the environment in")
+	f.Var(&c.srvPath, "s", "")
+	f.StringVar(&c.configFile, "config", "", "YAML config file containing environment configuration")
+	f.StringVar(&c.localName, "local", "", "local name for environment (as used for juju switch). Defaults to <envname>")
+}
+
+func (c *createCommand) Init(args []string) error {
+	if len(args) != 1 {
+		return errgo.Newf("got %d arguments, want 1", len(args))
+	}
+	if err := c.envPath.Set(args[0]); err != nil {
+		return errgo.Mask(err)
+	}
+	if c.srvPath.EntityPath == (params.EntityPath{}) {
+		return errgo.Newf("state server must be specified")
+	}
+	if c.localName == "" {
+		c.localName = string(c.envPath.Name)
+	}
+	return nil
+}
+
+func (c *createCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.newClient()
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	defer client.Close()
+
+	config := make(map[string]interface{})
+	if c.configFile != "" {
+		data, err := ioutil.ReadFile(c.configFile)
+		if err != nil {
+			return errgo.Notef(err, "cannot read configuration file")
+		}
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return errgo.Notef(err, "cannot unmarshal %q", c.configFile)
+		}
+	}
+	jesInfo, err := client.GetJES(&params.GetJES{
+		EntityPath: c.srvPath.EntityPath,
+	})
+	if err != nil {
+		return errgo.Notef(err, "cannot get JES info")
+	}
+
+	if err := c.setConfigDefaults(config, jesInfo); err != nil {
+		return errgo.Notef(err, "cannot add default values for configuration file")
+	}
+	// Generate a random password for the user.
+	// TODO potentially allow the password to be specified in
+	// the config file or as a command line flag or interactively?
+	password, err := utils.RandomPassword()
+	if err != nil {
+		return errgo.Notef(err, "cannot generate password")
+	}
+	store, err := configstore.Default()
+	if err != nil {
+		return errgo.Notef(err, "cannot get default configstore")
+	}
+	// Check that the environment doesn't exist already.
+	_, err = store.ReadInfo(c.localName)
+	if err == nil {
+		return errgo.Notef(err, "local environment %q already exists", c.localName)
+	}
+	if !errors.IsNotFound(err) {
+		return errgo.Notef(err, "cannot check for existing local environment")
+	}
+	resp, err := client.NewEnvironment(&params.NewEnvironment{
+		User: c.envPath.User,
+		Info: params.NewEnvironmentInfo{
+			Name:        c.envPath.Name,
+			Password:    password,
+			StateServer: fmt.Sprintf("%s/server/%s", c.srvPath.User, c.srvPath.Name),
+			Config:      config,
+		},
+	})
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	envInfo := store.CreateInfo(c.localName)
+	envInfo.SetAPIEndpoint(configstore.APIEndpoint{
+		Addresses:   resp.HostPorts,
+		CACert:      resp.CACert,
+		EnvironUUID: resp.UUID,
+		ServerUUID:  resp.ServerUUID,
+	})
+	envInfo.SetAPICredentials(configstore.APICredentials{
+		User:     resp.User,
+		Password: password,
+	})
+	if err := envInfo.Write(); err != nil {
+		return errgo.Notef(err, "cannot write environment info")
+	}
+	return nil
+}
+
+func (c *createCommand) setConfigDefaults(config map[string]interface{}, jesInfo *params.JESInfo) error {
+	// Authorized keys are special because the path is relative
+	// to $HOME/.ssh by default.
+	if _, ok := jesInfo.Template["authorized-keys"]; ok && config["authorized-keys"] == nil {
+		// Load authorized-keys-path into authorized-keys if necessary.
+		path, _ := config["authorized-keys-path"].(string)
+		keys, err := jujuconfig.ReadAuthorizedKeys(path)
+		if err != nil {
+			return errgo.Notef(err, "cannot read authorized keys")
+		}
+		config["authorized-keys"] = keys
+		delete(config, "authorized-keys-path")
+	}
+
+	// Any string configuration attribute may be specified
+	// with a -path attribute.
+	for pathAttr, path := range config {
+		if !strings.HasSuffix(pathAttr, "-path") {
+			continue
+		}
+		attr := strings.TrimSuffix(pathAttr, "-path")
+		field, ok := jesInfo.Template[attr]
+		if !ok || field.Type != environschema.Tstring {
+			continue
+		}
+		pathStr, ok := path.(string)
+		if !ok || pathStr == "" {
+			// Probably just malformed - let the server deal with it.
+			continue
+		}
+		delete(config, pathAttr)
+		val, err := readFile(pathStr)
+		if err != nil {
+			return errgo.Notef(err, "cannot get value for %q", pathStr)
+		}
+		config[attr] = val
+	}
+
+	// Fill config attributes from appropriate environment variables
+	for name, attr := range jesInfo.Template {
+		if config[name] != nil {
+			continue
+		}
+		if attr.EnvVar != "" {
+			// TODO it could be a problem that this potentially
+			// enables a rogue JEM server to retrieve arbitrary
+			// environment variables from a client. Implement
+			// some kind of whitelisting scheme?
+			if v := os.Getenv(attr.EnvVar); v != "" {
+				config[name] = v
+				continue
+			}
+		}
+		if f := providerDefaults[jesInfo.ProviderType][name]; f != nil {
+			v, err := f(c)
+			if err != nil {
+				return errgo.Notef(err, "cannot make default value for %q", name)
+			}
+			config[name] = v
+		}
+	}
+	return nil
+}
+
+// readFile reads an attribute from the given file path.
+// If the path is relative, then it is treated as releative
+// to $JUJU_HOME. Also, an initial "~" is expanded to $HOME.
+func readFile(path string) (string, error) {
+	// The logic here is largely copied from the
+	// maybeReadAttrFromFile function in juju/environs/config.
+	path, err := utils.NormalizePath(path)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(path) {
+		if !osenv.IsJujuHomeSet() {
+			return "", errgo.Newf("JUJU_HOME not set, not attempting to read file %q", path)
+		}
+		path = osenv.JujuHomePath(path)
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", errgo.Mask(err)
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("file %q is empty", path)
+	}
+	return string(data), nil
+}
+
+var providerDefaults = map[string]map[string]func(*createCommand) (interface{}, error){
+	"azure": {
+		"availability-sets-enabled": constValue(true),
+	},
+	"ec2": {
+		"control-bucket": rawUUIDValue,
+	},
+	"joyent": {
+		"control-dir": uuidValue,
+	},
+	"local": {
+		"namespace": (*createCommand).localProviderNamespaceValue,
+		"proxy-ssh": constValue(false),
+	},
+	"maas": {
+		"maas-agent-name": uuidValue,
+	},
+	"openstack": {
+		"control-bucket": rawUUIDValue,
+	},
+}
+
+func constValue(v interface{}) func(*createCommand) (interface{}, error) {
+	return func(*createCommand) (interface{}, error) {
+		return v, nil
+	}
+}
+
+func uuidValue(*createCommand) (interface{}, error) {
+	return utils.NewUUID()
+}
+
+func rawUUIDValue(*createCommand) (interface{}, error) {
+	v, err := utils.NewUUID()
+	if err != nil {
+		return nil, err
+	}
+	return fmt.Sprintf("%x", v.Raw()), nil
+}
+
+func (c *createCommand) localProviderNamespaceValue() (interface{}, error) {
+	username := os.Getenv("USER")
+	if username == "" {
+		u, err := user.Current()
+		if err != nil {
+			return nil, errgo.Notef(err, "failed to determine username for namespace")
+		}
+		username = u.Username
+	}
+	return fmt.Sprintf("%s-%s", username, c.envPath.Name), nil
+}

--- a/cmd/juju-jem/jemcmd/create_test.go
+++ b/cmd/juju-jem/jemcmd/create_test.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/juju/juju"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v1"
+)
+
+type createSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&createSuite{})
+
+func (s *createSuite) TestCreate(c *gc.C) {
+	s.username = "bob"
+
+	// First add the state server that we're going to use
+	// to create the new environment.
+	stdout, stderr, code := run(c, c.MkDir(), "add-server", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	config := map[string]interface{}{
+		"authorized-keys": fakeSSHKey,
+		"state-server":    true,
+	}
+	data, err := yaml.Marshal(config)
+	c.Assert(err, gc.IsNil)
+	configPath := filepath.Join(c.MkDir(), "config.yaml")
+	err = ioutil.WriteFile(configPath, data, 0666)
+	c.Assert(err, gc.IsNil)
+	stdout, stderr, code = run(c, c.MkDir(),
+		"create",
+		"-s", "bob/foo",
+		"--config", configPath,
+		"bob/newenv",
+	)
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that we can attach to the new environment
+	// through the usual juju connection mechanism.
+	client, err := juju.NewAPIClientFromName("newenv")
+	c.Assert(err, gc.IsNil)
+	client.Close()
+}
+
+var createErrorTests = []struct {
+	about        string
+	args         []string
+	expectStderr string
+	expectCode   int
+}{{
+	about:        "too few arguments",
+	args:         []string{},
+	expectStderr: "got 0 arguments, want 1",
+	expectCode:   2,
+}, {
+	about:        "too many arguments",
+	args:         []string{"a", "b", "c"},
+	expectStderr: "got 3 arguments, want 1",
+	expectCode:   2,
+}, {
+	about:        "only one part in environ id",
+	args:         []string{"a"},
+	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectCode:   2,
+}, {
+	about:        "state server must be specified",
+	args:         []string{"foo/bar"},
+	expectStderr: `state server must be specified`,
+	expectCode:   2,
+}}
+
+func (s *createSuite) TestCreateError(c *gc.C) {
+	for i, test := range createErrorTests {
+		c.Logf("test %d: %s", i, test.about)
+		stdout, stderr, code := run(c, c.MkDir(), "create", test.args...)
+		c.Assert(code, gc.Equals, test.expectCode, gc.Commentf("stderr: %s", stderr))
+		c.Assert(stderr, gc.Matches, "(error:|ERROR) "+test.expectStderr+"\n")
+		c.Assert(stdout, gc.Equals, "")
+	}
+}

--- a/cmd/juju-jem/jemcmd/internal_test.go
+++ b/cmd/juju-jem/jemcmd/internal_test.go
@@ -1,0 +1,340 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/juju/juju/osenv"
+	corejujutesting "github.com/juju/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/environschema.v1"
+
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type internalSuite struct {
+	corejujutesting.JujuConnSuite
+}
+
+var _ = gc.Suite(&internalSuite{})
+
+var entityPathValueTests = []struct {
+	about            string
+	val              string
+	expectEntityPath params.EntityPath
+	expectError      string
+}{{
+	about: "success",
+	val:   "foo/bar",
+	expectEntityPath: params.EntityPath{
+		User: "foo",
+		Name: "bar",
+	},
+}, {
+	about:       "only one part",
+	val:         "a",
+	expectError: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+}, {
+	about:       "too many parts",
+	val:         "a/b/c",
+	expectError: `invalid JEM name "a/b/c" \(needs to be <user>/<name>\)`,
+}, {
+	about:       "empty server id",
+	val:         "",
+	expectError: `invalid JEM name "" \(needs to be <user>/<name>\)`,
+}}
+
+func (s *internalSuite) TestEntityPathValue(c *gc.C) {
+	for i, test := range entityPathValueTests {
+		c.Logf("test %d: %s", i, test.about)
+		var p entityPathValue
+		err := p.Set(test.val)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(p.EntityPath, gc.Equals, test.expectEntityPath)
+	}
+}
+
+func (s *internalSuite) TestCreateComnandSetConfigDefaults(c *gc.C) {
+	// Note: these values are set up by JujuConnSuite
+	// and are not the actual user's home and juju home.
+	home := utils.Home()
+	jujuHome := osenv.JujuHomePath()
+	tests := []struct {
+		about   string
+		envName string
+		jesInfo params.JESInfo
+		config  map[string]interface{}
+
+		// envVars holds a map from environment variable
+		// name to value. Each entry will be set at the start
+		// of the test.
+		envVars map[string]string
+
+		// files holds a map from file name to contents.
+		// Each entry will be created at the start of the test.
+		files map[string]string
+
+		expectError  string
+		expectConfig map[string]interface{}
+	}{{
+		about: "one parameter, no defaults",
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr": "hello",
+		},
+		expectConfig: map[string]interface{}{
+			"attr": "hello",
+		},
+	}, {
+		about: "environment variable defaults",
+		envVars: map[string]string{
+			"somevar": "avalue",
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type:   environschema.Tstring,
+					EnvVar: "somevar",
+				},
+			},
+		},
+		expectConfig: map[string]interface{}{
+			"attr": "avalue",
+		},
+	}, {
+		about: "default authorized keys",
+		files: map[string]string{
+			filepath.Join(home, ".ssh", "id_rsa.pub"): fakeSSHKey,
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"authorized-keys": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		expectConfig: map[string]interface{}{
+			"authorized-keys": fakeSSHKey,
+		},
+	}, {
+		about: "authorized keys from relative path",
+		files: map[string]string{
+			filepath.Join(home, ".ssh", "another.pub"): fakeSSHKey,
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"authorized-keys": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"authorized-keys-path": "another.pub",
+		},
+		expectConfig: map[string]interface{}{
+			"authorized-keys": fakeSSHKey,
+		},
+	}, {
+		about: "authorized keys from absolute path",
+		files: map[string]string{
+			filepath.Join(home, "key.pub"): fakeSSHKey,
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"authorized-keys": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"authorized-keys-path": filepath.Join(home, "key.pub"),
+		},
+		expectConfig: map[string]interface{}{
+			"authorized-keys": fakeSSHKey,
+		},
+	}, {
+		about: "attribute from relative path",
+		files: map[string]string{
+			filepath.Join(jujuHome, "x"): "content",
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr-path": "x",
+		},
+		expectConfig: map[string]interface{}{
+			"attr": "content",
+		},
+	}, {
+		about: "attribute from home-relative path",
+		files: map[string]string{
+			filepath.Join(home, "x"): "content",
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr-path": filepath.Join("~", "x"),
+		},
+		expectConfig: map[string]interface{}{
+			"attr": "content",
+		},
+	}, {
+		about: "attribute from absolute path",
+		files: map[string]string{
+			filepath.Join(home, "x"): "content",
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr-path": filepath.Join(home, "x"),
+		},
+		expectConfig: map[string]interface{}{
+			"attr": "content",
+		},
+	}, {
+		about: "empty file is an error",
+		files: map[string]string{
+			filepath.Join(jujuHome, "x"): "",
+		},
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr-path": "x",
+		},
+		expectError: `cannot get value for "x": file ".*home/ubuntu/.juju/x" is empty`,
+	}, {
+		about: "attribute from path ignored with non-string template entry",
+		jesInfo: params.JESInfo{
+			ProviderType: "something",
+			Template: environschema.Fields{
+				"attr": {
+					Type: environschema.Tint,
+				},
+			},
+		},
+		config: map[string]interface{}{
+			"attr-path": "nomatter",
+		},
+		expectConfig: map[string]interface{}{
+			"attr-path": "nomatter",
+		},
+	}, {
+		about: "provider default",
+		jesInfo: params.JESInfo{
+			ProviderType: "test",
+			Template: environschema.Fields{
+				"testattr": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		expectConfig: map[string]interface{}{
+			"testattr": "testattr-default-value",
+		},
+	}, {
+		about: "provider default error",
+		jesInfo: params.JESInfo{
+			ProviderType: "test",
+			Template: environschema.Fields{
+				"testattr-error": {
+					Type: environschema.Tstring,
+				},
+			},
+		},
+		expectError: `cannot make default value for "testattr-error": an error`,
+	}}
+	s.PatchValue(&providerDefaults, map[string]map[string]func(*createCommand) (interface{}, error){
+		"test": {
+			"testattr": func(*createCommand) (interface{}, error) {
+				return "testattr-default-value", nil
+			},
+			"testattr-error": func(*createCommand) (interface{}, error) {
+				return "", errgo.New("an error")
+			},
+		},
+	})
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.about)
+
+		for path, contents := range test.files {
+			err := os.MkdirAll(filepath.Dir(path), 0777)
+			c.Assert(err, gc.IsNil)
+			err = ioutil.WriteFile(path, []byte(contents), 0666)
+			c.Assert(err, gc.IsNil)
+		}
+		for name, val := range test.envVars {
+			os.Setenv(name, val)
+		}
+
+		var createCmd createCommand
+		createCmd.envPath.Name = params.Name(test.envName)
+
+		config := make(map[string]interface{})
+		for name, val := range test.config {
+			config[name] = val
+		}
+		err := createCmd.setConfigDefaults(config, &test.jesInfo)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(config, jc.DeepEquals, test.expectConfig)
+		}
+
+		// Remove the test files.
+		for path := range test.files {
+			err := os.Remove(path)
+			c.Assert(err, gc.IsNil)
+		}
+		for name := range test.envVars {
+			os.Setenv(name, "")
+		}
+	}
+}
+
+const fakeSSHKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCcEHVJtQyjN0eaNMAQIwhwknKj+8uZCqmzeA6EfnUEsrOHisoKjRVzb3bIRVgbK3SJ2/1yHPpL2WYynt3LtToKgp0Xo7LCsspL2cmUIWNYCbcgNOsT5rFeDsIDr9yQito8A3y31Mf7Ka7Rc0EHtCW4zC5yl/WZjgmMmw930+V1rDa5GjkqivftHE5AvLyRGvZJPOLH8IoO+sl02NjZ7dRhniBO9O5UIwxSkuGA5wvfLV7dyT/LH56gex7C2fkeBkZ7YGqTdssTX6DvFTHjEbBAsdWd8/rqXWtB6Xdi8sb3+aMpg9DRomZfb69Y+JuqWTUaq+q30qG2CTiqFRbgwRpp bob@somewhere\n"

--- a/params/params.go
+++ b/params/params.go
@@ -1,6 +1,8 @@
 package params
 
 import (
+	"fmt"
+
 	"github.com/juju/httprequest"
 	"gopkg.in/juju/environschema.v1"
 )
@@ -40,6 +42,10 @@ type ServerInfo struct {
 type EntityPath struct {
 	User User `httprequest:",path"`
 	Name Name `httprequest:",path"`
+}
+
+func (p EntityPath) String() string {
+	return fmt.Sprintf("%s/%s", p.User, p.Name)
 }
 
 // GetEnvironment holds parameters for retrieving
@@ -110,12 +116,16 @@ type NewEnvironmentInfo struct {
 // EnvironmentResponse holds the response body from
 // a NewEnvironment call.
 type EnvironmentResponse struct {
+	// User holds the admin user name associated
+	// with the environment.
+	User string `json:"user"`
+
 	// UUID holds the UUID of the environment.
 	UUID string `json:"uuid"`
 
 	// ServerUUID holds the UUID of the state server
 	// environment containing this environment.
-	ServerUUID  string `json:"server-uuid"`
+	ServerUUID string `json:"server-uuid"`
 
 	// CACert holds the CA certificate that will be used
 	// to validate the state server's certificate, in PEM format.

--- a/params/validate.go
+++ b/params/validate.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/juju/names"
 	"gopkg.in/errgo.v1"
@@ -16,6 +17,10 @@ func (u *User) UnmarshalText(t []byte) error {
 	if !names.IsValidUserName(u0) {
 		return errgo.WithCausef(nil, ErrBadRequest, "invalid user name %q", u0)
 	}
+	// Forbid double-hyphen because we use it as a separator.
+	if strings.Contains(u0, "--") {
+		return errgo.WithCausef(nil, ErrBadRequest, "invalid user name %q", u0)
+	}
 	*u = User(u0)
 	return nil
 }
@@ -26,6 +31,11 @@ func (n *Name) UnmarshalText(t []byte) error {
 	if !validName.Match(t) {
 		return errgo.WithCausef(nil, ErrBadRequest, "invalid name %q", t)
 	}
-	*n = Name(t)
+	// Forbid double-hyphen because we use it as a separator.
+	t0 := string(t)
+	if strings.Contains(t0, "--") {
+		return errgo.WithCausef(nil, ErrBadRequest, "invalid name %q", t0)
+	}
+	*n = Name(t0)
 	return nil
 }

--- a/params/validate_test.go
+++ b/params/validate_test.go
@@ -72,6 +72,32 @@ var validatorsTests = []struct {
 		User params.User `httprequest:",path"`
 	}),
 	expectError: `cannot unmarshal into field: invalid user name "foo_invalid"`,
+}, {
+	about: "double hyphen in user",
+	params: httprequest.Params{
+		Request: newHTTPRequest("", nil),
+		PathVar: httprouter.Params{{
+			Key:   "User",
+			Value: "foo--invalid",
+		}},
+	},
+	val: new(struct {
+		User params.User `httprequest:",path"`
+	}),
+	expectError: `cannot unmarshal into field: invalid user name "foo--invalid"`,
+}, {
+	about: "double hyphen in name",
+	params: httprequest.Params{
+		Request: newHTTPRequest("", nil),
+		PathVar: httprouter.Params{{
+			Key:   "Name",
+			Value: "foo--invalid",
+		}},
+	},
+	val: new(struct {
+		Name params.Name `httprequest:",path"`
+	}),
+	expectError: `cannot unmarshal into field: invalid name "foo--invalid"`,
 }}
 
 func (*suite) TestValidators(c *gc.C) {


### PR DESCRIPTION
We also change the behaviour of the new environment API endpoint
so that it creates a juju user based on the environment name, not the
authorized user. This means that the person that creates the environment
knows what password they'll get.
