### PR TITLE
internal/monitor: fix deadlock when mongo connection dies

### DIFF
--- a/internal/monitor/shim_test.go
+++ b/internal/monitor/shim_test.go
@@ -204,7 +204,7 @@ func (s *jemShimInMemory) controller(p params.EntityPath) *mongodoc.Controller {
 	return &c
 }
 
-func (s *jemShimInMemory) AddController(ctx context.Context, ctl *mongodoc.Controller) {
+func (s *jemShimInMemory) AddController(ctl *mongodoc.Controller) {
 	if ctl.Path == (params.EntityPath{}) {
 		panic("no path in controller")
 	}
@@ -215,7 +215,7 @@ func (s *jemShimInMemory) AddController(ctx context.Context, ctl *mongodoc.Contr
 	s.controllers[ctl.Path] = &ctl1
 }
 
-func (s *jemShimInMemory) AddModel(ctx context.Context, m *mongodoc.Model) {
+func (s *jemShimInMemory) AddModel(m *mongodoc.Model) {
 	if m.Path.IsZero() {
 		panic("no path in model")
 	}


### PR DESCRIPTION
We were not waiting for the controller monitors to
exit when returning an error due to AllControllers failing.

We also make sure that the controller monitors exit
when the allMonitor is exiting by killing them explicitly.
That should not have been a real problem because in
practice the controller monitors will also die when
the mongo connection goes away, but it's better to
be complete (and it means that the controller monitor
can be restarted immediately even when there's an
API open call that's taking a long time to complete.