### PR TITLE
internal/jem: fix error code in racy case

### DIFF
--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -502,6 +502,14 @@ func (db *Database) updateCounts(ctx context.Context, c *mgo.Collection, query b
 	}
 	err = c.Update(query, bson.D{{"$set", newCounts}})
 	if err != nil {
+		if err == mgo.ErrNotFound {
+			// This can happen if the document has been
+			// removed since we retrieved it. The error
+			// should be the same in this case (and we want
+			// to prevent the mongo session being discarded
+			// if it happens).
+			return params.ErrNotFound
+		}
 		return errgo.Notef(err, "cannot update count")
 	}
 	return nil


### PR DESCRIPTION
When we update counts, we get info from a document, then
update it. If the document is removed between those two
steps, the second update will fail with a mgo.ErrNotFound
error. If that happens, the mongo session will be dropped
because the checkError method only checks for ErrorCode
errors.

We change the code to return a params.ErrNotFound error
in that case.

This was the root cause of an intermittent test failure in internal/monitor
(TestWatcher would fail about one time in three) - this wouldn't
have been too much of a problem in production because the
monitor would be automatically restarted, but the test is using
a mock clock so the restart never happens (that's probably
a good thing, because a restart in the test indicates a problem
that we should know about).
Example test failure: http://ci-gce.theblues.io:8080/job/jem/881/console

No test because it's hard to test for reliably and the fix is simple.