### PR TITLE
internal/jujuapi: fix ModifyOfferAccess user tags

### DIFF
--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -115,7 +115,10 @@ func (r *controllerRoot) modifyOfferAcces(ctx context.Context, change jujuparams
 	if err != nil {
 		return errgo.WithCausef(err, params.ErrBadRequest, "")
 	}
-	user := params.User(userTag.Id())
+	user, err := conv.FromUserTag(userTag)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(conv.ErrLocalUser))
+	}
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
 		return errgo.Mask(r.jem.GrantOfferAccess(ctx, r.identity, user, change.OfferURL, change.Access), errgo.Is(params.ErrNotFound), errgo.Is(params.ErrBadRequest))

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -394,16 +394,17 @@ func (s *applicationOffersSuite) TestModifyOfferAccess(c *gc.C) {
 
 	offerURL := "user1@external/model-1.test-offer1"
 
-	err = client.RevokeOffer(identchecker.Everyone, "read", offerURL)
+	err = client.RevokeOffer(identchecker.Everyone+"@external", "read", offerURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = client.GrantOffer("test-user", "unknown", offerURL)
+	err = client.GrantOffer("test-user@external", "unknown", offerURL)
 	c.Assert(err, gc.ErrorMatches, `"unknown" offer access not valid`)
 
-	err = client.GrantOffer("test-user", "read", "no-such-offer")
+	err = client.GrantOffer("test-user@external", "read", "no-such-offer")
 	c.Assert(err, gc.ErrorMatches, `not found`)
 
-	err = client.GrantOffer("test-user", "admin", offerURL)
+	err = client.GrantOffer("test-user@external", "admin", offerURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	offer := mongodoc.ApplicationOffer{
@@ -416,7 +417,7 @@ func (s *applicationOffersSuite) TestModifyOfferAccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(accessLevel, gc.Equals, mongodoc.ApplicationOfferAdminAccess)
 
-	err = client.RevokeOffer("test-user", "consume", offerURL)
+	err = client.RevokeOffer("test-user@external", "consume", offerURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	accessLevel, err = s.JEM.DB.GetApplicationOfferAccess(ctx, params.User("test-user"), offer.OfferUUID)
@@ -427,7 +428,7 @@ func (s *applicationOffersSuite) TestModifyOfferAccess(c *gc.C) {
 	defer conn3.Close()
 	client3 := applicationoffers.NewClient(conn3)
 
-	err = client3.RevokeOffer("test-user", "read", offerURL)
+	err = client3.RevokeOffer("test-user@external", "read", offerURL)
 	c.Assert(err, gc.ErrorMatches, "not found")
 }
 
@@ -482,7 +483,7 @@ func (s *applicationOffersSuite) TestDestroyOffers(c *gc.C) {
 	offerURL := "user1@external/model-1.test-offer1"
 
 	// user2 will have read access
-	err = client.GrantOffer("user2", "read", offerURL)
+	err = client.GrantOffer("user2@external", "read", offerURL)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// try to destroy offer that does not exist

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -247,9 +247,9 @@ func (r *controllerRoot) userCredentials(ctx context.Context, ownerTag, cloudTag
 	if err != nil {
 		return nil, errgo.WithCausef(err, params.ErrBadRequest, "")
 	}
-	owner, err := user(ot)
+	owner, err := conv.FromUserTag(ot)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))
+		return nil, errgo.Mask(err, errgo.Is(conv.ErrLocalUser))
 	}
 	cld, err := names.ParseCloudTag(cloudTag)
 	if err != nil {
@@ -340,9 +340,9 @@ func (r *controllerRoot) credential(ctx context.Context, cloudCredentialTag stri
 
 	}
 	ownerTag := cct.Owner()
-	owner, err := user(ownerTag)
+	owner, err := conv.FromUserTag(ownerTag)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))
+		return nil, errgo.Mask(err, errgo.Is(conv.ErrLocalUser))
 	}
 
 	credPath := params.CredentialPath{
@@ -661,9 +661,9 @@ func (r *controllerRoot) updateCredential(ctx context.Context, cred jujuparams.T
 		return nil, errgo.WithCausef(err, params.ErrBadRequest, "")
 	}
 	ownerTag := tag.Owner()
-	owner, err := user(ownerTag)
+	owner, err := conv.FromUserTag(ownerTag)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))
+		return nil, errgo.Mask(err, errgo.Is(conv.ErrLocalUser))
 	}
 	if err := auth.CheckIsUser(ctx, r.identity, owner); err != nil {
 		return nil, errgo.Mask(err, errgo.Is(params.ErrUnauthorized))

--- a/internal/jujuapi/cloud_test.go
+++ b/internal/jujuapi/cloud_test.go
@@ -611,7 +611,7 @@ func (s *cloudSuite) TestCredential(c *gc.C) {
 	}, {
 		Error: &jujuparams.Error{
 			Message: `unsupported local user`,
-			Code:    jujuparams.CodeBadRequest,
+			Code:    jujuparams.CodeUserNotFound,
 		},
 	}})
 }

--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -938,7 +938,7 @@ var createModelTests = []struct {
 	ownerTag:      "user-test@local",
 	cloudTag:      names.NewCloudTag("dummy").String(),
 	credentialTag: "cloudcred-dummy_test@external_cred1",
-	expectError:   `unsupported local user \(bad request\)`,
+	expectError:   `unsupported local user \(user not found\)`,
 }, {
 	about:         "invalid user",
 	name:          "model-5",

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 
 	"github.com/CanonicalLtd/jimm/internal/auth"
+	"github.com/CanonicalLtd/jimm/internal/conv"
 	"github.com/CanonicalLtd/jimm/internal/jujuapi/rpc"
 	"github.com/CanonicalLtd/jimm/params"
 )
@@ -78,9 +79,9 @@ func (r *controllerRoot) userInfo(ctx context.Context, entity string) (*jujupara
 	if err != nil {
 		return nil, errgo.WithCausef(err, params.ErrBadRequest, "invalid user tag")
 	}
-	user, err := user(userTag)
+	user, err := conv.FromUserTag(userTag)
 	if err != nil {
-		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))
+		return nil, errgo.Mask(err, errgo.Is(conv.ErrLocalUser))
 	}
 	if r.identity.Id() != string(user) {
 		return nil, params.ErrUnauthorized

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/CanonicalLtd/jimm/internal/apiconn"
 	"github.com/CanonicalLtd/jimm/internal/auth"
+	"github.com/CanonicalLtd/jimm/internal/conv"
 	"github.com/CanonicalLtd/jimm/internal/jem"
 	"github.com/CanonicalLtd/jimm/internal/jemserver"
 	"github.com/CanonicalLtd/jimm/internal/servermon"
@@ -31,6 +32,7 @@ const (
 var errNotImplemented = errgo.New("not implemented")
 
 var errorCodes = map[error]string{
+	conv.ErrLocalUser:             jujuparams.CodeUserNotFound,
 	params.ErrAlreadyExists:       jujuparams.CodeAlreadyExists,
 	params.ErrBadRequest:          jujuparams.CodeBadRequest,
 	params.ErrForbidden:           jujuparams.CodeForbidden,


### PR DESCRIPTION
Change ModifyOfferAccess to correctly interpret user tags, rejecting
local tags and properly handling external users. Also standardise the
processing of user tags in the package.