### PR TITLE
internal/v2: fix migration

### DIFF
--- a/internal/jem/database.go
+++ b/internal/jem/database.go
@@ -209,7 +209,9 @@ func (db *Database) UpdateLegacyModel(ctx context.Context, model *mongodoc.Model
 func (db *Database) SetModelController(ctx context.Context, model params.EntityPath, newController params.EntityPath) (err error) {
 	defer db.checkError(ctx, &err)
 	err = db.Models().UpdateId(model.String(), bson.D{{
-		"controller", newController,
+		"$set", bson.D{{
+			"controller", newController,
+		}},
 	}})
 	if errgo.Cause(err) == mgo.ErrNotFound {
 		return errgo.WithCausef(err, params.ErrNotFound, "cannot update %s", model)

--- a/internal/jem/database_test.go
+++ b/internal/jem/database_test.go
@@ -828,13 +828,18 @@ func (s *databaseSuite) TestSetModelControllerSuccess(c *gc.C) {
 		Controller: params.EntityPath{"bob", "foo"},
 	})
 	c.Assert(err, gc.IsNil)
+	origDoc, err := s.database.Model(testContext, modelPath)
+	c.Assert(err, gc.IsNil)
 
 	err = s.database.SetModelController(testContext, params.EntityPath{"bob", "foo"}, params.EntityPath{"x", "y"})
 	c.Assert(err, gc.Equals, nil)
 
-	m, err := s.database.Model(testContext, modelPath)
+	newDoc, err := s.database.Model(testContext, modelPath)
 	c.Assert(err, gc.Equals, nil)
-	c.Assert(m.Controller, jc.DeepEquals, params.EntityPath{"x", "y"})
+
+	origDoc.Controller = params.EntityPath{"x", "y"}
+
+	c.Assert(newDoc, gc.DeepEquals, origDoc)
 }
 
 func (s *databaseSuite) TestSetModelLifeNotFound(c *gc.C) {

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -765,15 +765,15 @@ func (h *Handler) Migrate(arg *params.Migrate) error {
 	if err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
-	ctl, err := h.jem.Controller(ctx, arg.Controller)
-	if err != nil {
-		return errgo.NoteMask(err, "cannot access destination controller", errgo.Is(params.ErrNotFound))
-	}
-	conn, err := h.jem.OpenAPIFromDoc(ctx, ctl)
+	conn, err := h.jem.OpenAPI(ctx, model.Controller)
 	if err != nil {
 		return errgo.Mask(err)
 	}
 	defer conn.Close()
+	ctl, err := h.jem.Controller(ctx, arg.Controller)
+	if err != nil {
+		return errgo.NoteMask(err, "cannot access destination controller", errgo.Is(params.ErrNotFound))
+	}
 	zapctx.Info(ctx, "about to call InitiateMigration")
 	api := controllerapi.NewClient(conn)
 	_, err = controllerClientInitiateMigration(api, controllerapi.MigrationSpec{


### PR DESCRIPTION
Unfortunately the only decent test of this is to QA it, because we can't create more than one test controller at the same time.

To QA, start two controllers and add them to JIMM. Then migrate with:

    bhttp post $JIMM_URL/v2/model/$user/$modelname/migrate?controller=$destcontroller

and check that the model migrates OK.
