### PR TITLE
cmd/jaas-model/jemcmd: do not require mandatory parameters client side

### DIFF
--- a/cmd/jaas-model/jemcmd/create.go
+++ b/cmd/jaas-model/jemcmd/create.go
@@ -191,9 +191,6 @@ func (ctxt schemaContext) generateConfig(schema environschema.Fields) (map[strin
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
-		if val == nil && attr.Mandatory {
-			return nil, errgo.Newf("no value found for mandatory attribute %q", name)
-		}
 		if val != nil {
 			config[name] = val
 		}

--- a/cmd/jaas-model/jemcmd/create_test.go
+++ b/cmd/jaas-model/jemcmd/create_test.go
@@ -106,6 +106,10 @@ func (s *createSuite) TestCreateWithTemplate(c *gc.C) {
 	c.Assert(stderr, gc.Equals, "")
 
 	// Then add a template containing the mandatory controller parameter.
+	// TODO unfortunately the controller parameter is *not* mandatory.
+	// This means that there are no parameters we can use to test that
+	// this actually works. Unfortunately registering another provider for testing
+	// and using that is not currently feasible.
 	stdout, stderr, code = run(c, c.MkDir(), "create-template", "bob/template", "-c", "bob/foo", "controller=true")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")

--- a/cmd/jaas-model/jemcmd/internal_test.go
+++ b/cmd/jaas-model/jemcmd/internal_test.go
@@ -375,18 +375,6 @@ func (s *internalSuite) TestGenerateConfig(c *gc.C) {
 			"testattr-modelname": "modelname-foo",
 		},
 	}, {
-		about: "no value found for mandatory attribute",
-		controllerInfo: params.ControllerResponse{
-			ProviderType: "test",
-			Schema: environschema.Fields{
-				"attr": {
-					Type:      environschema.Tstring,
-					Mandatory: true,
-				},
-			},
-		},
-		expectError: `no value found for mandatory attribute "attr"`,
-	}, {
 		about: "mandatory attribute with value",
 		controllerInfo: params.ControllerResponse{
 			ProviderType: "test",


### PR DESCRIPTION
They might be provided by templates.

Fixes issue #96.
