### PR TITLE
cmd/jemd: make database name configurable

### DIFF
--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -68,6 +68,9 @@ func serve(confPath string) error {
 	if err != nil {
 		return errgo.Notef(err, "cannot read config file %q", confPath)
 	}
+	if conf.DBName == "" {
+		conf.DBName = "jem"
+	}
 	conf.IdentityLocation = strings.TrimSuffix(conf.IdentityLocation, "/")
 	if strings.HasSuffix(conf.IdentityLocation, "v1/discharger") {
 		// It's probably some old code that uses the old IdentityLocation
@@ -83,7 +86,7 @@ func serve(confPath string) error {
 		return errgo.Notef(err, "cannot dial mongo at %q", conf.MongoAddr)
 	}
 	defer session.Close()
-	db := session.DB("jem")
+	db := session.DB(conf.DBName)
 
 	zapctx.Debug(ctx, "setting up the API server")
 	var locator bakery.PublicKeyLocator

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 
 type Config struct {
 	MongoAddr string `yaml:"mongo-addr"`
+	DBName    string `yaml:"dbname"`
 	APIAddr   string `yaml:"api-addr"`
 	// TODO rename state-server-admin to controller-admin.
 	ControllerAdmin   params.User       `yaml:"state-server-admin"`

--- a/tools/register-existing-models/main.go
+++ b/tools/register-existing-models/main.go
@@ -49,6 +49,7 @@ type UsageSenderAuthorizationClient interface {
 
 type Config struct {
 	MongoAddr         string            `yaml:"mongo-addr"`
+	DBName            string            `yaml:"dbname"`
 	IdentityPublicKey *bakery.PublicKey `yaml:"identity-public-key"`
 	IdentityLocation  string            `yaml:"identity-location"`
 	AgentUsername     string            `yaml:"agent-username"`
@@ -128,6 +129,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to read the config file: %v\n", err)
 		os.Exit(2)
 	}
+	if conf.DBName == "" {
+		conf.DBName = "jem"
+	}
 
 	ctx := setUpLogging(context.Background(), conf.LoggingLevel)
 	zapctx.Debug(ctx, "connecting to mongo")
@@ -138,7 +142,7 @@ func main() {
 	}
 	defer session.Close()
 
-	err = updateModels(ctx, session.DB("jem").C("models"), conf)
+	err = updateModels(ctx, session.DB(conf.DBName).C("models"), conf)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
We want to be able to run several JEM instances on the same mongo backend.
