### PR TITLE
internal/v2: add GetTemplateModels endpoint

### DIFF
--- a/internal/jem/auth.go
+++ b/internal/jem/auth.go
@@ -171,6 +171,7 @@ type CanReadIter struct {
 	jem  *JEM
 	iter *mgo.Iter
 	err  error
+	n    int
 }
 
 // ACLEntity represents a mongo entity with access permissions.
@@ -186,6 +187,7 @@ func (iter *CanReadIter) Next(item ACLEntity) bool {
 		return false
 	}
 	for iter.iter.Next(item) {
+		iter.n++
 		if err := iter.jem.CheckCanRead(item); err != nil {
 			if errgo.Cause(err) == params.ErrUnauthorized {
 				// No permissions to look at the entity, so don't include
@@ -212,4 +214,11 @@ func (iter *CanReadIter) Err() error {
 		return iter.err
 	}
 	return iter.iter.Err()
+}
+
+// Count returns the total number of items traversed
+// by the iterator, including items that were not returned
+// because they were unauthorized.
+func (iter *CanReadIter) Count() int {
+	return iter.n
 }

--- a/internal/jem/auth_test.go
+++ b/internal/jem/auth_test.go
@@ -319,6 +319,7 @@ func (s *authSuite) TestCanReadIter(c *gc.C) {
 		testModels[0],
 		testModels[2],
 	})
+	c.Assert(crit.Count(), gc.Equals, 3)
 }
 
 // newRequestForUser builds a new *http.Request for method at path which

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -123,6 +123,14 @@ func (c *client) GetTemplate(p *params.GetTemplate) (*params.TemplateResponse, e
 	return r, err
 }
 
+// GetTemplate returns the models using the template.
+// It only returns names for the models that the user has read permission for.
+func (c *client) GetTemplateModels(p *params.GetTemplateModels) (*params.TemplateModelsResponse, error) {
+	var r *params.TemplateModelsResponse
+	err := c.Client.Call(p, &r)
+	return r, err
+}
+
 // GetTemplatePerm returns the ACL for a given template.
 // Only the owner (arg.EntityPath.User) can read the ACL.
 func (c *client) GetTemplatePerm(p *params.GetTemplatePerm) (params.ACL, error) {

--- a/params/params.go
+++ b/params/params.go
@@ -298,6 +298,23 @@ type GetTemplate struct {
 	EntityPath
 }
 
+// GetTemplate holds parameters for retrieving the models that are
+// using a template.
+type GetTemplateModels struct {
+	httprequest.Route `httprequest:"GET /v2/template/:User/:Name/models"`
+	EntityPath
+}
+
+// TemplateModelsResponse holds the paths of models that are using
+// a template.
+type TemplateModelsResponse struct {
+	ModelPaths []EntityPath
+	// Total holds the total number of models using the template.
+	// This can be greater than len(Models) when some of those
+	// models are not readable by the user.
+	Total int
+}
+
 // DeleteTemplate holds parameters for deletion of a template.
 type DeleteTemplate struct {
 	httprequest.Route `httprequest:"DELETE /v2/template/:User/:Name"`
@@ -433,6 +450,9 @@ type ModelResponse struct {
 	// noticed that the model's controller could not be
 	// contacted. It is empty when the model is available.
 	UnavailableSince *time.Time `json:"unavailable-since,omitempty"`
+
+	// Templates holds the paths of the templates that this model uses.
+	Templates []EntityPath
 }
 
 // AddTemplate holds parameters for adding or updating a template.


### PR DESCRIPTION
This allows clients to see all the models associated with a given set of templates
(a.k.a. credentials).

Fixes issue #122.
