### PR TITLE
internal/jem: select controller by its actual location

### DIFF
--- a/cmd/jaas-admin/admincmd/common_test.go
+++ b/cmd/jaas-admin/admincmd/common_test.go
@@ -120,11 +120,12 @@ func (s *commonSuite) addEnv(c *gc.C, pathStr, srvPathStr, credName string) {
 	err = srvPath.UnmarshalText([]byte(srvPathStr))
 	c.Assert(err, gc.IsNil)
 
+	credPath := params.CredentialPath{
+		Cloud:      "dummy",
+		EntityPath: params.EntityPath{path.User, params.Name(credName)},
+	}
 	err = s.jemClient(string(path.User)).UpdateCredential(&params.UpdateCredential{
-		CredentialPath: params.CredentialPath{
-			Cloud:      "dummy",
-			EntityPath: params.EntityPath{path.User, params.Name(credName)},
-		},
+		CredentialPath: credPath,
 		Credential: params.Credential{
 			AuthType: "empty",
 		},
@@ -136,7 +137,7 @@ func (s *commonSuite) addEnv(c *gc.C, pathStr, srvPathStr, credName string) {
 		Info: params.NewModelInfo{
 			Name:       path.Name,
 			Controller: &srvPath,
-			Credential: params.Name(credName),
+			Credential: credPath,
 			Config:     dummyEnvConfig,
 		},
 	})

--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -208,7 +208,10 @@ func (s *Suite) CreateModel(c *gc.C, path, ctlPath params.EntityPath, cred param
 		Info: params.NewModelInfo{
 			Name:       path.Name,
 			Controller: &ctlPath,
-			Credential: cred,
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{path.User, cred},
+			},
 			Location: map[string]string{
 				"cloud": "dummy",
 			},

--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -204,7 +204,7 @@ func (db *Database) ModelFromUUID(uuid string) (_ *mongodoc.Model, err error) {
 func (db *Database) controllerLocationQuery(cloud params.Cloud, region string, includeUnavailable bool) *mgo.Query {
 	q := make(bson.D, 0, 4)
 	if cloud != "" {
-		q = append(q, bson.DocElem{"cloud.name", cloud})
+		q = append(q, bson.DocElem{"location.cloud", cloud})
 	}
 	if region != "" {
 		q = append(q, bson.DocElem{"cloud.regions", bson.D{{"$elemMatch", bson.D{{"name", region}}}}})

--- a/internal/jem/export_test.go
+++ b/internal/jem/export_test.go
@@ -2,14 +2,15 @@ package jem
 
 var (
 	RandIntn                   = &randIntn
+	WallClock                  = &wallClock
+	NewDatabase                = newDatabase
+	ClearCredentialUpdate      = (*Database).clearCredentialUpdate
 	CredentialAddController    = (*Database).credentialAddController
 	CredentialRemoveController = (*Database).credentialRemoveController
-	UpdateCredential           = (*Database).updateCredential
-	UpdateControllerCredential = (*JEM).updateControllerCredential
 	SetCredentialUpdates       = (*Database).setCredentialUpdates
-	ClearCredentialUpdate      = (*Database).clearCredentialUpdate
-	NewDatabase                = newDatabase
-	WallClock                  = &wallClock
+	UpdateCredential           = (*Database).updateCredential
+	SelectController           = (*JEM).selectController
+	UpdateControllerCredential = (*JEM).updateControllerCredential
 )
 
 func DatabaseClose(db *Database) {

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -736,7 +736,7 @@ var createModelTests = []struct {
 	region:      "no-such-region",
 	cloudTag:    names.NewCloudTag("dummy").String(),
 	credential:  "dummy_test@external_cred1",
-	expectError: `no matching controllers found \(not found\)`,
+	expectError: `cannot select controller: no matching controllers found \(not found\)`,
 }, {
 	about:       "local user",
 	name:        "model-4",

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -56,7 +56,10 @@ var unauthorizedTests = []struct {
 	body: params.NewModelInfo{
 		Name:       "newmodel",
 		Controller: &params.EntityPath{"bob", "open"},
-		Credential: "cred1",
+		Credential: params.CredentialPath{
+			Cloud:      "dummy",
+			EntityPath: params.EntityPath{"bob", "cred1"},
+		},
 	},
 }, {
 	about:  "new model with inaccessible controller",
@@ -66,7 +69,10 @@ var unauthorizedTests = []struct {
 	body: params.NewModelInfo{
 		Name:       "newmodel",
 		Controller: &params.EntityPath{"bob", "private"},
-		Credential: "cred1",
+		Credential: params.CredentialPath{
+			Cloud:      "dummy",
+			EntityPath: params.EntityPath{"bob", "cred1"},
+		},
 	},
 }, {
 	about:  "set controller perm as non-owner",
@@ -739,6 +745,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "us-east-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "aws-us-east2"},
@@ -749,6 +759,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "us-east-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "aws-eu-west"},
@@ -759,6 +773,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "eu-west-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "gce-somewhere"},
@@ -769,6 +787,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "somewhere",
+		},
 	})
 	ctlId := params.EntityPath{"bob", "gce-down"}
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
@@ -780,6 +802,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "down",
+		},
 	})
 	err := s.JEM.DB.SetControllerUnavailableAt(ctlId, time.Now())
 	c.Assert(err, gc.IsNil)
@@ -792,6 +818,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "elsewhere",
+		},
 	})
 	s.IDMSrv.AddUser("alice", "somegroup")
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
@@ -803,6 +833,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "america",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"alice", "controller"},
@@ -813,6 +847,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "azure",
+			"region": "america",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"alice", "forgotten"},
@@ -823,6 +861,10 @@ func (s *APISuite) TestGetControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: false,
+		Location: map[string]string{
+			"cloud":  "azure",
+			"region": "america",
+		},
 	})
 
 	for i, test := range getControllerLocationsTests {
@@ -921,6 +963,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "us-east-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "aws-us-east2"},
@@ -931,6 +977,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "us-east-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "aws-eu-west"},
@@ -941,6 +991,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "aws",
+			"region": "eu-west-1",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"bob", "gce-somewhere"},
@@ -951,6 +1005,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "somewhere",
+		},
 	})
 	ctlId := params.EntityPath{"bob", "gce-down"}
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
@@ -962,6 +1020,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "down",
+		},
 	})
 	err := s.JEM.DB.SetControllerUnavailableAt(ctlId, time.Now())
 	c.Assert(err, gc.IsNil)
