### PR TITLE
cmd/juju-jem/jemcmd: create-template command

### DIFF
--- a/cmd/juju-jem/jemcmd/cmd.go
+++ b/cmd/juju-jem/jemcmd/cmd.go
@@ -71,6 +71,7 @@ func New() cmd.Command {
 	supercmd.Register(&getCommand{})
 	supercmd.Register(&listCommand{})
 	supercmd.Register(&listServersCommand{})
+	supercmd.Register(&createTemplateCommand{})
 
 	return supercmd
 }

--- a/cmd/juju-jem/jemcmd/create-template.go
+++ b/cmd/juju-jem/jemcmd/create-template.go
@@ -1,0 +1,91 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"github.com/juju/cmd"
+	"gopkg.in/errgo.v1"
+	"launchpad.net/gnuflag"
+
+	"github.com/CanonicalLtd/jem/params"
+	"github.com/juju/utils/keyvalues"
+)
+
+type createTemplateCommand struct {
+	commandBase
+
+	templatePath entityPathValue
+	srvPath      entityPathValue
+	attrs        map[string]string
+}
+
+var createTemplateDoc = `
+The create-template command adds a template for an environment to the JEM.
+A template holds some of the configuration attributes required by
+a state server, and may be used when creating a new environment.
+Secret attributes may be set but not retrieved.
+
+The <user>/<name> argument specifies the name that will be given to the
+template inside JEM.  Note that this exists in a different name space
+from environments and state servers.
+`
+
+func (c *createTemplateCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "create-template",
+		Args:    "<user>/<name> attr=val ...",
+		Purpose: "Add a template to JEM.",
+		Doc:     createTemplateDoc,
+	}
+}
+
+func (c *createTemplateCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.commandBase.SetFlags(f)
+	f.Var(&c.srvPath, "s", "state server to use as the schema for the template")
+	f.Var(&c.srvPath, "server", "")
+	// TODO
+	//f.BoolVar(&c.useDefaults, "default", false, "use environment variables to set default values")
+	// This would call setConfigDefaults on the configuration
+	// attributes so that it's easy to make a template with
+	// the current defaults.
+}
+
+func (c *createTemplateCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errgo.Newf("got %d arguments, want at least 1", len(args))
+	}
+	if err := c.templatePath.Set(args[0]); err != nil {
+		return errgo.Mask(err)
+	}
+	attrs, err := keyvalues.Parse(args[1:], true)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	c.attrs = attrs
+	return nil
+}
+
+func (c *createTemplateCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.newClient()
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	defer client.Close()
+
+	// TODO GetJES to find the schema when implementing
+	// the --default flag.
+	config := make(map[string]interface{})
+	for name, val := range c.attrs {
+		config[name] = val
+	}
+	if err := client.AddTemplate(&params.AddTemplate{
+		EntityPath: c.templatePath.EntityPath,
+		Info: params.AddTemplateInfo{
+			StateServer: c.srvPath.EntityPath,
+			Config:      config,
+		},
+	}); err != nil {
+		return errgo.Notef(err, "cannot add template")
+	}
+	return nil
+}

--- a/cmd/juju-jem/jemcmd/create-template_test.go
+++ b/cmd/juju-jem/jemcmd/create-template_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jem/params"
+	jc "github.com/juju/testing/checkers"
+)
+
+type createTemplateSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&createTemplateSuite{})
+
+func (s *createTemplateSuite) TestCreateTemplate(c *gc.C) {
+	s.idmSrv.AddUser("bob")
+	s.idmSrv.SetDefaultUser("bob")
+	client := s.jemClient("bob")
+
+	// First add the state server that we're going to use
+	// to create the new environment.
+	stdout, stderr, code := run(c, c.MkDir(), "add-server", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Then verify that the template does not already exit.
+	_, err := client.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "foo"},
+	})
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	stdout, stderr, code = run(c, c.MkDir(), "create-template", "--server", "bob/foo", "bob/mytemplate", "state-server=true", "apt-mirror=0.1.2.3")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+	tmpl, err := client.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "mytemplate"},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(tmpl.Config, jc.DeepEquals, map[string]interface{}{
+		"state-server": true,
+		"apt-mirror":   "0.1.2.3",
+	})
+}
+
+var createTemplateErrorTests = []struct {
+	about        string
+	args         []string
+	expectStderr string
+	expectCode   int
+}{{
+	about:        "too few arguments",
+	args:         []string{},
+	expectStderr: "got 0 arguments, want at least 1",
+	expectCode:   2,
+}, {
+	about:        "invalid template name",
+	args:         []string{"a"},
+	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectCode:   2,
+}, {
+	about:        "duplicate key",
+	args:         []string{"bob/foo", "x=y", "y=z", "x=p"},
+	expectStderr: `key "x" specified more than once`,
+	expectCode:   2,
+}}
+
+func (s *createTemplateSuite) TestCreateTemplateError(c *gc.C) {
+	for i, test := range createTemplateErrorTests {
+		c.Logf("test %d: %s", i, test.about)
+		stdout, stderr, code := run(c, c.MkDir(), "create-template", test.args...)
+		c.Assert(code, gc.Equals, test.expectCode, gc.Commentf("stderr: %s", stderr))
+		c.Assert(stderr, gc.Matches, "(error:|ERROR) "+test.expectStderr+"\n")
+		c.Assert(stdout, gc.Equals, "")
+	}
+}


### PR DESCRIPTION
We also make it possible to use setConfigDefaults from outside the create command,
in preparation for the (as yet unimplemented) --default flag to create-template).
