### PR TITLE
internal/jem: implement prometheus mongo-based stats

### DIFF
--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -95,41 +95,49 @@ func (s *jemSuite) TestPoolDoesNotReuseDeadConnection(c *gc.C) {
 	defer jem0.Close()
 	assertOK(jem0)
 
+	c.Logf("close connections")
 	// Close all current connections to the mongo instance,
 	// which should cause subsequent operations on jem1 to fail.
 	session.CloseConns()
 
 	// Get another JEM instance, which should be a new session,
 	// so operations on it should not fail.
+	c.Logf("make jem1")
 	jem1 := pool.JEM(context.TODO())
 	defer jem1.Close()
 	assertOK(jem1)
 
 	// Get another JEM instance which should clone the same session
 	// used by jem0 because only two sessions are available.
+	c.Logf("make jem2")
 	jem2 := pool.JEM(context.TODO())
 	defer jem2.Close()
 
 	// Perform another operation on jem0, which should fail and
 	// cause its session not to be reused.
+	c.Logf("check jem0 is broken")
 	assertBroken(jem0)
 
 	// The jem1 connection should still be working because it
 	// was created after the connections were broken.
+	c.Logf("check jem1 is ok")
 	assertOK(jem1)
 
+	c.Logf("check jem2 is ok")
 	// The jem2 connection should also be broken because it
 	// reused the same sessions as jem0
 	assertBroken(jem2)
 
 	// Get another instance, which should reuse the jem3 connection
 	// and work OK.
+	c.Logf("make jem3")
 	jem3 := pool.JEM(context.TODO())
 	defer jem3.Close()
 	assertOK(jem3)
 
 	// When getting the next instance, we should see that the connection
 	// that we would have used is broken and create another one.
+	c.Logf("make jem4")
 	jem4 := pool.JEM(context.TODO())
 	defer jem4.Close()
 	assertOK(jem4)

--- a/internal/jem/prometheus.go
+++ b/internal/jem/prometheus.go
@@ -1,0 +1,193 @@
+package jem
+
+import (
+	"golang.org/x/net/context"
+	"gopkg.in/errgo.v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/internal/servermon"
+	"github.com/CanonicalLtd/jem/internal/zapctx"
+	"github.com/CanonicalLtd/jem/internal/zaputil"
+)
+
+// Stats implements a Prometheus collector that provides information
+// about JIMM statistics.
+type Stats struct {
+	pool    *Pool
+	context context.Context
+	descs   []*prometheus.Desc
+}
+
+// statItem represents a single metric result from the Stats
+// collector.
+type statItem int
+
+// These constants each represent a single integer metric
+// result. See statsDescs for a description of what each one
+// means.
+const (
+	statApplicationsRunning statItem = iota
+	statControllersRunning
+	statMachinesRunning
+	statModelsRunning
+	statUnitsRunning
+	numStats
+)
+
+// currentStats holds a snapshot of the statistics gathers
+// for a single Stats.Collect call.
+type currentStats struct {
+	// values holds a value for each statItem constant,
+	// indexed by that constant.
+	values [numStats]int
+}
+
+// getStatsGauge returns a function that returns a metric
+// for the given stat item from a snapshot of the current
+// statistics.
+func getStatsGauge(c statItem) func(*currentStats) metric {
+	return func(s *currentStats) metric {
+		return metric{
+			kind:  dto.MetricType_GAUGE,
+			value: s.values[c],
+		}
+	}
+}
+
+// statsDescs holds information about all the stats
+// suitable for making *prometheus.Desc and prometheus.Metric
+// instances from.
+var statsDescs = []struct {
+	// name holds the name of the metric as seen by prometheus.
+	name string
+	// help holds the help text for the metric.
+	help string
+	// get returns the actual metric value from a snapshot
+	// of the current stats.
+	get func(*currentStats) metric
+}{{
+	name: "applications_running",
+	help: "The current number of running applications.",
+	get:  getStatsGauge(statApplicationsRunning),
+}, {
+	name: "controllers_running",
+	help: "The current number of running controllers.",
+	get:  getStatsGauge(statControllersRunning),
+}, {
+	name: "machines_running",
+	help: "The current number of running machines.",
+	get:  getStatsGauge(statMachinesRunning),
+}, {
+	name: "models_running",
+	help: "The current number of running models.",
+	get:  getStatsGauge(statModelsRunning),
+}, {
+	name: "units_running",
+	help: "The current number of running units.",
+	get:  getStatsGauge(statUnitsRunning),
+}}
+
+// Stats returns an implementation of prometheus.Collector
+// that returns information on statistics obtained from the pool.
+func (p *Pool) Stats(ctx context.Context) *Stats {
+	s := &Stats{
+		context: ctx,
+		pool:    p,
+	}
+	for _, d := range statsDescs {
+		s.descs = append(s.descs, prometheus.NewDesc(
+			prometheus.BuildFQName("jem", "health", d.name),
+			d.help,
+			nil,
+			nil,
+		))
+	}
+	return s
+}
+
+// Collect implements prometheus.Collector.Describe by describing all
+// the statistics that can be obtained from JIMM.
+func (s *Stats) Describe(c chan<- *prometheus.Desc) {
+	for _, d := range s.descs {
+		c <- d
+	}
+}
+
+// Collect implements prometheus.Collector.Collect by collecting
+// all the statistic from JIMM.
+func (s *Stats) Collect(c chan<- prometheus.Metric) {
+	jem := s.pool.JEM(s.context)
+	defer jem.Close()
+	current, err := s.collectStats(jem)
+	if err != nil {
+		zapctx.Error(s.context, "cannot collect statistics", zaputil.Error(err))
+		servermon.StatsCollectFailCount.Inc()
+		return
+	}
+	for i, d := range statsDescs {
+		c <- &metricWithDesc{
+			metric: d.get(current),
+			desc:   s.descs[i],
+		}
+	}
+}
+
+// collectStats returns a snapshot of the current statistics from JIMM.
+func (s *Stats) collectStats(jem *JEM) (*currentStats, error) {
+	var cs currentStats
+	iter := jem.DB.Controllers().Find(nil).Iter()
+	var ctl mongodoc.Controller
+	for iter.Next(&ctl) {
+		cs.values[statControllersRunning]++
+		cs.values[statApplicationsRunning] += ctl.Stats.ServiceCount
+		cs.values[statMachinesRunning] += ctl.Stats.MachineCount
+		cs.values[statModelsRunning] += ctl.Stats.ModelCount
+		cs.values[statUnitsRunning] += ctl.Stats.UnitCount
+	}
+	if err := iter.Err(); err != nil {
+		return nil, errgo.Notef(err, "cannot gather stats")
+	}
+	return &cs, nil
+}
+
+// metricWithDesc implements prometheus.Metric
+// by combining a metric value with a description.
+type metricWithDesc struct {
+	metric
+	desc *prometheus.Desc
+}
+
+// Desc implements prometheus.Metric.Desc.
+func (m *metricWithDesc) Desc() *prometheus.Desc {
+	return m.desc
+}
+
+// metric implements half of the prometheus.Metric interface.
+type metric struct {
+	kind  dto.MetricType
+	value int
+}
+
+// Write implements prometheus.Metric.Write.
+func (m metric) Write(wm *dto.Metric) error {
+	switch m.kind {
+	case dto.MetricType_COUNTER:
+		wm.Counter = &dto.Counter{
+			Value: newFloat64(float64(m.value)),
+		}
+	case dto.MetricType_GAUGE:
+		wm.Gauge = &dto.Gauge{
+			Value: newFloat64(float64(m.value)),
+		}
+	default:
+		panic("unexpected metric type")
+	}
+	return nil
+}
+
+func newFloat64(f float64) *float64 {
+	return &f
+}

--- a/internal/jem/prometheus_test.go
+++ b/internal/jem/prometheus_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016 Canonical Ltd.
+
+package jem_test
+
+import (
+	"bufio"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/internal/auth"
+	"github.com/CanonicalLtd/jem/internal/mongodoc"
+	"github.com/CanonicalLtd/jem/params"
+)
+
+func (s *jemSuite) TestStats(c *gc.C) {
+	ctx := auth.ContextWithUser(testContext, "bob")
+
+	ctl1Id := s.addController(c, params.EntityPath{"bob", "controller1"})
+	err := s.jem.DB.SetControllerStats(ctx, ctl1Id, &mongodoc.ControllerStats{
+		UnitCount:    35,
+		ModelCount:   23,
+		ServiceCount: 5,
+		MachineCount: 500,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	ctl2Id := s.addController(c, params.EntityPath{"bob", "controller2"})
+	err = s.jem.DB.SetControllerStats(ctx, ctl2Id, &mongodoc.ControllerStats{
+		UnitCount:    1,
+		ModelCount:   1,
+		ServiceCount: 1,
+		MachineCount: 1,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	stats := s.pool.Stats(testContext)
+	err = prometheus.Register(stats)
+	c.Assert(err, gc.IsNil)
+	defer prometheus.Unregister(stats)
+	srv := httptest.NewServer(prometheus.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	c.Assert(err, gc.IsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	defer resp.Body.Close()
+	counts := make(map[string]float64)
+	for scan := bufio.NewScanner(resp.Body); scan.Scan(); {
+		t := scan.Text()
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		if i := strings.Index(t, "{"); i >= 0 {
+			j := strings.LastIndex(t, "}")
+			t = t[0:i] + t[j+1:]
+		}
+		fields := strings.Fields(t)
+		if len(fields) != 2 {
+			c.Logf("unexpected prometheus line %q", scan.Text())
+			continue
+		}
+		f, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			c.Logf("bad value in prometheus line %q", scan.Text())
+			continue
+		}
+		counts[fields[0]] += f
+	}
+
+	expectCounts := map[string]int{
+		"applications_running": 6,
+		"controllers_running":  2,
+		"models_running":       24,
+		"units_running":        36,
+		"machines_running":     501,
+	}
+	for name, count := range expectCounts {
+		name = "jem_health_" + name
+		c.Check(math.Trunc(counts[name]), gc.Equals, float64(count), gc.Commentf("%s", name))
+	}
+}

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -107,6 +107,7 @@ type ControllerStats struct {
 	ModelCount int
 
 	// ServiceCount holds the number of services hosted in the controller.
+	// TODO this should be named ApplicationCount.
 	ServiceCount int
 
 	// MachineCount holds the number of machines hosted in the controller.

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -10,12 +10,6 @@ import (
 )
 
 var (
-	ApplicationsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "jem",
-		Subsystem: "health",
-		Name:      "applications_running",
-		Help:      "The current number of running applications.",
-	}, []string{"ctl_path"})
 	AuthenticationFailCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "jem",
 		Subsystem: "auth",
@@ -45,12 +39,6 @@ var (
 		Subsystem: "auth",
 		Name:      "pool_put",
 		Help:      "The number of times an Authenticator has been replaced into the pool.",
-	})
-	ControllersRunning = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "jem",
-		Subsystem: "health",
-		Name:      "controllers_running",
-		Help:      "The current number of running controllers.",
 	})
 	DatabaseSessions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "jem",
@@ -88,12 +76,12 @@ var (
 		Name:      "login_success_count",
 		Help:      "The number of successful logins completed.",
 	})
-	MachinesRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	StatsCollectFailCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "jem",
 		Subsystem: "health",
-		Name:      "machines_running",
-		Help:      "The current number of running machines.",
-	}, []string{"ctl_path"})
+		Name:      "stats_collect_fail_count",
+		Help:      "The number of times we failed to collect stats from mongo.",
+	})
 	ModelLifetime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "jem",
 		Subsystem: "health",
