### PR TITLE
internal/v2: allow admin users to list all models.

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -260,6 +260,10 @@ type NewModel struct {
 type ListModels struct {
 	httprequest.Route `httprequest:"GET /v2/model"`
 
+	// All requests the list of models for all users. This is only
+	// available to admin users.
+	All bool `httprequest:"all,form"`
+
 	// TODO add parameters for restricting results.
 }
 


### PR DESCRIPTION
Add an all flag to the /v2/models endpoint so that admin users can list
all the models in the system. This is only on the HTTP endpoint.