### PR TITLE
internal/monitor, internal/apiconn: be resilient to broken controller connections

### DIFF
--- a/internal/monitor/export_test.go
+++ b/internal/monitor/export_test.go
@@ -1,0 +1,5 @@
+// Copyright 2016 Canonical Ltd.
+
+package monitor
+
+var APIConnectRetryDuration = &apiConnectRetryDuration

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -75,6 +75,9 @@ type jemInterface interface {
 
 // jujuAPI represents an API connection to a Juju controller.
 type jujuAPI interface {
+	// Evict closes the connection and removes it from the API connection cache.
+	Evict()
+
 	// WatchAllModels returns an allWatcher, from which you can request
 	// the Next collection of Deltas (for all models).
 	WatchAllModels() (allWatcher, error)

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -384,10 +384,12 @@ func (s *internalSuite) TestWatcherDialAPIError(c *gc.C) {
 
 func (s *internalSuite) TestWatcherMarksControllerAvailable(c *gc.C) {
 	jshim := newJEMShimInMemory()
+	apiShims := newJujuAPIShims()
+	defer apiShims.CheckAllClosed(c)
 	jshim1 := newJEMShimWithUpdateNotify(jemShimWithAPIOpener{
 		jemInterface: jshim,
 		openAPI: func(path params.EntityPath) (jujuAPI, error) {
-			return newJEMAPIShim(nil), nil
+			return apiShims.newJujuAPIShim(nil), nil
 		},
 	})
 	// Create a controller
@@ -570,10 +572,12 @@ func (s *internalSuite) TestAllMonitorMultiControllersWithAPIError(c *gc.C) {
 
 func (s *internalSuite) TestAllMonitorMultiControllerMultipleLeases(c *gc.C) {
 	jshim := newJEMShimInMemory()
+	apiShims := newJujuAPIShims()
+	defer apiShims.CheckAllClosed(c)
 	jshim1 := jemShimWithAPIOpener{
 		jemInterface: jshim,
 		openAPI: func(path params.EntityPath) (jujuAPI, error) {
-			return newJEMAPIShim(nil), nil
+			return apiShims.newJujuAPIShim(nil), nil
 		},
 	}
 	type leaseAcquisition struct {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -22,7 +22,7 @@ import (
 
 var logger = loggo.GetLogger("jem.internal.monitor")
 
-const (
+var (
 	// leaseAcquireInterval holds the duration the
 	// monitor waits before trying to reacquire new
 	// controller monitor leases.

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,9 +1,13 @@
 package monitor_test
 
 import (
+	"time"
+
+	jujuwatcher "github.com/juju/juju/state/watcher"
 	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 	"github.com/juju/juju/worker"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -61,6 +65,7 @@ func (s *monitorSuite) TestMonitor(c *gc.C) {
 // broken API connections.
 
 func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
+	s.PatchValue(monitor.APIConnectRetryDuration, 10*time.Millisecond)
 	pool, proxy := s.ProxiedPool(c)
 	defer pool.Close()
 	defer proxy.Close()
@@ -86,20 +91,11 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 	defer worker.Stop(m)
 
 	// Wait for the stats to be updated.
-	var ctl *mongodoc.Controller
-	for a := jujutesting.LongAttempt.Start(); a.Next(); {
-		ctl, err = jem.Controller(ctlPath)
-		c.Assert(err, gc.IsNil)
-		if ctl.Stats != (mongodoc.ControllerStats{}) {
-			break
-		}
-		if !a.HasNext() {
-			c.Fatalf("controller stats never changed")
-		}
-	}
-	c.Assert(ctl.Stats, jc.DeepEquals, mongodoc.ControllerStats{
+	stats := s.waitControllerStats(c, ctlPath, mongodoc.ControllerStats{})
+	c.Assert(stats, jc.DeepEquals, mongodoc.ControllerStats{
 		ModelCount: 1,
 	})
+	c.Logf("watcher period: %v", jujuwatcher.Period)
 
 	// Tear down the mongo connection and check that
 	// the monitoring continues.
@@ -110,18 +106,8 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 		Name: "wordpress",
 	})
 
-	oldStats := ctl.Stats
-	for a := jujutesting.LongAttempt.Start(); a.Next(); {
-		ctl, err = s.JEM.Controller(ctlPath)
-		c.Assert(err, gc.IsNil)
-		if ctl.Stats != oldStats {
-			break
-		}
-		if !a.HasNext() {
-			c.Fatalf("controller stats never changed")
-		}
-	}
-	c.Assert(ctl.Stats, jc.DeepEquals, mongodoc.ControllerStats{
+	stats = s.waitControllerStats(c, ctlPath, stats)
+	c.Assert(stats, jc.DeepEquals, mongodoc.ControllerStats{
 		ModelCount:   1,
 		ServiceCount: 1,
 	})
@@ -129,5 +115,60 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 	// Check that it shuts down cleanly.
 	err = worker.Stop(m)
 	c.Assert(err, gc.IsNil)
+}
 
+func (s *monitorSuite) TestMonitorWithBrokenJujuAPIConnection(c *gc.C) {
+	s.PatchValue(monitor.APIConnectRetryDuration, 10*time.Millisecond)
+	// Create a controller with API information that will cause
+	// it to connect through our proxy instead of directly.
+	apiInfo := s.APIInfo(c)
+	proxy := testing.NewTCPProxy(c, apiInfo.Addrs[0])
+	ctlPath := params.EntityPath{"bob", "foo"}
+	err := s.JEM.AddController(&mongodoc.Controller{
+		Path:          ctlPath,
+		HostPorts:     []string{proxy.Addr()},
+		CACert:        apiInfo.CACert,
+		AdminUser:     apiInfo.Tag.Id(),
+		AdminPassword: apiInfo.Password,
+	}, &mongodoc.Model{
+		UUID: apiInfo.ModelTag.Id(),
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Start a monitor.
+	m := monitor.New(s.Pool, "jem1")
+	defer worker.Stop(m)
+
+	// Wait for the stats to be updated.
+	stats := s.waitControllerStats(c, ctlPath, mongodoc.ControllerStats{})
+	c.Assert(stats, jc.DeepEquals, mongodoc.ControllerStats{
+		ModelCount: 1,
+	})
+
+	// Tear down the mongo connection, make a new service and
+	// check the monitoring continues OK.
+	proxy.CloseConns()
+
+	f := factory.NewFactory(s.State)
+	f.MakeService(c, &factory.ServiceParams{
+		Name: "wordpress",
+	})
+
+	stats = s.waitControllerStats(c, ctlPath, stats)
+	c.Assert(stats, jc.DeepEquals, mongodoc.ControllerStats{
+		ModelCount:   1,
+		ServiceCount: 1,
+	})
+}
+
+func (s *monitorSuite) waitControllerStats(c *gc.C, ctlPath params.EntityPath, oldStats mongodoc.ControllerStats) mongodoc.ControllerStats {
+	for a := jujutesting.LongAttempt.Start(); a.Next(); {
+		ctl, err := s.JEM.Controller(ctlPath)
+		c.Assert(err, gc.IsNil)
+		if ctl.Stats != oldStats {
+			return ctl.Stats
+		}
+	}
+	c.Fatalf("controller stats never changed")
+	panic("unreachable")
 }


### PR DESCRIPTION
Controller TCP connections can be broken.
This change makes the API connection cache refuse to return
connections that are known to be broken,
and the monitor now evicts API connections that are known bad.

Ideally the juju API client would mark a connection as broken
as soon as it gets a bad reply from the server (that would make
the Evict call in monitor/controller.go unnecessary), but that's something
that can happen later.

We now also check that all API connections are closed by the monitor
and fix one case where this wasn't happening.
