### PR TITLE
internal/jem: change monitor lease representation

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -67,11 +67,11 @@ type Controller struct {
 
 	// MonitorLeaseOwner holds the name of the agent
 	// currently responsible for monitoring the controller.
-	MonitorLeaseOwner string
+	MonitorLeaseOwner string `bson:",omitempty"`
 
 	// MonitorLeaseExpiry holds the time at which the
 	// current monitor's lease expires.
-	MonitorLeaseExpiry time.Time
+	MonitorLeaseExpiry time.Time `bson:",omitempty"`
 
 	// Stats holds runtime information about the controller.
 	Stats ControllerStats


### PR DESCRIPTION
We change the monitor lease fields in the mongo controller
document so that they're omitted when the lease isn't taken.
This means that the database is backwardly compatible
when upgraded, and also means that we don't store
zero time.Time values in the database (they don't look
very nice).

JEM instances that have already been deployed with
the monitoring enabled will need some manual database
tweaks to remove the zero fields.
