### PR TITLE
cmd/jem/jemcmd: Rename change perm to grant/revoke to match charm command

### DIFF
--- a/cmd/juju-jem/jemcmd/cmd.go
+++ b/cmd/juju-jem/jemcmd/cmd.go
@@ -56,15 +56,16 @@ func New() cmd.Command {
 		},
 	})
 	supercmd.Register(newAddControllerCommand())
-	supercmd.Register(newChangePermCommand())
 	supercmd.Register(newCreateCommand())
 	supercmd.Register(newCreateTemplateCommand())
 	supercmd.Register(newGetCommand())
 	supercmd.Register(newGenerateCommand())
+	supercmd.Register(newGrantCommand())
 	supercmd.Register(newListCommand())
 	supercmd.Register(newListServersCommand())
 	supercmd.Register(newListTemplatesCommand())
 	supercmd.Register(newRemoveCommand())
+	supercmd.Register(newRevokeCommand())
 
 	return supercmd
 }

--- a/cmd/juju-jem/jemcmd/revoke.go
+++ b/cmd/juju-jem/jemcmd/revoke.go
@@ -1,0 +1,145 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"gopkg.in/errgo.v1"
+	"launchpad.net/gnuflag"
+
+	"fmt"
+	"github.com/CanonicalLtd/jem/jemclient"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type revokeCommand struct {
+	commandBase
+
+	path entityPathValue
+
+	controller bool
+	template   bool
+	users      userSet
+}
+
+func newRevokeCommand() cmd.Command {
+	return modelcmd.WrapBase(&revokeCommand{})
+}
+
+var revokeDoc = `
+The revoke command removes permissions for a set of users
+or groups to read a model (default), controller, or template within JEM.
+Note that if a user access is revoked, that user may still have access
+if they are a member of a group that is still part of the read ACL.
+
+For example, to remove alice and bob from the read ACL of the model johndoe/mymodel,
+assuming they are currently mentioned in the ACL:
+
+    juju jem revoke johndoe/mymodel alice,bob
+`
+
+func (c *revokeCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "revoke",
+		Args:    "<user>/<modelname|controllername> username[,username]...",
+		Purpose: "revoke permissions of JEM entity",
+		Doc:     revokeDoc,
+	}
+}
+
+func (c *revokeCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.controller, "controller", false, "change ACL of controller not model")
+	f.BoolVar(&c.template, "template", false, "change ACL of template not model")
+}
+
+func (c *revokeCommand) Init(args []string) error {
+	// Validate and store the entity reference.
+	if len(args) == 0 {
+		return errgo.Newf("no model or controller specified")
+	}
+	if len(args) == 1 {
+		return errgo.Newf("no users specified")
+	}
+	if len(args) > 2 {
+		return errgo.Newf("too many arguments")
+	}
+	if err := c.path.Set(args[0]); err != nil {
+		return errgo.Mask(err)
+	}
+	if c.template && c.controller {
+		return errgo.New("cannot specify both --controller and --template")
+	}
+	c.users = make(userSet)
+	if err := c.users.Set(args[1]); err != nil {
+		return errgo.Notef(err, "invalid value %q", args[1])
+	}
+	return nil
+}
+
+func (c *revokeCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.newClient(ctxt)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	currentACL, err := c.getPerm(client)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	newReadPerms := make(userSet)
+	for _, u := range currentACL.Read {
+		newReadPerms[u] = true
+	}
+	for u := range c.users {
+		if _, ok := newReadPerms[u]; !ok {
+			fmt.Fprintf(ctxt.Stdout, "User %q was not granted before revoke.\n", u)
+		} else {
+			delete(newReadPerms, u)
+		}
+	}
+	return c.setPerm(client, params.ACL{
+		Read: newReadPerms.slice(),
+	})
+}
+
+func (c *revokeCommand) setPerm(client *jemclient.Client, acl params.ACL) error {
+	var err error
+	switch {
+	case c.controller:
+		err = client.SetControllerPerm(&params.SetControllerPerm{
+			EntityPath: c.path.EntityPath,
+			ACL:        acl,
+		})
+	case c.template:
+		err = client.SetTemplatePerm(&params.SetTemplatePerm{
+			EntityPath: c.path.EntityPath,
+			ACL:        acl,
+		})
+	default:
+		err = client.SetModelPerm(&params.SetModelPerm{
+			EntityPath: c.path.EntityPath,
+			ACL:        acl,
+		})
+	}
+	return errgo.Mask(err)
+}
+
+func (c *revokeCommand) getPerm(client *jemclient.Client) (params.ACL, error) {
+	var acl params.ACL
+	var err error
+	switch {
+	case c.controller:
+		acl, err = client.GetControllerPerm(&params.GetControllerPerm{
+			EntityPath: c.path.EntityPath,
+		})
+	case c.template:
+		acl, err = client.GetTemplatePerm(&params.GetTemplatePerm{
+			EntityPath: c.path.EntityPath,
+		})
+	default:
+		acl, err = client.GetModelPerm(&params.GetModelPerm{
+			EntityPath: c.path.EntityPath,
+		})
+	}
+	return acl, errgo.Mask(err)
+}

