### PR TITLE
internal/monitor: maintain current unit count

### DIFF
--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -362,6 +362,21 @@ func (db *Database) SetModelLife(ctlPath params.EntityPath, uuid string, life st
 	return nil
 }
 
+// SetModelUnitCount sets the number of units running on all models controlled
+// by the given controller that have the given UUID.
+// It does not return an error if there are no such models.
+func (db *Database) SetModelUnitCount(ctlPath params.EntityPath, uuid string, n int) (err error) {
+	defer db.checkError(&err)
+	_, err = db.Models().UpdateAll(
+		bson.D{{"uuid", uuid}, {"controller", ctlPath}},
+		bson.D{{"$set", bson.D{{"unitcount", n}}}},
+	)
+	if err != nil {
+		return errgo.Notef(err, "cannot update model")
+	}
+	return nil
+}
+
 // updateCredential stores the given credential in the database. If a
 // credential with the same name exists it is overwritten.
 func (db *Database) updateCredential(cred *mongodoc.Credential) (err error) {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -198,6 +198,9 @@ type Model struct {
 	// or "dead").
 	Life string
 
+	// UnitCount holds the current number of units in the model.
+	UnitCount int
+
 	// TODO record last time we saw changes on the model?
 
 	// Templates holds the paths of the templates that the model was created with.

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -44,6 +44,11 @@ type jemInterface interface {
 	// It does not return an error if there are no such models.
 	SetModelLife(ctlPath params.EntityPath, uuid string, life string) error
 
+	// SetModelUnitCount sets the number of units running on all models controlled
+	// by the given controller that have the given UUID.
+	// It does not return an error if there are no such models.
+	SetModelUnitCount(ctlPath params.EntityPath, uuid string, n int) error
+
 	// AllControllers returns all the controllers in the system.
 	AllControllers() ([]*mongodoc.Controller, error)
 

--- a/internal/monitor/shim.go
+++ b/internal/monitor/shim.go
@@ -57,6 +57,10 @@ func (j jemShim) SetModelLife(ctlPath params.EntityPath, uuid string, life strin
 	return errgo.Mask(j.DB.SetModelLife(ctlPath, uuid, life), errgo.Any)
 }
 
+func (j jemShim) SetModelUnitCount(ctlPath params.EntityPath, uuid string, n int) (err error) {
+	return errgo.Mask(j.DB.SetModelUnitCount(ctlPath, uuid, n), errgo.Any)
+}
+
 func (j jemShim) AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error) {
 	t, err := j.DB.AcquireMonitorLease(ctlPath, oldExpiry, oldOwner, newExpiry, newOwner)
 	if err != nil {


### PR DESCRIPTION
This is just the first step - in the next step we'll change this to
maintain maximum unit count and perhaps unit hours, and record the user
that created the model, then comes the API.
