### PR TITLE
internal/monitor: keep track of machines

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/yaml.v2"
 
 	"github.com/CanonicalLtd/jem/params"
-	"github.com/juju/loggo"
 )
 
 var logger = loggo.GetLogger("jem.config")

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -551,6 +551,10 @@ func (j *JEM) DestroyModel(conn *apiconn.Conn, model *mongodoc.Model) error {
 // can be read by the current user that matches the given attributes.
 // If the function returns an error, the iteration stops and
 // DoControllers returns the error with the same cause.
+//
+// Note that the same pointer is passed to the do function on
+// each iteration. It is the responsibility of the do function to
+// copy it if needed.
 func (j *JEM) DoControllers(ctx context.Context, cloud params.Cloud, region string, do func(c *mongodoc.Controller) error) error {
 	// Query all the controllers that match the attributes, building
 	// up all the possible values.

--- a/internal/mgosession/session.go
+++ b/internal/mgosession/session.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 
 	"github.com/juju/loggo"
-
 	mgo "gopkg.in/mgo.v2"
 )
 

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/network"
+	"github.com/juju/juju/state/multiwatcher"
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/params"
@@ -225,6 +226,14 @@ type Model struct {
 	// Creator holds the name of the user that issued the model creation
 	// request.
 	Creator string
+}
+
+// Machine holds information on a machine in a model, as discovered by the
+// controller monitor.
+type Machine struct {
+	// Id holds the combination of the model UUID and machine id.
+	Id   string `bson:"_id"`
+	Info *multiwatcher.MachineInfo
 }
 
 type ModelUserInfo struct {

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -50,6 +50,9 @@ type jemInterface interface {
 	// mentioned in the counts argument will not be affected.
 	UpdateModelCounts(uuid string, counts map[params.EntityCount]int, now time.Time) error
 
+	// UpdateMachineInfo updates the information associated with a machine.
+	UpdateMachineInfo(machine *multiwatcher.MachineInfo) error
+
 	// AllControllers returns all the controllers in the system.
 	AllControllers() ([]*mongodoc.Controller, error)
 

--- a/internal/monitor/shim.go
+++ b/internal/monitor/shim.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	apicontroller "github.com/juju/juju/api/controller"
+	"github.com/juju/juju/state/multiwatcher"
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/apiconn"
@@ -59,6 +60,10 @@ func (j jemShim) SetModelLife(ctlPath params.EntityPath, uuid string, life strin
 
 func (j jemShim) UpdateModelCounts(uuid string, counts map[params.EntityCount]int, now time.Time) (err error) {
 	return errgo.Mask(j.DB.UpdateModelCounts(uuid, counts, now), errgo.Any)
+}
+
+func (j jemShim) UpdateMachineInfo(info *multiwatcher.MachineInfo) error {
+	return errgo.Mask(j.DB.UpdateMachineInfo(info), errgo.Any)
 }
 
 func (j jemShim) AcquireMonitorLease(ctlPath params.EntityPath, oldExpiry time.Time, oldOwner string, newExpiry time.Time, newOwner string) (time.Time, error) {

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -4,8 +4,9 @@
 package jemclient
 
 import (
-	"github.com/CanonicalLtd/jem/params"
 	"github.com/juju/httprequest"
+
+	"github.com/CanonicalLtd/jem/params"
 )
 
 type client struct {


### PR DESCRIPTION
This will enable us to respond to ModelInfo API requests
without contacting the controller responsible for the model.