### PR TITLE
cmd/juju-jem/jemcmd: implement change-perm for templates

### DIFF
--- a/cmd/juju-jem/jemcmd/create-template.go
+++ b/cmd/juju-jem/jemcmd/create-template.go
@@ -4,11 +4,11 @@ package jemcmd
 
 import (
 	"github.com/juju/cmd"
+	"github.com/juju/utils/keyvalues"
 	"gopkg.in/errgo.v1"
 	"launchpad.net/gnuflag"
 
 	"github.com/CanonicalLtd/jem/params"
-	"github.com/juju/utils/keyvalues"
 )
 
 type createTemplateCommand struct {

--- a/internal/v1/api_test.go
+++ b/internal/v1/api_test.go
@@ -420,7 +420,7 @@ func (s *APISuite) TestAddJESUnauthenticatedWithBakeryProtocol(c *gc.C) {
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Method:  "PUT",
 		Handler: s.srv,
-		Header : map[string][]string{"Bakery-Protocol-Version": []string{"1"}},
+		Header:  map[string][]string{"Bakery-Protocol-Version": []string{"1"}},
 		URL:     "/v1/server/user/env",
 		ExpectBody: httptesting.BodyAsserter(func(c *gc.C, m json.RawMessage) {
 			// Allow any body - TestGetEnvironmentNotFound will check that it's a valid macaroon.

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -63,8 +63,8 @@ func (c *client) GetTemplate(p *params.GetTemplate) (*params.TemplateResponse, e
 
 // GetTemplatePerm returns the ACL for a given template.
 // Only the owner (arg.EntityPath.User) can read the ACL.
-func (c *client) GetTemplatePerm(p *params.GetTemplatePerm) (*params.ACL, error) {
-	var r *params.ACL
+func (c *client) GetTemplatePerm(p *params.GetTemplatePerm) (params.ACL, error) {
+	var r params.ACL
 	err := c.Client.Call(p, &r)
 	return r, err
 }


### PR DESCRIPTION
This allows us to share templates with other users and groups from the command line.
