### PR TITLE
internal/v1: use /env/foo/bar rather than /u/foo/env/bar

### DIFF
--- a/cmd/juju-jem/jemcmd/create.go
+++ b/cmd/juju-jem/jemcmd/create.go
@@ -109,7 +109,7 @@ func (c *createCommand) Run(ctxt *cmd.Context) error {
 			Info: params.NewEnvironmentInfo{
 				Name:        c.envPath.Name,
 				Password:    password,
-				StateServer: fmt.Sprintf("%s/server/%s", c.srvPath.User, c.srvPath.Name),
+				StateServer: c.srvPath.EntityPath,
 				Config:      config,
 			},
 		})

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -41,17 +41,16 @@ func (s *jemSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *jemSuite) TestAddStateServer(c *gc.C) {
+	srvPath := params.EntityPath{"bob", "x"}
 	srv := &mongodoc.StateServer{
 		Id:        "ignored",
-		User:      "bob",
-		Name:      "x",
+		Path:      srvPath,
 		CACert:    "certainly",
 		HostPorts: []string{"host1:1234", "host2:9999"},
 	}
 	env := &mongodoc.Environment{
 		Id:            "ignored",
-		User:          "ignored-user",
-		Name:          "ignored-name",
+		Path:          params.EntityPath{"ignored-user", "ignored-name"},
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	}
@@ -61,30 +60,27 @@ func (s *jemSuite) TestAddStateServer(c *gc.C) {
 	// Check that the fields have been mutated as expected.
 	c.Assert(srv, jc.DeepEquals, &mongodoc.StateServer{
 		Id:        "bob/x",
-		User:      "bob",
-		Name:      "x",
+		Path:      srvPath,
 		CACert:    "certainly",
 		HostPorts: []string{"host1:1234", "host2:9999"},
 	})
 	c.Assert(env, jc.DeepEquals, &mongodoc.Environment{
 		Id:            "bob/x",
-		User:          "bob",
-		Name:          "x",
+		Path:          srvPath,
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
-		StateServer:   "bob/x",
+		StateServer:   srvPath,
 	})
 
-	srv1, err := s.store.StateServer("bob/x")
+	srv1, err := s.store.StateServer(srvPath)
 	c.Assert(err, gc.IsNil)
 	c.Assert(srv1, jc.DeepEquals, &mongodoc.StateServer{
 		Id:        "bob/x",
-		User:      "bob",
-		Name:      "x",
+		Path:      srvPath,
 		CACert:    "certainly",
 		HostPorts: []string{"host1:1234", "host2:9999"},
 	})
-	env1, err := s.store.Environment("bob/x")
+	env1, err := s.store.Environment(srvPath)
 	c.Assert(err, gc.IsNil)
 	c.Assert(env1, jc.DeepEquals, env)
 
@@ -94,10 +90,10 @@ func (s *jemSuite) TestAddStateServer(c *gc.C) {
 }
 
 func (s *jemSuite) TestAddEnvironment(c *gc.C) {
+	srvPath := params.EntityPath{"bob", "x"}
 	env := &mongodoc.Environment{
 		Id:            "ignored",
-		User:          "bob",
-		Name:          "x",
+		Path:          srvPath,
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	}
@@ -105,13 +101,12 @@ func (s *jemSuite) TestAddEnvironment(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(env, jc.DeepEquals, &mongodoc.Environment{
 		Id:            "bob/x",
-		User:          "bob",
-		Name:          "x",
+		Path:          srvPath,
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	})
 
-	env1, err := s.store.Environment("bob/x")
+	env1, err := s.store.Environment(srvPath)
 	c.Assert(err, gc.IsNil)
 	c.Assert(env1, jc.DeepEquals, env)
 
@@ -135,14 +130,14 @@ func (s *jemSuite) TestSessionIsCopied(c *gc.C) {
 	// Check that we get an appropriate error when getting
 	// a non-existent environment, indicating that database
 	// access is going OK.
-	_, err = store.Environment("bob/x")
+	_, err = store.Environment(params.EntityPath{"bob", "x"})
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	// Close the session and check that we still get the
 	// same error.
 	session.Close()
 
-	_, err = store.Environment("bob/x")
+	_, err = store.Environment(params.EntityPath{"bob", "x"})
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	// Also check the macaroon storage as that also has its own session reference.

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -9,15 +9,13 @@ import (
 // collection with the same id.
 type StateServer struct {
 	// Id holds the primary key for a state server.
-	// It's actually in the form user/name.
-	Id string `bson:"_id"` // Actually user/name.
+	// It holds Path.String().
+	Id string `bson:"_id"`
 
-	// User holds the user name containing the state server.
-	User params.User
-
-	// Name holds the local name given to the state
-	// server. It is unique within a given user.
-	Name params.Name
+	// EntityPath holds the local user and name given to the
+	// state server, denormalized from Id for convenience
+	// and ease of indexing. Its string value is used as the Id value.
+	Path params.EntityPath
 
 	// CACert holds the CA certificate of the server.
 	CACert string
@@ -29,14 +27,14 @@ type StateServer struct {
 }
 
 type Environment struct {
-	Id string `bson:"_id"` // Actually user/name.
+	// Id holds the primary key for an environment.
+	// It holds Path.String().
+	Id string `bson:"_id"`
 
-	// User holds the user name containing the environment.
-	User params.User
-
-	// Name holds the local name given to the environment.
-	// It is unique within a given user.
-	Name params.Name
+	// EntityPath holds the local user and name given to the
+	// environment, denormalized from Id for convenience
+	// and ease of indexing. Its string value is used as the Id value.
+	Path params.EntityPath
 
 	// UUID holds the UUID of the environment.
 	UUID string
@@ -48,7 +46,7 @@ type Environment struct {
 	// AdminPassword holds the password for the admin user.
 	AdminPassword string
 
-	// StateServer holds the id of the environment's
-	// state server (e.g. bob/myjes)
-	StateServer string
+	// StateServer holds the path of the environment's
+	// state server.
+	StateServer params.EntityPath
 }

--- a/params/validate.go
+++ b/params/validate.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-var validName = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$")
+var validName = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$")
 
 type User string
 


### PR DESCRIPTION
This means that the user and name parts of an entity always stay
together which is simpler to reason about and makes
for simpler code too.