@@ -132,24 +120,12 @@ var (
 		Name:      "models_destroyed_count",
 		Help:      "The number of models destroyed.",
 	})
-	ModelsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "jem",
-		Subsystem: "health",
-		Name:      "models_running",
-		Help:      "The current number of running models.",
-	}, []string{"ctl_path"})
 	requestDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: "jem",
 		Subsystem: "handler",
 		Name:      "request_duration",
 		Help:      "The duration of a web request in seconds.",
 	}, []string{"path_pattern"})
-	UnitsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "jem",
-		Subsystem: "health",
-		Name:      "units_running",
-		Help:      "The current number of running units.",
-	}, []string{"ctl_path"})
 	WebsocketRequestDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: "jem",
 		Subsystem: "websocket",
@@ -159,26 +135,21 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(ApplicationsRunning)
 	prometheus.MustRegister(AuthenticationFailCount)
 	prometheus.MustRegister(AuthenticationSuccessCount)
 	prometheus.MustRegister(AuthenticatorPoolGet)
 	prometheus.MustRegister(AuthenticatorPoolNew)
 	prometheus.MustRegister(AuthenticatorPoolPut)
-	prometheus.MustRegister(ControllersRunning)
 	prometheus.MustRegister(DatabaseSessions)
 	prometheus.MustRegister(DatabaseFailCount)
 	prometheus.MustRegister(DeployedUnitCount)
 	prometheus.MustRegister(LoginFailCount)
 	prometheus.MustRegister(LoginRedirectCount)
 	prometheus.MustRegister(LoginSuccessCount)
-	prometheus.MustRegister(MachinesRunning)
 	prometheus.MustRegister(ModelLifetime)
 	prometheus.MustRegister(ModelsCreatedCount)
 	prometheus.MustRegister(ModelsCreatedFailCount)
-	prometheus.MustRegister(ModelsRunning)
 	prometheus.MustRegister(requestDuration)
-	prometheus.MustRegister(UnitsRunning)
 	prometheus.MustRegister(WebsocketRequestDuration)
 	prometheus.MustRegister(monitoring.NewMgoStatsCollector("jem"))
 }


### PR DESCRIPTION
This enables prometheus to obtain statistics that are directly
from the database rather than transient in the server memory.