### PR TITLE
internal/mgosession: throw away all sessions on error

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -89,8 +89,8 @@ func (p *Pool) Authenticator() *Authenticator {
 	}
 }
 
-func (p *Pool) rootKeyCollection(session *mgosession.Session) *mgo.Collection {
-	return p.params.MacaroonCollection.With(session.Session)
+func (p *Pool) rootKeyCollection(session *mgo.Session) *mgo.Collection {
+	return p.params.MacaroonCollection.With(session)
 }
 
 // An Authenticator can be used to authenticate a connection.
@@ -98,7 +98,7 @@ type Authenticator struct {
 	closed  bool
 	pool    *Pool
 	bakery  *bakery.Service
-	session *mgosession.Session
+	session *mgo.Session
 }
 
 // Close closes the authenticator instance.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -68,16 +68,6 @@ func (s *authSuite) TearDownTest(c *gc.C) {
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
-func (s authSuite) TestAuthenticator(c *gc.C) {
-	a1 := s.pool.Authenticator()
-	c.Assert(a1, gc.Not(gc.IsNil))
-	defer a1.Close()
-	a2 := s.pool.Authenticator()
-	c.Assert(a2, gc.Not(gc.IsNil))
-	defer a2.Close()
-	c.Assert(a1, gc.DeepEquals, a2)
-}
-
 func (s *authSuite) TestAuthenticateNoMacaroon(c *gc.C) {
 	a := s.pool.Authenticator()
 	defer a.Close()

--- a/internal/jem/export_test.go
+++ b/internal/jem/export_test.go
@@ -13,11 +13,3 @@ var (
 	UpdateControllerCredential = (*JEM).updateControllerCredential
 	RunWithContext             = runWithContext
 )
-
-func DatabaseClose(db *Database) {
-	db.session.Close()
-}
-
-func DatabaseSessionIsDead(db *Database) bool {
-	return !db.session.MayReuse()
-}

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -146,7 +146,7 @@ func (p *Pool) JEM() *JEM {
 	}
 	p.refCount++
 	return &JEM{
-		DB:   newDatabase(p.config.SessionPool.Session(), p.dbName),
+		DB:   newDatabase(p.config.SessionPool, p.dbName),
 		pool: p,
 	}
 }
@@ -191,7 +191,7 @@ func (j *JEM) Close() {
 		return
 	}
 	j.closed = true
-	j.DB.session.Close()
+	j.DB.Session.Close()
 	j.DB = nil
 	j.pool.decRef()
 }

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -68,7 +68,7 @@ func (s *jemSuite) TestPoolRequiresControllerAdmin(c *gc.C) {
 func (s *jemSuite) TestPoolDoesNotReuseDeadConnection(c *gc.C) {
 	session := jt.NewProxiedSession(c)
 	defer session.Close()
-	sessionPool := mgosession.NewPool(session.Session, 2)
+	sessionPool := mgosession.NewPool(session.Session, 3)
 	defer sessionPool.Close()
 	pool, err := jem.NewPool(jem.Params{
 		DB:              session.DB("jem"),
@@ -108,7 +108,6 @@ func (s *jemSuite) TestPoolDoesNotReuseDeadConnection(c *gc.C) {
 	// used by jem0 because only two sessions are available.
 	jem2 := pool.JEM()
 	defer jem2.Close()
-	c.Assert(jem2.DB.Session, gc.Equals, jem0.DB.Session)
 
 	// Perform another operation on jem0, which should fail and
 	// cause its session not to be reused.

--- a/internal/mgosession/export_test.go
+++ b/internal/mgosession/export_test.go
@@ -1,0 +1,3 @@
+package mgosession
+
+const PingInterval = pingInterval

--- a/internal/mgosession/session.go
+++ b/internal/mgosession/session.go
@@ -7,21 +7,29 @@ package mgosession
 
 import (
 	"sync"
-	"sync/atomic"
+	"time"
 
 	"github.com/juju/loggo"
+	"github.com/juju/utils/clock"
 	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/tomb.v2"
 )
 
 var logger = loggo.GetLogger("jem.internal.mgosession")
 
+const pingInterval = 1 * time.Second
+
+var Clock clock.Clock = clock.WallClock
+
 // Pool represents a pool of mgo sessions.
 type Pool struct {
+	tomb tomb.Tomb
+
 	// mu guards the fields below it.
 	mu sync.Mutex
 
 	// sessions holds all the sessions currently available for use.
-	sessions []*session
+	sessions []*mgo.Session
 
 	// sessionIndex holds the index of the next session that will
 	// be returned from Pool.Session.
@@ -38,9 +46,35 @@ type Pool struct {
 // NewPool returns a session pool that maintains a maximum
 // of maxSessions sessions available for reuse.
 func NewPool(s *mgo.Session, maxSessions int) *Pool {
-	return &Pool{
-		sessions: make([]*session, maxSessions),
+	p := &Pool{
+		sessions: make([]*mgo.Session, maxSessions),
 		session:  s.Copy(),
+	}
+	p.tomb.Go(p.pinger)
+	return p
+}
+
+// pinger occasionally pings the sessions in the pool
+// to make sure that they are OK, and resets the pool
+// if it gets an error. This means that even if nothing
+// external notices an error and calls Reset, our maximum
+// window for an outage is pingInterval.
+//
+// If there was an IsDead method on mgo.Session,
+// this would be unnecessary (as would Reset).
+// See https://github.com/go-mgo/mgo/issues/124.
+func (p *Pool) pinger() error {
+	for {
+		select {
+		case <-p.tomb.Dying():
+			return nil
+		case <-Clock.After(pingInterval):
+		}
+		session := p.Session()
+		if session.Ping() != nil {
+			p.Reset()
+		}
+		session.Close()
 	}
 }
 
@@ -49,35 +83,26 @@ func NewPool(s *mgo.Session, maxSessions int) *Pool {
 // with DoNotReuse.
 //
 // Session may be called concurrently.
-func (p *Pool) Session() *Session {
+func (p *Pool) Session() *mgo.Session {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closed {
 		panic("Session called on closed Pool")
 	}
 	s := p.sessions[p.sessionIndex]
-	if s == nil || s.status.isDead() {
-		if s != nil {
-			// The session is marked as dead so close it.
-			s.decRef()
-		} else {
-			logger.Debugf("creating new session %d", p.sessionIndex)
-		}
-		// Create a new session, either to replace an old one
-		// or to fill the empty slot. Note that the refCount
-		// is 1 because the entry in the pool counts as one reference.
-		s = &session{
-			session:  p.session.Copy(),
-			refCount: 1,
-		}
+	if s == nil {
+		logger.Debugf("creating new session %d", p.sessionIndex)
+		s = p.session.Copy()
+		// Ping the session so that we're sure that the returned session
+		// is attached to a mongodb socket otherwise we won't
+		// be limiting the number of sessions at all.
+		// Ignore the error because we'll do the same whether there's
+		// an error or not.
+		s.Ping()
 		p.sessions[p.sessionIndex] = s
 	}
 	p.sessionIndex = (p.sessionIndex + 1) % len(p.sessions)
-	s.incRef()
-	return &Session{
-		s:       s,
-		Session: s.session,
-	}
+	return s.Clone()
 }
 
 // Close closes the pool. It may be called concurrently with other
@@ -88,104 +113,28 @@ func (p *Pool) Close() {
 	if p.closed {
 		return
 	}
+	p.tomb.Kill(nil)
 	p.closed = true
+	p.closeSessions()
+	p.session.Close()
+	p.tomb.Wait()
+}
+
+// Reset resets the session pool so that no existing
+// sessions will be reused. This should be called
+// when an unexpected error has been encountered using
+// a session.
+func (p *Pool) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closeSessions()
+}
+
+func (p *Pool) closeSessions() {
 	for i, session := range p.sessions {
 		if session != nil {
-			session.decRef()
+			session.Close()
 			p.sessions[i] = nil
 		}
 	}
-	p.session.Close()
-}
-
-// Session wraps an mgo session object held in the pool.
-type Session struct {
-	// Session holds the embedded Session object.
-	// This should not be closed directly.
-	*mgo.Session
-
-	s      *session
-	closed bool
-}
-
-// Close closes the session. The embedded session should
-// not be used after calling this method.
-func (s *Session) Close() {
-	if s.closed {
-		return
-	}
-	s.closed = true
-	s.s.decRef()
-}
-
-// Clone clones the session so that it can be closed
-// independently.(for example if some concurrent process
-// wishes to use the session independently). Note that it does
-// not clone the embedded Session object.
-func (s *Session) Clone() *Session {
-	if s.closed {
-		panic("cannot clone closed session")
-	}
-	s.s.incRef()
-	return &Session{
-		s: s.s,
-		// Use s.s.session instead of s.Session because there's no
-		// possibility that someone might have changed it.
-		Session: s.s.session,
-	}
-}
-
-// DoNotReuse tags the Session object so that its
-// session will not be subsequently returned by the Pool.Session
-// method. Call this when you encounter a database
-// error that seems like it's probably fatal to the session.
-func (s *Session) DoNotReuse() {
-	s.s.status.setDead()
-}
-
-// MayReuse reports whether the session has not yet
-// marked as DoNotReuse. Note that calling DoNotReuse
-// on any clone of the session will also cause this to return false.
-func (s *Session) MayReuse() bool {
-	return !s.s.status.isDead()
-}
-
-// session is the internal session type. This exists
-// separately from Session solely so that the Session
-// object can have an idempotent Close method.
-type session struct {
-	// refCount holds the number of Session objects that
-	// currently refer to the session.
-	refCount int32
-
-	// status holds the status of the session.
-	status sessionStatus
-
-	// session holds the actual Session object.
-	// This should not be closed directly.
-	session *mgo.Session
-}
-
-func (s *session) incRef() {
-	atomic.AddInt32(&s.refCount, 1)
-}
-
-func (s *session) decRef() {
-	if atomic.AddInt32(&s.refCount, -1) == 0 {
-		s.session.Close()
-	}
-}
-
-// sessionStatus records the current status of a mgo session.
-type sessionStatus int32
-
-// setDead marks the session as dead, so that it won't be
-// reused for new JEM instances.
-func (s *sessionStatus) setDead() {
-	atomic.StoreInt32((*int32)(s), 1)
-}
-
-// isDead reports whether the session has been marked as dead.
-func (s *sessionStatus) isDead() bool {
-	return atomic.LoadInt32((*int32)(s)) != 0
 }


### PR DESCRIPTION
There is a problem with the current implementation that if the mongo
server restarts, all the sessions become invalid at the same point,
but we will only find out about each one in turn.

Therefore we change the mgosession package so that it throws
away all the sessions when an error is encountered,
which enables some simplification of the code.

We also start a pinger which resets the pool if it encounters
an error, which should limit the maximum time a bad mongo
session causes problems, even when we don't reset the
pool immediately because we diagnose a bad error.

This may fix some operational problems we've been seeing.