### PR TITLE
internal/jujuapi: implement UserManager facade

### DIFF
--- a/params/validate.go
+++ b/params/validate.go
@@ -2,7 +2,6 @@ package params
 
 import (
 	"regexp"
-	"strings"
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/names.v2"
@@ -14,11 +13,7 @@ type User string
 
 func (u *User) UnmarshalText(t []byte) error {
 	u0 := string(t)
-	if !names.IsValidUserName(u0) {
-		return errgo.WithCausef(nil, ErrBadRequest, "invalid user name %q", u0)
-	}
-	// Forbid double-hyphen because we use it as a separator.
-	if strings.Contains(u0, "--") {
+	if !names.IsValidUser(u0) {
 		return errgo.WithCausef(nil, ErrBadRequest, "invalid user name %q", u0)
 	}
 	*u = User(u0)
@@ -31,12 +26,7 @@ func (n *Name) UnmarshalText(t []byte) error {
 	if !validName.Match(t) {
 		return errgo.WithCausef(nil, ErrBadRequest, "invalid name %q", t)
 	}
-	// Forbid double-hyphen because we use it as a separator.
-	t0 := string(t)
-	if strings.Contains(t0, "--") {
-		return errgo.WithCausef(nil, ErrBadRequest, "invalid name %q", t0)
-	}
-	*n = Name(t0)
+	*n = Name(string(t))
 	return nil
 }
 

--- a/params/validate_test.go
+++ b/params/validate_test.go
@@ -87,26 +87,28 @@ var validatorsTests = []struct {
 		Request: newHTTPRequest("", nil),
 		PathVar: httprouter.Params{{
 			Key:   "User",
-			Value: "foo--invalid",
+			Value: "foo--valid",
 		}},
 	},
-	val: new(struct {
+	val: &struct {
 		User params.User `httprequest:",path"`
-	}),
-	expectError: `cannot unmarshal into field: invalid user name "foo--invalid"`,
+	}{
+		User: "foo--valid",
+	},
 }, {
 	about: "double hyphen in name",
 	params: httprequest.Params{
 		Request: newHTTPRequest("", nil),
 		PathVar: httprouter.Params{{
 			Key:   "Name",
-			Value: "foo--invalid",
+			Value: "foo--valid",
 		}},
 	},
-	val: new(struct {
+	val: &struct {
 		Name params.Name `httprequest:",path"`
-	}),
-	expectError: `cannot unmarshal into field: invalid name "foo--invalid"`,
+	}{
+		Name: "foo--valid",
+	},
 }, {
 	about: "bad user in entity path",
 	params: httprequest.Params{


### PR DESCRIPTION
This adds the missing UserManager facade for the most part it only tells
users that they are unauthorized. Also this fixes some problems that
would have been encountered by users in domains other than the default.