### PR TITLE
snaps/jaas: change the name of the personal-files interface

### DIFF
--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -7,7 +7,7 @@ base: core18
 confinement: strict
 
 plugs:
-  juju-data:
+  dot-local-share-juju:
     interface: personal-files
     read:
     - $HOME/.local/share/juju


### PR DESCRIPTION
Change the name of the interface as suggested in
https://forum.snapcraft.io/t/please-allow-personal-files-interface-for-jaas/14508.