### PR TITLE
Use metering location configuration value for the usagesender worker.

### DIFF
--- a/internal/apitest/apitest.go
+++ b/internal/apitest/apitest.go
@@ -67,6 +67,9 @@ type Suite struct {
 }
 
 func (s *Suite) SetUpTest(c *gc.C) {
+	if s.ServerParams.MeteringLocation == "" {
+		s.ServerParams.MeteringLocation = "https://0.1.2.3/omnibus"
+	}
 	s.IDMSrv = idmtest.NewServer()
 	s.JujuConnSuite.ControllerConfigAttrs = map[string]interface{}{
 		controller.IdentityURL:       s.IDMSrv.URL,
@@ -147,7 +150,7 @@ func (s *Suite) NewServer(c *gc.C, session *mgo.Session, idmSrv *idmtest.Server,
 		AgentKey:                s.IDMSrv.UserPublicKey("agent"),
 		ControllerUUID:          "914487b5-60e7-42bb-bd63-1adc3fd3a388",
 		WebsocketRequestTimeout: 3 * time.Minute,
-		UsageSenderURL:          "https://0.1.2.3/omnibus/v2",
+		UsageSenderURL:          "https://0.1.2.3/omnibus",
 		UsageSenderSpoolPath:    s.MetricsSpoolPath,
 	}
 	if params.UsageSenderURL != "" {

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -235,7 +235,7 @@ func New(ctx context.Context, config Params, versions map[string]NewAPIHandlerFu
 	}
 	if config.UsageSenderURL != "" {
 		worker, err := usagesender.NewSendModelUsageWorker(usagesender.SendModelUsageWorkerConfig{
-			OmnibusURL:     config.UsageSenderURL,
+			OmnibusURL:     config.MeteringLocation,
 			Pool:           p,
 			Period:         usageSenderPeriod,
 			Context:        ctx,

--- a/internal/jujuapi/api_test.go
+++ b/internal/jujuapi/api_test.go
@@ -28,7 +28,8 @@ func (s *apiSuite) TestGUI(c *gc.C) {
 	cred := s.AssertUpdateCredential(c, "bob", "dummy", "cred1", "empty")
 	_, uuid := s.CreateModel(c, params.EntityPath{"bob", "gui-model"}, params.EntityPath{"bob", "controller-1"}, cred)
 	jemSrv := s.NewServer(c, s.Session, s.IDMSrv, jem.ServerParams{
-		GUILocation: "https://jujucharms.com.test",
+		GUILocation:      "https://jujucharms.com.test",
+		MeteringLocation: "http://0.1.2.3/omnibus",
 	})
 	defer jemSrv.Close()
 	AssertRedirect(c, RedirectParams{
@@ -54,7 +55,8 @@ func (s *apiSuite) TestGUINotFound(c *gc.C) {
 
 func (s *apiSuite) TestGUIModelNotFound(c *gc.C) {
 	jemSrv := s.NewServer(c, s.Session, s.IDMSrv, jem.ServerParams{
-		GUILocation: "https://jujucharms.com.test",
+		GUILocation:      "https://jujucharms.com.test",
+		MeteringLocation: "http://0.1.2.3/omnibus",
 	})
 	defer jemSrv.Close()
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{

--- a/internal/usagesender/worker_test.go
+++ b/internal/usagesender/worker_test.go
@@ -72,7 +72,7 @@ func (s *usageSenderSuite) SetUpTest(c *gc.C) {
 	// Set up the clock mockery.
 	s.Clock = jujutesting.NewClock(epoch)
 
-	s.ServerParams.UsageSenderURL = s.server.URL
+	s.ServerParams.MeteringLocation = s.server.URL
 
 	s.Suite.SetUpTest(c)
 }


### PR DESCRIPTION
JIMM has two configuration values in its config file: `metering-location` and `usage-sender-url`. The intended purpose was to use usage-sender-url for authorizations and metering-location for sending metrics, but metering-location was not being used. This PR fixes that.