### PR TITLE
do not automatically add a controller model for the controller

### DIFF
--- a/cmd/jaas-model/modelcmd/grant_test.go
+++ b/cmd/jaas-model/modelcmd/grant_test.go
@@ -24,6 +24,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/foo", "bob/foo", "cred")
 
 	// Check that alice can't get controller or model.
 	aliceClient := s.jemClient("alice")

--- a/cmd/jaas-model/modelcmd/list_test.go
+++ b/cmd/jaas-model/modelcmd/list_test.go
@@ -21,6 +21,7 @@ func (s *listSuite) TestList(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
+	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
 	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
 	s.addEnv(c, "bob/foo-2", "bob/foo", "cred1")
 

--- a/cmd/jaas-model/modelcmd/remove_test.go
+++ b/cmd/jaas-model/modelcmd/remove_test.go
@@ -20,6 +20,7 @@ func (s *removeSuite) TestRemoveModel(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
 
 	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
 
@@ -42,12 +43,14 @@ func (s *removeSuite) TestRemoveController(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
 
 	// Add a second controller, that won't be deleted.
 	stdout, stderr, code = run(c, c.MkDir(), "add-controller", "bob/bar")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/bar", "bob/bar", "cred1")
 
 	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
 
@@ -89,12 +92,12 @@ func (s *removeSuite) TestRemoveMultipleModels(c *gc.C) {
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "bob/foo", "bob/foo-1")
 	c.Assert(code, gc.Equals, 1, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
-	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: DELETE http://.*/v2/model/bob/foo: cannot remove model "bob/foo" because it is a controller`+"\n")
+	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: DELETE http://.*/v2/model/bob/foo: model "bob/foo" not found`+"\n")
 
 	stdout, stderr, code = run(c, c.MkDir(), "list")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stderr, gc.Equals, "")
-	c.Assert(stdout, gc.Equals, "bob/foo\n")
+	c.Assert(stdout, gc.Equals, "")
 }
 
 func (s *removeSuite) TestRemoveVerbose(c *gc.C) {
@@ -105,6 +108,7 @@ func (s *removeSuite) TestRemoveVerbose(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
 
 	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
 

--- a/cmd/jaas-model/modelcmd/revoke_test.go
+++ b/cmd/jaas-model/modelcmd/revoke_test.go
@@ -24,6 +24,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
+	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
 
 	// Check that alice can't get controller or model.
 	aliceClient := s.jemClient("alice")

--- a/internal/jem/auth_test.go
+++ b/internal/jem/auth_test.go
@@ -472,9 +472,8 @@ func (s *authSuite) TestDoControllers(c *gc.C) {
 		Public: true,
 	}}
 	for i := range testControllers {
-		err := s.jem.AddController(&testControllers[i], &mongodoc.Model{
-			Path: testControllers[i].Path,
-		})
+		err := s.jem.AddController(&testControllers[i])
+
 		c.Assert(err, gc.IsNil)
 	}
 	req := s.newRequestForUser(c, "GET", "/", "bob", "bob-group")
@@ -585,9 +584,8 @@ func (s *authSuite) TestDoControllersErrorResponse(c *gc.C) {
 		Public: true,
 	}}
 	for i := range testControllers {
-		err := s.jem.AddController(&testControllers[i], &mongodoc.Model{
-			Path: testControllers[i].Path,
-		})
+		err := s.jem.AddController(&testControllers[i])
+
 		c.Assert(err, gc.IsNil)
 	}
 	req := s.newRequestForUser(c, "GET", "/", "bob", "bob-group")
@@ -752,9 +750,8 @@ func (s *authSuite) TestSelectController(c *gc.C) {
 		Public: true,
 	}}
 	for i := range testControllers {
-		err := s.jem.AddController(&testControllers[i], &mongodoc.Model{
-			Path: testControllers[i].Path,
-		})
+		err := s.jem.AddController(&testControllers[i])
+
 		c.Assert(err, gc.IsNil)
 	}
 	req := s.newRequestForUser(c, "GET", "/", "bob", "bob-group")

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -64,16 +64,13 @@ func (s *jemAPIConnSuite) TestPoolOpenAPI(c *gc.C) {
 		AdminUser:     info.Tag.Id(),
 		AdminPassword: info.Password,
 	}
-	m := &mongodoc.Model{
-		UUID: info.ModelTag.Id(),
-	}
 
 	// Sanity check that we're really talking to the controller.
 	minfo, err := s.APIState.Client().ModelInfo()
 	c.Assert(err, gc.IsNil)
 	c.Assert(minfo.UUID, gc.Equals, s.ControllerConfig.ControllerUUID())
 
-	err = s.store.AddController(ctl, m)
+	err = s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
 
 	// Open the API and check that it works.
@@ -95,7 +92,7 @@ func (s *jemAPIConnSuite) TestPoolOpenAPI(c *gc.C) {
 
 	// Open it with OpenAPIFromDocs and check
 	// that we still get the same connection.
-	conn1, err = s.store.OpenAPIFromDocs(m, ctl)
+	conn1, err = s.store.OpenAPIFromDoc(ctl)
 	c.Assert(err, gc.IsNil)
 	c.Assert(conn1.Connection, gc.Equals, conn.Connection)
 	err = conn1.Close()
@@ -123,21 +120,7 @@ func (s *jemAPIConnSuite) TestPoolOpenAPI(c *gc.C) {
 func (s *jemAPIConnSuite) TestPoolOpenAPIError(c *gc.C) {
 
 	conn, err := s.store.OpenAPI(params.EntityPath{"bob", "notthere"})
-	c.Assert(err, gc.ErrorMatches, `cannot get model: model "bob/notthere" not found`)
-	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
-	c.Assert(conn, gc.IsNil)
-
-	// Insert an model with a deliberately missing controller.
-	m := &mongodoc.Model{
-		Path:       params.EntityPath{"bob", "model"},
-		UUID:       "modeluuid",
-		Controller: params.EntityPath{"no", "controller"},
-	}
-	err = s.store.AddModel(m)
-	c.Assert(err, gc.IsNil)
-
-	conn, err = s.store.OpenAPI(params.EntityPath{"bob", "model"})
-	c.Assert(err, gc.ErrorMatches, `cannot get controller for model "modeluuid": controller "no/controller" not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot get controller: controller "bob/notthere" not found`)
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 	c.Assert(conn, gc.IsNil)
 }

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -86,11 +86,7 @@ func (s *jemSuite) TestAddController(c *gc.C) {
 			}},
 		},
 	}
