### PR TITLE
internal/jujuapi: no ApplicationOffers in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ version/init.go: version/init.go.tmpl FORCE
 	gofmt -r "unknownVersion -> Version{GitCommit: \"${GIT_COMMIT}\", Version: \"${GIT_VERSION}\",}" $<  | tee $@ > /dev/null
 
 jemd: version/init.go
-	go build -v $(PROJECT)/cmd/jemd
+	go build -tags release -v $(PROJECT)/cmd/jemd
 
 jimm-$(GIT_VERSION).tar.xz: jimm-release/bin/jemd
 	tar c -C jimm-release . | xz > $@

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -1,5 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 
+// +build !release
+
 package jujuapi
 
 import (

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -1,5 +1,7 @@
 // Copyright 2020 Canonical Ltd.
 
+// +build !release
+
 package jujuapi_test
 
 import (

--- a/internal/monitor/interface.go
+++ b/internal/monitor/interface.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	jujuparams "github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cloud"
-	"github.com/juju/names/v4"
 	"github.com/juju/version"
 
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
@@ -133,9 +131,6 @@ type jujuAPI interface {
 
 	// ServerVersion holds the version of the API server that we are connected to.
 	ServerVersion() (version.Number, bool)
-
-	// Clouds gets the clouds supported by the controller.
-	Clouds() (map[names.CloudTag]cloud.Cloud, error)
 }
 
 // allWatcher represents a watcher of all events on a controller.

--- a/internal/monitor/shim.go
+++ b/internal/monitor/shim.go
@@ -6,10 +6,8 @@ import (
 	"context"
 	"time"
 
-	cloudapi "github.com/juju/juju/api/cloud"
 	apicontroller "github.com/juju/juju/api/controller"
 	jujuparams "github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/cloud"
 	"github.com/juju/names/v4"
 	"gopkg.in/errgo.v1"
 
@@ -146,12 +144,4 @@ func (a apiShim) WatchAllModels() (allWatcher, error) {
 		return nil, errgo.Mask(err, errgo.Any)
 	}
 	return w, nil
-}
-
-func (a apiShim) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
-	clouds, err := cloudapi.NewClient(a.Conn).Clouds()
-	if err != nil {
-		return nil, errgo.Mask(err, errgo.Any)
-	}
-	return clouds, nil
 }

--- a/internal/monitor/shim_test.go
+++ b/internal/monitor/shim_test.go
@@ -559,10 +559,6 @@ func (s *jujuAPIShim) ServerVersion() (version.Number, bool) {
 	return s.serverVersion, true
 }
 
-func (s *jujuAPIShim) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
-	return s.clouds, nil
-}
-
 type watcherShim struct {
 	jujuAPIShim *jujuAPIShim
 	mu          sync.Mutex


### PR DESCRIPTION
Omit the ApplicationOffers facade in release builds as cross-model
relations won't work properly in JAAS until at least juju 2.9.