### PR TITLE
internal/monitor: add watcher

### DIFF
--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/juju/state/multiwatcher"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/tomb.v2"
 
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )
 
@@ -25,13 +27,24 @@ type controllerMonitor struct {
 	leaseExpiry time.Time
 
 	// jem holds the current JEM database connection.
-	jem *jem.JEM
+	jem jemInterface
 
 	// ctlPath holds the path of the controller we're monitoring.
 	ctlPath params.EntityPath
 
 	// ownerId holds this agent's name, the owner of the lease.
 	ownerId string
+}
+
+// Kill implements worker.Worker.Kill by killing the controller monitor.
+func (m *controllerMonitor) Kill() {
+	m.tomb.Kill(nil)
+}
+
+// Wait implements worker.Worker.Wait by waiting for
+// the controller monitor to terminate.
+func (m *controllerMonitor) Wait() error {
+	return m.tomb.Wait()
 }
 
 var errMonitoringStopped = errgo.New("monitoring stopped because lease lost or controller removed")
@@ -86,7 +99,7 @@ func (m *controllerMonitor) renewLease(renew bool) error {
 // it returns errMonitoringStopped if the controller has been
 // removed or the lease is unavailable,
 // and it always acquires a lease leaseExpiryDuration from now.
-func acquireLease(j *jem.JEM, ctlPath params.EntityPath, oldExpiry time.Time, oldOwner, newOwner string) (time.Time, error) {
+func acquireLease(j jemInterface, ctlPath params.EntityPath, oldExpiry time.Time, oldOwner, newOwner string) (time.Time, error) {
 	t, err := j.AcquireMonitorLease(ctlPath, oldExpiry, oldOwner, Clock.Now().Add(leaseExpiryDuration), newOwner)
 	switch errgo.Cause(err) {
 	case nil:
@@ -96,4 +109,238 @@ func acquireLease(j *jem.JEM, ctlPath params.EntityPath, oldExpiry time.Time, ol
 	default:
 		return time.Time{}, errgo.Mask(err)
 	}
+}
+
+// watcher runs the controller monitor watcher itself.
+// It returns errMonitoringStopped if m.tomb is killed
+// or the controller is removed.
+func (m *controllerMonitor) watcher() error {
+	for {
+		logger.Debugf("monitor dialing controller %v", m.ctlPath)
+		conn, err := m.dialAPI()
+		switch errgo.Cause(err) {
+		case nil:
+			err := m.watch(conn)
+			conn.Close()
+			if errgo.Cause(err) == tomb.ErrDying {
+				return errMonitoringStopped
+			}
+			if err != nil {
+				logger.Infof("watch controller %v died: %v", m.ctlPath, err)
+			}
+		case params.ErrNotFound:
+			logger.Infof("watch controller %v terminating because controller was removed", m.ctlPath)
+			return errMonitoringStopped
+		case tomb.ErrDying:
+			// The controller has been removed or we've been explicitly stopped.
+			return errMonitoringStopped
+		case jem.ErrAPIConnection:
+			// We've failed to connect to the API. Log the error and
+			// try again.
+			// TODO update the controller doc with the error?
+			logger.Errorf("cannot connect to controller %v: %v", m.ctlPath, err)
+			// Sleep for a while so we don't batter the network.
+			select {
+			case <-m.tomb.Dying():
+				// The controllerMonitor is dying.
+				return errMonitoringStopped
+			case <-Clock.After(apiConnectRetryDuration):
+			}
+		default:
+			// Some other error has happened (probably a mongo
+			// failure), so die with an error which will force everything
+			// to tear down.
+			return errgo.Notef(err, "cannot dial API for controller %v", m.ctlPath)
+		}
+	}
+}
+
+// dialAPI makes an API connection while also monitoring for shutdown.
+// If the tomb starts dying while dialing, it returns tomb.ErrDying. If
+// we can't make an API connection because the controller has been
+// removed, it returns an error with a params.ErrNotFound cause. If it
+// can't make a connection because the dial itself failed, it returns an
+// error with a jem.ErrAPIConnection cause.
+func (m *controllerMonitor) dialAPI() (jujuAPI, error) {
+	type apiConnReply struct {
+		conn jujuAPI
+		err  error
+	}
+	reply := make(chan apiConnReply, 1)
+	// Make an independent copy of the JEM instance
+	// because this goroutine might live on beyond
+	// the allMonitor's lifetime.
+	j := m.jem.Clone()
+	go func() {
+		// Open the API to the controller's admin model.
+		conn, err := j.OpenAPI(m.ctlPath)
+
+		// Close before sending the reply rather than deferring
+		// so that if our reply causes everything to be stopped,
+		// we know that the JEM is closed before that.
+		j.Close()
+		reply <- apiConnReply{
+			conn: conn,
+			err:  err,
+		}
+	}()
+	select {
+	case r := <-reply:
+		return r.conn, errgo.Mask(r.err, errgo.Is(params.ErrNotFound), errgo.Is(jem.ErrAPIConnection))
+	case <-m.tomb.Dying():
+		return nil, tomb.ErrDying
+	}
+}
+
+// watch reads events from the API megawatcher and
+// updates runtime stats in the controller document in response
+// to those.
+func (m *controllerMonitor) watch(conn jujuAPI) error {
+	apiw, err := conn.WatchAllModels()
+	if err != nil {
+		return errgo.Notef(err, "cannot watch all models")
+	}
+	defer apiw.Stop()
+
+	w := newWatcherState(m.jem, m.ctlPath)
+	type reply struct {
+		deltas []multiwatcher.Delta
+		err    error
+	}
+	replyc := make(chan reply, 1)
+	for {
+		go func() {
+			// Ideally rpc.Client would have a Go method
+			// similar to net/rpc's Go method, so we could
+			// avoid making a goroutine each time, but currently
+			// it does not.
+			d, err := apiw.Next()
+			replyc <- reply{d, err}
+		}()
+		var r reply
+		select {
+		case r = <-replyc:
+		case <-m.tomb.Dying():
+			return tomb.ErrDying
+		}
+		if r.err != nil {
+			return errgo.Notef(r.err, "watcher error waiting for next event")
+		}
+		w.changed = false
+		for _, d := range r.deltas {
+			if err := w.addDelta(d); err != nil {
+				return errgo.Mask(err)
+			}
+		}
+		if w.changed {
+			if err := m.jem.SetControllerStats(m.ctlPath, &w.stats); err != nil {
+				return errgo.Notef(err, "cannot set controller stats")
+			}
+		}
+	}
+}
+
+// watcherState holds the state that's maintained when watching
+// a controller.
+type watcherState struct {
+	jem jemInterface
+
+	// entities holds a map from entity tag to whether it exists.
+	entities map[multiwatcher.EntityId]bool
+
+	// ctlPath holds the path to the controller.
+	ctlPath params.EntityPath
+
+	// changed holds whether the stats have been updated
+	// since the last time it was set to false.
+	changed bool
+
+	// stats holds the current known statistics about the controller.
+	stats mongodoc.ControllerStats
+
+	// modelLife holds the currently known lifecycle status
+	// of all the models in the controller.
+	modelLife map[string]multiwatcher.Life
+}
+
+func newWatcherState(j jemInterface, ctlPath params.EntityPath) *watcherState {
+	return &watcherState{
+		jem:       j,
+		ctlPath:   ctlPath,
+		modelLife: make(map[string]multiwatcher.Life),
+		entities:  make(map[multiwatcher.EntityId]bool),
+	}
+}
+
+func (w *watcherState) addDelta(d multiwatcher.Delta) error {
+	logger.Debugf("controller %v saw change %#v", w.ctlPath, d)
+	switch e := d.Entity.(type) {
+	case *multiwatcher.ModelInfo:
+		w.adjustCount(&w.stats.ModelCount, d)
+		// TODO update the model information concurrently?
+		if d.Removed {
+			if err := w.modelRemoved(e.ModelUUID); err != nil {
+				return errgo.Notef(err, "cannot mark model as removed")
+			}
+			break
+		}
+		if err := w.modelChanged(e); err != nil {
+			return errgo.Mask(err)
+		}
+	case *multiwatcher.UnitInfo:
+		w.adjustCount(&w.stats.UnitCount, d)
+	case *multiwatcher.ServiceInfo:
+		w.adjustCount(&w.stats.ServiceCount, d)
+	case *multiwatcher.MachineInfo:
+		// TODO for top level machines, increment instance count?
+		w.adjustCount(&w.stats.MachineCount, d)
+	}
+	return nil
+}
+
+// adjustCount increments or decrements the value pointed
+// to by n depending on whether delta.Removed is true.
+// It sets w.changed to true to indicate that something has
+// changed and keeps track of whether the entity id exists.
+func (w *watcherState) adjustCount(n *int, delta multiwatcher.Delta) {
+	id := delta.Entity.EntityId()
+	if delta.Removed {
+		// Technically there's no need for the test here as we shouldn't
+		// get two Removes in a row, but let's be defensive.
+		if w.entities[id] {
+			w.changed = true
+			delete(w.entities, id)
+			*n -= 1
+		}
+		return
+	}
+	if !w.entities[id] {
+		w.entities[id] = true
+		w.changed = true
+		*n += 1
+	}
+}
+
+// modelRemoved is called when we know that the model with the
+// given UUID has been removed.
+func (w *watcherState) modelRemoved(uuid string) error {
+	return w.setModelLife(uuid, "dead")
+}
+
+// modelChanged is called when we're given new information about
+// a model.
+func (w *watcherState) modelChanged(m *multiwatcher.ModelInfo) error {
+	// TODO set other info about the model here too?
+	return w.setModelLife(m.ModelUUID, m.Life)
+}
+
+func (w *watcherState) setModelLife(uuid string, life multiwatcher.Life) error {
+	if life == w.modelLife[uuid] {
+		return nil
+	}
+	if err := w.jem.SetModelLife(w.ctlPath, uuid, string(life)); err != nil {
+		return errgo.Notef(err, "cannot update model")
+	}
+	w.modelLife[uuid] = life
+	return nil
 }

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -9,6 +9,8 @@ import (
 	corejujutesting "github.com/juju/juju/juju/testing"
 	jujuwatcher "github.com/juju/juju/state/watcher"
 	jujutesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/worker"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
@@ -83,13 +85,13 @@ func (s *internalSuite) TestLeaseUpdater(c *gc.C) {
 
 	// The controller monitor assumes that it already has the
 	// lease when started, so acquire the lease.
-	expiry, err := acquireLease(s.jem, ctlPath, time.Time{}, "", "jem1")
+	expiry, err := acquireLease(jemShim{s.jem}, ctlPath, time.Time{}, "", "jem1")
 	c.Assert(err, gc.IsNil)
 
 	m := &controllerMonitor{
 		ctlPath:     ctlPath,
 		leaseExpiry: expiry,
-		jem:         s.jem,
+		jem:         jemShim{s.jem},
 		ownerId:     "jem1",
 	}
 	done := make(chan error)
@@ -137,7 +139,7 @@ func (s *internalSuite) TestLeaseUpdaterWhenControllerRemoved(c *gc.C) {
 	m := &controllerMonitor{
 		ctlPath:     ctlPath,
 		leaseExpiry: epoch.Add(leaseExpiryDuration),
-		jem:         s.jem,
+		jem:         jemShim{s.jem},
 		ownerId:     "jem1",
 	}
 	defer m.tomb.Kill(nil)
@@ -160,6 +162,250 @@ func (s *internalSuite) TestLeaseUpdaterWhenControllerRemoved(c *gc.C) {
 	c.Assert(errgo.Cause(err), gc.Equals, errMonitoringStopped)
 }
 
+func (s *internalSuite) TestWatcher(c *gc.C) {
+	// Add some entities to the admin model.
+	f := factory.NewFactory(s.State)
+	svc := f.MakeService(c, &factory.ServiceParams{
+		Name: "wordpress",
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Service: svc,
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Service: svc,
+	})
+	modelSt := f.MakeModel(c, &factory.ModelParams{
+		Name: "jem-somemodel",
+	})
+	defer modelSt.Close()
+
+	// Add some JEM entities.
+	ctlPath := params.EntityPath{"bob", "foo"}
+	info := s.APIInfo(c)
+	err := s.jem.AddController(&mongodoc.Controller{
+		Path:          ctlPath,
+		HostPorts:     info.Addrs,
+		CACert:        info.CACert,
+		AdminUser:     info.Tag.Id(),
+		AdminPassword: info.Password,
+	}, &mongodoc.Model{
+		UUID: info.ModelTag.Id(),
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Make a JEM model that refers to the juju model.
+	modelPath := params.EntityPath{"alice", "bar"}
+	err = s.jem.AddModel(&mongodoc.Model{
+		Path:       modelPath,
+		Controller: ctlPath,
+		UUID:       modelSt.ModelUUID(),
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Start the watcher.
+	jshim := newJEMShimWithUpdateNotify(s.jem)
+	m := &controllerMonitor{
+		ctlPath: ctlPath,
+		jem:     jshim,
+		ownerId: "jem1",
+	}
+	m.tomb.Go(m.watcher)
+	// Ensure we always wait for the watcher to stop, otherwise
+	// it can use the JEM connection after the test returns, with
+	// nasty results.
+	defer func() {
+		m.tomb.Kill(nil)
+		err := m.tomb.Wait()
+		c.Check(errgo.Cause(err), gc.Equals, errMonitoringStopped)
+	}()
+
+	// The watcher should set the model life and the
+	// controller stats. We have two models, so we'll see
+	// two set.
+	waitEvent(c, jshim.modelLifeSet, "model life")
+	waitEvent(c, jshim.modelLifeSet, "model life")
+	waitEvent(c, jshim.controllerStatsSet, "controller stats")
+	jshim.assertNoEvent(c)
+
+	s.assertControllerStats(c, ctlPath, mongodoc.ControllerStats{
+		ModelCount:   2,
+		ServiceCount: 1,
+		UnitCount:    2,
+		MachineCount: 2,
+	})
+	s.assertModelLife(c, ctlPath, "alive")
+	s.assertModelLife(c, modelPath, "alive")
+
+	// Add another service and check that the service count is maintained.
+	f.MakeService(c, &factory.ServiceParams{
+		Name: "mysql",
+	})
+
+	waitEvent(c, jshim.controllerStatsSet, "controller stats")
+	s.assertControllerStats(c, ctlPath, mongodoc.ControllerStats{
+		ModelCount:   2,
+		ServiceCount: 2,
+		UnitCount:    2,
+		MachineCount: 2,
+	})
+
+	stm, err := modelSt.Model()
+	c.Assert(err, gc.IsNil)
+	err = stm.Destroy()
+	c.Assert(err, gc.IsNil)
+
+	// Destroy the model and check that its life status changes.
+	waitEvent(c, jshim.modelLifeSet, "model life")
+	jshim.assertNoEvent(c)
+
+	s.assertModelLife(c, modelPath, "dead")
+
+	err = modelSt.RemoveAllModelDocs()
+	c.Assert(err, gc.IsNil)
+
+	// We won't see the model life set because it's still the same as before.
+	waitEvent(c, jshim.controllerStatsSet, "controller stats")
+	jshim.assertNoEvent(c)
+
+	s.assertControllerStats(c, ctlPath, mongodoc.ControllerStats{
+		ModelCount:   1,
+		ServiceCount: 2,
+		UnitCount:    2,
+		MachineCount: 2,
+	})
+	s.assertModelLife(c, modelPath, "dead")
+}
+
+func (s *internalSuite) TestWatcherKilledWhileDialingAPI(c *gc.C) {
+	info := s.APIInfo(c)
+	ctlPath := params.EntityPath{"bob", "foo"}
+	err := s.jem.AddController(&mongodoc.Controller{
+		Path:      ctlPath,
+		UUID:      "some-uuid",
+		CACert:    info.CACert,
+		AdminUser: "bob",
+		HostPorts: []string{"0.1.2.3:4567"},
+	}, &mongodoc.Model{
+		UUID: "some-uuid",
+	})
+	c.Assert(err, gc.IsNil)
+
+	openCh := make(chan struct{})
+
+	// Start the watcher.
+	jshim := jemShimWithAPIOpener{
+		openAPI: func(path params.EntityPath) (jujuAPI, error) {
+			openCh <- struct{}{}
+			<-openCh
+			return nil, errgo.New("ignored error")
+		},
+		jemInterface: jemShim{s.jem},
+	}
+	m := &controllerMonitor{
+		ctlPath: ctlPath,
+		jem:     jshim,
+		ownerId: "jem1",
+	}
+	m.tomb.Go(m.watcher)
+	// Ensure we always wait for the watcher to stop, otherwise
+	// it can use the JEM connection after the test returns, with
+	// nasty results.
+	defer func() {
+		m.tomb.Kill(nil)
+		err := m.tomb.Wait()
+		c.Check(errgo.Cause(err), gc.Equals, errMonitoringStopped)
+	}()
+
+	// Wait for the API to be opened.
+	waitEvent(c, openCh, "open API")
+
+	// Kill the watcher tomb and check that it dies even
+	// though the API open is still going.
+	m.tomb.Kill(nil)
+	waitEvent(c, m.tomb.Dead(), "watcher termination")
+	err = m.tomb.Wait()
+	c.Check(errgo.Cause(err), gc.Equals, errMonitoringStopped)
+
+	// Let the asynchronously started API opener terminate.
+	openCh <- struct{}{}
+}
+
+func (s *internalSuite) TestWatcherDialAPIError(c *gc.C) {
+	ctlPath := params.EntityPath{"bob", "foo"}
+	err := s.jem.AddController(&mongodoc.Controller{
+		Path:      ctlPath,
+		UUID:      "some-uuid",
+		CACert:    jujutesting.CACert,
+		AdminUser: "bob",
+		HostPorts: []string{"0.1.2.3:4567"},
+	}, &mongodoc.Model{
+		UUID: "some-uuid",
+	})
+	c.Assert(err, gc.IsNil)
+
+	apiErrorCh := make(chan error)
+
+	// Start the watcher.
+	jshim := jemShimWithAPIOpener{
+		openAPI: func(path params.EntityPath) (jujuAPI, error) {
+			return nil, <-apiErrorCh
+		},
+		jemInterface: jemShim{s.jem},
+	}
+	m := &controllerMonitor{
+		ctlPath: ctlPath,
+		jem:     jshim,
+		ownerId: "jem1",
+	}
+	m.tomb.Go(m.watcher)
+	// Ensure we always wait for the watcher to stop, otherwise
+	// it can use the JEM connection after the test returns, with
+	// nasty results.
+	defer worker.Stop(m)
+
+	// First send a jem.ErrAPIConnection error. This should cause the
+	// watcher to pause for a while and retry.
+	select {
+	case apiErrorCh <- errgo.WithCausef(nil, jem.ErrAPIConnection, ""):
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("timed out waiting for API connection")
+	}
+
+	// Check that the watcher doesn't try again immediately.
+	select {
+	case apiErrorCh <- errgo.New("oh no you don't"):
+		c.Fatalf("watcher did not wait before retrying")
+	case <-time.After(jujutesting.ShortWait):
+	}
+
+	// Advance the time until past the retry time.
+	s.clock.Advance(apiConnectRetryDuration)
+
+	select {
+	case apiErrorCh <- errgo.New("fatal error"):
+	case <-time.After(jujutesting.LongWait):
+		c.Fatalf("timed out waiting for retried API connection")
+	}
+
+	// This non-ErrAPIConnection error should cause the
+	// watcher to die.
+	waitEvent(c, m.tomb.Dead(), "watcher dead")
+
+	c.Assert(m.tomb.Err(), gc.ErrorMatches, "cannot dial API for controller bob/foo: fatal error")
+}
+
+func (s *internalSuite) assertControllerStats(c *gc.C, ctlPath params.EntityPath, stats mongodoc.ControllerStats) {
+	ctlDoc, err := s.jem.Controller(ctlPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ctlDoc.Stats, jc.DeepEquals, stats)
+}
+
+func (s *internalSuite) assertModelLife(c *gc.C, modelPath params.EntityPath, life string) {
+	modelDoc, err := s.jem.Model(modelPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(modelDoc.Life, gc.Equals, life)
+}
+
 func (s *internalSuite) assertLease(c *gc.C, ctlPath params.EntityPath, t time.Time, owner string) {
 	ctl, err := s.jem.Controller(ctlPath)
 	c.Assert(err, gc.IsNil)
@@ -173,4 +419,21 @@ func parseTime(s string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+func waitEvent(c *gc.C, ch <-chan struct{}, what string) {
+	select {
+	case <-ch:
+	case <-time.After(jujutesting.LongWait):
+		select {}
+		c.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+func assertNoEvent(c *gc.C, ch <-chan struct{}, what string) {
+	select {
+	case <-ch:
+		c.Fatalf("unexpected event received: %v", what)
+	case <-time.After(jujutesting.ShortWait):
+	}
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -11,8 +11,12 @@ package monitor
 import (
 	"time"
 
+	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
+
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
 )
 
 var logger = loggo.GetLogger("jem.internal.monitor")
@@ -21,8 +25,86 @@ const (
 	// leaseExpiryDuration holds the length of time
 	// a lease is acquired for.
 	leaseExpiryDuration = time.Minute
+
+	// apiConnectRetryDuration holds the length of time
+	// a controller monitor will wait after a failed API
+	// connection before trying again.
+	apiConnectRetryDuration = 5 * time.Second
 )
 
 // Clock holds the clock implementation used by the monitor.
 // This is exported so it can be changed for testing purposes.
 var Clock clock.Clock = clock.WallClock
+
+// jemInterface holds the interface required by allMonitor to
+// talk to the JEM database. It is defined as an interface so
+// it can be faked for testing purposes.
+type jemInterface interface {
+	// Clone returns an independent copy of the receiver
+	// that uses a cloned database connection. The
+	// returned value must be closed after use.
+	Clone() jemInterface
+
+	// SetControllerStats sets the stats associated with the controller
+	// with the given path. It returns an error with a params.ErrNotFound
+	// cause if the controller does not exist.
+	SetControllerStats(ctlPath params.EntityPath, stats *mongodoc.ControllerStats) error
+	
+	// SetModelLife sets the Life field of all models controlled
+	// by the given controller that have the given UUID.
+	// It does not return an error if there are no such models.
+	SetModelLife(ctlPath params.EntityPath, uuid string, life string) error
+	// Close closes the JEM instance. This should be called when
+	// the JEM instance is finished with.
+	Close()
+
+	// AllControllers returns all the controllers in the system.
+	AllControllers() ([]*mongodoc.Controller, error)
+
+	// OpenAPI opens an API connection to the model with the given path
+	// and returns it along with the information used to connect.
+	// If the model does not exist, the error will have a cause
+	// of params.ErrNotFound.
+	//
+	// If the model API connection could not be made, the error
+	// will have a cause of jem.ErrAPIConnection.
+	//
+	// The returned connection must be closed when finished with.
+	OpenAPI(params.EntityPath) (jujuAPI, error)
+
+	// AcquireMonitorLease acquires or renews the lease on a controller.
+	// The lease will only be changed if the lease in the database
+	// has the given old expiry time and owner.
+	// When acquired, the lease will have the given new owner
+	// and expiration time.
+	//
+	// If newOwner is empty, the lease will be dropped, the
+	// returned time will be zero and newExpiry will be ignored.
+	//
+	// If the controller has been removed, an error with a params.ErrNotFound
+	// cause will be returned. If the lease has been obtained by someone else
+	// an error with a jem.ErrLeaseUnavailable cause will be returned.
+	AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error)
+}
+
+// jujuAPI represents an API connection to a Juju controller.
+type jujuAPI interface {
+	// WatchAllModels returns an allWatcher, from which you can request
+	// the Next collection of Deltas (for all models).
+	WatchAllModels() (allWatcher, error)
+
+	// Close closes the API connection.
+	Close() error
+}
+
+// allWatcher represents a watcher of all events on a controller.
+type allWatcher interface {
+	// Next returns a new set of deltas. It will block until there
+	// are deltas to return. The first calls to Next on a given watcher
+	// will return the entire state of the system without blocking.
+	Next() ([]multiwatcher.Delta, error)
+
+	// Stop stops the watcher and causes any outstanding Next calls
+	// to return an error.
+	Stop() error
+}

--- a/internal/monitor/shim.go
+++ b/internal/monitor/shim.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor
+
+import (
+	apicontroller "github.com/juju/juju/api/controller"
+	"gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jem/internal/apiconn"
+	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+// jemShim implements the jemInterface interface
+// by using a *jem.JEM directly.
+type jemShim struct {
+	*jem.JEM
+}
+
+func (j jemShim) Clone() jemInterface {
+	return jemShim{j.JEM.Clone()}
+}
+
+func (j jemShim) OpenAPI(path params.EntityPath) (jujuAPI, error) {
+	conn, err := j.JEM.OpenAPI(path)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Any)
+	}
+	return apiShim{conn}, nil
+}
+
+func (j jemShim) AllControllers() ([]*mongodoc.Controller, error) {
+	var ctls []*mongodoc.Controller
+	err := j.DB.Controllers().Find(nil).All(&ctls)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return ctls, nil
+}
+
+type apiShim struct {
+	*apiconn.Conn
+}
+
+func (a apiShim) WatchAllModels() (allWatcher, error) {
+	w, err := apicontroller.NewClient(a.Conn).WatchAllModels()
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Any)
+	}
+	return w, nil
+}

--- a/internal/monitor/shim_test.go
+++ b/internal/monitor/shim_test.go
@@ -1,0 +1,303 @@
+package monitor
+
+import (
+	"sync"
+	"time"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/state/multiwatcher"
+	jujutesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+func newJEMShimWithUpdateNotify(j *jem.JEM) jemShimWithUpdateNotify {
+	return jemShimWithUpdateNotify{
+		controllerStatsSet: make(chan struct{}, 10),
+		modelLifeSet:       make(chan struct{}, 10),
+		leaseAcquired:      make(chan struct{}, 10),
+		jemInterface:       jemShim{j},
+	}
+}
+
+type jemShimWithUpdateNotify struct {
+	controllerStatsSet chan struct{}
+	modelLifeSet       chan struct{}
+	leaseAcquired      chan struct{}
+	jemInterface
+}
+
+func (s jemShimWithUpdateNotify) Clone() jemInterface {
+	s.jemInterface = s.jemInterface.Clone()
+	return s
+}
+
+func (s jemShimWithUpdateNotify) assertNoEvent(c *gc.C) {
+	var event string
+	select {
+	case <-s.controllerStatsSet:
+		event = "controller stats"
+	case <-s.modelLifeSet:
+		event = "model life"
+	case <-s.leaseAcquired:
+		event = "lease acquired"
+
+	case <-time.After(jujutesting.ShortWait):
+		return
+	}
+	c.Fatalf("unexpected event received: %v", event)
+}
+
+func (s jemShimWithUpdateNotify) SetControllerStats(ctlPath params.EntityPath, stats *mongodoc.ControllerStats) error {
+	logger.Infof("SetControllerStats called %v %#v", ctlPath, stats)
+	if err := s.jemInterface.SetControllerStats(ctlPath, stats); err != nil {
+		return err
+	}
+	s.controllerStatsSet <- struct{}{}
+	return nil
+}
+
+func (s jemShimWithUpdateNotify) SetModelLife(ctlPath params.EntityPath, uuid string, life string) error {
+	logger.Infof("SetModelLife called %v %v %v", ctlPath, uuid, life)
+	if err := s.jemInterface.SetModelLife(ctlPath, uuid, life); err != nil {
+		return err
+	}
+	s.modelLifeSet <- struct{}{}
+	return nil
+}
+
+func (s jemShimWithUpdateNotify) AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error) {
+	t, err := s.jemInterface.AcquireMonitorLease(ctlPath, oldExpiry, oldOwner, newExpiry, newOwner)
+	if err != nil {
+		return time.Time{}, err
+	}
+	s.leaseAcquired <- struct{}{}
+	return t, err
+}
+
+type jemShimWithAPIOpener struct {
+	// openAPI is called when the OpenAPI method is called.
+	openAPI func(path params.EntityPath) (jujuAPI, error)
+	jemInterface
+}
+
+func (s jemShimWithAPIOpener) OpenAPI(path params.EntityPath) (jujuAPI, error) {
+	return s.openAPI(path)
+}
+
+func (s jemShimWithAPIOpener) Clone() jemInterface {
+	s.jemInterface = s.jemInterface.Clone()
+	return s
+}
+
+type jemShimWithMonitorLeaseAcquirer struct {
+	// acquireMonitorLease is called when the AcquireMonitorLease
+	// method is called.
+	acquireMonitorLease func(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error)
+	jemInterface
+}
+
+func (s jemShimWithMonitorLeaseAcquirer) AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error) {
+	return s.acquireMonitorLease(ctlPath, oldExpiry, oldOwner, newExpiry, newOwner)
+}
+
+func (s jemShimWithMonitorLeaseAcquirer) Clone() jemInterface {
+	s.jemInterface = s.jemInterface.Clone()
+	return s
+}
+
+type jemShimInMemory struct {
+	mu          sync.Mutex
+	refCount    int
+	controllers map[params.EntityPath]*mongodoc.Controller
+	models      map[params.EntityPath]*mongodoc.Model
+}
+
+var _ jemInterface = (*jemShimInMemory)(nil)
+
+func newJEMShimInMemory() *jemShimInMemory {
+	return &jemShimInMemory{
+		controllers: make(map[params.EntityPath]*mongodoc.Controller),
+		models:      make(map[params.EntityPath]*mongodoc.Model),
+	}
+}
+
+func (s *jemShimInMemory) AddController(ctl *mongodoc.Controller) {
+	if ctl.Path == (params.EntityPath{}) {
+		panic("no path in controller")
+	}
+	ctl.Id = ctl.Path.String()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ctl1 := *ctl
+	s.controllers[ctl.Path] = &ctl1
+}
+
+func (s *jemShimInMemory) AddModel(m *mongodoc.Model) {
+	if m.Path.IsZero() {
+		panic("no path in model")
+	}
+	if m.Controller.IsZero() {
+		panic("no controller in model")
+	}
+	m.Id = m.Path.String()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m1 := *m
+	s.models[m.Path] = &m1
+}
+
+func (s *jemShimInMemory) Clone() jemInterface {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refCount++
+	return s
+}
+
+func (s *jemShimInMemory) SetControllerStats(ctlPath params.EntityPath, stats *mongodoc.ControllerStats) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ctl, ok := s.controllers[ctlPath]
+	if !ok {
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
+	}
+	ctl.Stats = *stats
+	return nil
+}
+
+func (s *jemShimInMemory) SetModelLife(ctlPath params.EntityPath, uuid string, life string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range s.models {
+		if m.Controller == ctlPath && m.UUID == uuid {
+			m.Life = life
+		}
+	}
+	return nil
+}
+
+func (s *jemShimInMemory) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refCount--
+	if s.refCount < 0 {
+		panic("close too many times")
+	}
+}
+
+func (s *jemShimInMemory) AllControllers() ([]*mongodoc.Controller, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var r []*mongodoc.Controller
+	for _, c := range s.controllers {
+		c1 := *c
+		r = append(r, &c1)
+	}
+	return r, nil
+}
+
+func (s *jemShimInMemory) OpenAPI(params.EntityPath) (jujuAPI, error) {
+	return nil, errgo.New("jemShimInMemory doesn't implement OpenAPI")
+}
+
+func (s *jemShimInMemory) AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ctl, ok := s.controllers[ctlPath]
+	if !ok {
+		return time.Time{}, errgo.WithCausef(nil, params.ErrNotFound, "")
+	}
+	if ctl.MonitorLeaseOwner != oldOwner || !ctl.MonitorLeaseExpiry.UTC().Equal(oldExpiry.UTC()) {
+		return time.Time{}, errgo.WithCausef(nil, jem.ErrLeaseUnavailable, "")
+	}
+	ctl.MonitorLeaseOwner = newOwner
+	if newOwner == "" {
+		ctl.MonitorLeaseExpiry = time.Time{}
+	} else {
+		ctl.MonitorLeaseExpiry = mongodoc.Time(newExpiry)
+	}
+	return ctl.MonitorLeaseExpiry, nil
+}
+
+var _ jujuAPI = (*jemAPIShim)(nil)
+
+type jemAPIShim struct {
+	mu           sync.Mutex
+	watcherCount int
+	closed       bool
+	initial      []multiwatcher.Delta
+}
+
+// newJEMAPIShim returns an implementation of the jujuAPI interface
+// that, when WatchAllModels is called, returns the given initial
+// deltas and then nothing.
+func newJEMAPIShim(initial []multiwatcher.Delta) *jemAPIShim {
+	return &jemAPIShim{
+		initial: initial,
+	}
+}
+
+func (s *jemAPIShim) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+// WatcherCount returns the number of currently open API watchers.
+func (s *jemAPIShim) WatcherCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watcherCount
+}
+
+func (s *jemAPIShim) IsClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+func (s *jemAPIShim) WatchAllModels() (allWatcher, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.watcherCount++
+	return &watcherShim{
+		jemAPIShim: s,
+		stopped:    make(chan struct{}),
+		initial:    s.initial,
+	}, nil
+}
+
+type watcherShim struct {
+	jemAPIShim *jemAPIShim
+	mu         sync.Mutex
+	stopped    chan struct{}
+	initial    []multiwatcher.Delta
+}
+
+func (s *watcherShim) Next() ([]multiwatcher.Delta, error) {
+	s.mu.Lock()
+	d := s.initial
+	s.initial = nil
+	s.mu.Unlock()
+	if len(d) > 0 {
+		return d, nil
+	}
+	<-s.stopped
+	return nil, &jujuparams.Error{
+		Message: "fake watcher was stopped",
+		Code:    jujuparams.CodeStopped,
+	}
+}
+
+func (s *watcherShim) Stop() error {
+	close(s.stopped)
+	s.jemAPIShim.mu.Lock()
+	s.jemAPIShim.watcherCount--
+	s.jemAPIShim.mu.Unlock()
+	return nil
+}


### PR DESCRIPTION
This adds the code that's responsible for monitoring an
individual controller and keeping the state updated
accordingly.

We introduce the jemInterface type which makes it
possible to mock out the JEM store access and API
connections.
