### PR TITLE
internal/v2: change unknown scope to global in API addresses

### DIFF
--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -72,6 +72,13 @@ func (s *websocketSuite) TestLoginToModel(c *gc.C) {
 	defer conn.Close()
 	nhps, err := network.ParseHostPorts(s.APIInfo(c).Addrs...)
 	c.Assert(err, jc.ErrorIsNil)
+	// Change all unknown scopes to public.
+	for i := range nhps {
+		nhp := &nhps[i]
+		if nhp.Scope == network.ScopeUnknown {
+			nhp.Scope = network.ScopePublic
+		}
+	}
 	err = conn.Login(nil, "", "", nil)
 	c.Assert(errgo.Cause(err), jc.DeepEquals, &api.RedirectError{
 		Servers: [][]network.HostPort{nhps},

--- a/internal/v2/export_test.go
+++ b/internal/v2/export_test.go
@@ -2,4 +2,5 @@ package v2
 
 var (
 	SchemaForProviderType = &schemaForProviderType
+	MongodocAPIHostPorts  = mongodocAPIHostPorts
 )


### PR DESCRIPTION
This means that we should not return any scope-unknown API addresses from
the JIMM controller, so the GUI should see them OK.
