### PR TITLE
internal/jem: copy mgo session for bakery storage too

### DIFF
--- a/internal/apiconn/cache_test.go
+++ b/internal/apiconn/cache_test.go
@@ -26,7 +26,7 @@ func (s *cacheSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	pool, err := jem.NewPool(
 		s.Session.DB("jem"),
-		&bakery.NewServiceParams{
+		bakery.NewServiceParams{
 			Location: "here",
 		},
 	)

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -28,7 +28,7 @@ func (s *jemAPIConnSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	pool, err := jem.NewPool(
 		s.Session.DB("jem"),
-		&bakery.NewServiceParams{
+		bakery.NewServiceParams{
 			Location: "here",
 		},
 	)

--- a/internal/jem/server.go
+++ b/internal/jem/server.go
@@ -57,7 +57,7 @@ func NewServer(config ServerParams, versions map[string]NewAPIHandlerFunc) (*Ser
 		Location: "jem",
 		Locator:  config.PublicKeyLocator,
 	}
-	p, err := NewPool(config.DB, &bparams)
+	p, err := NewPool(config.DB, bparams)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}


### PR DESCRIPTION
This fixes the usual session problems. I verified that the
new test failed with the old code.
