### PR TITLE
internal/jem: new scheme for session sharing

### DIFF
--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -93,9 +93,8 @@ func serve(confPath string) error {
 	}
 	cfg := jem.ServerParams{
 		DB: db,
-		// TODO(mhilton): make these configurable.
-		MaxDBClones:          1000,
-		MaxDBAge:             time.Minute,
+		// TODO(mhilton): make this configurable.
+		MaxMgoSessions:       100,
 		ControllerAdmin:      conf.ControllerAdmin,
 		IdentityLocation:     conf.IdentityLocation,
 		PublicKeyLocator:     locator,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -80,7 +80,6 @@ type Pool struct {
 // NewPool creates a new Pool from which Authenticator objects may be
 // retrieved.
 func NewPool(p Params) *Pool {
-	servermon.DatabaseConnections.Inc()
 	servermon.DatabaseSessions.Inc()
 	pool := &Pool{
 		params: p,
@@ -143,7 +142,7 @@ func (p *Pool) Close() {
 	p.collection = nil
 }
 
-// An Authentciator can be used to authenticate a connection.
+// An Authenticator can be used to authenticate a connection.
 type Authenticator struct {
 	params     Params
 	bakery     *bakery.Service
@@ -243,7 +242,6 @@ type collection struct {
 // Copy creates a new collection with a copied underlaying database
 // connection.
 func (c *collection) Copy() *collection {
-	servermon.DatabaseConnections.Inc()
 	servermon.DatabaseSessions.Inc()
 	return &collection{
 		Collection: c.Collection.With(c.Collection.Database.Session.Copy()),
@@ -261,7 +259,6 @@ func (c *collection) Close() {
 		c.Collection.Database.Session.Close()
 		c.Collection = nil
 		servermon.DatabaseSessions.Dec()
-		servermon.DatabaseConnections.Dec()
 	}
 }
 

--- a/internal/jem/export_test.go
+++ b/internal/jem/export_test.go
@@ -1,19 +1,23 @@
 package jem
 
-import "unsafe"
-
 var (
-	ControllerLocationQuery    = (Database).controllerLocationQuery
+	ControllerLocationQuery    = (*Database).controllerLocationQuery
 	RandIntn                   = &randIntn
-	CredentialAddController    = (Database).credentialAddController
-	CredentialRemoveController = (Database).credentialRemoveController
-	UpdateCredential           = (Database).updateCredential
+	CredentialAddController    = (*Database).credentialAddController
+	CredentialRemoveController = (*Database).credentialRemoveController
+	UpdateCredential           = (*Database).updateCredential
 	UpdateControllerCredential = (*JEM).updateControllerCredential
-	SetCredentialUpdates       = (Database).setCredentialUpdates
+	SetCredentialUpdates       = (*Database).setCredentialUpdates
+	ClearCredentialUpdate      = (*Database).clearCredentialUpdate
 	NewDatabase                = newDatabase
 	WallClock                  = &wallClock
+	DatabaseDecRef             = (*Database).decRef
 )
 
-func RefCount(db Database) uintptr {
-	return uintptr(unsafe.Pointer(db.cnt))
+func DatabaseSessionIsDead(db *Database) bool {
+	return db.status.isDead()
+}
+
+func DatabaseSetAlive(db *Database) {
+	db.status = 0
 }

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -28,8 +28,6 @@ func (s *jemAPIConnSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	pool, err := jem.NewPool(jem.Params{
 		DB:              s.Session.DB("jem"),
-		MaxDBClones:     1000,
-		MaxDBAge:        time.Minute,
 		ControllerAdmin: "controller-admin",
 	})
 	c.Assert(err, gc.IsNil)

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -41,14 +41,10 @@ type Params struct {
 	// store the JEM information.
 	DB *mgo.Database
 
-	// MaxDBClones holds the maximum number of clones of a Database
-	// copy that the server will make before creating a new Database
-	// copy.
-	MaxDBClones int
-
-	// MaxDBAge holds the maximum age of a Database copy that the server
-	// will keep cloning before creating a new Database copy.
-	MaxDBAge time.Duration
+	// MaxMgoSessions holds the maximum number of sessions
+	// that will be held in the pool. The actual number of sessions
+	// may temporarily go above this.
+	MaxMgoSessions int
 
 	// ControllerAdmin holds the identity of the user
 	// or group that is allowed to create controllers.
@@ -117,8 +113,7 @@ func New(config Params, versions map[string]NewAPIHandlerFunc) (*Server, error) 
 	}
 	jconfig := jem.Params{
 		DB:              config.DB,
-		MaxDBClones:     config.MaxDBClones,
-		MaxDBAge:        config.MaxDBAge,
+		MaxMgoSessions:  config.MaxMgoSessions,
 		ControllerAdmin: config.ControllerAdmin,
 	}
 	p, err := jem.NewPool(jconfig)
@@ -134,8 +129,8 @@ func New(config Params, versions map[string]NewAPIHandlerFunc) (*Server, error) 
 			ExpiryDuration: 24 * time.Hour,
 		},
 		MacaroonCollection:  jem.DB.Macaroons(),
-		MaxCollectionClones: config.MaxDBClones,
-		MaxCollectionAge:    config.MaxDBAge,
+		MaxCollectionClones: 100,             // TODO remove me!
+		MaxCollectionAge:    5 * time.Minute, // TODO remove me!
 		PermChecker:         idmclient.NewPermChecker(idmClient, time.Hour),
 		IdentityLocation:    config.IdentityLocation,
 	})

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -475,7 +475,7 @@ func (c cloud) userCredentials(ownerTag, cloudTag string) ([]string, error) {
 
 	}
 	var cloudCreds []string
-	it := jem.NewCanReadIter(c.h.context, c.h.jem.DB.Credentials().Find(
+	it := c.h.jem.DB.NewCanReadIter(c.h.context, c.h.jem.DB.Credentials().Find(
 		bson.D{{
 			"path.entitypath.user", owner.Name(),
 		}, {
@@ -709,7 +709,7 @@ func (m modelManager) ListModels(_ jujuparams.Entity) (jujuparams.UserModelList,
 func allModels(h *wsHandler) (jujuparams.UserModelList, error) {
 	var models []jujuparams.UserModel
 
-	it := jem.NewCanReadIter(h.context, h.jem.DB.Models().Find(nil).Sort("_id").Iter())
+	it := h.jem.DB.NewCanReadIter(h.context, h.jem.DB.Models().Find(nil).Sort("_id").Iter())
 
 	var model mongodoc.Model
 	for it.Next(&model) {

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -28,7 +28,6 @@ import (
 	"gopkg.in/macaroon.v1"
 
 	"github.com/CanonicalLtd/jem/internal/apitest"
-	"github.com/CanonicalLtd/jem/internal/jem"
 	"github.com/CanonicalLtd/jem/internal/jujuapi"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
@@ -488,7 +487,7 @@ func (s *websocketSuite) TestListModels(c *gc.C) {
 	ctlPath := s.AssertAddController(c, params.EntityPath{User: "test", Name: "controller-1"}, true)
 	cred := s.AssertUpdateCredential(c, "test", "dummy", "cred1", "empty")
 	cred2 := s.AssertUpdateCredential(c, "test2", "dummy", "cred1", "empty")
-	err := jem.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
+	err := s.JEM.DB.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
 		Read: []string{"test2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -497,7 +496,7 @@ func (s *websocketSuite) TestListModels(c *gc.C) {
 	s.assertCreateModel(c, "model-2", "test2", "", "", string(cred2), nil)
 	mi = s.assertCreateModel(c, "model-3", "test2", "", "", string(cred2), nil)
 	modelUUID3 := mi.UUID
-	err = jem.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
+	err = s.JEM.DB.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
 		Read: []string{"test"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -525,7 +524,7 @@ func (s *websocketSuite) TestModelInfo(c *gc.C) {
 	ctlPath := s.AssertAddController(c, params.EntityPath{User: "test", Name: "controller-1"}, true)
 	s.AssertUpdateCredential(c, "test", "dummy", "cred1", "empty")
 	s.AssertUpdateCredential(c, "test2", "dummy", "cred1", "empty")
-	err := jem.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
+	err := s.JEM.DB.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
 		Read: []string{"test2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -541,7 +540,7 @@ func (s *websocketSuite) TestModelInfo(c *gc.C) {
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 
-	err = jem.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
+	err = s.JEM.DB.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
 		Read: []string{"test"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -612,7 +611,7 @@ func (s *websocketSuite) TestAllModels(c *gc.C) {
 	ctlPath := s.AssertAddController(c, params.EntityPath{User: "test", Name: "controller-1"}, true)
 	s.AssertUpdateCredential(c, "test", "dummy", "cred1", "empty")
 	s.AssertUpdateCredential(c, "test2", "dummy", "cred1", "empty")
-	err := jem.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
+	err := s.JEM.DB.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
 		Read: []string{"test2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -627,7 +626,7 @@ func (s *websocketSuite) TestAllModels(c *gc.C) {
 	defer conn.Close()
 	client := controller.NewClient(conn)
 
-	err = jem.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
+	err = s.JEM.DB.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
 		Read: []string{"test"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -656,7 +655,7 @@ func (s *websocketSuite) TestModelStatus(c *gc.C) {
 	ctlPath := s.AssertAddController(c, params.EntityPath{User: "test", Name: "controller-1"}, true)
 	s.AssertUpdateCredential(c, "test", "dummy", "cred1", "empty")
 	s.AssertUpdateCredential(c, "test2", "dummy", "cred1", "empty")
-	err := jem.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
+	err := s.JEM.DB.SetACL(s.JEM.DB.Controllers(), ctlPath, params.ACL{
 		Read: []string{"test2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -672,7 +671,7 @@ func (s *websocketSuite) TestModelStatus(c *gc.C) {
 	defer conn.Close()
 	client := controller.NewClient(conn)
 
-	err = jem.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
+	err = s.JEM.DB.SetACL(s.JEM.DB.Models(), params.EntityPath{User: "test2", Name: "model-3"}, params.ACL{
 		Read: []string{"test"},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -51,17 +51,17 @@ var (
 		Name:      "controllers_running",
 		Help:      "The current number of running controllers.",
 	})
-	DatabaseConnections = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "jem",
-		Subsystem: "database",
-		Name:      "database_connections",
-		Help:      "The number of database connections in use, these are shared between database sessions.",
-	})
 	DatabaseSessions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "jem",
 		Subsystem: "database",
 		Name:      "database_sessions",
-		Help:      "The number of database session objects, some of these will be sharing connections.",
+		Help:      "The number of database sessions.",
+	})
+	DatabaseFailCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "jem",
+		Subsystem: "database",
+		Name:      "fail_count",
+		Help:      "The number of times a database error was considered fatal.",
 	})
 	DeployedUnitCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "jem",
@@ -159,8 +159,8 @@ func init() {
 	prometheus.MustRegister(AuthenticatorPoolNew)
 	prometheus.MustRegister(AuthenticatorPoolPut)
 	prometheus.MustRegister(ControllersRunning)
-	prometheus.MustRegister(DatabaseConnections)
 	prometheus.MustRegister(DatabaseSessions)
+	prometheus.MustRegister(DatabaseFailCount)
 	prometheus.MustRegister(DeployedUnitCount)
 	prometheus.MustRegister(LoginFailCount)
 	prometheus.MustRegister(LoginRedirectCount)

--- a/server.go
+++ b/server.go
@@ -30,14 +30,10 @@ type ServerParams struct {
 	// store the JEM information.
 	DB *mgo.Database
 
-	// MaxDBClones holds the maximum number of clones of a Database
-	// copy that the server will make before creating a new Database
-	// copy.
-	MaxDBClones int
-
-	// MaxDBAge holds the maximum age of a Database copy that the server
-	// will keep cloning before creating a new Database copy.
-	MaxDBAge time.Duration
+	// MaxMgoSessions holds the maximum number of sessions
+	// that will be held in the pool. The actual number of sessions
+	// may temporarily go above this.
+	MaxMgoSessions int
 
 	// ControllerAdmin holds the identity of the user
 	// or group that is allowed to create controllers.


### PR DESCRIPTION
The current scheme has the issue that the code has no idea when
a session has become unusable, so a bad session will continue
to be used for some time after a mongo connection has been
severed.

This PR proposes a new scheme where we check the error after
any database operation; if there's an error that we don't recognise,
then it's probably because of a database error, so we avoid reusing
that session, making a new copy instead.

We maintain a number of current sessions that we use in round-robin
fashion so not all clients will be using the same session.

In a subsequent PR, we will change the internal/auth package to
use the same scheme, possibly factoring out some of the existing
logic into something more reusable.