@@ -974,6 +1036,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "gce",
+			"region": "elsewhere",
+		},
 	})
 	s.IDMSrv.AddUser("alice", "somegroup")
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
@@ -985,6 +1051,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud":  "azure",
+			"region": "america",
+		},
 	})
 	s.AssertAddControllerDoc(c, &mongodoc.Controller{
 		Path: params.EntityPath{"alice", "forgotten"},
@@ -995,6 +1065,10 @@ func (s *APISuite) TestAllControllerLocations(c *gc.C) {
 			}},
 		},
 		Public: false,
+		Location: map[string]string{
+			"cloud":  "azure",
+			"region": "america",
+		},
 	})
 
 	for i, test := range getAllControllerLocationsTests {
@@ -1054,6 +1128,9 @@ func (s *APISuite) TestGetSchemaAmbiguous(c *gc.C) {
 			ProviderType: "another",
 		},
 		Public: true,
+		Location: map[string]string{
+			"cloud": "dummy",
+		},
 	})
 
 	resp, err := s.NewClient("bob").GetSchema(&params.GetSchema{
@@ -1089,7 +1166,10 @@ func (s *APISuite) TestNewModel(c *gc.C) {
 		JSONBody: params.NewModelInfo{
 			Name:       params.Name("bar"),
 			Controller: &ctlId,
-			Credential: cred,
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{"bob", cred},
+			},
 			Location: map[string]string{
 				"cloud": "dummy",
 			},
@@ -1138,8 +1218,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "success",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "dummy",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"cloud": "dummy",
 		},
@@ -1151,8 +1234,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "no matching cloud",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "aws",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"cloud": "aws",
 		},
@@ -1166,8 +1252,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "no matching region",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "aws",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"region": "us-east-1",
 		},
@@ -1181,8 +1270,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "unrecognised location parameter",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "aws",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"dimension": "5th",
 		},
@@ -1196,8 +1288,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "invalid location parameter",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "aws",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"cloud.blah": "dummy",
 		},
@@ -1211,8 +1306,11 @@ var newModelWithoutExplicitControllerTests = []struct {
 	about: "invalid cloud name",
 	user:  "alice",
 	info: params.NewModelInfo{
-		Name:       "test-model",
-		Credential: "cred1",
+		Name: "test-model",
+		Credential: params.CredentialPath{
+			Cloud:      "aws",
+			EntityPath: params.EntityPath{"alice", "cred1"},
+		},
 		Location: map[string]string{
 			"cloud": "bad/name",
 		},
@@ -1220,7 +1318,7 @@ var newModelWithoutExplicitControllerTests = []struct {
 			"secret": "a secret",
 		},
 	},
-	expectError:      `cannot select controller: invalid cloud "bad/name"`,
+	expectError:      `invalid cloud "bad/name"`,
 	expectErrorCause: params.ErrBadRequest,
 }}
 
