### PR TITLE
internal/v2: remove GetSchema

### DIFF
--- a/internal/jemerror/error.go
+++ b/internal/jemerror/error.go
@@ -35,7 +35,7 @@ func errToResp(err error) (int, interface{}) {
 	status := http.StatusInternalServerError
 	switch errorBody.Code {
 	case params.ErrNotFound,
-		params.ErrAmbiguousLocation:
+		params.ErrAmbiguousChoice:
 
 		status = http.StatusNotFound
 	case params.ErrForbidden,

--- a/internal/v2/export_test.go
+++ b/internal/v2/export_test.go
@@ -1,6 +1,5 @@
 package v2
 
 var (
-	SchemaForProviderType = &schemaForProviderType
-	MongodocAPIHostPorts  = mongodocAPIHostPorts
+	MongodocAPIHostPorts = mongodocAPIHostPorts
 )

--- a/jemclient/client.go
+++ b/jemclient/client.go
@@ -56,23 +56,6 @@ func (c *Client) GetAllControllerLocations(p *params.GetAllControllerLocations) 
 	return r, err
 }
 
-// GetSchema returns the schema that should be used for
-// the model configuration when starting a controller
-// with a location matching p.Location.
-//
-//
-// If controllers of more than one provider type
-// are matched, it will return an error with a params.ErrAmbiguousLocation
-// cause.
-//
-// If no controllers are matched, it will return an error with
-// a params.ErrNotFound cause.
-func (c *Client) GetSchema(p *params.GetSchema) (*params.SchemaResponse, error) {
-	var r *params.SchemaResponse
-	err := c.callWithLocationAttrs(p.Location, p, &r)
-	return r, err
-}
-
 // callWithLocationAttrs makes an API call to the endpoint implied
 // by p, attaching the given location attributes as URL query parameters,
 // and storing the result into the value pointed to by the value in r.

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -83,23 +83,6 @@ func (c *client) GetModelPerm(p *params.GetModelPerm) (params.ACL, error) {
 	return r, err
 }
 
-// GetSchema returns the schema that should be used for
-// the model configuration when starting a controller
-// with a location matching p.Location.
-//
-//
-// If controllers of more than one provider type
-// are matched, it will return an error with a params.ErrAmbiguousLocation
-// cause.
-//
-// If no controllers are matched, it will return an error with
-// a params.ErrNotFound cause.
-func (c *client) GetSchema(p *params.GetSchema) (*params.SchemaResponse, error) {
-	var r *params.SchemaResponse
-	err := c.Client.Call(p, &r)
-	return r, err
-}
-
 // ListController returns all the controllers stored in JEM.
 // Currently the ProviderType field in each ControllerResponse is not
 // populated.
@@ -138,6 +121,7 @@ func (c *client) SetControllerPerm(p *params.SetControllerPerm) error {
 // Only the owner (arg.EntityPath.User) can change the permissions
 // on an an entity. The owner can always read an entity, even
 // if it has empty ACL.
+// TODO remove this.
 func (c *client) SetModelPerm(p *params.SetModelPerm) error {
 	return c.Client.Call(p, nil)
 }

--- a/params/error.go
+++ b/params/error.go
@@ -19,14 +19,14 @@ func (code ErrorCode) ErrorCode() ErrorCode {
 }
 
 const (
-	ErrNotFound          ErrorCode = "not found"
-	ErrForbidden         ErrorCode = "forbidden"
-	ErrBadRequest        ErrorCode = "bad request"
-	ErrUnauthorized      ErrorCode = "unauthorized"
-	ErrAlreadyExists     ErrorCode = "already exists"
-	ErrMethodNotAllowed  ErrorCode = "method not allowed"
-	ErrAmbiguousLocation ErrorCode = "ambiguous location"
-	ErrStillAlive        ErrorCode = "controller is still alive"
+	ErrNotFound         ErrorCode = "not found"
+	ErrForbidden        ErrorCode = "forbidden"
+	ErrBadRequest       ErrorCode = "bad request"
+	ErrUnauthorized     ErrorCode = "unauthorized"
+	ErrAlreadyExists    ErrorCode = "already exists"
+	ErrMethodNotAllowed ErrorCode = "method not allowed"
+	ErrAmbiguousChoice  ErrorCode = "ambiguous choice"
+	ErrStillAlive       ErrorCode = "controller is still alive"
 )
 
 // Error represents an error - it is returned for any response that fails.


### PR DESCRIPTION
Also remove Schema from ControllerResponse and rename
ErrAmbiguousLocation to ErrAmbiguousChoice in
preparation for using that error when there's more
than one choice for a credential.

Technically this a backwardly incompatible change but nothing
out there uses schemas - we shouldn't be creating models
other than through the websocket API which doesn't use them.