### PR TITLE
internal/jujuapi: support /gui endpoint

### DIFF
--- a/cmd/jemd/config.yaml
+++ b/cmd/jemd/config.yaml
@@ -52,3 +52,4 @@ tls-key: |
   -----END RSA PRIVATE KEY-----
 controller-uuid: 00000000-0000-0000-0000-000000000001
 default-cloud: aws
+gui-location: https://jujucharms.com

--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -105,6 +105,7 @@ func serve(confPath string) error {
 		RunMonitor:           true,
 		ControllerUUID:       conf.ControllerUUID,
 		WebsocketPingTimeout: websocketPingTimeout,
+		GUILocation:          conf.GUILocation,
 	}
 	server, err := jem.NewServer(cfg)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	TLSKey            string            `yaml:"tls-key"`
 	ControllerUUID    string            `yaml:"controller-uuid"`
 	MaxMgoSessions    int               `yaml:"max-mgo-sessions"`
+	GUILocation       string            `yaml:"gui-location"`
 }
 
 func (c *Config) validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,6 +87,7 @@ tls-key: |
   -----END RSA PRIVATE KEY-----
 controller-uuid: 00000000-0000-0000-0000-000000000000
 max-mgo-sessions: 200
+gui-location: https://jujucharms.com
 `
 
 func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error) {
@@ -129,6 +130,7 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 		},
 		ControllerUUID: "00000000-0000-0000-0000-000000000000",
 		MaxMgoSessions: 200,
+		GUILocation:    "https://jujucharms.com",
 	})
 }
 

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -74,6 +74,10 @@ type Params struct {
 	// WebsocketPingTimeout is the time to wait before failing a
 	// connection because the server has not received a ping.
 	WebsocketPingTimeout time.Duration
+
+	// GUILocation holds the address that serves the GUI that will be
+	// used with this controller.
+	GUILocation string
 }
 
 // Server represents a JEM HTTP server.

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -4,22 +4,32 @@
 package jujuapi
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/juju/httprequest"
 	"github.com/julienschmidt/httprouter"
+	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/auth"
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/jemerror"
 	"github.com/CanonicalLtd/jem/internal/jemserver"
+	"github.com/CanonicalLtd/jem/params"
 )
 
 func NewAPIHandler(jp *jem.Pool, ap *auth.Pool, params jemserver.Params) ([]httprequest.Handler, error) {
-	return []httprequest.Handler{
+	return append(
+		jemerror.Mapper.Handlers(func(p httprequest.Params) (*handler, error) {
+			return &handler{
+				params: params,
+				jem:    jp.JEM(),
+			}, nil
+		}),
 		newWebSocketHandler(jp, ap, params),
 		newRootWebSocketHandler(jp, ap, params, "/"),
 		newRootWebSocketHandler(jp, ap, params, "/api"),
-	}, nil
+	), nil
 }
 
 func newWebSocketHandler(jp *jem.Pool, ap *auth.Pool, params jemserver.Params) httprequest.Handler {
@@ -46,4 +56,32 @@ func newRootWebSocketHandler(jp *jem.Pool, ap *auth.Pool, params jemserver.Param
 			wsServer.ServeHTTP(w, r)
 		},
 	}
+}
+
+type handler struct {
+	params jemserver.Params
+	jem    *jem.JEM
+}
+
+func (h *handler) Close() error {
+	h.jem.Close()
+	return nil
+}
+
+type guiRequest struct {
+	httprequest.Route `httprequest:"GET /gui/:UUID"`
+	UUID              string `httprequest:",path"`
+}
+
+// GUI provides a GUI by redirecting to the store front.
+func (h *handler) GUI(p httprequest.Params, arg *guiRequest) error {
+	if h.params.GUILocation == "" {
+		return errgo.WithCausef(nil, params.ErrNotFound, "no GUI location specified")
+	}
+	m, err := h.jem.DB.ModelFromUUID(arg.UUID)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	http.Redirect(p.Response, p.Request, fmt.Sprintf("%s/u/%s/%s", h.params.GUILocation, m.Path.User, m.Path.Name), http.StatusMovedPermanently)
+	return nil
 }

--- a/internal/jujuapi/api_test.go
+++ b/internal/jujuapi/api_test.go
@@ -1,0 +1,93 @@
+// Copyright 2016 Canonical Ltd.
+
+package jujuapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/testing/httptesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem"
+	"github.com/CanonicalLtd/jem/internal/apitest"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type apiSuite struct {
+	apitest.Suite
+}
+
+var _ = gc.Suite(&apiSuite{})
+
+func (s *apiSuite) TestGUI(c *gc.C) {
+	s.AssertAddController(c, params.EntityPath{User: "bob", Name: "controller-1"}, true)
+	cred := s.AssertUpdateCredential(c, "bob", "dummy", "cred1", "empty")
+	_, uuid := s.CreateModel(c, params.EntityPath{"bob", "gui-model"}, params.EntityPath{"bob", "controller-1"}, cred)
+	jemSrv := s.NewServer(c, s.Session, s.IDMSrv, jem.ServerParams{
+		GUILocation: "https://jujucharms.com.test",
+	})
+	defer jemSrv.Close()
+	AssertRedirect(c, RedirectParams{
+		Handler:        jemSrv,
+		Method:         "GET",
+		URL:            fmt.Sprintf("/gui/%s", uuid),
+		ExpectCode:     http.StatusMovedPermanently,
+		ExpectLocation: "https://jujucharms.com.test/u/bob/gui-model",
+	})
+}
+
+func (s *apiSuite) TestGUINotFound(c *gc.C) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		URL:          fmt.Sprintf("/gui/%s", "000000000000-0000-0000-0000-00000000"),
+		Handler:      s.JEMSrv,
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: "no GUI location specified",
+		},
+	})
+}
+
+func (s *apiSuite) TestGUIModelNotFound(c *gc.C) {
+	jemSrv := s.NewServer(c, s.Session, s.IDMSrv, jem.ServerParams{
+		GUILocation: "https://jujucharms.com.test",
+	})
+	defer jemSrv.Close()
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		URL:          fmt.Sprintf("/gui/%s", "000000000000-0000-0000-0000-00000000"),
+		Handler:      jemSrv,
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `model "000000000000-0000-0000-0000-00000000" not found`,
+		},
+	})
+}
+
+type RedirectParams struct {
+	Method         string
+	URL            string
+	Handler        http.Handler
+	ExpectCode     int
+	ExpectLocation string
+}
+
+// AssertRedirect checks that a handler returns a redirect
+func AssertRedirect(c *gc.C, p RedirectParams) {
+	if p.Method == "" {
+		p.Method = "GET"
+	}
+	req, err := http.NewRequest(p.Method, p.URL, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	rr := httptest.NewRecorder()
+	p.Handler.ServeHTTP(rr, req)
+	if p.ExpectCode == 0 {
+		c.Assert(300 <= rr.Code && rr.Code < 400, gc.Equals, true, gc.Commentf("Expected redirect status (3XX), got %d", rr.Code))
+	} else {
+		c.Assert(rr.Code, gc.Equals, p.ExpectCode)
+	}
+	c.Assert(rr.HeaderMap.Get("Location"), gc.Equals, p.ExpectLocation)
+}

--- a/server.go
+++ b/server.go
@@ -62,6 +62,10 @@ type ServerParams struct {
 	// WebsocketPingTimeout is the time to wait before failing a
 	// connection because the server has not received a ping.
 	WebsocketPingTimeout time.Duration
+
+	// GUILocation holds the address that serves the GUI that will be
+	// used with this controller.
+	GUILocation string
 }
 
 // HandleCloser represents an HTTP handler that can


### PR DESCRIPTION
The /gui endpoint in implemented by redirecting to a configured location,
if one is configured.