### PR TITLE
internal/jujuapi: fix login on verification error

### DIFF
--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -265,7 +265,7 @@ func (a admin) Login(req jujuparams.LoginRequest) (jujuparams.LoginResultV1, err
 	// JAAS only supports macaroon login, ignore all the other fields.
 	attr, err := a.h.jem.Bakery.CheckAny(req.Macaroons, nil, checkers.TimeBefore)
 	if err != nil {
-		if verr, ok := err.(*bakery.VerificationError); ok {
+		if verr, ok := errgo.Cause(err).(*bakery.VerificationError); ok {
 			m, err := a.h.jem.NewMacaroon()
 			if err != nil {
 				return jujuparams.LoginResultV1{}, errgo.Notef(err, "cannot create macaroon")

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -23,6 +23,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/names.v2"
+	"gopkg.in/macaroon.v1"
 
 	"github.com/CanonicalLtd/jem/internal/apitest"
 	"github.com/CanonicalLtd/jem/internal/jujuapi"
@@ -118,6 +119,16 @@ func (s *websocketSuite) TestLoginToController(c *gc.C) {
 	var resp jujuparams.RedirectInfoResult
 	err = conn.APICall("Admin", 3, "", "RedirectInfo", nil, &resp)
 	c.Assert(err, gc.ErrorMatches, "not redirected")
+}
+
+func (s *websocketSuite) TestLoginToControllerWithInvalidMacaroon(c *gc.C) {
+	s.AssertAddController(c, params.EntityPath{User: "test", Name: "controller-1"}, true)
+	invalidMacaroon, err := macaroon.New(nil, "", "")
+	c.Assert(err, gc.IsNil)
+	conn := s.open(c, &api.Info{
+		Macaroons: []macaroon.Slice{{invalidMacaroon}},
+	}, "test")
+	conn.Close()
 }
 
 func (s *websocketSuite) TestUnimplementedMethodFails(c *gc.C) {


### PR DESCRIPTION
The error cause from CheckAny is sometimes wrapped.

To QA, do something with a JEM controller (thus obtaining a macaroon),
then either wait 24 hours for the macaroon to expire or edit the macaroon
in $HOME/.go-cookies so that it's invalid, then check that you
can still list-models.
