### PR TITLE
internal/jem: select credential automatically

### DIFF
--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -84,6 +84,9 @@ func (db *Database) ensureIndexes() error {
 	}, {
 		db.Models(),
 		mgo.Index{Key: []string{"uuid"}, Unique: true},
+	}, {
+		db.Credentials(),
+		mgo.Index{Key: []string{"path.entitypath.user", "path.cloud"}},
 	}}
 	for _, idx := range indexes {
 		err := idx.c.EnsureIndex(idx.i)

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -1000,12 +1000,12 @@ var createModelTests = []struct {
 	credentialTag: "cloudcred-dummy_test@external_cred1",
 	expectError:   `no cloud specified for model; please specify one`,
 }, {
-	about:         "no credential tag",
+	about:         "no credential tag selects unambigous creds",
 	name:          "model-8",
 	ownerTag:      "user-test@external",
 	cloudTag:      names.NewCloudTag("dummy").String(),
 	region:        "dummy-region",
-	credentialTag: "",
+	credentialTag: "cloudcred-dummy_test@external_cred1",
 }}
 
 func (s *websocketSuite) TestCreateModel(c *gc.C) {


### PR DESCRIPTION
If there's exactly one credential available, use it.
If there's more than one then return an error to avoid
making an arbitrary decision that may be wrong.