### PR TITLE
cmd/juju-jem/jemcmd: add --template flag to create

### DIFF
--- a/cmd/juju-jem/jemcmd/add-server_test.go
+++ b/cmd/juju-jem/jemcmd/add-server_test.go
@@ -57,12 +57,12 @@ var addServerErrorTests = []struct {
 }, {
 	about:        "invalid server name",
 	args:         []string{"a"},
-	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectStderr: `invalid entity path "a": wrong number of parts in entity path`,
 	expectCode:   2,
 }, {
 	about:        "invalid name checked by server",
 	args:         []string{"bad!name/foo"},
-	expectStderr: `invalid path: invalid user name "bad!name"`,
+	expectStderr: `invalid entity path "bad!name/foo": invalid user name "bad!name"`,
 	expectCode:   2,
 }}
 

--- a/cmd/juju-jem/jemcmd/changeperm_test.go
+++ b/cmd/juju-jem/jemcmd/changeperm_test.go
@@ -146,7 +146,7 @@ var changepermErrorTests = []struct {
 }, {
 	about:        "only one part in path",
 	args:         []string{"a"},
-	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectStderr: `invalid entity path "a": wrong number of parts in entity path`,
 	expectCode:   2,
 }, {
 	about:        "empty user name",

--- a/cmd/juju-jem/jemcmd/create-template.go
+++ b/cmd/juju-jem/jemcmd/create-template.go
@@ -4,11 +4,11 @@ package jemcmd
 
 import (
 	"github.com/juju/cmd"
-	"github.com/juju/utils/keyvalues"
 	"gopkg.in/errgo.v1"
 	"launchpad.net/gnuflag"
 
 	"github.com/CanonicalLtd/jem/params"
+	"github.com/juju/utils/keyvalues"
 )
 
 type createTemplateCommand struct {
@@ -56,6 +56,9 @@ func (c *createTemplateCommand) Init(args []string) error {
 	}
 	if err := c.templatePath.Set(args[0]); err != nil {
 		return errgo.Mask(err)
+	}
+	if c.srvPath.EntityPath == (params.EntityPath{}) {
+		return errgo.Newf("--server flag required but not provided")
 	}
 	attrs, err := keyvalues.Parse(args[1:], true)
 	if err != nil {

--- a/cmd/juju-jem/jemcmd/create-template_test.go
+++ b/cmd/juju-jem/jemcmd/create-template_test.go
@@ -61,11 +61,16 @@ var createTemplateErrorTests = []struct {
 }, {
 	about:        "invalid template name",
 	args:         []string{"a"},
-	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectStderr: `invalid entity path "a": wrong number of parts in entity path`,
+	expectCode:   2,
+}, {
+	about:        "state server not provided",
+	args:         []string{"bob/foo"},
+	expectStderr: `--server flag required but not provided`,
 	expectCode:   2,
 }, {
 	about:        "duplicate key",
-	args:         []string{"bob/foo", "x=y", "y=z", "x=p"},
+	args:         []string{"bob/foo", "--server", "foo/bar", "x=y", "y=z", "x=p"},
 	expectStderr: `key "x" specified more than once`,
 	expectCode:   2,
 }}

--- a/cmd/juju-jem/jemcmd/get_test.go
+++ b/cmd/juju-jem/jemcmd/get_test.go
@@ -56,7 +56,7 @@ var getErrorTests = []struct {
 }, {
 	about:        "only one part in environ id",
 	args:         []string{"a"},
-	expectStderr: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectStderr: `invalid entity path "a": wrong number of parts in entity path`,
 	expectCode:   2,
 }}
 

--- a/cmd/juju-jem/jemcmd/internal_test.go
+++ b/cmd/juju-jem/jemcmd/internal_test.go
@@ -39,15 +39,15 @@ var entityPathValueTests = []struct {
 }, {
 	about:       "only one part",
 	val:         "a",
-	expectError: `invalid JEM name "a" \(needs to be <user>/<name>\)`,
+	expectError: `invalid entity path "a": wrong number of parts in entity path`,
 }, {
 	about:       "too many parts",
 	val:         "a/b/c",
-	expectError: `invalid JEM name "a/b/c" \(needs to be <user>/<name>\)`,
+	expectError: `invalid entity path "a/b/c": wrong number of parts in entity path`,
 }, {
-	about:       "empty server id",
+	about:       "empty string",
 	val:         "",
-	expectError: `invalid JEM name "" \(needs to be <user>/<name>\)`,
+	expectError: `invalid entity path "": wrong number of parts in entity path`,
 }}
 
 func (s *internalSuite) TestEntityPathValue(c *gc.C) {
@@ -61,6 +61,45 @@ func (s *internalSuite) TestEntityPathValue(c *gc.C) {
 		}
 		c.Assert(err, gc.IsNil)
 		c.Assert(p.EntityPath, gc.Equals, test.expectEntityPath)
+	}
+}
+
+var entityPathsValueTests = []struct {
+	about             string
+	val               string
+	expectEntityPaths []params.EntityPath
+	expectError       string
+}{{
+	about: "success",
+	val:   "foo/bar,baz/arble",
+	expectEntityPaths: []params.EntityPath{{
+		User: "foo",
+		Name: "bar",
+	}, {
+		User: "baz",
+		Name: "arble",
+	}},
+}, {
+	about:       "no paths",
+	val:         "",
+	expectError: `empty entity paths`,
+}, {
+	about:       "invalid entry",
+	val:         "a/b/c,foo/bar",
+	expectError: `invalid entity path "a/b/c": wrong number of parts in entity path`,
+}}
+
+func (s *internalSuite) TestEntityPathsValue(c *gc.C) {
+	for i, test := range entityPathsValueTests {
+		c.Logf("test %d: %s", i, test.about)
+		var p entityPathsValue
+		err := p.Set(test.val)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(p.paths, jc.DeepEquals, test.expectEntityPaths)
 	}
 }
 


### PR DESCRIPTION
This lets templates be used to create environments.

Also standardise the entity path parsing to use the
parsing in the params package.