-	m := &mongodoc.Model{
-		Id:   "ignored",
-		Path: params.EntityPath{"ignored-user", "ignored-name"},
-	}
-	err := s.store.AddController(ctl, m)
+	err := s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
 
 	// Check that the fields have been mutated as expected.
@@ -107,11 +103,6 @@ func (s *jemSuite) TestAddController(c *gc.C) {
 				Name: "foo",
 			}},
 		},
-	})
-	c.Assert(m, jc.DeepEquals, &mongodoc.Model{
-		Id:         "bob/x",
-		Path:       ctlPath,
-		Controller: ctlPath,
 	})
 
 	ctl1, err := s.store.Controller(ctlPath)
@@ -130,11 +121,8 @@ func (s *jemSuite) TestAddController(c *gc.C) {
 			}},
 		},
 	})
-	m1, err := s.store.Model(ctlPath)
-	c.Assert(err, gc.IsNil)
-	c.Assert(m1, jc.DeepEquals, m)
 
-	err = s.store.AddController(ctl, m)
+	err = s.store.AddController(ctl)
 	c.Assert(err, gc.ErrorMatches, "already exists")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrAlreadyExists)
 
@@ -153,15 +141,8 @@ func (s *jemSuite) TestAddController(c *gc.C) {
 			}},
 		},
 	}
-	m2 := &mongodoc.Model{
-		Id:   "bob/noty",
-		Path: params.EntityPath{"ignored-user", "ignored-name"},
-	}
-	err = s.store.AddController(ctl2, m2)
+	err = s.store.AddController(ctl2)
 	c.Assert(err, gc.IsNil)
