### PR TITLE
internal/jem: store model creator

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -130,7 +130,7 @@ func (s *authSuite) TestAuthenticateRequest(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckIsUser(c *gc.C) {
-	ctx := auth.AuthenticateForTest(context.Background(), "bob")
+	ctx := auth.ContextWithUser(context.Background(), "bob")
 	err := auth.CheckIsUser(ctx, "bob")
 	c.Assert(err, jc.ErrorIsNil)
 	err = auth.CheckIsUser(ctx, "alice")
@@ -139,7 +139,7 @@ func (s *authSuite) TestCheckIsUser(c *gc.C) {
 }
 
 func (s *authSuite) TestCheckACL(c *gc.C) {
-	ctx := auth.AuthenticateForTest(context.Background(), "bob")
+	ctx := auth.ContextWithUser(context.Background(), "bob")
 	err := auth.CheckACL(ctx, []string{"bob", "charlie"})
 	c.Assert(err, jc.ErrorIsNil)
 	err = auth.CheckACL(ctx, []string{"alice", "charlie"})
@@ -183,7 +183,7 @@ var canReadTests = []struct {
 }}
 
 func (s *authSuite) TestCheckCanRead(c *gc.C) {
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	for i, test := range canReadTests {
 		c.Logf("%d. %q %#v", i, test.owner, test.readers)
 		err := auth.CheckCanRead(ctx, testEntity{

--- a/internal/jem/database_test.go
+++ b/internal/jem/database_test.go
@@ -1035,8 +1035,7 @@ var checkReadACLTests = []struct {
 func (s *databaseSuite) TestCheckReadACL(c *gc.C) {
 	for i, test := range checkReadACLTests {
 		c.Logf("%d. %s", i, test.about)
-		gs := append(test.groups, test.user)
-		ctx := auth.AuthenticateForTest(context.Background(), gs...)
+		ctx := auth.ContextWithUser(context.Background(), test.user, test.groups...)
 		entity := params.EntityPath{
 			User: params.User(test.owner),
 			Name: params.Name(fmt.Sprintf("test%d", i)),
@@ -1088,7 +1087,7 @@ func (s *databaseSuite) TestCanReadIter(c *gc.C) {
 		err := s.database.AddModel(&testModels[i])
 		c.Assert(err, gc.IsNil)
 	}
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	it := s.database.Models().Find(nil).Sort("_id").Iter()
 	crit := s.database.NewCanReadIter(ctx, it)
 	var models []mongodoc.Model
@@ -1246,7 +1245,7 @@ var setDeadTests = []struct {
 	about: "CanReadIter",
 	run: func(db *jem.Database) {
 		it := db.Models().Find(nil).Sort("_id").Iter()
-		ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+		ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 		crit := db.NewCanReadIter(ctx, it)
 		crit.Next(&mongodoc.Model{})
 		crit.Err()
@@ -1255,7 +1254,7 @@ var setDeadTests = []struct {
 	about: "CanReadIter with Close",
 	run: func(db *jem.Database) {
 		it := db.Models().Find(nil).Sort("_id").Iter()
-		ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+		ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 		crit := db.NewCanReadIter(ctx, it)
 		crit.Next(&mongodoc.Model{})
 		crit.Close()

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -360,6 +360,7 @@ func (j *JEM) CreateModel(ctx context.Context, p CreateModelParams) (*mongodoc.M
 		Path:         p.Path,
 		Controller:   p.ControllerPath,
 		CreationTime: wallClock.Now(),
+		Creator:      auth.Username(ctx),
 	}
 	if err := j.DB.AddModel(modelDoc); err != nil {
 		return nil, nil, errgo.Mask(err, errgo.Is(params.ErrAlreadyExists))

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -227,7 +227,7 @@ func (s *jemSuite) TestCreateModel(c *gc.C) {
 		Type: "empty",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	_, _, err = s.jem.CreateModel(ctx, jem.CreateModelParams{
 		Path:           ctlId,
 		ControllerPath: ctlId,
@@ -238,6 +238,7 @@ func (s *jemSuite) TestCreateModel(c *gc.C) {
 		Cloud: "dummy",
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(auth.Username(ctx), gc.Equals, "bob")
 	for i, test := range createModelTests {
 		c.Logf("test %d. %s", i, test.about)
 		if test.params.Path.Name == "" {
@@ -255,6 +256,7 @@ func (s *jemSuite) TestCreateModel(c *gc.C) {
 		c.Assert(m.Path, jc.DeepEquals, test.params.Path)
 		c.Assert(m.UUID, gc.Not(gc.Equals), "")
 		c.Assert(m.CreationTime.Equal(now), gc.Equals, true)
+		c.Assert(m.Creator, gc.Equals, "bob")
 	}
 }
 
@@ -680,7 +682,7 @@ func (s *jemSuite) TestDoControllers(c *gc.C) {
 
 		c.Assert(err, gc.IsNil)
 	}
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	for i, test := range doContollerTests {
 		c.Logf("test %d. %s", i, test.about)
 		var obtainedControllers []params.EntityPath
@@ -790,7 +792,7 @@ func (s *jemSuite) TestDoControllersErrorResponse(c *gc.C) {
 
 		c.Assert(err, gc.IsNil)
 	}
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	testCause := errgo.New("test-cause")
 	err := s.jem.DoControllers(ctx, "", "", func(ctl *mongodoc.Controller) error {
 		return errgo.WithCausef(nil, testCause, "test error")
@@ -976,7 +978,7 @@ func (s *jemSuite) TestSelectController(c *gc.C) {
 
 		c.Assert(err, gc.IsNil)
 	}
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 	for i, test := range selectContollerTests {
 		c.Logf("test %d. %s", i, test.about)
 		randIntn = &test.randIntn
@@ -1018,7 +1020,7 @@ func (s *jemSuite) TestController(c *gc.C) {
 	s.addController(c, params.EntityPath{"alice", "controller"})
 	s.addController(c, params.EntityPath{"bob", "controller"})
 	s.addController(c, params.EntityPath{"bob-group", "controller"})
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 
 	for i, test := range controllerTests {
 		c.Logf("tes %d. %s", i, test.path)
@@ -1092,7 +1094,7 @@ func (s *jemSuite) TestCredential(c *gc.C) {
 		cred.Id = cred.Path.String()
 		jem.UpdateCredential(s.jem.DB, &cred)
 	}
-	ctx := auth.AuthenticateForTest(context.Background(), "bob", "bob-group")
+	ctx := auth.ContextWithUser(context.Background(), "bob", "bob-group")
 
 	for i, test := range credentialTests {
 		c.Logf("tes %d. %s", i, test.path)
@@ -1143,7 +1145,7 @@ func (s *jemSuite) bootstrapModel(c *gc.C, path params.EntityPath) *mongodoc.Mod
 		Type: "empty",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	ctx := auth.AuthenticateForTest(context.Background(), string(path.User))
+	ctx := auth.ContextWithUser(context.Background(), string(path.User))
 	model, _, err := s.jem.CreateModel(ctx, jem.CreateModelParams{
 		Path:           path,
 		ControllerPath: ctlPath,

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -220,6 +220,10 @@ type Model struct {
 
 	// CreationTime holds the time the model was created.
 	CreationTime time.Time
+
+	// Creator holds the name of the user that issued the model creation
+	// request.
+	Creator string
 }
 
 type ModelUserInfo struct {


### PR DESCRIPTION
This also meant that we needed the testing auth context to
contain the user name, so we refactor the auth package
a little to do that and simplify it a little.
