### PR TITLE
internal/v2: add GetControllerLocations endpoint

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -449,9 +449,10 @@ func (j *JEM) DeleteTemplate(path params.EntityPath) error {
 
 // ControllerLocationQuery returns a mongo query that iterates through
 // all the controllers matching the given location attributes.
+// It returns an error if the location attribute keys aren't valid.
 func (j *JEM) ControllerLocationQuery(location map[string]string) (*mgo.Query, error) {
 	if err := validateLocationAttrs(location); err != nil {
-		return nil, errgo.WithCausef(err, params.ErrBadRequest, "bad controller location query")
+		return nil, errgo.Notef(err, "bad controller location query")
 	}
 	q := make(bson.D, 0, len(location))
 	for attr, val := range location {

--- a/jemclient/client.go
+++ b/jemclient/client.go
@@ -5,6 +5,8 @@
 package jemclient
 
 import (
+	"net/url"
+
 	"github.com/juju/httprequest"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
@@ -32,4 +34,21 @@ func New(p NewParams) *Client {
 	c.Client.Doer = p.Client
 	c.Client.UnmarshalError = httprequest.ErrorUnmarshaler(new(params.Error))
 	return &c
+}
+
+// GetControllerLocations returns all the available values for a given controller
+// location attribute.
+func (c *Client) GetControllerLocations(p *params.GetControllerLocations) (*params.ControllerLocationsResponse, error) {
+	// We implement this method on Client because the automatically
+	// generated method isn't sufficient to handle the general query parameters.
+	q := make(url.Values)
+	for attr, val := range p.Location {
+		q.Set(attr, val)
+	}
+	var r *params.ControllerLocationsResponse
+	// Technically the base URL could already contain query
+	// parameters, in which case this would be invalid, but
+	// that shouldn't be a problem in practice.
+	err := c.Client.CallURL(c.Client.BaseURL+"?"+q.Encode(), p, &r)
+	return r, err
 }

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -4,9 +4,8 @@
 package jemclient
 
 import (
-	"github.com/juju/httprequest"
-
 	"github.com/CanonicalLtd/jem/params"
+	"github.com/juju/httprequest"
 )
 
 type client struct {
@@ -41,6 +40,15 @@ func (c *client) DeleteTemplate(p *params.DeleteTemplate) error {
 // GetController returns information on a controller.
 func (c *client) GetController(p *params.GetController) (*params.ControllerResponse, error) {
 	var r *params.ControllerResponse
+	err := c.Client.Call(p, &r)
+	return r, err
+}
+
+// GetControllerLocations returns all the available values for a given controller
+// location attribute. The set of controllers is constrained by the URL query
+// parameters.
+func (c *client) GetControllerLocations(p *params.GetControllerLocations) (*params.ControllerLocationsResponse, error) {
+	var r *params.ControllerLocationsResponse
 	err := c.Client.Call(p, &r)
 	return r, err
 }

--- a/params/params.go
+++ b/params/params.go
@@ -74,6 +74,22 @@ type DeleteController struct {
 	EntityPath
 }
 
+type GetControllerLocations struct {
+	httprequest.Route `httprequest:"GET /v2/location/:Attr"`
+	Attr              string `httprequest:",path"`
+
+	// Location constrains the controllers that the
+	// set of returned values will be returned from
+	// to those with matching location attributes.
+	// Note that the values in this should be passed in the
+	// URL query parameters.
+	Location map[string]string
+}
+
+type ControllerLocationsResponse struct {
+	Values []string
+}
+
 // ControllerInfo holds information specifying how
 // to connect to an existing controller.
 type ControllerInfo struct {


### PR DESCRIPTION
This enables a client to find (for example) all possible values for
clouds and regions.
