### PR TITLE
internal/monitor: remove models even when we don't get a watch update

### DIFF
--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -148,6 +148,21 @@ func (db *Database) DeleteController(ctx context.Context, path params.EntityPath
 	return nil
 }
 
+// ModelUUIDsForController returns the model UUIDs of all the models in the given
+// controller.
+func (db *Database) ModelUUIDsForController(ctx context.Context, ctlPath params.EntityPath) (uuids []string, err error) {
+	defer db.checkError(ctx, &err)
+	iter := db.Models().Find(bson.D{{"controller", ctlPath}}).Select(bson.D{{"uuid", 1}}).Iter()
+	var m mongodoc.Model
+	for iter.Next(&m) {
+		uuids = append(uuids, m.UUID)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return uuids, nil
+}
+
 // AddModel adds a new model to the database.
 // It returns an error with a params.ErrAlreadyExists
 // cause if there is already an model with the given name.

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -61,6 +61,10 @@ type jemInterface interface {
 	// AllControllers returns all the controllers in the system.
 	AllControllers(ctx context.Context) ([]*mongodoc.Controller, error)
 
+	// ModelUUIDsForController returns the model UUIDs of all the models in the given
+	// controller.
+	ModelUUIDsForController(ctx context.Context, ctlPath params.EntityPath) ([]string, error)
+
 	// OpenAPI opens an API connection to the model with the given path
 	// and returns it along with the information used to connect.
 	// If the model does not exist, the error will have a cause
@@ -102,6 +106,10 @@ type jujuAPI interface {
 
 	// Close closes the API connection.
 	Close() error
+
+	// ModelExists reports whether the model with the given UUID
+	// exists on the controller.
+	ModelExists(uuid string) (bool, error)
 
 	// ServerVersion holds the version of the API server that we are connected to.
 	ServerVersion() (version.Number, bool)

--- a/internal/monitor/shim_test.go
+++ b/internal/monitor/shim_test.go
@@ -353,6 +353,15 @@ func (s *jemShimInMemory) AllControllers(ctx context.Context) ([]*mongodoc.Contr
 	return r, nil
 }
 
+func (s *jemShimInMemory) ModelUUIDsForController(ctx context.Context, ctlPath params.EntityPath) (uuids []string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range s.models {
+		uuids = append(uuids, m.UUID)
+	}
+	return uuids, nil
+}
+
 func (s *jemShimInMemory) ControllerUpdateCredentials(_ context.Context, ctlPath params.EntityPath) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -467,6 +476,10 @@ func (s *jujuAPIShim) WatchAllModels() (allWatcher, error) {
 		stopped:     make(chan struct{}),
 		initial:     s.initial,
 	}, nil
+}
+
+func (s *jujuAPIShim) ModelExists(uuid string) (bool, error) {
+	panic("unexpected call to ModelExists")
 }
 
 func (s *jujuAPIShim) ServerVersion() (version.Number, bool) {


### PR DESCRIPTION
If a controller's watcher is broken or the jimm instance is restarted
after a model has been deleted but before we've received the
life change, we can end up with an entry in the jimm database
for which there is no corresponding controller model.

Fix this by enumerating all the local models before we start watching,
so that they'll be deleted if we don't see a model update in the
first watcher delta (the delta which has all information on controller).