### PR TITLE
internal/jem: iterate through application offers

### DIFF
--- a/internal/jem/applicationoffers_test.go
+++ b/internal/jem/applicationoffers_test.go
@@ -547,6 +547,10 @@ func (s *applicationoffersSuite) TestFindApplicationOffers(c *gc.C) {
 				UserName:    "user1@external",
 				DisplayName: "user1",
 				Access:      "admin",
+			}, {
+				UserName:    "user2@external",
+				DisplayName: "user2",
+				Access:      "read",
 			}},
 		},
 		ApplicationName: offer1.ApplicationName,
@@ -579,7 +583,5 @@ func (s *applicationoffersSuite) TestFindApplicationOffers(c *gc.C) {
 		ApplicationName: offer2.ApplicationName,
 		CharmURL:        offer2.CharmURL,
 		Connections:     []jujuparams.OfferConnection{},
-	},
-	})
-
+	}})
 }


### PR DESCRIPTION
Change the ListApplicationOffers database call to a more powerful
IterApplication offers, which returns an iterator. Also change all
supported filters to be part of the mongodb query. This means that a
ListApplicationOffers call can now be serviced by a single mongodb
query.