### PR TITLE
internal/v2: Add model status endpoint

### DIFF
--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -4,9 +4,8 @@
 package jemclient
 
 import (
-	"github.com/juju/httprequest"
-
 	"github.com/CanonicalLtd/jem/params"
+	"github.com/juju/httprequest"
 )
 
 type client struct {
@@ -79,6 +78,13 @@ func (c *client) GetModel(p *params.GetModel) (*params.ModelResponse, error) {
 // Only the owner (arg.EntityPath.User) can read the ACL.
 func (c *client) GetModelPerm(p *params.GetModelPerm) (params.ACL, error) {
 	var r params.ACL
+	err := c.Client.Call(p, &r)
+	return r, err
+}
+
+// JujuStatus retrieves and returns the status of the specifed model.
+func (c *client) JujuStatus(p *params.JujuStatus) (*params.JujuStatusResponse, error) {
+	var r *params.JujuStatusResponse
 	err := c.Client.Call(p, &r)
 	return r, err
 }

--- a/params/params.go
+++ b/params/params.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/juju/httprequest"
+	jujuparams "github.com/juju/juju/apiserver/params"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/environschema.v1"
 )
@@ -483,4 +484,15 @@ type Count struct {
 	// existed for two seconds, this metric will record four
 	// seconds.
 	TotalTime int64 `json:"total-time"`
+}
+
+// JujuStatus requests the status of the specified model.
+type JujuStatus struct {
+	httprequest.Route `httprequest:"GET /v2/model/:User/:Name/status"`
+	EntityPath
+}
+
+// JujuStatusResponse contains the full status of a juju model.
+type JujuStatusResponse struct {
+	Status jujuparams.FullStatus `json:"status"`
 }


### PR DESCRIPTION
Support retrieving the full model status using the JSON API.