### PR TITLE
internal/monitor: fix panic in monitor when controller is removed

### DIFF
--- a/internal/apiconn/cache.go
+++ b/internal/apiconn/cache.go
@@ -70,7 +70,7 @@ func (cache *Cache) EvictAll() {
 // responsibility of the caller to ensure this.
 //
 // The cause of any error returned from dial will be
-// returned intact.
+// returned unmasked.
 func (cache *Cache) OpenAPI(
 	envUUID string,
 	dial func() (api.Connection, *api.Info, error),


### PR DESCRIPTION
We're not allowed to return ErrDying from a tomb goroutine
when the tomb isn't already dying.

Fix this by returning ErrDying only when we are already dying,
and returning another error otherwise. We check the error
in the allMonitor, which means that we'll print a more meaniningful
error when a controller monitor dies.