--- a/cmd/juju-jem/jemcmd/revoke_test.go
+++ b/cmd/juju-jem/jemcmd/revoke_test.go
@@ -1,0 +1,220 @@
+// Copyright 2015 Canonical Ltd.
+
+package jemcmd_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type revokeSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&revokeSuite{})
+
+func (s *revokeSuite) TestRevoke(c *gc.C) {
+	s.idmSrv.SetDefaultUser("bob")
+
+	// First add a controller. This also adds an model that we can
+	// alter for our test.
+	stdout, stderr, code := run(c, c.MkDir(), "add-controller", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that alice can't get server or model.
+	aliceClient := s.jemClient("alice")
+	_, err := aliceClient.GetController(&params.GetController{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "GET http://.*/v2/controller/bob/foo: unauthorized")
+	_, err = aliceClient.GetModel(&params.GetModel{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "GET http://.*/v2/model/bob/foo: unauthorized")
+
+	// Add alice to model permissions list.
+	stdout, stderr, code = run(c, c.MkDir(),
+		"grant",
+		"bob/foo",
+		"alice",
+	)
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that alice can get model but not server.
+	_, err = aliceClient.GetController(&params.GetController{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "GET http://.*/v2/controller/bob/foo: unauthorized")
+	_, err = aliceClient.GetModel(&params.GetModel{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Add alice to server permissions list.
+	stdout, stderr, code = run(c, c.MkDir(),
+		"grant",
+		"--controller",
+		"bob/foo",
+		"alice",
+	)
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that alice can now access the server.
+	_, err = aliceClient.GetController(&params.GetController{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Remove alice.
+	stdout, stderr, code = run(c, c.MkDir(),
+		"revoke",
+		"bob/foo",
+		"alice",
+	)
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	bobClient := s.jemClient("bob")
+
+	acl, err := bobClient.GetModelPerm(&params.GetModelPerm{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(acl, jc.DeepEquals, params.ACL{
+		Read: []string{},
+	})
+}
+
+func (s *revokeSuite) TestRevokeChangeTemplatePerm(c *gc.C) {
+	s.idmSrv.AddUser("bob")
+	s.idmSrv.SetDefaultUser("bob")
+
+	// First add the controller that we're going to use
+	// to create the new template.
+	stdout, stderr, code := run(c, c.MkDir(), "add-controller", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	stdout, stderr, code = run(c, c.MkDir(), "create-template", "--controller", "bob/foo", "bob/mytemplate", "controller=true", "apt-mirror=0.1.2.3")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that we can't read the template as another user
+	// but we can as bob.
+	aliceClient := s.jemClient("alice")
+	_, err := aliceClient.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "mytemplate"},
+	})
+	c.Assert(err, gc.ErrorMatches, "GET http://.*/v2/template/bob/mytemplate: unauthorized")
+
+	bobClient := s.jemClient("bob")
+	_, err = bobClient.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "mytemplate"},
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Change the permissions of the template to allow alice.
+	stdout, stderr, code = run(c, c.MkDir(), "grant", "--template", "bob/mytemplate", "alice")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that alice can now read the template.
+	_, err = aliceClient.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "mytemplate"},
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Change the permissions of the template to revoke alice.
+	stdout, stderr, code = run(c, c.MkDir(), "revoke", "--template", "bob/mytemplate", "alice")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that alice cannot now read the template.
+	_, err = aliceClient.GetTemplate(&params.GetTemplate{
+		EntityPath: params.EntityPath{"bob", "mytemplate"},
+	})
+	c.Assert(err, gc.ErrorMatches, "GET http://.*/v2/template/bob/mytemplate: unauthorized")
+}
+
+var revokeErrorTests = []struct {
+	about        string
+	args         []string
+	expectStderr string
+	expectCode   int
+}{{
+	about:        "no model specified",
+	args:         []string{},
+	expectStderr: "no model or controller specified",
+	expectCode:   2,
+}, {
+	about:        "no users specified",
+	args:         []string{"bob/mymodel"},
+	expectStderr: "no users specified",
+	expectCode:   2,
+}, {
+	about:        "too many arguments",
+	args:         []string{"a", "b", "c"},
+	expectStderr: "too many arguments",
+	expectCode:   2,
+}, {
+	about:        "only one part in path",
+	args:         []string{"a", "b"},
+	expectStderr: `invalid entity path "a": wrong number of parts in entity path`,
+	expectCode:   2,
+}, {
+	about:        "empty user name",
+	args:         []string{"bob/b", "bob,"},
+	expectStderr: `invalid value "bob,": empty user found`,
+	expectCode:   2,
+}, {
+	about:        "invalid user name",
+	args:         []string{"bob/b", "bob,!kung"},
+	expectStderr: `invalid value "bob,!kung": invalid user name "!kung"`,
+	expectCode:   2,
+}, {
+	about:        "--controller not allowed with --template",
+	args:         []string{"--controller", "--template", "foo/bar", "bob"},
+	expectStderr: `cannot specify both --controller and --template`,
+	expectCode:   2,
+}}
+
+func (s *revokeSuite) TestRevokeGetError(c *gc.C) {
+	for i, test := range revokeErrorTests {
+		c.Logf("test %d: %s", i, test.about)
+		stdout, stderr, code := run(c, c.MkDir(), "revoke", test.args...)
+		c.Assert(code, gc.Equals, test.expectCode, gc.Commentf("stderr: %s", stderr))
+		c.Assert(stderr, gc.Matches, "(error:|ERROR) "+test.expectStderr+"\n")
+		c.Assert(stdout, gc.Equals, "")
+	}
+}


### PR DESCRIPTION
This follows the same pattern used in github.com/juju/charmstore-client/cmd/charm.
