### PR TITLE
internal/monitor: mark controllers as unavailable

### DIFF
--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -19,8 +19,8 @@ import (
 
 	external_jem "github.com/CanonicalLtd/jem"
 	"github.com/CanonicalLtd/jem/internal/idmtest"
-	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/jemclient"
 	"github.com/CanonicalLtd/jem/params"
 )

--- a/internal/debugapi/api.go
+++ b/internal/debugapi/api.go
@@ -8,8 +8,8 @@ import (
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/jem"
-	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/internal/jemerror"
+	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/version"
 )
 

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -69,6 +69,11 @@ type Controller struct {
 
 	// Stats holds runtime information about the controller.
 	Stats ControllerStats
+
+	// UnavailableSince is empty when the controller is marked
+	// as available; otherwise it holds the time when it became
+	// unavailable.
+	UnavailableSince time.Time `bson:",omitempty"`
 }
 
 // ControllerStats holds statistics about a controller.

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -1,0 +1,96 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor
+
+import (
+	"time"
+
+	"github.com/juju/juju/state/multiwatcher"
+
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+// jemInterface holds the interface required by allMonitor to
+// talk to the JEM database. It is defined as an interface so
+// it can be faked for testing purposes.
+type jemInterface interface {
+	// Close closes the JEM instance. This should be called when
+	// the JEM instance is finished with.
+	Close()
+
+	// Clone returns an independent copy of the receiver
+	// that uses a cloned database connection. The
+	// returned value must be closed after use.
+	Clone() jemInterface
+
+	// SetControllerStats sets the stats associated with the controller
+	// with the given path. It returns an error with a params.ErrNotFound
+	// cause if the controller does not exist.
+	SetControllerStats(ctlPath params.EntityPath, stats *mongodoc.ControllerStats) error
+
+	// SetControllerUnavailableAt marks the controller as having been unavailable
+	// since at least the given time. If the controller was already marked
+	// as unavailable, its time isn't changed.
+	// This method does not return an error when the controller doesn't exist.
+	SetControllerUnavailableAt(ctlPath params.EntityPath, t time.Time) error
+
+	// SetControllerAvailable marks the given controller as available.
+	// This method does not return an error when the controller doesn't exist.
+	SetControllerAvailable(ctlPath params.EntityPath) error
+
+	// SetModelLife sets the Life field of all models controlled
+	// by the given controller that have the given UUID.
+	// It does not return an error if there are no such models.
+	SetModelLife(ctlPath params.EntityPath, uuid string, life string) error
+
+	// AllControllers returns all the controllers in the system.
+	AllControllers() ([]*mongodoc.Controller, error)
+
+	// OpenAPI opens an API connection to the model with the given path
+	// and returns it along with the information used to connect.
+	// If the model does not exist, the error will have a cause
+	// of params.ErrNotFound.
+	//
+	// If the model API connection could not be made, the error
+	// will have a cause of jem.ErrAPIConnection.
+	//
+	// The returned connection must be closed when finished with.
+	OpenAPI(params.EntityPath) (jujuAPI, error)
+
+	// AcquireMonitorLease acquires or renews the lease on a controller.
+	// The lease will only be changed if the lease in the database
+	// has the given old expiry time and owner.
+	// When acquired, the lease will have the given new owner
+	// and expiration time.
+	//
+	// If newOwner is empty, the lease will be dropped, the
+	// returned time will be zero and newExpiry will be ignored.
+	//
+	// If the controller has been removed, an error with a params.ErrNotFound
+	// cause will be returned. If the lease has been obtained by someone else
+	// an error with a jem.ErrLeaseUnavailable cause will be returned.
+	AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error)
+}
+
+// jujuAPI represents an API connection to a Juju controller.
+type jujuAPI interface {
+	// WatchAllModels returns an allWatcher, from which you can request
+	// the Next collection of Deltas (for all models).
+	WatchAllModels() (allWatcher, error)
+
+	// Close closes the API connection.
+	Close() error
+}
+
+// allWatcher represents a watcher of all events on a controller.
+type allWatcher interface {
+	// Next returns a new set of deltas. It will block until there
+	// are deltas to return. The first calls to Next on a given watcher
+	// will return the entire state of the system without blocking.
+	Next() ([]multiwatcher.Delta, error)
+
+	// Stop stops the watcher and causes any outstanding Next calls
+	// to return an error.
+	Stop() error
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -11,14 +11,12 @@ package monitor
 import (
 	"time"
 
-	"github.com/juju/juju/state/multiwatcher"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/clock"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/tomb.v2"
 
 	"github.com/CanonicalLtd/jem/internal/jem"
-	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )
 
@@ -118,79 +116,6 @@ func (m *allMonitor) Wait() error {
 // allMonitor has terminated.
 func (m *allMonitor) Dead() <-chan struct{} {
 	return m.tomb.Dead()
-}
-
-// jemInterface holds the interface required by allMonitor to
-// talk to the JEM database. It is defined as an interface so
-// it can be faked for testing purposes.
-type jemInterface interface {
-	// Clone returns an independent copy of the receiver
-	// that uses a cloned database connection. The
-	// returned value must be closed after use.
-	Clone() jemInterface
-
-	// SetControllerStats sets the stats associated with the controller
-	// with the given path. It returns an error with a params.ErrNotFound
-	// cause if the controller does not exist.
-	SetControllerStats(ctlPath params.EntityPath, stats *mongodoc.ControllerStats) error
-
-	// SetModelLife sets the Life field of all models controlled
-	// by the given controller that have the given UUID.
-	// It does not return an error if there are no such models.
-	SetModelLife(ctlPath params.EntityPath, uuid string, life string) error
-	// Close closes the JEM instance. This should be called when
-	// the JEM instance is finished with.
-	Close()
-
-	// AllControllers returns all the controllers in the system.
-	AllControllers() ([]*mongodoc.Controller, error)
-
-	// OpenAPI opens an API connection to the model with the given path
-	// and returns it along with the information used to connect.
-	// If the model does not exist, the error will have a cause
-	// of params.ErrNotFound.
-	//
-	// If the model API connection could not be made, the error
-	// will have a cause of jem.ErrAPIConnection.
-	//
-	// The returned connection must be closed when finished with.
-	OpenAPI(params.EntityPath) (jujuAPI, error)
-
-	// AcquireMonitorLease acquires or renews the lease on a controller.
-	// The lease will only be changed if the lease in the database
-	// has the given old expiry time and owner.
-	// When acquired, the lease will have the given new owner
-	// and expiration time.
-	//
-	// If newOwner is empty, the lease will be dropped, the
-	// returned time will be zero and newExpiry will be ignored.
-	//
-	// If the controller has been removed, an error with a params.ErrNotFound
-	// cause will be returned. If the lease has been obtained by someone else
-	// an error with a jem.ErrLeaseUnavailable cause will be returned.
-	AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error)
-}
-
-// jujuAPI represents an API connection to a Juju controller.
-type jujuAPI interface {
-	// WatchAllModels returns an allWatcher, from which you can request
-	// the Next collection of Deltas (for all models).
-	WatchAllModels() (allWatcher, error)
-
-	// Close closes the API connection.
-	Close() error
-}
-
-// allWatcher represents a watcher of all events on a controller.
-type allWatcher interface {
-	// Next returns a new set of deltas. It will block until there
-	// are deltas to return. The first calls to Next on a given watcher
-	// will return the entire state of the system without blocking.
-	Next() ([]multiwatcher.Delta, error)
-
-	// Stop stops the watcher and causes any outstanding Next calls
-	// to return an error.
-	Stop() error
 }
 
 // allMonitor is responsible for monitoring all controllers using

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/CanonicalLtd/jem/internal/apiconn"
 	"github.com/CanonicalLtd/jem/internal/jem"
-	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/internal/jemerror"
+	"github.com/CanonicalLtd/jem/internal/jemserver"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -4,8 +4,9 @@
 package jemclient
 
 import (
-	"github.com/CanonicalLtd/jem/params"
 	"github.com/juju/httprequest"
+
+	"github.com/CanonicalLtd/jem/params"
 )
 
 type client struct {

--- a/params/params.go
+++ b/params/params.go
@@ -3,6 +3,7 @@ package params
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
@@ -307,6 +308,11 @@ type ControllerResponse struct {
 
 	// Location holds location attributes associated with the controller.
 	Location map[string]string
+
+	// UnavailableSince holds the time that the JEM server
+	// noticed that the model's controller could not be
+	// contacted. It is empty when the model is available.
+	UnavailableSince *time.Time `json:"unavailable-since,omitempty"`
 }
 
 // GetController holds parameters for retrieving information on a Controller.
@@ -396,6 +402,16 @@ type ModelResponse struct {
 	// HostPorts holds host/port pairs (in host:port form)
 	// of the controller API endpoints.
 	HostPorts []string `json:"host-ports"`
+
+	// Life holds the last reported lifecycle status of the model.
+	// It is omitted when we have no information on the model's
+	// life yet.
+	Life string `json:"life,omitempty"`
+
+	// UnavailableSince holds the time that the JEM server
+	// noticed that the model's controller could not be
+	// contacted. It is empty when the model is available.
+	UnavailableSince *time.Time `json:"unavailable-since,omitempty"`
 }
 
 // AddTemplate holds parameters for adding or updating a template.


### PR DESCRIPTION
When we can't contact a controller, mark it as unavailable
and include the time so that we can know how long it's
been unavailable for.

We don't make this information available in the API yet
although we add the fields to the params in preparation
for that.

Also make some of the logging messages in JEM a little
more informative and less noisy (don't log when there's an error,
as the error will be logged at a higher level anyway).
