### PR TITLE
internal/jem: use controller region if one is not specified.

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -377,16 +377,12 @@ func (j *JEM) CreateModel(ctx context.Context, p CreateModelParams) (*mongodoc.M
 	if err := j.DB.AddModel(modelDoc); err != nil {
 		return nil, errgo.Mask(err, errgo.Is(params.ErrAlreadyExists))
 	}
-	region := p.Region
-	if region == "" {
-		region = ctl.Location["region"]
-	}
 	mmClient := modelmanager.NewClient(conn.Connection)
 	m, err := mmClient.CreateModel(
 		string(p.Path.Name),
 		UserTag(p.Path.User).Id(),
 		ctl.Location["cloud"],
-		region,
+		p.Region,
 		CloudCredentialTag(p.Credential),
 		p.Attributes,
 	)


### PR DESCRIPTION
If the region is not specified when creating the model, pass on the
not-specifiedness to juju which will make the appropriate selection.