### PR TITLE
internal/v1: expose life and availability in API

### DIFF
--- a/cmd/jaas-model/jemcmd/add-controller_test.go
+++ b/cmd/jaas-model/jemcmd/add-controller_test.go
@@ -22,8 +22,8 @@ var addControllerTests = []struct {
 	args     []string
 	location map[string]string
 }{{
-	about:    "simple",
-	args:     []string{},
+	about: "simple",
+	args:  []string{},
 }, {
 	about:    "add cloud",
 	args:     []string{"cloud=aws"},

--- a/cmd/jaas-model/jemcmd/cmd.go
+++ b/cmd/jaas-model/jemcmd/cmd.go
@@ -62,7 +62,7 @@ func New() cmd.Command {
 	supercmd.Register(newGenerateCommand())
 	supercmd.Register(newGrantCommand())
 	supercmd.Register(newListCommand())
-	supercmd.Register(newListServersCommand())
+	supercmd.Register(newListControllersCommand())
 	supercmd.Register(newLocationsCommand())
 	supercmd.Register(newListTemplatesCommand())
 	supercmd.Register(newRemoveCommand())

--- a/cmd/jaas-model/jemcmd/create.go
+++ b/cmd/jaas-model/jemcmd/create.go
@@ -257,7 +257,7 @@ func (ctxt schemaContext) getVal1(attr form.NamedAttr, checker schema.Checker) (
 		return val, path, nil
 	}
 	// TODO it could be a problem that this potentially
-	// enables a rogue JEM server to retrieve arbitrary
+	// enables a rogue JEM controller to retrieve arbitrary
 	// model variables from a client. Implement
 	// some kind of whitelisting scheme?
 	val, _, err = form.DefaultFromEnv(attr, checker)

--- a/cmd/jaas-model/jemcmd/generate_test.go
+++ b/cmd/jaas-model/jemcmd/generate_test.go
@@ -93,7 +93,7 @@ func (s *generateSuite) TestGenerateWithTemplates(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stderr, gc.Equals, "")
 
-	// The controller server attribute should be omitted.
+	// The controller attribute should be omitted.
 	c.Assert(stdout, gc.Not(gc.Matches), `(.|\n)*controller:(.|\n)*`)
 
 	// But the other attributes should still be there.

--- a/cmd/jaas-model/jemcmd/grant_test.go
+++ b/cmd/jaas-model/jemcmd/grant_test.go
@@ -25,7 +25,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can't get server or model.
+	// Check that alice can't get controller or model.
 	aliceClient := s.jemClient("alice")
 	_, err := aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
@@ -52,7 +52,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can get model but not server.
+	// Check that alice can get model but not controller.
 	_, err = aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
 			User: "bob",
@@ -68,7 +68,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	// Add alice to server permissions list.
+	// Add alice to controller permissions list.
 	stdout, stderr, code = run(c, c.MkDir(),
 		"grant",
 		"--controller",
@@ -79,7 +79,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can now access the server.
+	// Check that alice can now access the controller.
 	_, err = aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
 			User: "bob",

--- a/cmd/jaas-model/jemcmd/list-controllers.go
+++ b/cmd/jaas-model/jemcmd/list-controllers.go
@@ -12,34 +12,34 @@ import (
 	"github.com/CanonicalLtd/jem/params"
 )
 
-type listServersCommand struct {
+type listControllersCommand struct {
 	commandBase
 }
 
-func newListServersCommand() cmd.Command {
-	return modelcmd.WrapBase(&listServersCommand{})
+func newListControllersCommand() cmd.Command {
+	return modelcmd.WrapBase(&listControllersCommand{})
 }
 
-var listServersDoc = `
+var listControllersDoc = `
 The list-controllers command lists available controllers.
 `
 
-func (c *listServersCommand) Info() *cmd.Info {
+func (c *listControllersCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "list-controllers",
 		Purpose: "list controllers",
-		Doc:     listServersDoc,
+		Doc:     listControllersDoc,
 	}
 }
 
-func (c *listServersCommand) Init(args []string) error {
+func (c *listControllersCommand) Init(args []string) error {
 	if len(args) != 0 {
 		return errgo.Newf("got %d arguments, want none", len(args))
 	}
 	return nil
 }
 
-func (c *listServersCommand) Run(ctxt *cmd.Context) error {
+func (c *listControllersCommand) Run(ctxt *cmd.Context) error {
 	client, err := c.newClient(ctxt)
 	if err != nil {
 		return errgo.Mask(err)

--- a/cmd/jaas-model/jemcmd/remove_test.go
+++ b/cmd/jaas-model/jemcmd/remove_test.go
@@ -37,7 +37,7 @@ func (s *removeSuite) TestRemoveModel(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "bob/foo\n")
 }
 
-func (s *removeSuite) TestRemoveServer(c *gc.C) {
+func (s *removeSuite) TestRemoveController(c *gc.C) {
 	s.idmSrv.SetDefaultUser("bob")
 
 	// First add a controller and an model.
@@ -54,7 +54,15 @@ func (s *removeSuite) TestRemoveServer(c *gc.C) {
 
 	s.addEnv(c, "bob/foo-1", "bob/foo")
 
+	// Without the --force flag, we'll be forbidden because the controller
+	// is live.
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "--controller", "bob/foo")
+	c.Assert(code, gc.Equals, 1, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: .*: cannot delete controller while it is still alive\n`)
+
+	// We can use the --force flag to remove it.
+	stdout, stderr, code = run(c, c.MkDir(), "remove", "--force", "--controller", "bob/foo")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
@@ -117,7 +125,7 @@ func (s *removeSuite) TestRemoveMultipleModels(c *gc.C) {
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "bob/foo", "bob/foo-1")
 	c.Assert(code, gc.Equals, 1, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
-	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: DELETE http://.*/v2/model/bob/foo: cannot remove model "bob/foo" because it is a controller`+"\nERROR not all models removed successfully\n")
+	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: DELETE http://.*/v2/model/bob/foo: cannot remove model "bob/foo" because it is a controller`+"\n")
 
 	stdout, stderr, code = run(c, c.MkDir(), "list")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))

--- a/cmd/jaas-model/jemcmd/revoke_test.go
+++ b/cmd/jaas-model/jemcmd/revoke_test.go
@@ -25,7 +25,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can't get server or model.
+	// Check that alice can't get controller or model.
 	aliceClient := s.jemClient("alice")
 	_, err := aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
@@ -52,7 +52,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can get model but not server.
+	// Check that alice can get model but not controller.
 	_, err = aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
 			User: "bob",
@@ -68,7 +68,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	// Add alice to server permissions list.
+	// Add alice to controller permissions list.
 	stdout, stderr, code = run(c, c.MkDir(),
 		"grant",
 		"--controller",
@@ -79,7 +79,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	// Check that alice can now access the server.
+	// Check that alice can now access the controller.
 	_, err = aliceClient.GetController(&params.GetController{
 		EntityPath: params.EntityPath{
 			User: "bob",

--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -90,6 +90,7 @@ func serve(confPath string) error {
 		PublicKeyLocator: locator,
 		AgentUsername:    conf.AgentUsername,
 		AgentKey:         conf.AgentKey,
+		RunMonitor:       true,
 	}
 	server, err := jem.NewServer(cfg)
 	if err != nil {

--- a/internal/jemerror/error.go
+++ b/internal/jemerror/error.go
@@ -39,6 +39,7 @@ func errToResp(err error) (int, interface{}) {
 
 		status = http.StatusNotFound
 	case params.ErrForbidden,
+		params.ErrStillAlive,
 		params.ErrAlreadyExists:
 
 		status = http.StatusForbidden

--- a/internal/jemserver/server_test.go
+++ b/internal/jemserver/server_test.go
@@ -190,6 +190,7 @@ func (s *serverSuite) TestServerRunsMonitor(c *gc.C) {
 	params := jemserver.Params{
 		DB:            db,
 		AgentUsername: "foo",
+		RunMonitor:    true,
 	}
 	// Patch the API opening timeout so that it doesn't take the
 	// usual 15 seconds to fail - we don't, it holds on to the

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -70,7 +70,7 @@ type Controller struct {
 	// Stats holds runtime information about the controller.
 	Stats ControllerStats
 
-	// UnavailableSince is empty when the controller is marked
+	// UnavailableSince is zero when the controller is marked
 	// as available; otherwise it holds the time when it became
 	// unavailable.
 	UnavailableSince time.Time `bson:",omitempty"`
@@ -174,7 +174,7 @@ type Template struct {
 	Config map[string]interface{}
 
 	// Location holds the location attributes associated with the template.
-	Location map[string]string	`bson:",omitempty"`
+	Location map[string]string `bson:",omitempty"`
 }
 
 func (t *Template) Owner() params.User {

--- a/params/error.go
+++ b/params/error.go
@@ -27,6 +27,7 @@ const (
 	ErrMethodNotAllowed              ErrorCode = "method not allowed"
 	ErrAmbiguousLocation             ErrorCode = "ambiguous location"
 	ErrIncompatibleTemplateLocations ErrorCode = "incompatible template locations"
+	ErrStillAlive                    ErrorCode = "controller is still alive"
 )
 
 // Error represents an error - it is returned for any response that fails.

--- a/params/params.go
+++ b/params/params.go
@@ -92,6 +92,8 @@ type AddController struct {
 type DeleteController struct {
 	httprequest.Route `httprequest:"DELETE /v2/controller/:User/:Name"`
 	EntityPath
+	// Force forces the delete even if the controller is still alive.
+	Force bool `httprequest:"force,form"`
 }
 
 type GetAllControllerLocations struct {
@@ -314,8 +316,8 @@ type ControllerResponse struct {
 	// UnavailableSince holds the time that the JEM server
 	// noticed that the model's controller could not be
 	// contacted. It is empty when the model is available.
-	UnavailableSince *time.Time `json:"unavailable-since,omitempty"`
-	Location map[string]string `json:"location,omitempty"`
+	UnavailableSince *time.Time        `json:"unavailable-since,omitempty"`
+	Location         map[string]string `json:"location,omitempty"`
 }
 
 // GetController holds parameters for retrieving information on a Controller.
@@ -408,7 +410,7 @@ type ModelResponse struct {
 
 	// Life holds the last reported lifecycle status of the model.
 	// It is omitted when we have no information on the model's
-	// life yet.
+	// life yet. Possible values are "alive", "dying" and "dead".
 	Life string `json:"life,omitempty"`
 
 	// UnavailableSince holds the time that the JEM server

--- a/server.go
+++ b/server.go
@@ -41,6 +41,10 @@ type ServerParams struct {
 	// authentication.
 	AgentUsername string
 	AgentKey      *bakery.KeyPair
+
+	// RunMonitor specifies that the monitor worker should be run.
+	// This should always be set when running the server in production.
+	RunMonitor bool
 }
 
 // HandleCloser represents an HTTP handler that can


### PR DESCRIPTION
We also make it so that you can't delete a controller when
it's alive unless you pass the force flag.

And we don't run the monitor by default so that it
can't interfere with tests. We choose this default because
we only have the production config in one place
but tests create ServerParams all over the place.
