### PR TITLE
Move DestroyModel logic into jem package

### DIFF
--- a/cmd/jaas-admin/admincmd/remove_test.go
+++ b/cmd/jaas-admin/admincmd/remove_test.go
@@ -103,7 +103,7 @@ func (s *removeSuite) TestRemoveMultipleModels(c *gc.C) {
 	stdout, stderr, code = run(c, c.MkDir(), "remove", "bob/foo", "bob/foo-1")
 	c.Assert(code, gc.Equals, 1, gc.Commentf("stderr: %s", stderr))
 	c.Assert(stdout, gc.Equals, "")
-	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: Delete .*/v2/model/bob/foo: model "bob/foo" not found`+"\n")
+	c.Assert(stderr, gc.Matches, `cannot remove bob/foo: Delete .*/v2/model/bob/foo: model not found`+"\n")
 
 	stdout, stderr, code = run(c, c.MkDir(), "models")
 	c.Assert(code, gc.Equals, 0, gc.Commentf("stderr: %s", stderr))

--- a/internal/apiconn/modelmanager.go
+++ b/internal/apiconn/modelmanager.go
@@ -4,6 +4,7 @@ package apiconn
 
 import (
 	"context"
+	"time"
 
 	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/environs/config"
@@ -258,4 +259,43 @@ func (c *Conn) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelS
 		}
 	}
 	return errgo.WithCausef(nil, params.ErrNotFound, "controller model not found")
+}
+
+// DestroyModel starts the destruction of the given model. This method uses
+// the highest available method from:
+//
+//  - ModelManager(7).DestroyModels
+//  - ModelManager(4).DestroyModels
+//  - ModelManager(2).DestroyModels
+func (c *Conn) DestroyModel(ctx context.Context, uuid string, destroyStorage *bool, force *bool, maxWait *time.Duration) error {
+	mt := names.NewModelTag(uuid)
+	args := jujuparams.DestroyModelsParams{
+		Models: []jujuparams.DestroyModelParams{{
+			ModelTag:       mt.String(),
+			DestroyStorage: destroyStorage,
+			Force:          force,
+			MaxWait:        maxWait,
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	var err error
+	switch {
+	case c.HasFacadeVersion("ModelManager", 7):
+		err = c.APICall("ModelManager", 7, "", "DestroyModels", &args, &resp)
+	case c.HasFacadeVersion("ModelManager", 4):
+		err = c.APICall("ModelManager", 4, "", "DestroyModels", &args, &resp)
+	default:
+		err = c.APICall("ModelManager", 2, "", "DestroyModels",
+			&jujuparams.Entities{Entities: []jujuparams.Entity{{Tag: mt.String()}}},
+			&resp,
+		)
+	}
+
+	if err != nil {
+		return newAPIError(err)
+	}
+	return newAPIError(resp.Results[0].Error)
 }

--- a/internal/jem/jem.go
+++ b/internal/jem/jem.go
@@ -1111,26 +1111,6 @@ func (j *JEM) RevokeModel(ctx context.Context, conn *apiconn.Conn, model *mongod
 	return nil
 }
 
-// DestroyModel destroys the specified model. The model will have its
-// Life set to dying, but won't be removed until it is removed from the
-// controller.
-func (j *JEM) DestroyModel(ctx context.Context, conn *apiconn.Conn, model *mongodoc.Model, destroyStorage *bool, force *bool, maxWait *time.Duration) error {
-	client := modelmanager.NewClient(conn)
-	if err := client.DestroyModel(names.NewModelTag(model.UUID), destroyStorage, force, maxWait); err != nil {
-		return errgo.Mask(err, jujuparams.IsCodeHasPersistentStorage)
-	}
-	if err := j.DB.SetModelLife(ctx, model.Controller, model.UUID, "dying"); err != nil {
-		// If this update fails then don't worry as the watcher
-		// will detect the state change and update as appropriate.
-		zapctx.Warn(ctx, "error updating model life", zap.Error(err), zap.String("model", model.UUID))
-	}
-	j.DB.AppendAudit(ctx, &params.AuditModelDestroyed{
-		ID:   model.Id,
-		UUID: model.UUID,
-	})
-	return nil
-}
-
 // EarliestControllerVersion returns the earliest agent version
 // that any of the available public controllers is known to be running.
 // If there are no available controllers or none of their versions are

--- a/internal/jem/modelmanager.go
+++ b/internal/jem/modelmanager.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Canonical Ltd.
+
+package jem
+
+import (
+	"context"
+	"time"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"go.uber.org/zap"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
+
+	"github.com/CanonicalLtd/jimm/internal/apiconn"
+	"github.com/CanonicalLtd/jimm/internal/mongodoc"
+	"github.com/CanonicalLtd/jimm/internal/zapctx"
+	"github.com/CanonicalLtd/jimm/params"
+)
+
+// DestroyModel destroys the specified model. The model will have its
+// Life set to dying, but won't be removed until it is removed from the
+// controller.
+func (j *JEM) DestroyModel(ctx context.Context, id identchecker.ACLIdentity, model *mongodoc.Model, destroyStorage *bool, force *bool, maxWait *time.Duration) error {
+	if err := j.GetModel(ctx, id, jujuparams.ModelAdminAccess, model); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound), errgo.Is(params.ErrUnauthorized))
+	}
+	conn, err := j.OpenAPI(ctx, model.Controller)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	if err := conn.DestroyModel(ctx, model.UUID, destroyStorage, force, maxWait); err != nil {
+		return errgo.Mask(err, apiconn.IsAPIError)
+	}
+	if err := j.DB.SetModelLife(ctx, model.Controller, model.UUID, "dying"); err != nil {
+		// If this update fails then don't worry as the watcher
+		// will detect the state change and update as appropriate.
+		zapctx.Warn(ctx, "error updating model life", zap.Error(err), zap.String("model", model.UUID))
+	}
+	j.DB.AppendAudit(ctx, &params.AuditModelDestroyed{
+		ID:   model.Id,
+		UUID: model.UUID,
+	})
+	return nil
+}

--- a/internal/jem/modelmanager_test.go
+++ b/internal/jem/modelmanager_test.go
@@ -1,0 +1,134 @@
+// Copyright 2020 Canonical Ltd.
+
+package jem_test
+
+import (
+	"context"
+
+	modelmanagerapi "github.com/juju/juju/api/modelmanager"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
+
+	"github.com/CanonicalLtd/jimm/internal/jem"
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
+	"github.com/CanonicalLtd/jimm/internal/mgosession"
+	"github.com/CanonicalLtd/jimm/internal/mongodoc"
+	"github.com/CanonicalLtd/jimm/internal/pubsub"
+	"github.com/CanonicalLtd/jimm/params"
+)
+
+type modelManagerSuite struct {
+	jemtest.JujuConnSuite
+	pool                           *jem.Pool
+	sessionPool                    *mgosession.Pool
+	jem                            *jem.JEM
+	usageSenderAuthorizationClient *testUsageSenderAuthorizationClient
+}
+
+var _ = gc.Suite(&controllerSuite{})
+
+func (s *modelManagerSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	s.sessionPool = mgosession.NewPool(context.TODO(), s.Session, 5)
+	publicCloudMetadata, _, err := cloud.PublicCloudMetadata()
+	c.Assert(err, gc.Equals, nil)
+	s.usageSenderAuthorizationClient = &testUsageSenderAuthorizationClient{}
+	s.PatchValue(&jem.NewUsageSenderAuthorizationClient, func(_ string, _ *httpbakery.Client) (jem.UsageSenderAuthorizationClient, error) {
+		return s.usageSenderAuthorizationClient, nil
+	})
+	pool, err := jem.NewPool(context.TODO(), jem.Params{
+		DB:                  s.Session.DB("jem"),
+		ControllerAdmin:     "controller-admin",
+		SessionPool:         s.sessionPool,
+		PublicCloudMetadata: publicCloudMetadata,
+		UsageSenderURL:      "test-usage-sender-url",
+		Pubsub: &pubsub.Hub{
+			MaxConcurrency: 10,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+	s.pool = pool
+	s.jem = s.pool.JEM(context.TODO())
+	s.PatchValue(&utils.OutgoingAccessAllowed, true)
+}
+
+func (s *modelManagerSuite) TearDownTest(c *gc.C) {
+	s.jem.Close()
+	s.pool.Close()
+	s.sessionPool.Close()
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *modelManagerSuite) TestDestroyModel(c *gc.C) {
+	model := s.bootstrapModel(c, params.EntityPath{User: "bob", Name: "model"})
+	conn, err := s.jem.OpenAPI(testContext, model.Controller)
+	c.Assert(err, gc.Equals, nil)
+	defer conn.Close()
+
+	// Sanity check the model exists
+	client := modelmanagerapi.NewClient(conn)
+	_, err = client.ModelInfo([]names.ModelTag{
+		names.NewModelTag(model.UUID),
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.jem.DestroyModel(testContext, jemtest.NewIdentity("bob"), model, nil, nil, nil)
+	c.Assert(err, gc.Equals, nil)
+
+	// Check the model is dying.
+	m := mongodoc.Model{Path: model.Path}
+	err = s.jem.DB.GetModel(testContext, &m)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(m.Life(), gc.Equals, "dying")
+
+	// Check that it can be destroyed twice.
+	err = s.jem.DestroyModel(testContext, jemtest.NewIdentity("bob"), model, nil, nil, nil)
+	c.Assert(err, gc.Equals, nil)
+
+	// Check the model is still dying.
+	err = s.jem.DB.GetModel(testContext, &m)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(m.Life(), gc.Equals, "dying")
+}
+
+func (s *modelManagerSuite) TestDestroyModelWithStorage(c *gc.C) {
+	model := s.bootstrapModel(c, params.EntityPath{User: "bob", Name: "model"})
+	conn, err := s.jem.OpenAPI(testContext, model.Controller)
+	c.Assert(err, gc.Equals, nil)
+	defer conn.Close()
+
+	// Sanity check the model exists
+	tag := names.NewModelTag(model.UUID)
+	client := modelmanagerapi.NewClient(conn)
+	_, err = client.ModelInfo([]names.ModelTag{tag})
+	c.Assert(err, gc.Equals, nil)
+
+	modelState, err := s.StatePool.Get(model.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: f.MakeApplication(c, &factory.ApplicationParams{
+			Charm: f.MakeCharm(c, &factory.CharmParams{
+				Name: "storage-block",
+			}),
+			Storage: map[string]state.StorageConstraints{
+				"data": {Pool: "modelscoped"},
+			},
+		}),
+	})
+
+	err = s.jem.DestroyModel(testContext, jemtest.NewIdentity("bob"), model, nil, nil, nil)
+	c.Assert(err, jc.Satisfies, jujuparams.IsCodeHasPersistentStorage)
+}
+
+func (s *modelManagerSuite) bootstrapModel(c *gc.C, path params.EntityPath) *mongodoc.Model {
+	return bootstrapModel(c, path, s.APIInfo(c), s.jem)
+}

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -398,7 +398,7 @@ func (s *APISuite) TestDeleteModelNotFound(c *gc.C) {
 		Handler: s.JEMSrv,
 		URL:     "/v2/model/user/foo",
 		ExpectBody: &params.Error{
-			Message: `model "user/foo" not found`,
+			Message: `model not found`,
 			Code:    params.ErrNotFound,
 		},
 		ExpectStatus: http.StatusNotFound,


### PR DESCRIPTION
The DestroyModel logic is now handled internally in the jem package.