### PR TITLE
internal/v1: implement ACLs on templates

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -19,7 +19,7 @@ type StateServer struct {
 	Path params.EntityPath
 
 	// ACL holds permissions for the server.
-	ACL ACL
+	ACL params.ACL
 
 	// CACert holds the CA certificate of the server.
 	CACert string
@@ -28,6 +28,14 @@ type StateServer struct {
 	// of host-port addresses for the API servers,
 	// with the most-recently-dialed address at the start.
 	HostPorts []string
+}
+
+func (s *StateServer) Owner() params.User {
+	return s.Path.User
+}
+
+func (s *StateServer) GetACL() params.ACL {
+	return s.ACL
 }
 
 type Environment struct {
@@ -41,7 +49,7 @@ type Environment struct {
 	Path params.EntityPath
 
 	// ACL holds permissions for the environment.
-	ACL ACL
+	ACL params.ACL
 
 	// UUID holds the UUID of the environment.
 	UUID string
@@ -58,6 +66,14 @@ type Environment struct {
 	StateServer params.EntityPath
 }
 
+func (e *Environment) Owner() params.User {
+	return e.Path.User
+}
+
+func (e *Environment) GetACL() params.ACL {
+	return e.ACL
+}
+
 type Template struct {
 	// Id holds the primary key for a template.
 	// It holds Path.String().
@@ -69,7 +85,7 @@ type Template struct {
 	Path params.EntityPath
 
 	// ACL holds permissions for the environment.
-	ACL ACL
+	ACL params.ACL
 
 	// Schema holds the schema used to create the template.
 	Schema environschema.Fields
@@ -78,10 +94,10 @@ type Template struct {
 	Config map[string]interface{}
 }
 
-// ACL holds lists of users and groups that are
-// allowed to perform specific actions.
-type ACL struct {
-	// Read holds users and groups that are allowed to read the
-	// entity.
-	Read []string `bson:",omitempty"`
+func (t *Template) Owner() params.User {
+	return t.Path.User
+}
+
+func (t *Template) GetACL() params.ACL {
+	return t.ACL
 }

--- a/internal/v1/auth.go
+++ b/internal/v1/auth.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/CanonicalLtd/jem/params"
 )
@@ -63,8 +65,17 @@ func (h *Handler) checkIsAdmin() error {
 	return h.checkIsUser(params.User(h.config.StateServerAdmin))
 }
 
-func (h *Handler) checkIsUser(name params.User) error {
-	ok, err := h.jem.PermChecker.Allow(h.auth.username, []string{string(name)})
+// checkIsUser checks whether the current user can
+// act as the given name.
+func (h *Handler) checkIsUser(user params.User) error {
+	return h.checkACL([]string{string(user)})
+}
+
+// checkACL checks whether the current user is
+// allowed to access an entity with the given ACL.
+// It returns params.ErrUnauthorized if not.
+func (h *Handler) checkACL(acl []string) error {
+	ok, err := h.jem.PermChecker.Allow(h.auth.username, acl)
 	if err != nil {
 		return errgo.Notef(err, "cannot check permissions")
 	}
@@ -72,4 +83,101 @@ func (h *Handler) checkIsUser(name params.User) error {
 		return params.ErrUnauthorized
 	}
 	return nil
+}
+
+// checkCanRead checks whether the current user is
+// allowed to read the given entity. The owner
+// is always allowed to access an entity, regardless
+// of its ACL.
+func (h *Handler) checkCanRead(e aclEntity) error {
+	acl := append([]string{string(e.Owner())}, e.GetACL().Read...)
+	return h.checkACL(acl)
+}
+
+// checkReadACL checks that the entity with the given path in the
+// given collection can be read by the currently authenticated user.
+func (h *Handler) checkReadACL(coll *mgo.Collection, path params.EntityPath) error {
+	// The user can always access their own entities.
+	if err := h.checkIsUser(path.User); err == nil {
+		return nil
+	}
+	acl, err := h.getACL(coll, path)
+	if errgo.Cause(err) == params.ErrNotFound {
+		// The document is not found - and we've already checked
+		// that the currently authenticated user cannot speak for
+		// path.User, so return an unauthorized error to stop
+		// people probing for the existence of other people's entities.
+		return params.ErrUnauthorized
+	}
+	if err := h.checkACL(acl.Read); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrUnauthorized))
+	}
+	return nil
+}
+
+var selectACL = bson.D{{"acl", 1}}
+
+func (h *Handler) getACL(coll *mgo.Collection, path params.EntityPath) (params.ACL, error) {
+	var doc struct {
+		ACL params.ACL
+	}
+	if err := coll.FindId(path.String()).Select(selectACL).One(&doc); err != nil {
+		if err == mgo.ErrNotFound {
+			err = params.ErrNotFound
+		}
+		return params.ACL{}, errgo.Mask(err, errgo.Is(mgo.ErrNotFound))
+	}
+	return doc.ACL, nil
+}
+
+// listIter returns an iterator that iterates over items
+// in the given iterator, skipping over those that
+// the currently logged in user does not have permissions
+// to see.
+func (h *Handler) listIter(iter *mgo.Iter) *listIter {
+	return &listIter{
+		h:    h,
+		Iter: iter,
+	}
+}
+
+type listIter struct {
+	h *Handler
+	*mgo.Iter
+	err error
+}
+
+// aclEntity represents an entity with access permissions.
+type aclEntity interface {
+	GetACL() params.ACL
+	Owner() params.User
+}
+
+// Next reads the next item from the iterator into the given
+// item and returns whether it has done so.
+func (iter *listIter) Next(item aclEntity) bool {
+	if iter.err != nil {
+		return false
+	}
+	for iter.Iter.Next(item) {
+		if err := iter.h.checkCanRead(item); err != nil {
+			if errgo.Cause(err) == params.ErrUnauthorized {
+				// No permissions to look at the entity, so don't include
+				// it in the results.
+				continue
+			}
+			iter.err = errgo.Mask(err)
+			iter.Iter.Close()
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+func (iter *listIter) Err() error {
+	if iter.err != nil {
+		return iter.err
+	}
+	return iter.Iter.Err()
 }

--- a/params/params.go
+++ b/params/params.go
@@ -56,7 +56,9 @@ type GetTemplatePerm struct {
 
 // ACL holds an access control list for an entity.
 type ACL struct {
-	Read []string
+	// Read holds users and groups that are allowed to read the
+	// entity.
+	Read []string `json:"read"`
 }
 
 // AddJES holds the parameters for adding a new state server.


### PR DESCRIPTION
We also refactor the auth code a little to factor out
common code make it easier for the subsequent ListTemplates
endpoint implementation (next PR)
