### PR TITLE
internal/jem: unique model uuids

### DIFF
--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -165,13 +165,6 @@ func (s *Suite) AddController(c *gc.C, path params.EntityPath, public bool) erro
 	if err := s.NewClient(path.User).AddController(p); err != nil {
 		return err
 	}
-	// Add a model as most tests often expect it to be there.
-	err := s.JEM.DB.AddModel(&mongodoc.Model{
-		Path:       path,
-		Controller: path,
-		UUID:       info.ModelTag.Id(),
-	})
-	c.Assert(err, jc.ErrorIsNil)
 	return nil
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -43,7 +43,7 @@ func (s *authSuite) SetUpTest(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.sessionPool = mgosession.NewPool(s.Session, 5)
-	s.pool = auth.NewPool(auth.Params{
+	s.pool, err = auth.NewPool(auth.Params{
 		Bakery:   bakery,
 		RootKeys: mgostorage.NewRootKeys(100),
 		RootKeysPolicy: mgostorage.Policy{
@@ -60,6 +60,7 @@ func (s *authSuite) SetUpTest(c *gc.C) {
 		),
 		IdentityLocation: s.idmSrv.URL.String(),
 	})
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *authSuite) TearDownTest(c *gc.C) {

--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -65,6 +65,26 @@ func (db *Database) clone() *Database {
 	}
 }
 
+func (db *Database) ensureIndexes() error {
+	indexes := []struct {
+		c *mgo.Collection
+		i mgo.Index
+	}{{
+		db.Controllers(),
+		mgo.Index{Key: []string{"uuid"}},
+	}, {
+		db.Models(),
+		mgo.Index{Key: []string{"uuid"}, Unique: true},
+	}}
+	for _, idx := range indexes {
+		err := idx.c.EnsureIndex(idx.i)
+		if err != nil {
+			return errgo.Notef(err, "cannot ensure index with keys %v on collection %s", idx.i, idx.c.Name)
+		}
+	}
+	return nil
+}
+
 // AddController adds a new controller to the database. It returns an
 // error with a params.ErrAlreadyExists cause if there is already a
 // controller with the given name. The Id field in ctl will be set from

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -95,6 +95,11 @@ func NewPool(p Params) (*Pool, error) {
 		connCache: apiconn.NewCache(apiconn.CacheParams{}),
 		refCount:  1,
 	}
+	jem := pool.JEM()
+	defer jem.Close()
+	if err := jem.DB.ensureIndexes(); err != nil {
+		return nil, errgo.Notef(err, "cannot ensure indexes")
+	}
 	return pool, nil
 }
 

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -1156,3 +1156,8 @@ func (s *jemSuite) bootstrapModel(c *gc.C, path params.EntityPath) *mongodoc.Mod
 	c.Assert(err, jc.ErrorIsNil)
 	return model
 }
+
+// fakeUUID returns something that looks like a UUID but actually uses n.
+func fakeUUID(n int) string {
+	return fmt.Sprintf("00000000-0000-0000-0000-00000000%.04x", n)
+}

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -124,7 +124,7 @@ func New(config Params, versions map[string]NewAPIHandlerFunc) (*Server, error) 
 	}
 	jem := p.JEM()
 	defer jem.Close()
-	authPool := auth.NewPool(auth.Params{
+	authPool, err := auth.NewPool(auth.Params{
 		Bakery:   bakery,
 		RootKeys: mgostorage.NewRootKeys(100),
 		RootKeysPolicy: mgostorage.Policy{
@@ -135,6 +135,9 @@ func New(config Params, versions map[string]NewAPIHandlerFunc) (*Server, error) 
 		PermChecker:        idmclient.NewPermChecker(idmClient, time.Hour),
 		IdentityLocation:   config.IdentityLocation,
 	})
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot make auth pool")
+	}
 	srv := &Server{
 		router:      httprouter.New(),
 		pool:        p,

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -512,10 +512,6 @@ func (s *websocketSuite) TestListModels(c *gc.C) {
 	models, err := client.ListModels("test")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []base.UserModel{{
-		Name:  "controller-1",
-		UUID:  "deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		Owner: "test@external",
-	}, {
 		Name:  "model-1",
 		UUID:  modelUUID1,
 		Owner: "test@external",
@@ -640,11 +636,6 @@ func (s *websocketSuite) TestAllModels(c *gc.C) {
 	models, err := client.AllModels()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(models, jc.DeepEquals, []base.UserModel{{
-		Name:           "controller-1",
-		UUID:           s.State.ModelUUID(),
-		Owner:          "test@external",
-		LastConnection: nil,
-	}, {
 		Name:           "model-1",
 		UUID:           modelUUID1,
 		Owner:          "test@external",


### PR DESCRIPTION
We add an index to the models collection so that you
can no longer have multiple models with the same UUID.
We would like to do the same for controllers but that's
much harder because we can have controllers with multiple
UUIDs in our tests because of juju testing package restrictions.

Havinging a one-to-one correspondence of UUIDs with
model entries means that we can more easily do
more complex model stats updates.

We also take the opportunity to add the macaroons root
keys index too.
