### PR TITLE
jaas-admin: allow an additional hostname when adding a controller

### DIFF
--- a/cmd/jaas-admin/admincmd/add-controller_test.go
+++ b/cmd/jaas-admin/admincmd/add-controller_test.go
@@ -28,6 +28,11 @@ var addControllerTests = []struct {
 	args:           []string{},
 	expectLocation: map[string]string{"cloud": "dummy", "region": "dummy-region"},
 	expectPublic:   true,
+}, {
+	about:          "with api endpoint",
+	args:           []string{"--public-hostname=localhost"},
+	expectLocation: map[string]string{"cloud": "dummy", "region": "dummy-region"},
+	expectPublic:   true,
 }}
 
 func (s *addControllerSuite) TestAddController(c *gc.C) {
@@ -43,7 +48,7 @@ func (s *addControllerSuite) TestAddController(c *gc.C) {
 			},
 		})
 		c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
-		test.args = append([]string{fmt.Sprintf("bob/foo-%v", i)}, test.args...)
+		test.args = append(test.args, fmt.Sprintf("bob/foo-%v", i))
 		stdout, stderr, code := run(c, c.MkDir(), "add-controller", test.args...)
 		c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 		c.Assert(stdout, gc.Equals, "")
@@ -70,7 +75,6 @@ func (s *addControllerSuite) TestAddController(c *gc.C) {
 			})
 		}
 	}
-
 }
 
 var addControllerErrorTests = []struct {

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -317,6 +317,18 @@ func (s *APISuite) TestAddController(c *gc.C) {
 			Public:         true,
 			Cloud:          "dummy",
 		},
+	}, {
+		about: "controller with additional host address",
+		body: params.ControllerInfo{
+			HostPorts:      append(info.Addrs, "example.com:443"),
+			CACert:         info.CACert,
+			User:           info.Tag.Id(),
+			Password:       info.Password,
+			ControllerUUID: info.ModelTag.Id(),
+			Cloud:          "dummy",
+			Region:         "dummy-region",
+			Public:         true,
+		},
 	}}
 	s.IDMSrv.AddUser("alice", "beatles", "controller-admin")
 	s.IDMSrv.AddUser("bob", "beatles")


### PR DESCRIPTION
This allows for DNS names to be used with JIMM controllers.
