### PR TITLE
Implement the /gui-archive API endpoint.

### DIFF
--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/juju/httprequest"
+	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/julienschmidt/httprouter"
 	"github.com/uber-go/zap"
 	"golang.org/x/net/context"
@@ -98,4 +99,14 @@ func (h *handler) GUI(p httprequest.Params, arg *guiRequest) error {
 	}
 	http.Redirect(p.Response, p.Request, fmt.Sprintf("%s/u/%s/%s", h.params.GUILocation, m.Path.User, m.Path.Name), http.StatusMovedPermanently)
 	return nil
+}
+
+type guiArchiveRequest struct {
+	httprequest.Route `httprequest:"GET /gui-archive"`
+}
+
+// GUIArchive provides information on GUI versions for compatibility with Juju
+// controllers. In this case, no versions are returned.
+func (h *handler) GUIArchive(*guiArchiveRequest) (jujuparams.GUIArchiveResponse, error) {
+	return jujuparams.GUIArchiveResponse{}, nil
 }

--- a/internal/jujuapi/api_test.go
+++ b/internal/jujuapi/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	jujuparams "github.com/juju/juju/apiserver/params"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
@@ -64,6 +65,16 @@ func (s *apiSuite) TestGUIModelNotFound(c *gc.C) {
 			Code:    params.ErrNotFound,
 			Message: `model "000000000000-0000-0000-0000-00000000" not found`,
 		},
+	})
+}
+
+func (s *apiSuite) TestGUIArchive(c *gc.C) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.JEMSrv,
+		Method:       "GET",
+		URL:          "/gui-archive",
+		ExpectStatus: http.StatusOK,
+		ExpectBody:   jujuparams.GUIArchiveResponse{},
 	})
 }
 


### PR DESCRIPTION
The endpoint is used by the "juju gui" command. It does not have to return any specific version, but it needs to succeeds. This branch is part of the work for addressing https://github.com/CanonicalLtd/jujucharms.com/issues/447