-	m3, err := s.store.Model(ctlPath2)
-	c.Assert(err, gc.IsNil)
-	c.Assert(m3, jc.DeepEquals, m2)
 }
 
 func (s *jemSuite) TestSetControllerAvailability(c *gc.C) {
@@ -169,7 +150,7 @@ func (s *jemSuite) TestSetControllerAvailability(c *gc.C) {
 	ctl := &mongodoc.Controller{
 		Path: ctlPath,
 	}
-	err := s.store.AddController(ctl, &mongodoc.Model{})
+	err := s.store.AddController(ctl)
 
 	// Check that we can mark it as unavailable.
 	t0 := time.Now()
@@ -260,7 +241,7 @@ func (s *jemSuite) TestControllerLocationQuery(c *gc.C) {
 		UnavailableSince: ut,
 		Public:           true,
 	}} {
-		err := s.store.AddController(ctl, &mongodoc.Model{})
+		err := s.store.AddController(ctl)
 		c.Assert(err, gc.IsNil)
 	}
 
@@ -325,11 +306,7 @@ func (s *jemSuite) TestDeleteController(c *gc.C) {
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	}
-	m := &mongodoc.Model{
-		Id:   "dalek/who",
-		Path: params.EntityPath{"ignored", "ignored"},
-	}
-	err := s.store.AddController(ctl, m)
+	err := s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
 	err = s.store.DeleteController(ctlPath)
 	c.Assert(err, gc.IsNil)
@@ -352,11 +329,7 @@ func (s *jemSuite) TestDeleteController(c *gc.C) {
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	}
-	m2 := &mongodoc.Model{
-		Id:   "dalek/exterminated",
-		Path: params.EntityPath{"ignored", "ignored"},
-	}
-	err = s.store.AddController(ctl2, m2)
+	err = s.store.AddController(ctl2)
 	c.Assert(err, gc.IsNil)
 
 	err = s.store.DeleteController(ctlPath)
@@ -377,16 +350,8 @@ func (s *jemSuite) TestDeleteModel(c *gc.C) {
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
 	}
-	m := &mongodoc.Model{
-		Id:   "dalek/who",
-		Path: params.EntityPath{"ignored", "ignored"},
-	}
-	err := s.store.AddController(ctl, m)
+	err := s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
-
-	err = s.store.DeleteModel(m.Path)
-	c.Assert(err, gc.ErrorMatches, `cannot remove model "dalek/who" because it is a controller`)
-	c.Assert(errgo.Cause(err), gc.Equals, params.ErrForbidden)
 
 	modelPath := params.EntityPath{"dalek", "exterminate"}
 	m2 := &mongodoc.Model{
@@ -514,10 +479,8 @@ func (s *jemSuite) TestEnsureUserSuccess(c *gc.C) {
 		HostPorts:     []string{"host1:1234", "host2:9999"},
 		AdminUser:     "foo-admin",
 		AdminPassword: "foo-password",
-	}, &mongodoc.Model{
-		Id:   "ignored",
-		Path: params.EntityPath{"ignored-user", "ignored-name"},
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// Calling EnsureUser should populate the initial user entry.
@@ -735,7 +698,8 @@ func (s *jemSuite) TestAcquireLease(c *gc.C) {
 			UUID:               "fake-uuid",
 			MonitorLeaseOwner:  test.actualOldOwner,
 			MonitorLeaseExpiry: test.actualOldExpiry,
-		}, &mongodoc.Model{})
+		})
+
 		c.Assert(err, gc.IsNil)
 		t, err := s.store.AcquireMonitorLease(test.ctlPath, test.oldExpiry, test.oldOwner, test.newExpiry, test.newOwner)
 		if test.expectError != "" {
@@ -766,7 +730,8 @@ func (s *jemSuite) TestSetControllerStats(c *gc.C) {
 	err := s.store.AddController(&mongodoc.Controller{
 		Path: ctlPath,
 		UUID: "fake-uuid",
-	}, &mongodoc.Model{})
+	})
+
 	c.Assert(err, gc.IsNil)
 
 	stats := &mongodoc.ControllerStats{
@@ -792,8 +757,14 @@ func (s *jemSuite) TestSetModelLifeSuccess(c *gc.C) {
 	err := s.store.AddController(&mongodoc.Controller{
 		Path: ctlPath,
 		UUID: "fake-uuid",
-	}, &mongodoc.Model{
-		UUID: "fake-uuid",
+	})
+	c.Assert(err, gc.IsNil)
+
+	// Add a model to the controller.
+	err = s.store.AddModel(&mongodoc.Model{
+		Path:       params.EntityPath{"bob", "foo"},
+		UUID:       "fake-uuid",
+		Controller: params.EntityPath{"bob", "foo"},
 	})
 	c.Assert(err, gc.IsNil)
 
@@ -911,7 +882,7 @@ func (s *jemSuite) TestCredentialAddController(c *gc.C) {
 	ctl := &mongodoc.Controller{
 		Path: ctlPath,
 	}
-	err = s.store.AddController(ctl, &mongodoc.Model{})
+	err = s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
 
 	err = jem.CredentialAddController(s.store, user, cloud, name, ctlPath)
@@ -972,7 +943,7 @@ func (s *jemSuite) TestCredentialRemoveController(c *gc.C) {
 	ctl := &mongodoc.Controller{
 		Path: ctlPath,
 	}
-	err = s.store.AddController(ctl, &mongodoc.Model{})
+	err = s.store.AddController(ctl)
 	c.Assert(err, gc.IsNil)
 
 	err = jem.CredentialAddController(s.store, user, cloud, name, ctlPath)
@@ -1033,9 +1004,8 @@ func (s *jemSuite) TestSetACL(c *gc.C) {
 	err := s.store.AddController(&mongodoc.Controller{
 		Path: ctlPath,
 		UUID: "fake-uuid",
-	}, &mongodoc.Model{
-		UUID: "fake-uuid",
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	err = s.store.SetACL(s.store.DB.Controllers(), ctlPath, params.ACL{
@@ -1061,9 +1031,8 @@ func (s *jemSuite) TestGrant(c *gc.C) {
 	err := s.store.AddController(&mongodoc.Controller{
 		Path: ctlPath,
 		UUID: "fake-uuid",
-	}, &mongodoc.Model{
-		UUID: "fake-uuid",
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	err = s.store.Grant(s.store.DB.Controllers(), ctlPath, "t1")
@@ -1085,9 +1054,8 @@ func (s *jemSuite) TestRevoke(c *gc.C) {
 	err := s.store.AddController(&mongodoc.Controller{
 		Path: ctlPath,
 		UUID: "fake-uuid",
-	}, &mongodoc.Model{
-		UUID: "fake-uuid",
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	err = s.store.SetACL(s.store.DB.Controllers(), ctlPath, params.ACL{
@@ -1117,9 +1085,8 @@ func (s *jemSuite) TestCloud(c *gc.C) {
 			Name:         "my-cloud",
 			ProviderType: "ec2",
 		},
-	}, &mongodoc.Model{
-		UUID: "fake-uuid",
 	})
+
 	c.Assert(err, gc.IsNil)
 	cld, err := s.store.Cloud("my-cloud")
 	c.Assert(err, gc.IsNil)

--- a/internal/jem/juju_test.go
+++ b/internal/jem/juju_test.go
@@ -124,10 +124,17 @@ func (s *jujuSuite) TestCreateModel(c *gc.C) {
 		Name:  "cred1",
 		Type:  "empty",
 	})
-	c.Assert(err, jc.ErrorIsNil)
 	conn, err := s.store.OpenAPI(ctlId)
 	c.Assert(err, jc.ErrorIsNil)
 	defer conn.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	_, _, err = s.store.CreateModel(conn, jem.CreateModelParams{
+		Path:           params.EntityPath{"bob", "controller"},
+		ControllerPath: params.EntityPath{"bob", "controller"},
+		Credential:     "cred1",
+		Cloud:          "dummy",
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	for i, test := range createModelTests {
 		c.Logf("test %d. %s", i, test.about)
 		if test.params.Path.Name == "" {
@@ -337,15 +344,12 @@ func (s *jujuSuite) addController(c *gc.C, path params.EntityPath) params.Entity
 		AdminUser:     info.Tag.Id(),
 		AdminPassword: info.Password,
 	}
-	m := &mongodoc.Model{
-		UUID: info.ModelTag.Id(),
-	}
 	// Sanity check that we're really talking to the controller.
 	minfo, err := s.APIState.Client().ModelInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(minfo.UUID, gc.Equals, s.ControllerConfig.ControllerUUID())
 
-	err = s.store.AddController(ctl, m)
+	err = s.store.AddController(ctl)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/internal/jemserver/server_test.go
+++ b/internal/jemserver/server_test.go
@@ -188,7 +188,7 @@ func (s *serverSuite) TestServerRunsMonitor(c *gc.C) {
 		CACert:    jujutesting.CACert,
 		AdminUser: "bob",
 		HostPorts: []string{"0.1.2.3:4567"},
-	}, &mongodoc.Model{})
+	})
 	c.Assert(err, gc.IsNil)
 
 	params := jemserver.Params{

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -34,9 +34,8 @@ func (s *monitorSuite) TestMonitor(c *gc.C) {
 		CACert:        info.CACert,
 		AdminUser:     info.Tag.Id(),
 		AdminPassword: info.Password,
-	}, &mongodoc.Model{
-		UUID: info.ModelTag.Id(),
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// Start a monitor.
@@ -81,9 +80,8 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 		CACert:        apiInfo.CACert,
 		AdminUser:     apiInfo.Tag.Id(),
 		AdminPassword: apiInfo.Password,
-	}, &mongodoc.Model{
-		UUID: apiInfo.ModelTag.Id(),
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// Start a monitor.
@@ -130,9 +128,8 @@ func (s *monitorSuite) TestMonitorWithBrokenJujuAPIConnection(c *gc.C) {
 		CACert:        apiInfo.CACert,
 		AdminUser:     apiInfo.Tag.Id(),
 		AdminPassword: apiInfo.Password,
-	}, &mongodoc.Model{
-		UUID: apiInfo.ModelTag.Id(),
 	})
+
 	c.Assert(err, gc.IsNil)
 
 	// Start a monitor.

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -111,15 +111,12 @@ func (h *Handler) AddController(arg *params.AddController) error {
 		UUID:          arg.Info.ControllerUUID,
 		Public:        arg.Info.Public,
 	}
-	m := &mongodoc.Model{
-		UUID: arg.Info.ControllerUUID,
-	}
 	logger.Infof("dialling model")
-	// Attempt to connect to the model before accepting it.
-	conn, err := h.jem.OpenAPIFromDocs(m, ctl)
+	// Attempt to connect to the controller before accepting it.
+	conn, err := h.jem.OpenAPIFromDoc(ctl)
 	if err != nil {
 		logger.Infof("cannot open API: %v", err)
-		return badRequestf(err, "cannot connect to model")
+		return badRequestf(err, "cannot connect to controller")
 	}
 	defer conn.Close()
 
@@ -134,7 +131,6 @@ func (h *Handler) AddController(arg *params.AddController) error {
 		return errgo.Notef(err, "cannot get model information")
 	}
 	info := res[0].Result
-	m.UUID = info.ControllerUUID
 	ctl.UUID = info.ControllerUUID
 
 	// Find out the cloud information.
@@ -173,7 +169,7 @@ func (h *Handler) AddController(arg *params.AddController) error {
 	// connecting to.
 	ctl.HostPorts = collapseHostPorts(conn.APIHostPorts())
 
-	err = h.jem.AddController(ctl, m)
+	err = h.jem.AddController(ctl)
 	if err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrAlreadyExists))
 	}


### PR DESCRIPTION
We no longer need a model to exist in the database to match the controller, so don't use them anymore. The recent change to juju that makes the controller UUID different from it's controller model has made the usefulness of any link obsolete.
