### PR TITLE
internal/{jem,jujuapi}: close API connection

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -534,6 +534,7 @@ func (j *JEM) ControllerUpdateCredentials(ctx context.Context, ctlPath params.En
 	if err != nil {
 		return errgo.Notef(err, "cannot connect to controller")
 	}
+	defer conn.Close()
 	for _, credPath := range ctl.UpdateCredentials {
 		if err := j.updateControllerCredential(ctx, ctl.Path, credPath, conn, nil); err != nil {
 			zapctx.Warn(ctx,

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -1085,6 +1085,7 @@ func (m modelManager) destroyModel(ctx context.Context, arg jujuparams.Entity) e
 	if err != nil {
 		return errgo.Mask(err)
 	}
+	defer conn.Close()
 	if err := m.h.jem.DestroyModel(ctx, conn, model); err != nil {
 		return errgo.Mask(err)
 	}


### PR DESCRIPTION
The missed Close in UpdateCredentials was causing the underlying
API connection to be retained, and as UpdateCredentials is
called every time a new watcher connection is made, this
was causing the API server to run out of file descriptors.