### PR TITLE
internal/v2: remove notion of template incompatiblity

### DIFF
--- a/internal/jemerror/error.go
+++ b/internal/jemerror/error.go
@@ -44,8 +44,7 @@ func errToResp(err error) (int, interface{}) {
 
 		status = http.StatusForbidden
 	case params.ErrBadRequest,
-		httprequest.ErrUnmarshal,
-		params.ErrIncompatibleTemplateLocations:
+		httprequest.ErrUnmarshal:
 
 		status = http.StatusBadRequest
 	case params.ErrUnauthorized:

--- a/params/error.go
+++ b/params/error.go
@@ -19,15 +19,14 @@ func (code ErrorCode) ErrorCode() ErrorCode {
 }
 
 const (
-	ErrNotFound                      ErrorCode = "not found"
-	ErrForbidden                     ErrorCode = "forbidden"
-	ErrBadRequest                    ErrorCode = "bad request"
-	ErrUnauthorized                  ErrorCode = "unauthorized"
-	ErrAlreadyExists                 ErrorCode = "already exists"
-	ErrMethodNotAllowed              ErrorCode = "method not allowed"
-	ErrAmbiguousLocation             ErrorCode = "ambiguous location"
-	ErrIncompatibleTemplateLocations ErrorCode = "incompatible template locations"
-	ErrStillAlive                    ErrorCode = "controller is still alive"
+	ErrNotFound          ErrorCode = "not found"
+	ErrForbidden         ErrorCode = "forbidden"
+	ErrBadRequest        ErrorCode = "bad request"
+	ErrUnauthorized      ErrorCode = "unauthorized"
+	ErrAlreadyExists     ErrorCode = "already exists"
+	ErrMethodNotAllowed  ErrorCode = "method not allowed"
+	ErrAmbiguousLocation ErrorCode = "ambiguous location"
+	ErrStillAlive        ErrorCode = "controller is still alive"
 )
 
 // Error represents an error - it is returned for any response that fails.


### PR DESCRIPTION
We now  treat all locations inside templates as just hints, so if we
specify a location when creating a new model, that location overrides
any locations specified in the templates.

Also, if several templates are specified with mismatching location attributes,
we act as if that attribute wasn't specified at all.

We also improve support for empty (non-existent) location attributes
in queries and when adding controllers. Specifically, when we query
for an empty attribute, we select controllers that do not have that attribute;
when adding a controller with an explicitly empty attribute, we make
sure that the attribute doesn't exist in the database.

We also fix SetControllerLocation so that it correctly returns a bad-request
error when the location attributes are invalid.

Fixes #123.
