### PR TITLE
add contextual information to log messages

### DIFF
--- a/cmd/jaas-admin/admincmd/add-controller.go
+++ b/cmd/jaas-admin/admincmd/add-controller.go
@@ -71,7 +71,6 @@ func (c *addControllerCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	logger.Debugf("client: %#v\n", client)
 	info, err := getControllerInfo(c.controllerName)
 	if err != nil {
 		return errgo.Mask(err)

--- a/cmd/jaas-admin/admincmd/cmd.go
+++ b/cmd/jaas-admin/admincmd/cmd.go
@@ -11,15 +11,12 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
-	"github.com/juju/loggo"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
 	"github.com/CanonicalLtd/jem/jemclient"
 	"github.com/CanonicalLtd/jem/params"
 )
-
-var logger = loggo.GetLogger("jaas-admin")
 
 // jujuLoggingConfigEnvKey matches osenv.JujuLoggingConfigEnvKey
 // in the Juju project.

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juju/loggo"
 	"github.com/uber-go/zap"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
@@ -17,8 +16,6 @@ import (
 
 	"github.com/CanonicalLtd/jem/params"
 )
-
-var logger = loggo.GetLogger("jem.config")
 
 type Config struct {
 	MongoAddr string `yaml:"mongo-addr"`
@@ -61,21 +58,20 @@ func (c *Config) validate() error {
 	return nil
 }
 
-func (c *Config) TLSConfig() *tls.Config {
+func (c *Config) TLSConfig() (*tls.Config, error) {
 	if c.TLSCert == "" || c.TLSKey == "" {
-		return nil
+		return nil, nil
 	}
 
 	cert, err := tls.X509KeyPair([]byte(c.TLSCert), []byte(c.TLSKey))
 	if err != nil {
-		logger.Errorf("cannot create certificate: %s", err)
-		return nil
+		return nil, errgo.Notef(err, "cannot create certificate")
 	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{
 			cert,
 		},
-	}
+	}, nil
 }
 
 // Read reads a jem configuration file from the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,7 +105,8 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Check that the TLS configuration creates a valid *tls.Config
-	tlsConfig := conf.TLSConfig()
+	tlsConfig, err := conf.TLSConfig()
+	c.Assert(err, gc.IsNil)
 	c.Assert(tlsConfig, gc.Not(gc.IsNil))
 	conf.TLSCert = ""
 	conf.TLSKey = ""

--- a/internal/apiconn/cache.go
+++ b/internal/apiconn/cache.go
@@ -5,15 +5,12 @@ import (
 
 	"github.com/golang/groupcache/singleflight"
 	"github.com/juju/juju/api"
-	"github.com/juju/loggo"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jem/internal/zapctx"
 	"github.com/CanonicalLtd/jem/internal/zaputil"
 )
-
-var logger = loggo.GetLogger("jem.internal.apiconn")
 
 // Cache holds a cache of connections to API servers.
 //

--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -71,17 +71,17 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	s.JEMSrv = s.NewServer(c, s.Session, s.IDMSrv, external_jem.ServerParams{})
 	s.httpSrv = httptest.NewServer(s.JEMSrv)
 
-	s.SessionPool = mgosession.NewPool(s.Session, 1)
+	s.SessionPool = mgosession.NewPool(context.TODO(), s.Session, 1)
 	s.Pool = s.NewJEMPool(c, s.SessionPool)
-	s.JEM = s.Pool.JEM()
+	s.JEM = s.Pool.JEM(context.TODO())
 }
 
 // NewJEMPool returns a jem.Pool that uses the given
 // mgosession.Pool, enabling a custom session pool
 // to be used.
 func (s *Suite) NewJEMPool(c *gc.C, sessionPool *mgosession.Pool) *jem.Pool {
-	session := sessionPool.Session()
-	pool, err := jem.NewPool(jem.Params{
+	session := sessionPool.Session(context.TODO())
+	pool, err := jem.NewPool(context.TODO(), jem.Params{
 		DB:              session.DB("jem"),
 		ControllerAdmin: "controller-admin",
 		SessionPool:     sessionPool,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -62,11 +62,11 @@ type Pool struct {
 
 // NewPool creates a new Pool from which Authenticator objects may be
 // retrieved.
-func NewPool(params Params) (*Pool, error) {
+func NewPool(ctx context.Context, params Params) (*Pool, error) {
 	p := &Pool{
 		params: params,
 	}
-	auth := p.Authenticator()
+	auth := p.Authenticator(ctx)
 	defer auth.Close()
 	if err := params.RootKeys.EnsureIndex(p.rootKeyCollection(auth.session)); err != nil {
 		return nil, errgo.Notef(err, "cannot ensure index on root key store")
@@ -76,9 +76,9 @@ func NewPool(params Params) (*Pool, error) {
 
 // Authenticator retrieves an Authenticator object from the pool, which
 // must be closed after use.
-func (p *Pool) Authenticator() *Authenticator {
+func (p *Pool) Authenticator(ctx context.Context) *Authenticator {
 	servermon.AuthenticatorPoolGet.Inc()
-	session := p.params.SessionPool.Session()
+	session := p.params.SessionPool.Session(ctx)
 	return &Authenticator{
 		pool: p,
 		bakery: p.params.Bakery.WithRootKeyStore(p.params.RootKeys.NewStorage(

--- a/internal/ctxutil/ctxutil_test.go
+++ b/internal/ctxutil/ctxutil_test.go
@@ -3,12 +3,12 @@
 package ctxutil_test
 
 import (
-	"context"
 	"time"
 
-	"github.com/CanonicalLtd/jem/internal/ctxutil"
-
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/internal/ctxutil"
 )
 
 type ctxutilSuite struct {

--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -57,10 +57,10 @@ func (db *Database) checkError(ctx context.Context, err *error) {
 // newDatabase returns a new Database named dbName using
 // a session taken from the given pool. The database session
 // should be closed after the database is finished with.
-func newDatabase(pool *mgosession.Pool, dbName string) *Database {
+func newDatabase(ctx context.Context, pool *mgosession.Pool, dbName string) *Database {
 	return &Database{
 		sessionPool: pool,
-		Database:    pool.Session().DB(dbName),
+		Database:    pool.Session(ctx).DB(dbName),
 	}
 }
 

--- a/internal/jem/jem_apiconn_test.go
+++ b/internal/jem/jem_apiconn_test.go
@@ -29,15 +29,15 @@ var _ = gc.Suite(&jemAPIConnSuite{})
 
 func (s *jemAPIConnSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	s.sessionPool = mgosession.NewPool(s.Session, 5)
-	pool, err := jem.NewPool(jem.Params{
+	s.sessionPool = mgosession.NewPool(context.TODO(), s.Session, 5)
+	pool, err := jem.NewPool(context.TODO(), jem.Params{
 		DB:              s.Session.DB("jem"),
 		ControllerAdmin: "controller-admin",
 		SessionPool:     s.sessionPool,
 	})
 	c.Assert(err, gc.IsNil)
 	s.pool = pool
-	s.jem = s.pool.JEM()
+	s.jem = s.pool.JEM(context.TODO())
 	s.PatchValue(&jem.APIOpenTimeout, time.Duration(0))
 }
 

--- a/internal/jem/run.go
+++ b/internal/jem/run.go
@@ -5,9 +5,10 @@ package jem
 import (
 	"io"
 
+	"golang.org/x/net/context"
+
 	"github.com/CanonicalLtd/jem/internal/zapctx"
 	"github.com/CanonicalLtd/jem/internal/zaputil"
-	"golang.org/x/net/context"
 )
 
 // runWithContext runs the given function and completes either when the

--- a/internal/jemerror/error.go
+++ b/internal/jemerror/error.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 
 	"github.com/juju/httprequest"
-	"github.com/juju/loggo"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 
+	"github.com/CanonicalLtd/jem/internal/zapctx"
+	"github.com/CanonicalLtd/jem/internal/zaputil"
 	"github.com/CanonicalLtd/jem/params"
 )
-
-var logger = loggo.GetLogger("jem.internal.jemerror")
 
 // Mapper holds an ErrorMapper that can
 // translate from Go errors to standard JEM
@@ -25,7 +25,7 @@ type errorCoder interface {
 }
 
 func errToResp(err error) (int, interface{}) {
-	logger.Infof("returning error %#v", err)
+	zapctx.Info(context.TODO(), "HTTP error response", zaputil.Error(err))
 	// Allow bakery errors to be returned as the bakery would
 	// like them, so that httpbakery.Client.Do will work.
 	if err, ok := errgo.Cause(err).(*httpbakery.Error); ok {

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -117,19 +117,19 @@ func New(ctx context.Context, config Params, versions map[string]NewAPIHandlerFu
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot create bakery")
 	}
-	sessionPool := mgosession.NewPool(config.DB.Session, config.MaxMgoSessions)
+	sessionPool := mgosession.NewPool(ctx, config.DB.Session, config.MaxMgoSessions)
 	jconfig := jem.Params{
 		DB:              config.DB,
 		SessionPool:     sessionPool,
 		ControllerAdmin: config.ControllerAdmin,
 	}
-	p, err := jem.NewPool(jconfig)
+	p, err := jem.NewPool(ctx, jconfig)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}
-	jem := p.JEM()
+	jem := p.JEM(ctx)
 	defer jem.Close()
-	authPool, err := auth.NewPool(auth.Params{
+	authPool, err := auth.NewPool(ctx, auth.Params{
 		Bakery:   bakery,
 		RootKeys: mgostorage.NewRootKeys(100),
 		RootKeysPolicy: mgostorage.Policy{

--- a/internal/jemserver/server_test.go
+++ b/internal/jemserver/server_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/httprequest"
 	jujutesting "github.com/juju/juju/testing"
-	"github.com/juju/testing"
 	"github.com/juju/testing/httptesting"
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/net/context"
@@ -27,31 +26,10 @@ import (
 var testContext = context.Background()
 
 type serverSuite struct {
-	testing.IsolatedMgoSuite
-	jemtest.LoggingSuite
+	jemtest.IsolatedMgoSuite
 }
 
 var _ = gc.Suite(&serverSuite{})
-
-func (s *serverSuite) SetUpSuite(c *gc.C) {
-	s.IsolatedMgoSuite.SetUpSuite(c)
-	s.LoggingSuite.SetUpSuite(c)
-}
-
-func (s *serverSuite) TearDownSuite(c *gc.C) {
-	s.LoggingSuite.TearDownSuite(c)
-	s.IsolatedMgoSuite.TearDownSuite(c)
-}
-
-func (s *serverSuite) SetUpTest(c *gc.C) {
-	s.IsolatedMgoSuite.SetUpTest(c)
-	s.LoggingSuite.SetUpTest(c)
-}
-
-func (s *serverSuite) TearDownTest(c *gc.C) {
-	s.LoggingSuite.TearDownTest(c)
-	s.IsolatedMgoSuite.TearDownTest(c)
-}
 
 func (s *serverSuite) TestNewServerWithNoVersions(c *gc.C) {
 	params := jemserver.Params{
@@ -199,16 +177,16 @@ func (s *serverSuite) TestServerHasAccessControlAllowOrigin(c *gc.C) {
 
 func (s *serverSuite) TestServerRunsMonitor(c *gc.C) {
 	db := s.Session.DB("foo")
-	sessionPool := mgosession.NewPool(s.Session, 1)
+	sessionPool := mgosession.NewPool(context.TODO(), s.Session, 1)
 	defer sessionPool.Close()
-	pool, err := jem.NewPool(jem.Params{
+	pool, err := jem.NewPool(context.TODO(), jem.Params{
 		DB:              db,
 		ControllerAdmin: "controller-admin",
 		SessionPool:     sessionPool,
 	})
 	c.Assert(err, gc.IsNil)
 	defer pool.Close()
-	j := pool.JEM()
+	j := pool.JEM(context.TODO())
 	defer j.Close()
 
 	ctlPath := params.EntityPath{"bob", "foo"}

--- a/internal/jemtest/apitest.go
+++ b/internal/jemtest/apitest.go
@@ -3,6 +3,7 @@ package jemtest
 
 import (
 	corejujutesting "github.com/juju/juju/juju/testing"
+	jujutesting "github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 )
 
@@ -31,4 +32,31 @@ func (s *JujuConnSuite) SetUpTest(c *gc.C) {
 func (s *JujuConnSuite) TearDownTest(c *gc.C) {
 	s.LoggingSuite.TearDownTest(c)
 	s.JujuConnSuite.TearDownTest(c)
+}
+
+// IsolatedMgoSuite implements a variant of github.com/juju/testing.IsolatedMgoSuite
+// that uses zap for logging.
+type IsolatedMgoSuite struct {
+	jujutesting.IsolatedMgoSuite
+	LoggingSuite
+}
+
+func (s *IsolatedMgoSuite) SetUpSuite(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpSuite(c)
+	s.LoggingSuite.SetUpSuite(c)
+}
+
+func (s *IsolatedMgoSuite) TearDownSuite(c *gc.C) {
+	s.LoggingSuite.TearDownSuite(c)
+	s.IsolatedMgoSuite.TearDownSuite(c)
+}
+
+func (s *IsolatedMgoSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.LoggingSuite.SetUpTest(c)
+}
+
+func (s *IsolatedMgoSuite) TearDownTest(c *gc.C) {
+	s.LoggingSuite.TearDownTest(c)
+	s.IsolatedMgoSuite.TearDownTest(c)
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -327,7 +327,7 @@ func (a admin) Login(req jujuparams.LoginRequest) (jujuparams.LoginResult, error
 		}
 	}
 	// JIMM only supports macaroon login, ignore all the other fields.
-	authenticator := a.h.authPool.Authenticator()
+	authenticator := a.h.authPool.Authenticator(a.h.context)
 	defer authenticator.Close()
 	ctx, m, err := authenticator.Authenticate(a.h.context, req.Macaroons, checkers.TimeBefore)
 	if err != nil {

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -239,7 +239,6 @@ func (m *controllerMonitor) dialAPI(ctx context.Context) (jujuAPI, error) {
 		// so that if our reply causes everything to be stopped,
 		// we know that the JEM is closed before that.
 		j.Close()
-		zapctx.Info(ctx, "openAPI failed", zaputil.Error(err))
 		select {
 		case reply <- apiConnReply{
 			conn: conn,

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -52,15 +52,15 @@ var _ = gc.Suite(&internalSuite{})
 func (s *internalSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.idmSrv = idmtest.NewServer()
-	s.sessionPool = mgosession.NewPool(s.Session, 1)
-	pool, err := jem.NewPool(jem.Params{
+	s.sessionPool = mgosession.NewPool(context.TODO(), s.Session, 1)
+	pool, err := jem.NewPool(context.TODO(), jem.Params{
 		SessionPool:     s.sessionPool,
 		DB:              s.Session.DB("jem"),
 		ControllerAdmin: "controller-admin",
 	})
 	c.Assert(err, gc.IsNil)
 	s.pool = pool
-	s.jem = pool.JEM()
+	s.jem = pool.JEM(context.TODO())
 
 	// Set up the clock mockery.
 	s.clock = jujutesting.NewClock(epoch)

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -75,7 +75,7 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 	session := testing.NewProxiedSession(c)
 	defer session.Close()
 
-	sessionPool := mgosession.NewPool(session.Session, 2)
+	sessionPool := mgosession.NewPool(context.TODO(), session.Session, 2)
 	defer sessionPool.Close()
 
 	pool := s.NewJEMPool(c, sessionPool)
@@ -84,7 +84,7 @@ func (s *monitorSuite) TestMonitorWithBrokenMongoConnection(c *gc.C) {
 	// Create a controller.
 	apiInfo := s.APIInfo(c)
 	ctlPath := params.EntityPath{"bob", "foo"}
-	jem := pool.JEM()
+	jem := pool.JEM(context.TODO())
 	defer jem.Close()
 
 	hps, err := mongodoc.ParseAddresses(apiInfo.Addrs)

--- a/internal/zapctx/zapctx.go
+++ b/internal/zapctx/zapctx.go
@@ -24,6 +24,12 @@ func WithLogger(ctx context.Context, logger zap.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
+// WithFields returns a new context derived from ctx
+// that has a logger that always logs the given fields.
+func WithFields(ctx context.Context, fields ...zap.Field) context.Context {
+	return WithLogger(ctx, Logger(ctx).With(fields...))
+}
+
 // Logger returns the logger associated with the given
 // context. If there is no logger, it will return Default.
 func Logger(ctx context.Context) zap.Logger {

--- a/internal/zapctx/zapctx_test.go
+++ b/internal/zapctx/zapctx_test.go
@@ -2,10 +2,10 @@ package zapctx_test
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/juju/testing"
 	"github.com/uber-go/zap"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"github.com/CanonicalLtd/jem/internal/zapctx"
@@ -32,4 +32,14 @@ func (s *zapctxSuite) TestDefaultLogger(c *gc.C) {
 	s.PatchValue(&zapctx.Default, logger)
 	zapctx.Logger(context.Background()).Info("hello")
 	c.Assert(buf.String(), gc.Matches, `\[I\] .* hello\n`)
+}
+
+func (*zapctxSuite) TestWithFields(c *gc.C) {
+	var buf bytes.Buffer
+	logger := zap.New(zap.NewTextEncoder(), zap.Output(zap.AddSync(&buf)))
+
+	ctx := zapctx.WithLogger(context.Background(), logger)
+	ctx = zapctx.WithFields(ctx, zap.Int("foo", 999), zap.String("bar", "whee"))
+	zapctx.Logger(ctx).Info("hello")
+	c.Assert(buf.String(), gc.Matches, `\[I\] .* hello foo=999 bar=whee\n`)
 }

--- a/internal/zaputil/error_test.go
+++ b/internal/zaputil/error_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/CanonicalLtd/jem/internal/zaputil"
 	"github.com/uber-go/zap"
 	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jem/internal/zaputil"
 )
 
 type zaputilSuite struct{}


### PR DESCRIPTION
Log messages will now include the request UUID when available
and monitoring messages (including all sub-calls) will include the controller path.

We also eliminate all use of loggo except for that called
by juju code directly.

We still need to do a review of what we actually want to log and at what level.