### PR TITLE
send zap logging messages to gocheck output

### DIFF
--- a/cmd/jaas-admin/admincmd/common_test.go
+++ b/cmd/jaas-admin/admincmd/common_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/idmclient/idmtest"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/juju"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/CanonicalLtd/jem"
 	"github.com/CanonicalLtd/jem/cmd/jaas-admin/admincmd"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/jemclient"
 	"github.com/CanonicalLtd/jem/params"
 )
@@ -50,7 +50,7 @@ func run(c *gc.C, dir string, cmdName string, args ...string) (stdout, stderr st
 }
 
 type commonSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 
 	jemSrv  jem.HandleCloser
 	idmSrv  *idmtest.Server

--- a/cmd/jaas-admin/admincmd/internal_test.go
+++ b/cmd/jaas-admin/admincmd/internal_test.go
@@ -3,15 +3,15 @@
 package admincmd
 
 import (
-	corejujutesting "github.com/juju/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/params"
 )
 
 type internalSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 }
 
 var _ = gc.Suite(&internalSuite{})

--- a/internal/apiconn/cache_test.go
+++ b/internal/apiconn/cache_test.go
@@ -6,16 +6,16 @@ import (
 	"time"
 
 	"github.com/juju/juju/api"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/apiconn"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 )
 
 type cacheSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 }
 
 var _ = gc.Suite(&cacheSuite{})

