### PR TITLE
internal/monitor: fix failsafe logic

### DIFF
--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -350,9 +350,9 @@ func (s *internalSuite) TestModelRemovedWithFailedWatcher(c *gc.C) {
 	//	- Before the watcher update arrives which would tell jimm
 	//	to remove the model (perhaps because the
 	// 	watcher isn't currently working), the watcher is restarted.
-	//	- The model (machines and applications linked to trhat model too)
-	//  should then be removed from jimm, even though it doesn't exist in
-	//  the controller.
+	//	- The model (machines and applications linked to that model too)
+	//	should then be removed from jimm, even though it doesn't exist in
+	//	the controller.
 	//
 	// To simulate this, we add a model to the jimm database but don't
 	// add it to the underlying Juju state. It should be removed when we


### PR DESCRIPTION
On 2018-12-03, all the models for one controller (XXX) were deleted by JIMM. The controller in question had been flaky and was in the process of being restored.

Our theory is that the issue have happened because a failsafe check mechanism failed. When JIMM connects to a controller, it starts a watcher to watch all models. The first delta to arrive from the watcher should contain information on all the models in the controller. If a model does not appear there, then JIMM needs to delete the model (JIMM might have crashed part way through deleting a model previously). But JIMM doesn't exclusively rely on this signal - if it finds that a model seems to have been deleted, it also checks explicitly with the controller by invoking a ModelExists method.

This is defined as follows:

		func (a apiShim) ModelExists(uuid string) (bool, error) {
		if !names.IsValidModel(uuid) {
			return false, nil
		}
		results, err := apicontroller.NewClient(a.Conn).ModelStatus(names.NewModelTag(uuid))
		if err != nil {
			if jujuparams.IsCodeNotFound(err) {
				return false, nil
			}
			return false, errgo.Mask(err)
		}

		if len(results) != 1 {
			return false, errgo.Notef(err, "unexpected result count, %d, from ModelStatus call", len(results))
		}
		// A later version of the API adds an Error parameter, but we
		// can't use that yet, so rely on UUID as a proxy for "is found".
		return results[0].UUID != "", nil
	}

That last check ignored actual error because the actual API call did not return an error in its outermost error value, but in the error response value instead. The error in the error response value was added later when the Go API changed in a backwardly incompatible way. Previously, any error would result in the outermost error value being set. After the change, the outermost error value would be nil, and the error is inside the results document.

So when the controller was returning an error, this method would return (false, nil) instead of (false, someError), so we deleted the model document.

This PR changes that logic. Unfortunately this is very hard to test because to reproduce it, we need to have a controller that is successfully connected to, then returns a delta containing no models, then fails when queried for model existence.

So this doesn't add a regression test :-\