### PR TITLE
internal/jem: support missing credentials

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -60,7 +60,7 @@ gopkg.in/juju/blobstore.v2	git	51fa6e26128d74e445c72d3a91af555151cc3654	2016-01-
 gopkg.in/juju/charm.v6-unstable	git	83771c4919d6810bce5b7e63f46bea5fbfed0b93	2016-10-03T20:31:18Z
 gopkg.in/juju/charmrepo.v2-unstable	git	73c1113f7ddee0306f4b3c19773d35a3f153c04a	2016-08-11T14:04:21Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
-gopkg.in/juju/names.v2	git	3317ff7471a685109e262892b5f81b940ad5782f	2016-10-05T07:27:06Z
+gopkg.in/juju/names.v2	git	0847c26d322a121e52614f969fb82eae2820c715	2016-11-02T13:43:03Z
 gopkg.in/macaroon-bakery.v1	git	469b44e6f1f9479e115c8ae879ef80695be624d5	2016-06-22T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -216,6 +216,12 @@ var createModelTests = []struct {
 		Region: "not-a-region",
 	},
 	expectError: `cannot select controller: no matching controllers found`,
+}, {
+	about: "empty cloud credentials",
+	params: jem.CreateModelParams{
+		Path:  params.EntityPath{"bob", ""},
+		Cloud: "dummy",
+	},
 }}
 
 func (s *jemSuite) TestCreateModel(c *gc.C) {

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -806,83 +806,90 @@ func (s *websocketSuite) TestModelStatus(c *gc.C) {
 }
 
 var createModelTests = []struct {
-	about       string
-	name        string
-	ownerTag    string
-	region      string
-	cloudTag    string
-	credential  string
-	config      map[string]interface{}
-	expectError string
+	about         string
+	name          string
+	ownerTag      string
+	region        string
+	cloudTag      string
+	credentialTag string
+	config        map[string]interface{}
+	expectError   string
 }{{
-	about:      "success",
-	name:       "model",
-	ownerTag:   "user-test@external",
-	cloudTag:   names.NewCloudTag("dummy").String(),
-	credential: "dummy_test@external_cred1",
+	about:         "success",
+	name:          "model",
+	ownerTag:      "user-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
 }, {
-	about:       "unauthorized user",
-	name:        "model-2",
-	ownerTag:    "user-not-test@external",
-	cloudTag:    names.NewCloudTag("dummy").String(),
-	credential:  "dummy_test@external_cred1",
-	expectError: `unauthorized \(unauthorized access\)`,
+	about:         "unauthorized user",
+	name:          "model-2",
+	ownerTag:      "user-not-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `unauthorized \(unauthorized access\)`,
 }, {
-	about:       "existing model name",
-	name:        "existing-model",
-	ownerTag:    "user-test@external",
-	cloudTag:    names.NewCloudTag("dummy").String(),
-	credential:  "dummy_test@external_cred1",
-	expectError: "already exists",
+	about:         "existing model name",
+	name:          "existing-model",
+	ownerTag:      "user-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   "already exists",
 }, {
-	about:       "no controller",
-	name:        "model-3",
-	ownerTag:    "user-test@external",
-	region:      "no-such-region",
-	cloudTag:    names.NewCloudTag("dummy").String(),
-	credential:  "dummy_test@external_cred1",
-	expectError: `cannot select controller: no matching controllers found \(not found\)`,
+	about:         "no controller",
+	name:          "model-3",
+	ownerTag:      "user-test@external",
+	region:        "no-such-region",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `cannot select controller: no matching controllers found \(not found\)`,
 }, {
-	about:       "local user",
-	name:        "model-4",
-	ownerTag:    "user-test@local",
-	cloudTag:    names.NewCloudTag("dummy").String(),
-	credential:  "dummy_test@external_cred1",
-	expectError: `unauthorized \(unauthorized access\)`,
+	about:         "local user",
+	name:          "model-4",
+	ownerTag:      "user-test@local",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `unauthorized \(unauthorized access\)`,
 }, {
-	about:       "invalid user",
-	name:        "model-5",
-	ownerTag:    "user-test/test@external",
-	cloudTag:    names.NewCloudTag("dummy").String(),
-	credential:  "dummy_test@external_cred1",
-	expectError: `invalid owner tag: "user-test/test@external" is not a valid user tag \(bad request\)`,
+	about:         "invalid user",
+	name:          "model-5",
+	ownerTag:      "user-test/test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `invalid owner tag: "user-test/test@external" is not a valid user tag \(bad request\)`,
 }, {
-	about:      "specific cloud",
-	name:       "model-6",
-	ownerTag:   "user-test@external",
-	cloudTag:   names.NewCloudTag("dummy").String(),
-	credential: "dummy_test@external_cred1",
+	about:         "specific cloud",
+	name:          "model-6",
+	ownerTag:      "user-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	credentialTag: "cloudcred-dummy_test@external_cred1",
 }, {
-	about:      "specific cloud and region",
-	name:       "model-7",
-	ownerTag:   "user-test@external",
-	cloudTag:   names.NewCloudTag("dummy").String(),
-	region:     "dummy-region",
-	credential: "dummy_test@external_cred1",
+	about:         "specific cloud and region",
+	name:          "model-7",
+	ownerTag:      "user-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	region:        "dummy-region",
+	credentialTag: "cloudcred-dummy_test@external_cred1",
 }, {
-	about:       "bad cloud tag",
-	name:        "model-8",
-	ownerTag:    "user-test@external",
-	cloudTag:    "not-a-cloud-tag",
-	credential:  "dummy_test@external_cred1",
-	expectError: `invalid cloud tag: "not-a-cloud-tag" is not a valid tag \(bad request\)`,
+	about:         "bad cloud tag",
+	name:          "model-8",
+	ownerTag:      "user-test@external",
+	cloudTag:      "not-a-cloud-tag",
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `invalid cloud tag: "not-a-cloud-tag" is not a valid tag \(bad request\)`,
 }, {
-	about:       "no cloud tag",
-	name:        "model-8",
-	ownerTag:    "user-test@external",
-	cloudTag:    "",
-	credential:  "dummy_test@external_cred1",
-	expectError: `no cloud specified for model; please specify one`,
+	about:         "no cloud tag",
+	name:          "model-8",
+	ownerTag:      "user-test@external",
+	cloudTag:      "",
+	credentialTag: "cloudcred-dummy_test@external_cred1",
+	expectError:   `no cloud specified for model; please specify one`,
+}, {
+	about:         "no credential tag",
+	name:          "model-8",
+	ownerTag:      "user-test@external",
+	cloudTag:      names.NewCloudTag("dummy").String(),
+	region:        "dummy-region",
+	credentialTag: "",
 }}
 
 func (s *websocketSuite) TestCreateModel(c *gc.C) {
@@ -902,7 +909,7 @@ func (s *websocketSuite) TestCreateModel(c *gc.C) {
 			Config:             test.config,
 			CloudTag:           test.cloudTag,
 			CloudRegion:        test.region,
-			CloudCredentialTag: "cloudcred-" + test.credential,
+			CloudCredentialTag: test.credentialTag,
 		}, &mi)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
@@ -914,6 +921,13 @@ func (s *websocketSuite) TestCreateModel(c *gc.C) {
 		c.Assert(mi.OwnerTag, gc.Equals, test.ownerTag)
 		c.Assert(mi.ControllerUUID, gc.Equals, "914487b5-60e7-42bb-bd63-1adc3fd3a388")
 		c.Assert(mi.Users, gc.HasLen, 0)
+		if test.credentialTag == "" {
+			c.Assert(mi.CloudCredentialTag, gc.Equals, "")
+		} else {
+			tag, err := names.ParseCloudCredentialTag(mi.CloudCredentialTag)
+			c.Assert(err, gc.IsNil)
+			c.Assert(tag.String(), gc.Equals, test.credentialTag)
+		}
 		if test.cloudTag == "" {
 			c.Assert(mi.CloudTag, gc.Equals, "cloud-dummy")
 		} else {

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -349,6 +349,7 @@ func (h *Handler) GetModel(arg *params.GetModel) (*params.ModelResponse, error) 
 		Life:             m.Life,
 		UnavailableSince: newTime(ctl.UnavailableSince.UTC()),
 		Counts:           m.Counts,
+		Creator:          m.Creator,
 	}
 	return r, nil
 }
@@ -412,6 +413,7 @@ func (h *Handler) ListModels(arg *params.ListModels) (*params.ListModelsResponse
 			Life:             m.Life,
 			UnavailableSince: newTime(ctl.UnavailableSince.UTC()),
 			Counts:           m.Counts,
+			Creator:          m.Creator,
 		})
 	}
 	if err := modelIter.Err(); err != nil {

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -1409,6 +1409,7 @@ func (s *APISuite) TestGetModelWhenControllerUnavailable(c *gc.C) {
 		HostPorts:        info.Addrs,
 		Life:             "dying",
 		UnavailableSince: newTime(mongodoc.Time(t).UTC()),
+		Creator:          "bob",
 	})
 }
 
@@ -1747,6 +1748,7 @@ func (s *APISuite) TestListModels(c *gc.C) {
 		HostPorts:      info.Addrs,
 		ControllerPath: ctlId0,
 		Life:           "alive",
+		Creator:        "alice",
 	}, {
 		Path:           modelId1,
 		UUID:           uuid1,
@@ -1762,7 +1764,8 @@ func (s *APISuite) TestListModels(c *gc.C) {
 				Total:   3,
 			},
 		},
-		Life: "alive",
+		Life:    "alive",
+		Creator: "bob",
 	}, {
 		Path:           modelId2,
 		UUID:           uuid2,
@@ -1771,6 +1774,7 @@ func (s *APISuite) TestListModels(c *gc.C) {
 		HostPorts:      info.Addrs,
 		ControllerPath: ctlId0,
 		Life:           "alive",
+		Creator:        "charlie",
 	}}
 	tests := []struct {
 		user    params.User


### PR DESCRIPTION
When testing against the local provider, we want to be
able to start models with no credentials.

Also report the model creator in the HTTP API when
getting model info.
