### PR TITLE
internal/jem: remember some other details about a model

### DIFF
--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -257,6 +257,10 @@ func (s *jemSuite) TestCreateModel(c *gc.C) {
 		c.Assert(m.UUID, gc.Not(gc.Equals), "")
 		c.Assert(m.CreationTime.Equal(now), gc.Equals, true)
 		c.Assert(m.Creator, gc.Equals, "bob")
+		c.Assert(m.Cloud, gc.Equals, string(test.params.Cloud))
+		c.Assert(m.CloudRegion, gc.Equals, "dummy-region")
+		c.Assert(m.Credential, jc.DeepEquals, test.params.Credential)
+		c.Assert(m.DefaultSeries, gc.Equals, "xenial")
 	}
 }
 

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -226,6 +226,18 @@ type Model struct {
 	// Creator holds the name of the user that issued the model creation
 	// request.
 	Creator string
+
+	// Cloud holds the name of the cloud that the model was created in.
+	Cloud string
+
+	// CloudRegion holds the region of the cloud that the model was created in.
+	CloudRegion string `bson:",omitempty"`
+
+	// Credential holds a reference to the credential used to create the model.
+	Credential params.CredentialPath
+
+	// DefaultSeries holds the default series for the model.
+	DefaultSeries string
 }
 
 // Machine holds information on a machine in a model, as discovered by the


### PR DESCRIPTION
These details need to be returned from the JIMM ModelInfo call.