### PR TITLE
internal/v2: allow empty CA cert when adding a controller

### DIFF
--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -96,9 +96,6 @@ func (h *Handler) AddController(arg *params.AddController) error {
 	if len(arg.Info.HostPorts) == 0 {
 		return badRequestf(nil, "no host-ports in request")
 	}
-	if arg.Info.CACert == "" {
-		return badRequestf(nil, "no ca-cert in request")
-	}
 	if arg.Info.User == "" {
 		return badRequestf(nil, "no user in request")
 	}

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -197,19 +197,6 @@ func (s *APISuite) TestAddController(c *gc.C) {
 			Message: "no host-ports in request",
 		},
 	}, {
-		about: "no ca-cert",
-		body: params.ControllerInfo{
-			HostPorts:      info.Addrs,
-			User:           info.Tag.Id(),
-			Password:       info.Password,
-			ControllerUUID: info.ModelTag.Id(),
-		},
-		expectStatus: http.StatusBadRequest,
-		expectBody: params.Error{
-			Code:    "bad request",
-			Message: "no ca-cert in request",
-		},
-	}, {
 		about: "no user",
 		body: params.ControllerInfo{
 			HostPorts:      info.Addrs,


### PR DESCRIPTION
This allows us to add a controller with a connection that's officially signed.
