### PR TITLE
controller deprecation

### DIFF
--- a/cmd/jaas-admin/admincmd/cmd.go
+++ b/cmd/jaas-admin/admincmd/cmd.go
@@ -58,6 +58,7 @@ func New() cmd.Command {
 	supercmd.Register(newAddControllerCommand())
 	supercmd.Register(newControllersCommand())
 	supercmd.RegisterAlias("list-controllers", "controllers", nil)
+	supercmd.Register(newDeprecateControllerCommand())
 	supercmd.Register(newGrantCommand())
 	supercmd.Register(newModelsCommand())
 	supercmd.RegisterAlias("list-models", "models", nil)

--- a/cmd/jaas-admin/admincmd/common_test.go
+++ b/cmd/jaas-admin/admincmd/common_test.go
@@ -114,7 +114,7 @@ var dummyEnvConfig = map[string]interface{}{
 	"controller":      true,
 }
 
-func (s *commonSuite) addEnv(c *gc.C, pathStr, srvPathStr, credName string) {
+func (s *commonSuite) addModel(c *gc.C, pathStr, srvPathStr, credName string) {
 	var path, srvPath params.EntityPath
 	err := path.UnmarshalText([]byte(pathStr))
 	c.Assert(err, gc.IsNil)

--- a/cmd/jaas-admin/admincmd/deprecate-controller.go
+++ b/cmd/jaas-admin/admincmd/deprecate-controller.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Canonical Ltd.
+
+package admincmd
+
+import (
+	"github.com/juju/cmd"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/cmd/modelcmd"
+	"gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type deprecateControllerCommand struct {
+	commandBase
+
+	path  entityPathValue
+	unset bool
+}
+
+func newDeprecateControllerCommand() cmd.Command {
+	return modelcmd.WrapBase(&deprecateControllerCommand{})
+}
+
+var deprecateControllerDoc = `
+The deprecate-controller command marks a controller
+as deprecated. New models will not be created on
+deprecated controllers.
+
+Deprecation status can be reset by using the --unset flag.
+`
+
+func (c *deprecateControllerCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "deprecate-controller",
+		Args:    "<user>/<controllername>",
+		Purpose: "deprecate a controller for adding new models",
+		Doc:     deprecateControllerDoc,
+	}
+}
+
+func (c *deprecateControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.unset, "unset", false, "Undeprecate controller")
+}
+
+func (c *deprecateControllerCommand) Init(args []string) error {
+	// Validate and store the entity reference.
+	if len(args) == 0 {
+		return errgo.Newf("no controller specified")
+	}
+	if len(args) > 1 {
+		return errgo.Newf("too many arguments")
+	}
+	if err := c.path.Set(args[0]); err != nil {
+		return errgo.Mask(err)
+	}
+	return nil
+}
+
+func (c *deprecateControllerCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.newClient(ctxt)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	defer client.Close()
+	err = client.SetControllerDeprecated(&params.SetControllerDeprecated{
+		EntityPath: c.path.EntityPath,
+		Body: params.DeprecatedBody{
+			Deprecated: !c.unset,
+		},
+	})
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	return nil
+}

--- a/cmd/jaas-admin/admincmd/deprecate-controller_test.go
+++ b/cmd/jaas-admin/admincmd/deprecate-controller_test.go
@@ -1,0 +1,90 @@
+// Copyright 2015 Canonical Ltd.
+
+package admincmd_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jem/params"
+)
+
+type deprecateControllerSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&deprecateControllerSuite{})
+
+func (s *deprecateControllerSuite) TestRevoke(c *gc.C) {
+	s.idmSrv.AddUser("bob", adminUser)
+	s.idmSrv.SetDefaultUser("bob")
+
+	// First add a controller.
+	stdout, stderr, code := run(c, c.MkDir(), "add-controller", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	stdout, stderr, code = run(c, c.MkDir(), "deprecate-controller", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	// Check that the deprecated status is set correctly
+	// (rely on lower level testing to check that it's not chosen
+	// when a new model is added).
+	d, err := s.jemClient("bob").GetControllerDeprecated(&params.GetControllerDeprecated{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(d.Deprecated, gc.Equals, true)
+
+	// Check that we can unset the deprecated status.
+	stdout, stderr, code = run(c, c.MkDir(), "deprecate-controller", "--unset", "bob/foo")
+	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, gc.Equals, "")
+	c.Assert(stderr, gc.Equals, "")
+
+	d, err = s.jemClient("bob").GetControllerDeprecated(&params.GetControllerDeprecated{
+		EntityPath: params.EntityPath{
+			User: "bob",
+			Name: "foo",
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(d.Deprecated, gc.Equals, false)
+}
+
+var deprecateControllerErrorTests = []struct {
+	about        string
+	args         []string
+	expectStderr string
+	expectCode   int
+}{{
+	about:        "no controller specified",
+	args:         []string{},
+	expectStderr: "no controller specified",
+	expectCode:   2,
+}, {
+	about:        "too many arguments",
+	args:         []string{"a", "b"},
+	expectStderr: "too many arguments",
+	expectCode:   2,
+}, {
+	about:        "only one part in path",
+	args:         []string{"a"},
+	expectStderr: `invalid entity path "a": need <user>/<name>`,
+	expectCode:   2,
+}}
+
+func (s *deprecateControllerSuite) TestRevokeGetError(c *gc.C) {
+	for i, test := range deprecateControllerErrorTests {
+		c.Logf("test %d: %s", i, test.about)
+		stdout, stderr, code := run(c, c.MkDir(), "deprecate-controller", test.args...)
+		c.Assert(code, gc.Equals, test.expectCode, gc.Commentf("stderr: %s", stderr))
+		c.Assert(stderr, gc.Matches, "(error:|ERROR) "+test.expectStderr+"\n")
+		c.Assert(stdout, gc.Equals, "")
+	}
+}

--- a/cmd/jaas-admin/admincmd/grant_test.go
+++ b/cmd/jaas-admin/admincmd/grant_test.go
@@ -25,7 +25,7 @@ func (s *grantSuite) TestGrant(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/foo", "bob/foo", "cred")
+	s.addModel(c, "bob/foo", "bob/foo", "cred")
 
 	stdout, stderr, code = run(c, c.MkDir(), "revoke", "--controller", "bob/foo", "everyone")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))

--- a/cmd/jaas-admin/admincmd/models_test.go
+++ b/cmd/jaas-admin/admincmd/models_test.go
@@ -22,9 +22,9 @@ func (s *modelsSuite) TestModels(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
-	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
-	s.addEnv(c, "bob/foo-2", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-1", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-2", "bob/foo", "cred1")
 
 	stdout, stderr, code = run(c, c.MkDir(), "models")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
@@ -48,11 +48,11 @@ func (s *modelsSuite) TestAllModels(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	s.addEnv(c, "alice/bar", "alice/foo", "cred1")
+	s.addModel(c, "alice/bar", "alice/foo", "cred1")
 
 	s.idmSrv.AddUser("bob")
 	s.idmSrv.SetDefaultUser("bob")
-	s.addEnv(c, "bob/bar", "alice/foo", "cred1")
+	s.addModel(c, "bob/bar", "alice/foo", "cred1")
 
 	s.idmSrv.SetDefaultUser("alice")
 	stdout, stderr, code = run(c, c.MkDir(), "models")

--- a/cmd/jaas-admin/admincmd/remove_test.go
+++ b/cmd/jaas-admin/admincmd/remove_test.go
@@ -21,9 +21,9 @@ func (s *removeSuite) TestRemoveModel(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo", "bob/foo", "cred1")
 
-	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-1", "bob/foo", "cred1")
 
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "bob/foo-1")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
@@ -45,16 +45,16 @@ func (s *removeSuite) TestRemoveController(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo", "bob/foo", "cred1")
 
 	// Add a second controller, that won't be deleted.
 	stdout, stderr, code = run(c, c.MkDir(), "add-controller", "bob/bar")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/bar", "bob/bar", "cred1")
+	s.addModel(c, "bob/bar", "bob/bar", "cred1")
 
-	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-1", "bob/foo", "cred1")
 
 	// Without the --force flag, we'll be forbidden because the controller
 	// is live.
@@ -90,7 +90,7 @@ func (s *removeSuite) TestRemoveMultipleModels(c *gc.C) {
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
 
-	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-1", "bob/foo", "cred1")
 
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "bob/foo", "bob/foo-1")
 	c.Assert(code, gc.Equals, 1, gc.Commentf("stderr: %s", stderr))
@@ -112,9 +112,9 @@ func (s *removeSuite) TestRemoveVerbose(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo", "bob/foo", "cred1")
 
-	s.addEnv(c, "bob/foo-1", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo-1", "bob/foo", "cred1")
 
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "--verbose", "bob/foo-1")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))

--- a/cmd/jaas-admin/admincmd/revoke_test.go
+++ b/cmd/jaas-admin/admincmd/revoke_test.go
@@ -25,7 +25,7 @@ func (s *revokeSuite) TestRevoke(c *gc.C) {
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
 	c.Assert(stderr, gc.Equals, "")
-	s.addEnv(c, "bob/foo", "bob/foo", "cred1")
+	s.addModel(c, "bob/foo", "bob/foo", "cred1")
 
 	stdout, stderr, code = run(c, c.MkDir(), "revoke", "--controller", "bob/foo", "everyone")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -819,6 +819,10 @@ func (j *JEM) selectController(ctx context.Context, cloud params.Cloud, region s
 	var controllers []mongodoc.Controller
 	var otherControllers []mongodoc.Controller
 	err := j.DoControllers(ctx, cloud, region, func(c *mongodoc.Controller) error {
+		if c.Deprecated {
+			// Never add a model to deprecated controller.
+			return nil
+		}
 		if region != "" && c.Location["region"] == region {
 			controllers = append(controllers, *c)
 		} else {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -61,6 +61,10 @@ type Controller struct {
 	// controllers by location.
 	Public bool `bson:",omitempty"`
 
+	// Deprecated specifies whether a public controller is considered
+	// deprecated for the purposes of adding new models.
+	Deprecated bool `bson:",omitempty"`
+
 	// Cloud holds the details of the cloud provided by this controller.
 	Cloud Cloud
 

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -809,6 +809,28 @@ func (h *Handler) LogLevel(*params.LogLevel) (params.Level, error) {
 	}, nil
 }
 
+func (h *Handler) SetControllerDeprecated(req *params.SetControllerDeprecated) error {
+	ctx := h.context
+	if err := auth.CheckIsUser(ctx, req.EntityPath.User); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrUnauthorized))
+	}
+	if err := h.jem.DB.SetControllerDeprecated(ctx, req.EntityPath, req.Body.Deprecated); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	return nil
+}
+
+func (h *Handler) GetControllerDeprecated(req *params.GetControllerDeprecated) (*params.DeprecatedBody, error) {
+	ctx := h.context
+	ctl, err := h.jem.Controller(ctx, req.EntityPath)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound), errgo.Is(params.ErrUnauthorized))
+	}
+	return &params.DeprecatedBody{
+		Deprecated: ctl.Deprecated,
+	}, nil
+}
+
 // SetLogLevel configures the logging level of the running service.
 func (h *Handler) SetLogLevel(req *params.SetLogLevel) error {
 	ctx := h.context

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -121,6 +121,12 @@ var unauthorizedTests = []struct {
 	asUser: "other",
 	method: "GET",
 	path:   "/v2/model/bob/open/perm",
+}, {
+	about:  "set deprecated status as non-owner",
+	asUser: "other",
+	method: "PUT",
+	path:   "/v2/controller/bob/open",
+	body:   params.DeprecatedBody{},
 }}
 
 func (s *APISuite) TestUnauthorized(c *gc.C) {
@@ -1948,6 +1954,34 @@ func (s *APISuite) TestLogLevel(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unrecognized level: "not-a-level"`)
 	client.SetLogLevel(&params.SetLogLevel{
 		Level: params.Level{Level: "info"},
+	})
+}
+
+func (s *APISuite) TestGetSetControllerDeprecated(c *gc.C) {
+	ctlId := s.AssertAddController(c, params.EntityPath{"alice", "foo"}, false)
+
+	d, err := s.NewClient("alice").GetControllerDeprecated(&params.GetControllerDeprecated{
+		EntityPath: ctlId,
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(d, jc.DeepEquals, &params.DeprecatedBody{
+		Deprecated: false,
+	})
+
+	err = s.NewClient("alice").SetControllerDeprecated(&params.SetControllerDeprecated{
+		EntityPath: ctlId,
+		Body: params.DeprecatedBody{
+			Deprecated: true,
+		},
+	})
+	c.Assert(err, gc.IsNil)
+
+	d, err = s.NewClient("alice").GetControllerDeprecated(&params.GetControllerDeprecated{
+		EntityPath: ctlId,
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(d, jc.DeepEquals, &params.DeprecatedBody{
+		Deprecated: true,
 	})
 }
 

--- a/jemclient/client_generated.go
+++ b/jemclient/client_generated.go
@@ -43,6 +43,12 @@ func (c *client) GetController(p *params.GetController) (*params.ControllerRespo
 	return r, err
 }
 
+func (c *client) GetControllerDeprecated(p *params.GetControllerDeprecated) (*params.DeprecatedBody, error) {
+	var r *params.DeprecatedBody
+	err := c.Client.Call(p, &r)
+	return r, err
+}
+
 // GetControllerLocation returns a map of location attributes for a given controller.
 func (c *client) GetControllerLocation(p *params.GetControllerLocation) (params.ControllerLocation, error) {
 	var r params.ControllerLocation
@@ -127,6 +133,10 @@ func (c *client) NewModel(p *params.NewModel) (*params.ModelResponse, error) {
 	var r *params.ModelResponse
 	err := c.Client.Call(p, &r)
 	return r, err
+}
+
+func (c *client) SetControllerDeprecated(p *params.SetControllerDeprecated) error {
+	return c.Client.Call(p, nil)
 }
 
 // SetControllerPerm sets the permissions on a controller entity.

--- a/params/params.go
+++ b/params/params.go
@@ -26,6 +26,23 @@ type GetControllerPerm struct {
 	EntityPath
 }
 
+type SetControllerDeprecated struct {
+	httprequest.Route `httprequest:"PUT /v2/controller/:User/:Name/deprecated"`
+	EntityPath
+	Body DeprecatedBody `httprequest:",body"`
+}
+
+type GetControllerDeprecated struct {
+	httprequest.Route `httprequest:"GET /v2/controller/:User/:Name/deprecated"`
+	EntityPath
+}
+
+// DeprecatedBody holds the body of a SetControllerDeprecated request
+// or a GetControllerDeprecated response.
+type DeprecatedBody struct {
+	Deprecated bool `json:"deprecated"`
+}
+
 // SetModelPerm holds the parameters for setting the ACL on an model.
 type SetModelPerm struct {
 	httprequest.Route `httprequest:"PUT /v2/model/:User/:Name/perm"`
@@ -144,6 +161,10 @@ type ControllerInfo struct {
 	//
 	// Only privileged users may create public controllers.
 	Public bool `json:"public"`
+
+	// Deprecated holds whether the controller is considered deprecated
+	// for adding new models.
+	Deprecated bool `json:"deprecated"`
 }
 
 // EntityPath holds the path parameters for specifying


### PR DESCRIPTION
We allow a controller to be deprecated such that it won't
be used for adding new models.