### PR TITLE
Update jimm usage sender to send metrics to omnibus v4.

### DIFF
--- a/internal/usagesender/format.go
+++ b/internal/usagesender/format.go
@@ -1,0 +1,41 @@
+// Copyright 2018 Canonical Ltd.
+
+package usagesender
+
+import (
+	"time"
+)
+
+const (
+	ModelTag     = "model"
+	ModelNameTag = "model-name"
+)
+
+// MetricBatch is a batch of metrics that will be sent to
+// the metric collector
+type MetricBatch struct {
+	UUID        string    `json:"uuid"`
+	Created     time.Time `json:"created"`
+	Metrics     []Metric  `json:"metrics"`
+	Credentials []byte    `json:"credentials"`
+}
+
+// Metric represents a single Metric.
+type Metric struct {
+	Key   string            `json:"key"`
+	Value string            `json:"value"`
+	Time  time.Time         `json:"time"`
+	Tags  map[string]string `json:"tags"`
+}
+
+// Response represents the response from the metrics collector.
+type Response struct {
+	// UserStatus indicates the status of the users the metrics were sent for.
+	UserStatus map[string]UserStatus `json:"user-status"`
+}
+
+// UserStatus represents the status of the user.
+type UserStatus struct {
+	Code string `json:"status-code"`
+	Info string `json:"status-info"`
+}

--- a/internal/usagesender/worker.go
+++ b/internal/usagesender/worker.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/juju/httprequest"
-	romulus "github.com/juju/romulus/wireformat/metrics"
-	wireformat "github.com/juju/romulus/wireformat/metrics"
 	"github.com/juju/utils/clock"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -46,14 +44,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(UnacknowledgedMetricBatchesCount)
-}
-
-// metricBatch extends the romulus metric batch wireformat with a model name.
-// NOTE: stop-gap solution until we upgrade juju dependency.
-type metricBatch struct {
-	wireformat.MetricBatch
-
-	ModelName string `json:"model-name"`
 }
 
 // SendModelUsageWorkerConfig contains configuration values for the worker
@@ -171,45 +161,32 @@ func (w *sendModelUsageWorker) execute() error {
 		acknowledgedBatches[b.UUID] = false
 	}
 
-	response, err := w.send(batches)
+	_, err = w.send(batches)
 	if err != nil {
 		zapctx.Error(w.config.Context, "failed to send model usage", zaputil.Error(err))
+		monitorFailure(float64(len(batches)))
 		return errgo.Mask(err)
 	}
-	for _, userResponse := range response.UserResponses {
-		for _, ackBatchUUID := range userResponse.AcknowledgedBatches {
-			acknowledgedBatches[ackBatchUUID] = true
-			err = recorder.Remove(w.config.Context, ackBatchUUID)
-			if err != nil {
-				zapctx.Warn(w.config.Context, "failed to remove recorded metric")
-			}
+	for _, batch := range batches {
+		err = recorder.Remove(w.config.Context, batch.UUID)
+		if err != nil {
+			zapctx.Warn(w.config.Context, "failed to remove recorded metric")
 		}
-	}
-	// check if all batches were acknowledged
-	numberOfUnacknowledgedBatches := 0
-	for _, acknowledged := range acknowledgedBatches {
-		if !acknowledged {
-			numberOfUnacknowledgedBatches += 1
-		}
-	}
-	if numberOfUnacknowledgedBatches > 0 {
-		zapctx.Debug(w.config.Context, "model usage receipt was not acknowledged", zap.Int("unacknowledged-batches", numberOfUnacknowledgedBatches))
-		monitorFailure(float64(numberOfUnacknowledgedBatches))
 	}
 	return nil
 }
 
 type sendUsageRequest struct {
 	httprequest.Route `httprequest:"POST"`
-	Body              []metricBatch `httprequest:",body"`
+	Body              []MetricBatch `httprequest:",body"`
 }
 
 // Send sends the given metrics to omnibus.
-func (w *sendModelUsageWorker) send(usage []metricBatch) (*romulus.UserStatusResponse, error) {
+func (w *sendModelUsageWorker) send(usage []MetricBatch) (*Response, error) {
 	client := httprequest.Client{}
-	var resp romulus.UserStatusResponse
+	var resp Response
 	if err := client.CallURL(
-		w.config.OmnibusURL+"/metrics",
+		w.config.OmnibusURL+"/v4/jimm/metrics",
 		&sendUsageRequest{Body: usage},
 		&resp,
 	); err != nil {


### PR DESCRIPTION
Deploying JIMM with this change will require us to update the OmnibusURL config value (and remove the version suffix (`/v3`).