### PR TITLE
cmd/jemd: use exact matching for idm public key

### DIFF
--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -73,17 +73,16 @@ func serve(confPath string) error {
 	defer session.Close()
 	db := session.DB("jem")
 
-	ring := bakery.NewPublicKeyRing()
-	ring.AddPublicKeyForLocation(conf.IdentityLocation+"/", true, conf.IdentityPublicKey)
-
 	logger.Debugf("setting up the API server")
 	cfg := jem.ServerParams{
 		DB:               db,
 		StateServerAdmin: conf.StateServerAdmin,
 		IdentityLocation: conf.IdentityLocation,
-		PublicKeyLocator: ring,
-		AgentUsername:    conf.AgentUsername,
-		AgentKey:         conf.AgentKey,
+		PublicKeyLocator: bakery.PublicKeyLocatorMap{
+			conf.IdentityLocation: conf.IdentityPublicKey,
+		},
+		AgentUsername: conf.AgentUsername,
+		AgentKey:      conf.AgentKey,
 	}
 	server, err := jem.NewServer(cfg)
 	if err != nil {


### PR DESCRIPTION
This fixes a JEM bug where it cannot actually generate macaroons
because the prefix-matching bakery.PublicKeyRing does not match
https://api.jujucharms.com/identity against https://api.jujucharms.com/identity/.

Since we no longer rely on the prefix-matching logic (because the identity
serves its discharger at its root), we can just use the much more
simple PublicKeyLocatorMap instead.
