### PR TITLE
* Ability to delete servers, environments and templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ simplify:
 
 # Run the JEM server.
 server: install
-	jemd -logging-config INFO cmd/jemd/config.yaml
+	jemd -logging-config DEBUG cmd/jemd/config.yaml
 
 # Update the project Go dependencies to the required revision.
 deps: $(GOPATH)/bin/godeps

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -97,6 +97,118 @@ func (s *jemSuite) TestAddStateServer(c *gc.C) {
 	err = s.store.AddStateServer(srv, env)
 	c.Assert(err, gc.ErrorMatches, "already exists")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrAlreadyExists)
+
+	srvPath2 := params.EntityPath{"bob", "y"}
+	srv2 := &mongodoc.StateServer{
+		Id:        "ignored",
+		Path:      srvPath2,
+		CACert:    "certainly",
+		HostPorts: []string{"host1:1234", "host2:9999"},
+	}
+	env2 := &mongodoc.Environment{
+		Id:            "bob/noty",
+		Path:          params.EntityPath{"ignored-user", "ignored-name"},
+		AdminUser:     "foo-admin",
+		AdminPassword: "foo-password",
+	}
+	err = s.store.AddStateServer(srv2, env2)
+	c.Assert(err, gc.IsNil)
+	env3, err := s.store.Environment(srvPath2)
+	c.Assert(err, gc.IsNil)
+	c.Assert(env3, jc.DeepEquals, env2)
+}
+
+func (s *jemSuite) TestDeleteStateServer(c *gc.C) {
+	srvPath := params.EntityPath{"dalek", "who"}
+	srv := &mongodoc.StateServer{
+		Id:        "ignored",
+		Path:      srvPath,
+		CACert:    "certainly",
+		HostPorts: []string{"host1:1234", "host2:9999"},
+	}
+	env := &mongodoc.Environment{
+		Id:            "dalek/who",
+		Path:          params.EntityPath{"ignored", "ignored"},
+		AdminUser:     "foo-admin",
+		AdminPassword: "foo-password",
+	}
+	err := s.store.AddStateServer(srv, env)
+	c.Assert(err, gc.IsNil)
+	err = s.store.DeleteStateServer(srv)
+	c.Assert(err, gc.IsNil)
+
+	srv1, err := s.store.StateServer(srvPath)
+	c.Assert(srv1, gc.IsNil)
+	env1, err := s.store.Environment(srvPath)
+	c.Assert(env1, gc.IsNil)
+
+	err = s.store.DeleteStateServer(srv)
+	c.Assert(err, gc.ErrorMatches, "state server \"dalek/who\" not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	// Test with non-existing environment.
+	srv2 := &mongodoc.StateServer{
+		Id:        "dalek/who",
+		Path:      srvPath,
+		CACert:    "certainly",
+		HostPorts: []string{"host1:1234", "host2:9999"},
+	}
+	env2 := &mongodoc.Environment{
+		Id:            "dalek/exterminated",
+		Path:          params.EntityPath{"ignored", "ignored"},
+		AdminUser:     "foo-admin",
+		AdminPassword: "foo-password",
+	}
+	err = s.store.AddStateServer(srv2, env2)
+	c.Assert(err, gc.IsNil)
+
+	err = s.store.DeleteStateServer(srv2)
+	c.Assert(err, gc.IsNil)
+	srv3, err := s.store.StateServer(srvPath)
+	c.Assert(srv3, gc.IsNil)
+	env3, err := s.store.Environment(srvPath)
+	c.Assert(env3, gc.IsNil)
+}
+
+func (s *jemSuite) TestDeleteEnvironemtn(c *gc.C) {
+	srvPath := params.EntityPath{"dalek", "who"}
+	srv := &mongodoc.StateServer{
+		Id:        "ignored",
+		Path:      srvPath,
+		CACert:    "certainly",
+		HostPorts: []string{"host1:1234", "host2:9999"},
+	}
+	env := &mongodoc.Environment{
+		Id:            "dalek/who",
+		Path:          params.EntityPath{"ignored", "ignored"},
+		AdminUser:     "foo-admin",
+		AdminPassword: "foo-password",
+	}
+	err := s.store.AddStateServer(srv, env)
+	c.Assert(err, gc.IsNil)
+
+	err = s.store.DeleteEnvironment(env)
+	c.Assert(err, gc.ErrorMatches, "environment \"dalek/who\" is a state server: failed")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrBadRequest)
+
+	envPath := params.EntityPath{"dalek", "exterminate"}
+	env2 := &mongodoc.Environment{
+		Id:            "dalek/exterminate",
+		Path:          envPath,
+		AdminUser:     "foo-admin",
+		AdminPassword: "foo-password",
+	}
+	err = s.store.AddEnvironment(env2)
+	c.Assert(err, gc.IsNil)
+
+	err = s.store.DeleteEnvironment(env2)
+	c.Assert(err, gc.IsNil)
+	env3, err := s.store.Environment(envPath)
+	c.Assert(env3, gc.IsNil)
+
+	err = s.store.DeleteEnvironment(env2)
+	c.Assert(err, gc.ErrorMatches, "environment \"dalek/exterminate\" not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
 
 func (s *jemSuite) TestAddEnvironment(c *gc.C) {
@@ -168,6 +280,43 @@ func (s *jemSuite) TestAddTemplate(c *gc.C) {
 		"name":        "pluto",
 		"temperature": -400,
 	})
+}
+
+func (s *jemSuite) TestDeleteTemplate(c *gc.C) {
+	path := params.EntityPath{"bob", "x"}
+	tmpl := &mongodoc.Template{
+		Id:   "ignored",
+		Path: path,
+		Schema: environschema.Fields{
+			"name": {
+				Description: "name of environment",
+				Type:        environschema.Tstring,
+				Mandatory:   true,
+				Values:      []interface{}{"venus", "pluto"},
+			},
+			"temperature": {
+				Description: "temperature of environment",
+				Type:        environschema.Tint,
+				Example:     400,
+				Values:      []interface{}{-400, 864.0},
+			},
+		},
+		Config: map[string]interface{}{
+			"name":        "pluto",
+			"temperature": -400.0,
+		},
+	}
+	err := s.store.AddTemplate(tmpl)
+	c.Assert(err, gc.IsNil)
+
+	err = s.store.DeleteTemplate(tmpl)
+	c.Assert(err, gc.IsNil)
+	tmpl1, err := s.store.Template(path)
+	c.Assert(tmpl1, gc.IsNil)
+
+	err = s.store.DeleteTemplate(tmpl)
+	c.Assert(err, gc.ErrorMatches, "template \"bob/x\" not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
 
 func (s *jemSuite) TestSessionIsCopied(c *gc.C) {

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -5,9 +5,8 @@
 package jemclient
 
 import (
-	"github.com/juju/httprequest"
-
 	"github.com/CanonicalLtd/jem/params"
+	"github.com/juju/httprequest"
 )
 
 type client struct {
@@ -21,6 +20,21 @@ func (c *client) AddJES(p *params.AddJES) error {
 
 // AddTemplate adds a new template.
 func (c *client) AddTemplate(p *params.AddTemplate) error {
+	return c.Client.Call(p, nil)
+}
+
+// DeleteEnvironment deletes an environment from JEM.
+func (c *client) DeleteEnvironment(p *params.DeleteEnvironment) error {
+	return c.Client.Call(p, nil)
+}
+
+// RemoveJES removes an existing state server.
+func (c *client) DeleteJES(p *params.DeleteJES) error {
+	return c.Client.Call(p, nil)
+}
+
+// DeleteTemplate surpisingly deletes a template.
+func (c *client) DeleteTemplate(p *params.DeleteTemplate) error {
 	return c.Client.Call(p, nil)
 }
 

--- a/params/params.go
+++ b/params/params.go
@@ -68,6 +68,12 @@ type AddJES struct {
 	Info ServerInfo `httprequest:",body"`
 }
 
+// RemoveJES holds the parameters for removing the JES.
+type DeleteJES struct {
+	httprequest.Route `httprequest:"DELETE /v1/server/:User/:Name"`
+	EntityPath
+}
+
 // ServerInfo holds information specifying how
 // to connect to an existing state server.
 type ServerInfo struct {
@@ -132,6 +138,13 @@ func (p EntityPath) MarshalText() ([]byte, error) {
 // an environment.
 type GetEnvironment struct {
 	httprequest.Route `httprequest:"GET /v1/env/:User/:Name"`
+	EntityPath
+}
+
+// DeleteEnvironment holds parameters for deletion of
+// an environment.
+type DeleteEnvironment struct {
+	httprequest.Route `httprequest:"DELETE /v1/env/:User/:Name"`
 	EntityPath
 }
 
@@ -206,6 +219,12 @@ type TemplateResponse struct {
 // GetTemplate holds parameters for retrieving information on a template.
 type GetTemplate struct {
 	httprequest.Route `httprequest:"GET /v1/template/:User/:Name"`
+	EntityPath
+}
+
+// DeleteTemplate holds parameters for deletion of a template.
+type DeleteTemplate struct {
+	httprequest.Route `httprequest:"DELETE /v1/template/:User/:Name"`
 	EntityPath
 }
 


### PR DESCRIPTION
QA instructions that passed:
- set up JEM & IdM
- bootstrap AWS env
- use juju jem add-server add controller to JEM
- add aws template to JEM
- create environment using controller and template
- use bhttp to:
  1) delete env named by the server (will fail)
  2) delete template
  3) delete environment
  4) delete server
