### PR TITLE
Use httpbakery.PublicKeyRing in server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,6 @@ func (c *Config) validate() error {
 	if c.StateServerAdmin == "" {
 		missing = append(missing, "state-server-admin")
 	}
-	if c.IdentityPublicKey == nil {
-		missing = append(missing, "identity-public-key")
-	}
 	if c.IdentityLocation == "" {
 		missing = append(missing, "identity-location")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,7 +81,7 @@ func (s *ConfigSuite) TestReadConfigError(c *gc.C) {
 
 func (s *ConfigSuite) TestValidateConfigError(c *gc.C) {
 	cfg, err := s.readConfig(c, "")
-	c.Assert(err, gc.ErrorMatches, "missing fields mongo-addr, api-addr, state-server-admin, identity-public-key, identity-location in config file")
+	c.Assert(err, gc.ErrorMatches, "missing fields mongo-addr, api-addr, state-server-admin, identity-location in config file")
 	c.Assert(cfg, gc.IsNil)
 }
 


### PR DESCRIPTION
Remove the need to configure a public-key for identity, by using the httpbakery.PublicKeyRing which will automatically fetch public keys when required.
