### PR TITLE
internal/jujuapi: serve the websocket at /

### DIFF
--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -16,6 +16,7 @@ import (
 func NewAPIHandler(jp *jem.Pool, _ jemserver.Params) ([]httprequest.Handler, error) {
 	return []httprequest.Handler{
 		newWebSocketHandler(jp),
+		newRootWebSocketHandler(jp),
 	}, nil
 }
 
@@ -27,6 +28,19 @@ func newWebSocketHandler(jp *jem.Pool) httprequest.Handler {
 			j := jp.JEM()
 			defer j.Close()
 			wsServer := newWSServer(j, p.ByName("modeluuid"))
+			wsServer.ServeHTTP(w, r)
+		},
+	}
+}
+
+func newRootWebSocketHandler(jp *jem.Pool) httprequest.Handler {
+	return httprequest.Handler{
+		Method: "GET",
+		Path:   "/",
+		Handle: func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+			j := jp.JEM()
+			defer j.Close()
+			wsServer := newWSServer(j, "")
 			wsServer.ServeHTTP(w, r)
 		},
 	}

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -351,6 +351,18 @@ func (s *websocketSuite) TestUpdateCloudCredentialsErrors(c *gc.C) {
 	c.Assert(resp.Results, gc.HasLen, 4)
 }
 
+func (s *websocketSuite) TestLoginToRoot(c *gc.C) {
+	conn := s.open(c, &api.Info{
+		SkipLogin: true,
+	}, "test")
+	defer conn.Close()
+	err := conn.Login(nil, "", "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	var resp jujuparams.RedirectInfoResult
+	err = conn.APICall("Admin", 3, "", "RedirectInfo", nil, &resp)
+	c.Assert(err, gc.ErrorMatches, "not redirected")
+}
+
 func (s *websocketSuite) open(c *gc.C, info *api.Info, username string) api.Connection {
 	inf := *info
 	u, err := url.Parse(s.wsServer.URL)


### PR DESCRIPTION
Serve the websocket API at / as well as /model/:uuid/api. This is where juju-client uses it when it is talking directly to the controller.
