### PR TITLE
internal/apiconn: ApplicationOffers facade

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -743,7 +743,6 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -936,7 +935,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sys v0.0.0-20161012001920-9bb9f0998d48/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/apiconn/applicationoffers.go
+++ b/internal/apiconn/applicationoffers.go
@@ -1,0 +1,183 @@
+// Copyright 2020 Canonical Ltd.
+
+package apiconn
+
+import (
+	"context"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/jimm/internal/conv"
+	"github.com/CanonicalLtd/jimm/params"
+)
+
+// Offer creates a new ApplicationOffer on the controller. Offer uses the
+// Offer procedure on the ApplicationOffers facade version 2.
+func (c *Conn) Offer(ctx context.Context, offer jujuparams.AddApplicationOffer) error {
+	args := jujuparams.AddApplicationOffers{
+		Offers: []jujuparams.AddApplicationOffer{offer},
+	}
+
+	var resp jujuparams.ErrorResults
+	err := c.APICall("ApplicationOffers", 2, "", "Offer", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	return newAPIError(resp.Results[0].Error)
+}
+
+// ListApplicationOffers lists ApplicationOffers on the controller matching
+// the given filters. ListApplicationOffers uses the ListApplicationOffers
+// procedure on the ApplicationOffers facade version 2.
+func (c *Conn) ListApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error) {
+	args := jujuparams.OfferFilters{
+		Filters: filters,
+	}
+
+	var resp jujuparams.QueryApplicationOffersResults
+	err := c.APICall("ApplicationOffers", 2, "", "ListApplicationOffers", &args, &resp)
+	if err != nil {
+		return nil, newAPIError(err)
+	}
+	return resp.Results, nil
+}
+
+// FindApplicationOffers finds ApplicationOffers on the controller matching
+// the given filters. FindApplicationOffers uses the FindApplicationOffers
+// procedure on the ApplicationOffers facade version 2.
+func (c *Conn) FindApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error) {
+	args := jujuparams.OfferFilters{
+		Filters: filters,
+	}
+
+	var resp jujuparams.QueryApplicationOffersResults
+	err := c.APICall("ApplicationOffers", 2, "", "FindApplicationOffers", &args, &resp)
+	if err != nil {
+		return nil, newAPIError(err)
+	}
+	return resp.Results, nil
+}
+
+// GetApplicationOffer retrives the details of the specified
+// ApplicationOffer. The given ApplicationOfferAdminDetails must specify an
+// OfferURL the rest of the structure will be filled in by the API request.
+// GetApplicationOffer uses the ApplicationOffers procedure on the
+// ApplicationOffers facade version 2.
+func (c *Conn) GetApplicationOffer(ctx context.Context, info *jujuparams.ApplicationOfferAdminDetails) error {
+	args := jujuparams.OfferURLs{
+		OfferURLs: []string{info.OfferURL},
+	}
+
+	var resp jujuparams.ApplicationOffersResults
+	err := c.APICall("ApplicationOffers", 2, "", "ApplicationOffers", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	if resp.Results[0].Error != nil {
+		return newAPIError(resp.Results[0].Error)
+	}
+	*info = *resp.Results[0].Result
+	return nil
+}
+
+// GrantApplicationOfferAccess grants the specified permission to the
+// given user on the given application offer. GrantApplicationOfferAccess
+// uses the ModifyOfferAccess procedure on the ApplicationOffers facade
+// version 2.
+func (c *Conn) GrantApplicationOfferAccess(ctx context.Context, offerURL string, user params.User, access jujuparams.OfferAccessPermission) error {
+	args := jujuparams.ModifyOfferAccessRequest{
+		Changes: []jujuparams.ModifyOfferAccess{{
+			UserTag:  conv.ToUserTag(user).String(),
+			Action:   jujuparams.GrantOfferAccess,
+			Access:   access,
+			OfferURL: offerURL,
+		}},
+	}
+
+	var resp jujuparams.ErrorResults
+	err := c.APICall("ApplicationOffers", 2, "", "ModifyOfferAccess", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	return newAPIError(resp.Results[0].Error)
+}
+
+// RevokeApplicationOfferAccess revokes the specified permission from the
+// given user on the given application offer. RevokeApplicationOfferAccess
+// uses the ModifyOfferAccess procedure on the ApplicationOffers facade
+// version 1.
+func (c *Conn) RevokeApplicationOfferAccess(ctx context.Context, offerURL string, user params.User, access jujuparams.OfferAccessPermission) error {
+	args := jujuparams.ModifyOfferAccessRequest{
+		Changes: []jujuparams.ModifyOfferAccess{{
+			UserTag:  conv.ToUserTag(user).String(),
+			Action:   jujuparams.RevokeOfferAccess,
+			Access:   access,
+			OfferURL: offerURL,
+		}},
+	}
+
+	var resp jujuparams.ErrorResults
+	err := c.APICall("ApplicationOffers", 2, "", "ModifyOfferAccess", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	return newAPIError(resp.Results[0].Error)
+}
+
+// DestroyApplicationOffer destroys the given application offer.
+// DestroyApplicationOffer uses the DestroyOffers procedure
+// from the ApplicationOffers facade version 2.
+func (c *Conn) DestroyApplicationOffer(ctx context.Context, offer string, force bool) error {
+	args := jujuparams.DestroyApplicationOffers{
+		OfferURLs: []string{offer},
+		Force:     force,
+	}
+
+	var resp jujuparams.ErrorResults
+	err := c.APICall("ApplicationOffers", 2, "", "DestroyOffers", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	return newAPIError(resp.Results[0].Error)
+}
+
+// GetApplicationOfferConsumeDetails retrieves the details needed to
+// consume an application offer. The given ConsumeOfferDetails structure
+// must include an Offer.OfferURL and the rest of the structure will be
+// filled in by the API call. GetApplicationOfferConsumeDetails uses the
+// GetConsumeDetails procedure on the ApplicationOffers facade version 2.
+func (c *Conn) GetApplicationOfferConsumeDetails(ctx context.Context, info *jujuparams.ConsumeOfferDetails) error {
+	args := jujuparams.OfferURLs{
+		OfferURLs: []string{info.Offer.OfferURL},
+	}
+
+	var resp jujuparams.ConsumeOfferDetailsResults
+	err := c.APICall("ApplicationOffers", 2, "", "GetConsumeDetails", &args, &resp)
+	if err != nil {
+		return newAPIError(err)
+	}
+	if len(resp.Results) != 1 {
+		return errgo.Newf("unexpected number of results (expected 1, got %d)", len(resp.Results))
+	}
+	if resp.Results[0].Error != nil {
+		return newAPIError(resp.Results[0].Error)
+	}
+	*info = resp.Results[0].ConsumeOfferDetails
+	return nil
+}

--- a/internal/apiconn/applicationoffers_test.go
+++ b/internal/apiconn/applicationoffers_test.go
@@ -1,0 +1,612 @@
+// Copyright 2020 Canonical Ltd.
+
+package apiconn_test
+
+import (
+	"context"
+
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+
+	"github.com/juju/juju/api"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jimm/internal/apiconn"
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
+	"github.com/CanonicalLtd/jimm/internal/mongodoc"
+	"github.com/CanonicalLtd/jimm/params"
+)
+
+type applicationoffersSuite struct {
+	jemtest.JujuConnSuite
+
+	cache *apiconn.Cache
+	conn  *apiconn.Conn
+	model mongodoc.Model
+}
+
+var _ = gc.Suite(&applicationoffersSuite{})
+
+func (s *applicationoffersSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.cache = apiconn.NewCache(apiconn.CacheParams{})
+
+	ctx := context.Background()
+	var err error
+	s.conn, err = s.cache.OpenAPI(ctx, s.ControllerConfig.ControllerUUID(), func() (api.Connection, *api.Info, error) {
+		apiInfo := s.APIInfo(c)
+		return apiOpen(
+			&api.Info{
+				Addrs:    apiInfo.Addrs,
+				CACert:   apiInfo.CACert,
+				Tag:      apiInfo.Tag,
+				Password: apiInfo.Password,
+			},
+			api.DialOpts{},
+		)
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	s.model.Path = params.EntityPath{
+		User: "test-user",
+		Name: "test-model",
+	}
+
+	err = s.conn.CreateModel(ctx, &s.model)
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *applicationoffersSuite) TearDownTest(c *gc.C) {
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	if s.cache != nil {
+		s.cache.Close()
+	}
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *applicationoffersSuite) TestOffer(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *applicationoffersSuite) TestOfferError(c *gc.C) {
+	err := s.conn.Offer(context.Background(), jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			"url": "url",
+		},
+	})
+	c.Check(err, gc.ErrorMatches, `api error: getting offered application test-app: application "test-app" not found`)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersError(c *gc.C) {
+	_, err := s.conn.ListApplicationOffers(context.Background(), nil)
+	c.Assert(err, gc.ErrorMatches, `api error: at least one offer filter is required`)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersNoOffers(c *gc.C) {
+	offers, err := s.conn.ListApplicationOffers(context.Background(), []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersMatching(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err := s.conn.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.DeepEquals, []jujuparams.ApplicationOfferAdminDetails{info})
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersNoMatch(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err := s.conn.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName:       string(s.model.Path.User) + "@external",
+		ModelName:       string(s.model.Path.Name),
+		ApplicationName: "no-such-app",
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersError(c *gc.C) {
+	_, err := s.conn.FindApplicationOffers(context.Background(), nil)
+	c.Assert(err, gc.ErrorMatches, `api error: at least one offer filter is required`)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersNoOffers(c *gc.C) {
+	offers, err := s.conn.FindApplicationOffers(context.Background(), []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersMatching(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err := s.conn.FindApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.DeepEquals, []jujuparams.ApplicationOfferAdminDetails{info})
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersNoMatch(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err := s.conn.FindApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName:       string(s.model.Path.User) + "@external",
+		ModelName:       string(s.model.Path.Name),
+		ApplicationName: "no-such-app",
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOffer(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.model.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "cs:quantal/wordpress-1",
+	})
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferNotFound(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err := s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.ErrorMatches, `api error: application offer "test-user@external/test-model.test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestGrantApplicationOfferAccess(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err = s.conn.GrantApplicationOfferAccess(ctx, offerURL, params.User("test-user-2"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = offerURL
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.model.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Users: []jujuparams.OfferUserDetails{{
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferConsumeAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "cs:quantal/wordpress-1",
+	})
+}
+
+func (s *applicationoffersSuite) TestGrantApplicationOfferAccessNotFound(c *gc.C) {
+	ctx := context.Background()
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err := s.conn.GrantApplicationOfferAccess(ctx, offerURL, params.User("test-user-2"), jujuparams.OfferConsumeAccess)
+	c.Check(err, gc.ErrorMatches, `api error: application offer "test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestRevokeApplicationOfferAccess(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err = s.conn.GrantApplicationOfferAccess(ctx, offerURL, params.User("test-user-2"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = offerURL
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.model.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Users: []jujuparams.OfferUserDetails{{
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferConsumeAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "cs:quantal/wordpress-1",
+	})
+
+	err = s.conn.RevokeApplicationOfferAccess(ctx, offerURL, params.User("test-user-2"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.conn.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.model.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Users: []jujuparams.OfferUserDetails{{
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+		CharmURL:        "cs:quantal/wordpress-1",
+	})
+}
+
+func (s *applicationoffersSuite) TestRevokeApplicationOfferAccessNotFound(c *gc.C) {
+	ctx := context.Background()
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err := s.conn.RevokeApplicationOfferAccess(ctx, offerURL, params.User("test-user-2"), jujuparams.OfferConsumeAccess)
+	c.Check(err, gc.ErrorMatches, `api error: application offer "test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestDestroyApplicationOffer(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err := s.conn.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 1)
+
+	offerURL := "test-user@external/test-model.test-offer"
+	err = s.conn.DestroyApplicationOffer(ctx, offerURL, false)
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err = s.conn.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: string(s.model.Path.User) + "@external",
+		ModelName: string(s.model.Path.Name),
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferConsumeDetails(c *gc.C) {
+	c.ExpectFailure("juju bug #1893940")
+
+	modelState, err := s.StatePool.Get(s.model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.conn.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.model.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ConsumeOfferDetails
+	info.Offer = &jujuparams.ApplicationOfferDetails{
+		OfferURL: "test-user@external/test-model.test-offer",
+	}
+	err = s.conn.GetApplicationOfferConsumeDetails(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.Offer.OfferUUID, gc.Not(gc.Equals), "")
+	info.Offer.OfferUUID = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ConsumeOfferDetails{
+		Offer: &jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.model.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+		},
+	})
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferConsumeDetailsNotFound(c *gc.C) {
+	var info jujuparams.ConsumeOfferDetails
+	info.Offer = &jujuparams.ApplicationOfferDetails{
+		OfferURL: "test-user@external/test-model.test-offer",
+	}
+	err := s.conn.GetApplicationOfferConsumeDetails(context.Background(), &info)
+	c.Check(err, gc.ErrorMatches, `api error: application offer "test-user@external/test-model.test-offer" not found`)
+}


### PR DESCRIPTION
Add client support for the ApplicationOffers facade. Note that a number
of the tests are expected to fail because of juju bug
https://bugs.launchpad.net/juju/+bug/1893940.