### PR TITLE
internal/jujuapi: return default cloud if only one cloud available

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -685,6 +685,9 @@ func (j *JEM) DestroyModel(ctx context.Context, conn *apiconn.Conn, model *mongo
 // If the function returns an error, the iteration stops and
 // DoControllers returns the error with the same cause.
 //
+// If cloud is empty, all clouds are selected. If region is empty,
+// all regions are selected.
+//
 // Note that the same pointer is passed to the do function on
 // each iteration. It is the responsibility of the do function to
 // copy it if needed.

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -179,6 +179,8 @@ func (h *Handler) AddController(arg *params.AddController) error {
 	if err != nil {
 		return errgo.Notef(err, "cannot get clouds")
 	}
+	// Note: currently juju controllers only ever have exactly one
+	// cloud. This code will need to change if that changes.
 	for k, v := range clouds {
 		ctl.Cloud.Name = params.Cloud(k.Id())
 		ctl.Cloud.ProviderType = v.Type


### PR DESCRIPTION
This means that when we have a single-cloud controller, the user
won't need to enter a cloud name when adding a model.
