### PR TITLE
cmd/jemd: use zap for logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/loggo"
+	"github.com/uber-go/zap"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/yaml.v2"
@@ -34,6 +35,7 @@ type Config struct {
 	ControllerUUID    string            `yaml:"controller-uuid"`
 	MaxMgoSessions    int               `yaml:"max-mgo-sessions"`
 	GUILocation       string            `yaml:"gui-location"`
+	LoggingLevel      zap.Level         `yaml:"logging-level"`
 }
 
 func (c *Config) validate() error {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -49,6 +49,8 @@ github.com/prometheus/client_model	git	fa8ad6fec33561be4280a8f0514318c79d7f6cb6	
 github.com/prometheus/common	git	dd586c1c5abb0be59e60f942c22af711a2008cb4	2016-05-03T22:05:32Z
 github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-04-11T19:08:41Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
+github.com/uber-go/atomic	git	9e99152552a6ce13fa3b2ce4a9c4fb117cca4506	2016-10-27T16:36:08Z
+github.com/uber-go/zap	git	d616285ecd2c3b9b67debb73a93c6795e24f4c96	2016-11-15T21:07:30Z
 golang.org/x/crypto	git	8e06e8ddd9629eb88639aba897641bff8031f1d3	2016-09-22T17:06:29Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/amz.v3	git	18899065239e006cc73b0e66800c98c2ce4eee50	2016-10-06T07:29:34Z

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/zap"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
@@ -38,6 +39,10 @@ type NewAPIHandlerFunc func(*jem.Pool, *auth.Pool, Params) ([]httprequest.Handle
 // It must be kept in sync with identical definition in the
 // top level jem package.
 type Params struct {
+	// Logger holds the logger that will be used to log
+	// server messages.
+	Logger zap.Logger
+
 	// DB holds the mongo database that will be used to
 	// store the JEM information.
 	DB *mgo.Database

--- a/internal/zapctx/package_test.go
+++ b/internal/zapctx/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+
+package zapctx_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t)
+}
+

--- a/internal/zapctx/zapctx.go
+++ b/internal/zapctx/zapctx.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Canonical Ltd.
+
+// Package zapctx provides support for associating zap loggers
+// (see github.com/uber-go/zap) with contexts.
+package zapctx
+
+import (
+	"os"
+
+	"github.com/uber-go/zap"
+	"golang.org/x/net/context"
+)
+
+// Default holds the logger returned by Logger when
+// there is no logger in the context.
+var Default = zap.New(zap.NewJSONEncoder(), zap.Output(os.Stderr))
+
+// loggerKey holds the context key used for loggers.
+type loggerKey struct{}
+
+// WithLogger returns a new context derived from ctx that
+// is associated with the given logger.
+func WithLogger(ctx context.Context, logger zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// Logger returns the logger associated with the given
+// context. If there is no logger, it will return Default.
+func Logger(ctx context.Context) zap.Logger {
+	if logger, _ := ctx.Value(loggerKey{}).(zap.Logger); logger != nil {
+		return logger
+	}
+	return Default
+}

--- a/internal/zapctx/zapctx_test.go
+++ b/internal/zapctx/zapctx_test.go
@@ -1,0 +1,35 @@
+package zapctx_test
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/juju/testing"
+	"github.com/uber-go/zap"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/internal/zapctx"
+)
+
+type zapctxSuite struct {
+	testing.CleanupSuite
+}
+
+var _ = gc.Suite(&zapctxSuite{})
+
+func (*zapctxSuite) TestLogger(c *gc.C) {
+	var buf bytes.Buffer
+	logger := zap.New(zap.NewTextEncoder(), zap.Output(zap.AddSync(&buf)))
+	ctx := zapctx.WithLogger(context.Background(), logger)
+	zapctx.Logger(ctx).Info("hello")
+	c.Assert(buf.String(), gc.Matches, `\[I\] .* hello\n`)
+}
+
+func (s *zapctxSuite) TestDefaultLogger(c *gc.C) {
+	var buf bytes.Buffer
+	logger := zap.New(zap.NewTextEncoder(), zap.Output(zap.AddSync(&buf)))
+
+	s.PatchValue(&zapctx.Default, logger)
+	zapctx.Logger(context.Background()).Info("hello")
+	c.Assert(buf.String(), gc.Matches, `\[I\] .* hello\n`)
+}

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/uber-go/zap"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/mgo.v2"
@@ -26,6 +27,10 @@ var versions = map[string]jemserver.NewAPIHandlerFunc{
 
 // ServerParams holds configuration for a new API server.
 type ServerParams struct {
+	// Logger holds the logger that will be used to log
+	// server messages.
+	Logger zap.Logger
+
 	// DB holds the mongo database that will be used to
 	// store the JEM information.
 	DB *mgo.Database


### PR DESCRIPTION
We want to have structured, context-sensitive logging
and the zap package provides that in a decent way.

We set up loggo so that it will log to a zap logger
and create a new zapctx package that will log
messages to loggers found in Context values.

We add a new logging-level value to the configuration
file and deprecate the logging-config flag (printing
a warning if it's set).

An example logging line, as logged through loggo:

    {"level":"info","ts":1479908675.7637515,"msg":"dialing \"wss://10.0.8.99:17070/api\"","module":"juju.api","file":"/home/rog/src/go/src/github.com/juju/juju/api/apiclient.go","line":530}