### PR TITLE
Change the error to badrequest when not finding a template for creating a model

### DIFF
--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"net/url"
 	"reflect"
@@ -501,7 +502,7 @@ func (h *Handler) configWithTemplates(config map[string]interface{}, paths []par
 	for _, path := range paths {
 		tmpl, err := h.jem.Template(path)
 		if err != nil {
-			return nil, badRequestf(err, "cannot get template %q", path)
+			return nil, errgo.NoteMask(err, fmt.Sprintf("cannot get template %q", path), errgo.Is(params.ErrNotFound))
 		}
 		if err := h.jem.CheckCanRead(tmpl); err != nil {
 			return nil, errgo.Mask(err, errgo.Is(params.ErrUnauthorized))
@@ -540,7 +541,10 @@ func (h *Handler) NewModel(args *params.NewModel) (*params.ModelResponse, error)
 	}
 	config, err := h.configWithTemplates(args.Info.Config, args.Info.TemplatePaths)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))
+		if errgo.Cause(err) == params.ErrNotFound {
+			return nil, badRequestf(err, "invalid template provided")
+		}
+		return nil, err
 	}
 	// Ensure that the attributes look reasonably OK before bothering
 	// the controller with them.

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -1206,7 +1206,7 @@ func (s *APISuite) TestNewModelWithTemplateNotFound(c *gc.C) {
 			TemplatePaths: []params.EntityPath{{"bob", "creds"}},
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, `POST .*/v2/model/bob: cannot get template "bob/creds": template "bob/creds" not found`)
+	c.Assert(err, gc.ErrorMatches, `POST .*/v2/model/bob: invalid template provided: cannot get template "bob/creds": template "bob/creds" not found`)
 	c.Check(errgo.Cause(err), gc.Equals, params.ErrBadRequest)
 	c.Assert(resp, gc.IsNil)
 }


### PR DESCRIPTION
Previously, it would return a 500 status code in this case.
