### PR TITLE
internal/monitor: add lease updater

### DIFF
--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -1,0 +1,99 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+// controllerMonitor is responsible for monitoring a single
+// controller.
+type controllerMonitor struct {
+	// tomb is killed when the controller being monitored
+	// has been removed.
+	tomb tomb.Tomb
+
+	// leaseExpiry holds the time that the currently held lease
+	// will expire. It is maintained by the leaseUpdater goroutine.
+	leaseExpiry time.Time
+
+	// jem holds the current JEM database connection.
+	jem *jem.JEM
+
+	// ctlPath holds the path of the controller we're monitoring.
+	ctlPath params.EntityPath
+
+	// ownerId holds this agent's name, the owner of the lease.
+	ownerId string
+}
+
+var errMonitoringStopped = errgo.New("monitoring stopped because lease lost or controller removed")
+
+// leaseUpdater is responsible for updating the controller's lease
+// as long as we still have the lease, the controller still exists,
+// and the monitor is still alive.
+func (m *controllerMonitor) leaseUpdater() error {
+	for {
+		// Renew after ¾ of the lease time has passed.
+		renewTime := m.leaseExpiry.Add(-leaseExpiryDuration / 4)
+		select {
+		case <-Clock.After(renewTime.Sub(Clock.Now())):
+		case <-m.tomb.Dying():
+			// Try to drop the lease because the monitor might
+			// not be starting again on this JEM instance.
+			if err := m.renewLease(false); err != nil {
+				return errgo.NoteMask(err, "cannot drop lease", errgo.Is(errMonitoringStopped))
+			}
+			return tomb.ErrDying
+		}
+		// It's time to renew the lease.
+		if err := m.renewLease(true); err != nil {
+			msg := fmt.Sprintf("cannot renew lease on %v", m.ctlPath)
+			return errgo.NoteMask(err, msg, errgo.Is(errMonitoringStopped))
+		}
+	}
+}
+
+// renewLease renews the lease (or drops it if renew is false)
+// and updates the m.leaseExpiry to be the new lease expiry time.
+//
+// If the lease cannot be renewed because someone else
+// has acquired it or the controller has been removed,
+// it returns an error with an errMonitoringStopped cause.
+func (m *controllerMonitor) renewLease(renew bool) error {
+	var ownerId string
+	if renew {
+		ownerId = m.ownerId
+	}
+	t, err := acquireLease(m.jem, m.ctlPath, m.leaseExpiry, m.ownerId, ownerId)
+	if err == nil {
+		logger.Debugf("controller %v acquired lease successfully (new time %v)", m.ctlPath, t)
+		m.leaseExpiry = t
+		return nil
+	}
+	logger.Infof("controller %v acquire lease failed: %v", m.ctlPath, err)
+	return errgo.Mask(err, errgo.Is(errMonitoringStopped))
+}
+
+// acquireLease is like jem.JEM.AcquireMonitorLease except that
+// it returns errMonitoringStopped if the controller has been
+// removed or the lease is unavailable,
+// and it always acquires a lease leaseExpiryDuration from now.
+func acquireLease(j *jem.JEM, ctlPath params.EntityPath, oldExpiry time.Time, oldOwner, newOwner string) (time.Time, error) {
+	t, err := j.AcquireMonitorLease(ctlPath, oldExpiry, oldOwner, Clock.Now().Add(leaseExpiryDuration), newOwner)
+	switch errgo.Cause(err) {
+	case nil:
+		return t, nil
+	case jem.ErrLeaseUnavailable, params.ErrNotFound:
+		return time.Time{}, errgo.WithCausef(err, errMonitoringStopped, "%s", "")
+	default:
+		return time.Time{}, errgo.Mask(err)
+	}
+}

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -1,0 +1,176 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor
+
+import (
+	"time"
+
+	"github.com/juju/idmclient"
+	corejujutesting "github.com/juju/juju/juju/testing"
+	jujuwatcher "github.com/juju/juju/state/watcher"
+	jujutesting "github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/tomb.v2"
+
+	"github.com/CanonicalLtd/jem/internal/idmtest"
+	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type internalSuite struct {
+	corejujutesting.JujuConnSuite
+	idmSrv *idmtest.Server
+	pool   *jem.Pool
+	jem    *jem.JEM
+
+	// startTime holds the time that the testing clock is initially
+	// set to.
+	startTime time.Time
+
+	// clock holds the mock clock used by the monitor package.
+	clock *jujutesting.Clock
+}
+
+// We don't want to wait for the usual 5s poll interval.
+func init() {
+	jujuwatcher.Period = 50 * time.Millisecond
+}
+
+var _ = gc.Suite(&internalSuite{})
+
+func (s *internalSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.idmSrv = idmtest.NewServer()
+	pool, err := jem.NewPool(
+		jem.ServerParams{
+			DB: s.Session.DB("jem"),
+		},
+		bakery.NewServiceParams{
+			Location: "here",
+		},
+		idmclient.New(idmclient.NewParams{
+			BaseURL: s.idmSrv.URL.String(),
+			Client:  s.idmSrv.Client("agent"),
+		}),
+	)
+	c.Assert(err, gc.IsNil)
+	s.pool = pool
+	s.jem = pool.JEM()
+
+	// Set up the clock mockery.
+	s.clock = jujutesting.NewClock(epoch)
+	s.PatchValue(&Clock, s.clock)
+}
+
+func (s *internalSuite) TearDownTest(c *gc.C) {
+	s.jem.Close()
+	s.pool.Close()
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+var epoch = parseTime("2016-01-01T12:00:00Z")
+
+func (s *internalSuite) TestLeaseUpdater(c *gc.C) {
+	ctlPath := params.EntityPath{"bob", "foo"}
+	err := s.jem.AddController(&mongodoc.Controller{
+		Path: ctlPath,
+		UUID: "fake-uuid",
+	}, &mongodoc.Model{})
+
+	// The controller monitor assumes that it already has the
+	// lease when started, so acquire the lease.
+	expiry, err := acquireLease(s.jem, ctlPath, time.Time{}, "", "jem1")
+	c.Assert(err, gc.IsNil)
+
+	m := &controllerMonitor{
+		ctlPath:     ctlPath,
+		leaseExpiry: expiry,
+		jem:         s.jem,
+		ownerId:     "jem1",
+	}
+	done := make(chan error)
+	go func() {
+		done <- m.leaseUpdater()
+	}()
+
+	// Advance the clock until the lease updater will need
+	// to renew the lease.
+	s.clock.Advance(leaseExpiryDuration * 5 / 6)
+
+	// Wait for the lease to actually be renewed.
+	var ctl *mongodoc.Controller
+	for a := jujutesting.LongAttempt.Start(); a.Next(); {
+		ctl, err = s.jem.Controller(ctlPath)
+		c.Assert(err, gc.IsNil)
+		if !ctl.MonitorLeaseExpiry.Equal(expiry) {
+			break
+		}
+		if !a.HasNext() {
+			c.Fatalf("lease never acquired")
+		}
+	}
+	c.Assert(ctl.MonitorLeaseExpiry.UTC(), gc.DeepEquals, s.clock.Now().Add(leaseExpiryDuration))
+	c.Assert(ctl.MonitorLeaseOwner, gc.Equals, "jem1")
+
+	// Kill the monitor and wait for the updater to exit.
+	m.tomb.Kill(nil)
+
+	select {
+	case err = <-done:
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("lease updater never stopped")
+	}
+	c.Assert(err, gc.Equals, tomb.ErrDying)
+
+	// Check that the lease has been dropped.
+	s.assertLease(c, ctlPath, time.Time{}, "")
+}
+
+func (s *internalSuite) TestLeaseUpdaterWhenControllerRemoved(c *gc.C) {
+	ctlPath := params.EntityPath{"bob", "foo"}
+
+	// Start the lease updater with no controller existing.
+	m := &controllerMonitor{
+		ctlPath:     ctlPath,
+		leaseExpiry: epoch.Add(leaseExpiryDuration),
+		jem:         s.jem,
+		ownerId:     "jem1",
+	}
+	defer m.tomb.Kill(nil)
+	done := make(chan error)
+	go func() {
+		done <- m.leaseUpdater()
+	}()
+
+	// Advance the clock until the lease updater will need
+	// to renew the lease.
+	s.clock.Advance(leaseExpiryDuration * 5 / 6)
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("lease updater never stopped")
+	}
+	c.Assert(err, gc.ErrorMatches, `cannot renew lease on bob/foo: controller removed`)
+	c.Assert(errgo.Cause(err), gc.Equals, errMonitoringStopped)
+}
+
+func (s *internalSuite) assertLease(c *gc.C, ctlPath params.EntityPath, t time.Time, owner string) {
+	ctl, err := s.jem.Controller(ctlPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ctl.MonitorLeaseExpiry.UTC(), jc.DeepEquals, mongodoc.Time(t).UTC())
+	c.Assert(ctl.MonitorLeaseOwner, gc.Equals, owner)
+}
+
+func parseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,28 @@
+// Copyright 2016 Canonical Ltd.
+
+// Package monitor provides monitoring for the controllers in JEM.
+//
+// We maintain a lease field
+// in each controller which we hold as long as we monitor
+// the controller so that we don't have multiple units redundantly
+// monitoring the same controller.
+package monitor
+
+import (
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
+)
+
+var logger = loggo.GetLogger("jem.internal.monitor")
+
+const (
+	// leaseExpiryDuration holds the length of time
+	// a lease is acquired for.
+	leaseExpiryDuration = time.Minute
+)
+
+// Clock holds the clock implementation used by the monitor.
+// This is exported so it can be changed for testing purposes.
+var Clock clock.Clock = clock.WallClock

--- a/internal/monitor/package_test.go
+++ b/internal/monitor/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t)
+}


### PR DESCRIPTION
This is the first component of the monitor - a long-lived
goroutine that maintains a lease on a controller,
renewing the lease after it's three-quarters through its
lifetime.
