### PR TITLE
internal/v2: exclude empty results from GetAllLocations

### DIFF
--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -384,6 +384,10 @@ func (h *Handler) GetAllControllerLocations(p httprequest.Params, arg *params.Ge
 	}
 	locSet := make(map[string]map[string]string)
 	err = h.doControllers(attrs, func(ctl *mongodoc.Controller) error {
+		if len(ctl.Location) == 0 {
+			// Ignore controllers with no location set.
+			return nil
+		}
 		data, err := json.Marshal(ctl.Location)
 		if err != nil {
 			panic(errgo.Notef(err, "can't marshal map for some weird reason"))

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -877,6 +877,7 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 		"cloud":  "azure",
 		"region": "america",
 	})
+	s.assertAddController(c, params.EntityPath{"alice", "forgotten"}, nil)
 
 	s.IDMSrv.AddUser("alice", "somegroup")
 


### PR DESCRIPTION
It's not useful to see empty results in the list.