--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -1,4 +1,4 @@
-// Package apitest provides a test fixture for testing JEM APIs.
+// Package apitest provides test fixtures for testing JEM.
 package apitest
 
 import (
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/idmclient/idmtest"
 	controllerapi "github.com/juju/juju/api/controller"
 	"github.com/juju/juju/controller"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	"github.com/rogpeppe/fastuuid"
@@ -23,6 +22,7 @@ import (
 	external_jem "github.com/CanonicalLtd/jem"
 	"github.com/CanonicalLtd/jem/internal/jem"
 	"github.com/CanonicalLtd/jem/internal/jemserver"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/internal/mgosession"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/jemclient"
@@ -32,7 +32,7 @@ import (
 // Suite implements a test fixture that contains a JEM server
 // and an identity discharging server.
 type Suite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 
 	// JEMSrv holds a running instance of JEM.
 	JEMSrv *jemserver.Server

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -6,20 +6,20 @@ import (
 	"time"
 
 	cloudapi "github.com/juju/juju/api/cloud"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/apiconn"
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/internal/mgosession"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )
 
 type jemAPIConnSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 	pool        *jem.Pool
 	sessionPool *mgosession.Pool
 	jem         *jem.JEM

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/api/controller"
 	modelmanagerapi "github.com/juju/juju/api/modelmanager"
 	jujuparams "github.com/juju/juju/apiserver/params"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state/multiwatcher"
 	jujujujutesting "github.com/juju/juju/testing"
 	jt "github.com/juju/testing"
@@ -24,13 +23,14 @@ import (
 	"github.com/CanonicalLtd/jem/internal/apiconn"
 	"github.com/CanonicalLtd/jem/internal/auth"
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/internal/mgosession"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )
 
 type jemSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 	pool        *jem.Pool
 	sessionPool *mgosession.Pool
 	jem         *jem.JEM

--- a/internal/jemtest/apitest.go
+++ b/internal/jemtest/apitest.go
@@ -1,0 +1,34 @@
+// Package jemtest provides test fixtures for testing JEM.
+package jemtest
+
+import (
+	corejujutesting "github.com/juju/juju/juju/testing"
+	gc "gopkg.in/check.v1"
+)
+
+// JujuConnSuite implements a variant of github.com/juju/juju/juju/testing.JujuConnSuite
+// that uses zap for logging.
+type JujuConnSuite struct {
+	corejujutesting.JujuConnSuite
+	LoggingSuite
+}
+
+func (s *JujuConnSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+	s.LoggingSuite.SetUpSuite(c)
+}
+
+func (s *JujuConnSuite) TearDownSuite(c *gc.C) {
+	s.LoggingSuite.TearDownSuite(c)
+	s.JujuConnSuite.TearDownSuite(c)
+}
+
+func (s *JujuConnSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.LoggingSuite.SetUpTest(c)
+}
+
+func (s *JujuConnSuite) TearDownTest(c *gc.C) {
+	s.LoggingSuite.TearDownTest(c)
+	s.JujuConnSuite.TearDownTest(c)
+}

--- a/internal/jemtest/logging.go
+++ b/internal/jemtest/logging.go
@@ -1,0 +1,65 @@
+package jemtest
+
+import (
+	"strings"
+
+	"github.com/juju/loggo"
+	"github.com/uber-go/zap"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/internal/zapctx"
+	"github.com/CanonicalLtd/jem/internal/zaputil"
+)
+
+// LoggingSuite is a replacement for github.com/juju/testing.LoggingSuite
+// zap logging but also replaces the global loggo logger.
+// When used with juju/testing.LoggingSuite, it should
+// be set up after that.
+type LoggingSuite struct{}
+
+func (s *LoggingSuite) SetUpSuite(c *gc.C) {
+	s.setUp(c)
+}
+
+func (s *LoggingSuite) TearDownSuite(c *gc.C) {
+}
+
+func (s *LoggingSuite) SetUpTest(c *gc.C) {
+	s.setUp(c)
+}
+
+func (s *LoggingSuite) TearDownTest(c *gc.C) {
+}
+
+func (s *LoggingSuite) setUp(c *gc.C) {
+	output := gocheckZapWriter{c}
+	logger := zap.New(zap.NewTextEncoder(zap.TextNoTime()), zap.Output(output), zap.DebugLevel)
+	zapctx.Default = logger
+
+	loggo.ResetLogging()
+	// Don't use the default writer for the test logging, which
+	// means we can still get logging output from tests that
+	// replace the default writer.
+	loggo.RegisterWriter(loggo.DefaultWriterName, discardWriter{})
+	loggo.RegisterWriter("loggingsuite", zaputil.NewLoggoWriter(logger))
+	err := loggo.ConfigureLoggers("DEBUG")
+	c.Assert(err, gc.IsNil)
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(entry loggo.Entry) {
+}
+
+type gocheckZapWriter struct {
+	c *gc.C
+}
+
+func (w gocheckZapWriter) Write(buf []byte) (int, error) {
+	w.c.Output(1, strings.TrimSuffix(string(buf), "\n"))
+	return len(buf), nil
+}
+
+func (w gocheckZapWriter) Sync() error {
+	return nil
+}

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/idmclient/idmtest"
-	corejujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/multiwatcher"
 	jujuwatcher "github.com/juju/juju/state/watcher"
@@ -22,13 +21,14 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/CanonicalLtd/jem/internal/jem"
+	"github.com/CanonicalLtd/jem/internal/jemtest"
 	"github.com/CanonicalLtd/jem/internal/mgosession"
 	"github.com/CanonicalLtd/jem/internal/mongodoc"
 	"github.com/CanonicalLtd/jem/params"
 )
 
 type internalSuite struct {
-	corejujutesting.JujuConnSuite
+	jemtest.JujuConnSuite
 	idmSrv      *idmtest.Server
 	sessionPool *mgosession.Pool
 	pool        *jem.Pool
@@ -592,8 +592,7 @@ func (s *internalSuite) TestControllerMonitor(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	jshim := newJEMShimWithUpdateNotify(jemShim{s.jem})
-	m := newControllerMonitor(controllerMonitorParams{
-		context:     context.TODO(),
+	m := newControllerMonitor(context.TODO(), controllerMonitorParams{
 		ctlPath:     ctlPath,
 		jem:         jshim,
 		ownerId:     "jem1",
@@ -661,8 +660,7 @@ func (s *internalSuite) TestControllerMonitorDiesWithMonitoringStoppedErrorWhenC
 	c.Assert(err, gc.IsNil)
 	err = s.jem.DB.DeleteController(context.TODO(), ctlPath)
 	c.Assert(err, gc.IsNil)
-	m := newControllerMonitor(controllerMonitorParams{
-		context:     context.TODO(),
+	m := newControllerMonitor(context.TODO(), controllerMonitorParams{
 		ctlPath:     ctlPath,
 		jem:         jemShim{s.jem},
 		ownerId:     "jem1",

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -195,9 +195,9 @@ func (m *allMonitor) startMonitors() error {
 		}
 		// We've acquired the lease.
 		m.monitoring[ctl.Path] = true
-
-		ctlMonitor := newControllerMonitor(controllerMonitorParams{
-			context:     m.context, // TODO add logging context here.
+		// TODO add controller-specific logging context to context
+		// here before passing it to newControllerMonitor.
+		ctlMonitor := newControllerMonitor(m.context, controllerMonitorParams{
 			ctlPath:     ctl.Path,
 			jem:         m.jem,
 			ownerId:     m.ownerId,

--- a/internal/zaputil/loggo.go
+++ b/internal/zaputil/loggo.go
@@ -1,0 +1,36 @@
+package zaputil
+
+import (
+	"github.com/juju/loggo"
+	"github.com/uber-go/zap"
+)
+
+var loggoToZap = map[loggo.Level]zap.Level{
+	loggo.TRACE:    zap.DebugLevel, // There's no zap equivalent to TRACE.
+	loggo.DEBUG:    zap.DebugLevel,
+	loggo.INFO:     zap.InfoLevel,
+	loggo.WARNING:  zap.WarnLevel,
+	loggo.ERROR:    zap.ErrorLevel,
+	loggo.CRITICAL: zap.ErrorLevel, // There's no zap equivalent to CRITICAL.
+}
+
+// NewLoggoWriter returns a loggo.Writer that writes to the
+// given zap logger.
+func NewLoggoWriter(logger zap.Logger) loggo.Writer {
+	return zapLoggoWriter{
+		logger: logger,
+	}
+}
+
+// zapLoggoWriter implements a loggo.Writer by writing to a zap.Logger,
+// so can be used as an adaptor from loggo to zap.
+type zapLoggoWriter struct {
+	logger zap.Logger
+}
+
+// zapLoggoWriter implements loggo.Writer.Write by writing the entry
+// to w.logger. It ignores entry.Timestamp because zap will affix its
+// own timestamp.
+func (w zapLoggoWriter) Write(entry loggo.Entry) {
+	w.logger.Log(loggoToZap[entry.Level], entry.Message, zap.String("module", entry.Module), zap.String("file", entry.Filename), zap.Int("line", entry.Line))
+}


### PR DESCRIPTION
We make a new LoggingSuite type that sets up the zap
logger, and a new JujuConnSuite type that uses it.

Unfortunately we can't do anything about the messages
that are logged before LoggingSuite.SetUpTest is called,
messages before that do not look consistent with the
zap-logged messages.