### PR TITLE
Log usage sender authorization errors.

### DIFF
--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -439,7 +439,7 @@ func (j *JEM) CreateModel(ctx context.Context, p CreateModelParams) (_ *mongodoc
 			ctx,
 			string(p.Path.User))
 		if err != nil {
-			return nil, errgo.Mask(err)
+			zapctx.Warn(ctx, "failed to obtain credentials for model", zaputil.Error(err), zap.String("user", string(p.Path.User)))
 		}
 	}
 


### PR DESCRIPTION
Metrics are still send but will not be used for rating - only as KPI metrics.