@@ -1327,7 +1425,10 @@ func (s *APISuite) TestNewModelUnderGroup(c *gc.C) {
 		JSONBody: params.NewModelInfo{
 			Name:       params.Name("bar"),
 			Controller: &ctlId,
-			Credential: cred,
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{"beatles", cred},
+			},
 			Location: map[string]string{
 				"cloud": "dummy",
 			},
@@ -1389,6 +1490,8 @@ func (s *APISuite) TestNewModelCannotOpenAPI(c *gc.C) {
 		Path:      params.EntityPath{"bob", "foo"},
 		AdminUser: "admin",
 	})
+	s.AssertUpdateCredential(c, "bob", "dummy", "cred1", "empty")
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Method:  "POST",
 		URL:     "/v2/model/bob",
@@ -1396,37 +1499,15 @@ func (s *APISuite) TestNewModelCannotOpenAPI(c *gc.C) {
 		JSONBody: params.NewModelInfo{
 			Name:       params.Name("bar"),
 			Controller: &params.EntityPath{"bob", "foo"},
-			Credential: "cred1",
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{"bob", "cred1"},
+			},
 		},
 		ExpectBody: params.Error{
 			Message: `cannot connect to controller: cannot connect to API: validating info for opening an API connection: missing addresses not valid`,
 		},
 		ExpectStatus: http.StatusInternalServerError,
-		Do:           apitest.Do(s.IDMSrv.Client("bob")),
-	})
-}
-
-func (s *APISuite) TestNewModelInvalidConfig(c *gc.C) {
-	ctlId := s.AssertAddController(c, params.EntityPath{"bob", "foo"}, false)
-	cred := s.AssertUpdateCredential(c, "bob", "dummy", "cred1", "empty")
-
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Method:  "POST",
-		URL:     "/v2/model/bob",
-		Handler: s.JEMSrv,
-		JSONBody: params.NewModelInfo{
-			Name:       params.Name("bar"),
-			Controller: &ctlId,
-			Credential: cred,
-			Config: map[string]interface{}{
-				"authorized-keys": 123,
-			},
-		},
-		ExpectBody: params.Error{
-			Message: `cannot validate attributes: authorized-keys: expected string, got float64(123)`,
-			Code:    params.ErrBadRequest,
-		},
-		ExpectStatus: http.StatusBadRequest,
 		Do:           apitest.Do(s.IDMSrv.Client("bob")),
 	})
 }
@@ -1438,8 +1519,11 @@ func (s *APISuite) TestNewModelTwice(c *gc.C) {
 	body := &params.NewModelInfo{
 		Name:       "bar",
 		Controller: &ctlId,
-		Credential: cred,
-		Config:     dummyModelConfig,
+		Credential: params.CredentialPath{
+			Cloud:      "dummy",
+			EntityPath: params.EntityPath{"bob", cred},
+		},
+		Config: dummyModelConfig,
 	}
 	p := httptesting.JSONCallParams{
 		Method:     "POST",
@@ -1477,7 +1561,10 @@ func (s *APISuite) TestNewModelCannotCreate(c *gc.C) {
 		JSONBody: params.NewModelInfo{
 			Name:       "bar",
 			Controller: &ctlId,
-			Credential: cred,
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{"bob", cred},
+			},
 			Config: map[string]interface{}{
 				"authorized-keys": sshKey,
 				"logging-config":  "bad>",
@@ -1515,8 +1602,11 @@ func (s *APISuite) TestNewModelUnauthorized(c *gc.C) {
 		JSONBody: params.NewModelInfo{
 			Name:       "bar",
 			Controller: &ctlId,
-			Credential: cred,
-			Config:     dummyModelConfig,
+			Credential: params.CredentialPath{
+				Cloud:      "dummy",
+				EntityPath: params.EntityPath{"bob", cred},
+			},
+			Config: dummyModelConfig,
 		},
 		ExpectBody: params.Error{
 			Message: `unauthorized`,

--- a/params/params.go
+++ b/params/params.go
@@ -357,7 +357,7 @@ type NewModelInfo struct {
 
 	// Credential holds the name of the provider credential that will
 	// be used to provision machines in the new model.
-	Credential Name `json:"credential"`
+	Credential CredentialPath `json:"credential"`
 
 	// Config holds the configuration attributes to use to create the new model.
 	Config map[string]interface{} `json:"config"`


### PR DESCRIPTION
Always deploy models in the same cloud and region as the controller.
