### PR TITLE
internal/auth: remove IdentityFromContext

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -191,35 +191,3 @@ func (c *IdentityClient) DeclaredIdentity(ctx context.Context, declared map[stri
 		Reason: errgo.Newf("user not in %q domain", c.p.Domain),
 	}
 }
-
-type authKey struct{}
-
-// ContextWithIdentity returns the given context with the given identity
-// attached.
-func ContextWithIdentity(ctx context.Context, id identchecker.ACLIdentity) context.Context {
-	return context.WithValue(ctx, authKey{}, id)
-}
-
-// IdentityFromContext returns the identity that was previously attached
-// to the context using ContextWithIdentity. If no identity has been
-// attached then an Identity with no authority is returned.
-func IdentityFromContext(ctx context.Context) identchecker.ACLIdentity {
-	if aid, _ := ctx.Value(authKey{}).(identchecker.ACLIdentity); aid != nil {
-		return aid
-	}
-	return noIdentity{}
-}
-
-type noIdentity struct{}
-
-func (noIdentity) Id() string {
-	return ""
-}
-
-func (noIdentity) Domain() string {
-	return ""
-}
-
-func (noIdentity) Allow(context.Context, []string) (bool, error) {
-	return false, nil
-}

--- a/internal/jem/audit.go
+++ b/internal/jem/audit.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/CanonicalLtd/jimm/internal/auth"
 	"go.uber.org/zap"
 
 	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/CanonicalLtd/jimm/internal/zapctx"
@@ -16,10 +16,10 @@ import (
 )
 
 // AppendAudit appends the given entry to the audit log.
-func (db *Database) AppendAudit(ctx context.Context, e params.AuditEntry) {
+func (db *Database) AppendAudit(ctx context.Context, id identchecker.ACLIdentity, e params.AuditEntry) {
 	common := e.Common()
 	common.Created_ = time.Now()
-	common.Originator = auth.IdentityFromContext(ctx).Id()
+	common.Originator = id.Id()
 	common.Type_ = params.AuditLogType(e)
 
 	if err := db.Audits().Insert(&params.AuditLogEntry{

--- a/internal/jem/audit_test.go
+++ b/internal/jem/audit_test.go
@@ -4,8 +4,9 @@ package jem_test
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	gc "gopkg.in/check.v1"
 
@@ -46,7 +47,7 @@ func (s *auditSuite) TestAddAuditModelCreated(c *gc.C) {
 		Cloud:   "somecloud",
 		Region:  "someregion",
 	}
-	s.database.AppendAudit(testContext, &content)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &content)
 	entries, err := s.database.GetAuditEntries(testContext, time.Time{}, time.Time{}, "")
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(entries, jemtest.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), params.AuditLogEntries{{
@@ -58,7 +59,8 @@ func (s *auditSuite) TestAddAuditModelCreated(c *gc.C) {
 			Cloud:   "somecloud",
 			Region:  "someregion",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditModelCreated{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditModelCreated{}),
 			},
 		},
 	}})
@@ -69,7 +71,7 @@ func (s *auditSuite) TestAddAuditModelDestroyed(c *gc.C) {
 		ID:   "someid",
 		UUID: "someuuid",
 	}
-	s.database.AppendAudit(testContext, &content)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &content)
 	entries, err := s.database.GetAuditEntries(testContext, time.Time{}, time.Time{}, "")
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(entries, jemtest.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), params.AuditLogEntries{{
@@ -77,7 +79,8 @@ func (s *auditSuite) TestAddAuditModelDestroyed(c *gc.C) {
 			ID:   "someid",
 			UUID: "someuuid",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditModelDestroyed{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditModelDestroyed{}),
 			},
 		},
 	}})
@@ -89,7 +92,7 @@ func (s *auditSuite) TestAddAuditCloudCreated(c *gc.C) {
 		Cloud:  "somecloud",
 		Region: "someregion",
 	}
-	s.database.AppendAudit(testContext, &content)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &content)
 	entries, err := s.database.GetAuditEntries(testContext, time.Time{}, time.Time{}, "")
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(entries, jemtest.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), params.AuditLogEntries{{
@@ -98,7 +101,8 @@ func (s *auditSuite) TestAddAuditCloudCreated(c *gc.C) {
 			Cloud:  "somecloud",
 			Region: "someregion",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditCloudCreated{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditCloudCreated{}),
 			},
 		},
 	}})
@@ -108,14 +112,15 @@ func (s *auditSuite) TestAddAuditCloudRemoved(c *gc.C) {
 	content := params.AuditCloudRemoved{
 		ID: "someid",
 	}
-	s.database.AppendAudit(testContext, &content)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &content)
 	entries, err := s.database.GetAuditEntries(testContext, time.Time{}, time.Time{}, "")
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(entries, jemtest.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), params.AuditLogEntries{{
 		Content: &params.AuditCloudRemoved{
 			ID: "someid",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditCloudRemoved{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditCloudRemoved{}),
 			},
 		},
 	}})
@@ -130,13 +135,13 @@ func (s *auditSuite) TestGetAuditEntries(c *gc.C) {
 		Cloud:   "somecloud",
 		Region:  "someregion",
 	}
-	s.database.AppendAudit(testContext, &created)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &created)
 
 	content := params.AuditModelDestroyed{
 		ID:   "someid",
 		UUID: "someuuid",
 	}
-	s.database.AppendAudit(testContext, &content)
+	s.database.AppendAudit(testContext, jemtest.NewIdentity("test"), &content)
 	entries, err := s.database.GetAuditEntries(testContext, time.Time{}, time.Time{}, "")
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(entries, jemtest.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), params.AuditLogEntries{{
@@ -148,7 +153,8 @@ func (s *auditSuite) TestGetAuditEntries(c *gc.C) {
 			Cloud:   "somecloud",
 			Region:  "someregion",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditModelCreated{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditModelCreated{}),
 			},
 		},
 	}, {
@@ -156,7 +162,8 @@ func (s *auditSuite) TestGetAuditEntries(c *gc.C) {
 			ID:   "someid",
 			UUID: "someuuid",
 			AuditEntryCommon: params.AuditEntryCommon{
-				Type_: params.AuditLogType(&params.AuditModelDestroyed{}),
+				Originator: "test",
+				Type_:      params.AuditLogType(&params.AuditModelDestroyed{}),
 			},
 		},
 	}})

--- a/internal/jem/cloud.go
+++ b/internal/jem/cloud.go
@@ -144,7 +144,7 @@ func (j *JEM) AddHostedCloud(ctx context.Context, id identchecker.ACLIdentity, n
 		return errgo.Mask(err)
 	}
 
-	j.DB.AppendAudit(ctx, &params.AuditCloudCreated{
+	j.DB.AppendAudit(ctx, id, &params.AuditCloudCreated{
 		ID:    string(name) + "/",
 		Cloud: string(name),
 	})
@@ -189,7 +189,7 @@ func (j *JEM) RemoveCloud(ctx context.Context, id identchecker.ACLIdentity, clou
 		return errgo.Mask(err)
 	}
 
-	j.DB.AppendAudit(ctx, &params.AuditCloudRemoved{
+	j.DB.AppendAudit(ctx, id, &params.AuditCloudRemoved{
 		ID:     cr.Id,
 		Cloud:  string(cr.Cloud),
 		Region: cr.Region,

--- a/internal/jem/export_test.go
+++ b/internal/jem/export_test.go
@@ -13,4 +13,5 @@ var (
 	Shuffle                     = &shuffle
 	MongodocAPIHostPorts        = mongodocAPIHostPorts
 	ControllerUpdateCredentials = (*JEM).controllerUpdateCredentials
+	DoControllers               = (*JEM).doControllers
 )

--- a/internal/jem/modelmanager.go
+++ b/internal/jem/modelmanager.go
@@ -48,7 +48,7 @@ func (j *JEM) DestroyModel(ctx context.Context, id identchecker.ACLIdentity, mod
 		// will detect the state change and update as appropriate.
 		zapctx.Warn(ctx, "error updating model life", zap.Error(err), zap.String("model", model.UUID))
 	}
-	j.DB.AppendAudit(ctx, &params.AuditModelDestroyed{
+	j.DB.AppendAudit(ctx, id, &params.AuditModelDestroyed{
 		ID:   model.Id,
 		UUID: model.UUID,
 	})
@@ -241,7 +241,7 @@ func (j *JEM) CreateModel(ctx context.Context, id identchecker.ACLIdentity, p Cr
 		j.DB.checkError(ctx, &err)
 		return errgo.Notef(err, "cannot update model %s in database", modelDoc.UUID)
 	}
-	j.DB.AppendAudit(ctx, &params.AuditModelCreated{
+	j.DB.AppendAudit(ctx, id, &params.AuditModelCreated{
 		ID:             modelDoc.Id,
 		UUID:           modelDoc.UUID,
 		Owner:          string(modelDoc.Owner()),
@@ -349,7 +349,7 @@ func (j *JEM) selectCredential(ctx context.Context, id identchecker.ACLIdentity,
 		}
 	}
 	var creds []mongodoc.Credential
-	iter := j.DB.NewCanReadIter(auth.ContextWithIdentity(ctx, id), j.DB.Credentials().Find(query).Iter())
+	iter := j.DB.NewCanReadIter(id, j.DB.Credentials().Find(query).Iter())
 	var cred mongodoc.Credential
 	for iter.Next(ctx, &cred) {
 		creds = append(creds, cred)

--- a/internal/jem/prometheus_test.go
+++ b/internal/jem/prometheus_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	gc "gopkg.in/check.v1"
 
-	"github.com/CanonicalLtd/jimm/internal/auth"
 	"github.com/CanonicalLtd/jimm/internal/jem"
 	"github.com/CanonicalLtd/jimm/internal/jemtest"
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
@@ -25,12 +24,10 @@ import (
 )
 
 func (s *jemSuite) TestModelStats(c *gc.C) {
-	ctx := auth.ContextWithIdentity(testContext, jemtest.NewIdentity("bob"))
-
 	ctl1Id := s.addController(c, params.EntityPath{"bob", "controller1"})
 	ctl2Id := s.addController(c, params.EntityPath{"bob", "controller2"})
 	s.addController(c, params.EntityPath{"bob", "controller3"})
-	err := s.jem.DB.AddModel(ctx, &mongodoc.Model{
+	err := s.jem.DB.AddModel(testContext, &mongodoc.Model{
 		Path: params.EntityPath{
 			User: "bob",
 			Name: "model1",
@@ -54,7 +51,7 @@ func (s *jemSuite) TestModelStats(c *gc.C) {
 	})
 	c.Assert(err, gc.Equals, nil)
 
-	err = s.jem.DB.AddModel(ctx, &mongodoc.Model{
+	err = s.jem.DB.AddModel(testContext, &mongodoc.Model{
 		Path: params.EntityPath{
 			User: "bob",
 			Name: "model2",
@@ -78,7 +75,7 @@ func (s *jemSuite) TestModelStats(c *gc.C) {
 	})
 	c.Assert(err, gc.Equals, nil)
 
-	err = s.jem.DB.AddModel(ctx, &mongodoc.Model{
+	err = s.jem.DB.AddModel(testContext, &mongodoc.Model{
 		Path: params.EntityPath{
 			User: "bob",
 			Name: "model3",

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -13,7 +13,6 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
-	"github.com/CanonicalLtd/jimm/internal/auth"
 	"github.com/CanonicalLtd/jimm/internal/conv"
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
 	"github.com/CanonicalLtd/jimm/internal/servermon"
@@ -61,10 +60,9 @@ func (r *controllerRoot) Login(ctx context.Context, req jujuparams.LoginRequest)
 		return facades[i].Name < facades[j].Name
 	})
 
-	ctx = auth.ContextWithIdentity(ctx, id)
 	servermon.LoginSuccessCount.Inc()
 	username := id.Id()
-	srvVersion, err := r.jem.EarliestControllerVersion(ctx)
+	srvVersion, err := r.jem.EarliestControllerVersion(ctx, id)
 	if err != nil {
 		return jujuparams.LoginResult{}, errgo.Mask(err)
 	}

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rogpeppe/fastuuid"
 	"gopkg.in/errgo.v1"
 
-	"github.com/CanonicalLtd/jimm/internal/auth"
 	"github.com/CanonicalLtd/jimm/internal/jujuapi/rpc"
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
 	"github.com/CanonicalLtd/jimm/params"
@@ -108,7 +107,7 @@ func (r *controllerRoot) IdentityProviderURL(ctx context.Context) (jujuparams.St
 // ControllerVersion returns the version information associated with this
 // controller binary.
 func (r *controllerRoot) ControllerVersion(ctx context.Context) (jujuparams.ControllerVersionResults, error) {
-	srvVersion, err := r.jem.EarliestControllerVersion(ctx)
+	srvVersion, err := r.jem.EarliestControllerVersion(ctx, r.identity)
 	if err != nil {
 		return jujuparams.ControllerVersionResults{}, errgo.Mask(err)
 	}
@@ -135,7 +134,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 
 	id := fmt.Sprintf("%v", r.generator.Next())
 
-	watcher, err := newModelSummaryWatcher(auth.ContextWithIdentity(ctx, r.identity), id, r, r.jem.Pubsub())
+	watcher, err := newModelSummaryWatcher(ctx, id, r, r.jem.Pubsub())
 	if err != nil {
 		return jujuparams.SummaryWatcherID{}, errgo.Mask(err)
 	}
@@ -147,7 +146,6 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 }
 
 func (r *controllerRoot) AllModels(ctx context.Context) (jujuparams.UserModelList, error) {
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	return r.allModels(ctx)
 }
 

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/modelmanager"
 	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/controller"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
@@ -231,14 +232,14 @@ func (s *controllerSuite) TestControllerVersion(c *gc.C) {
 	err := conn.APICall("Controller", 8, "", "ControllerVersion", nil, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, jujuparams.ControllerVersionResults{
-		Version:   "0.0.0",
+		Version:   jujuversion.Current.String(),
 		GitCommit: jimmversion.VersionInfo.GitCommit,
 	})
 
 	err = conn.APICall("Controller", 9, "", "ControllerVersion", nil, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, jujuparams.ControllerVersionResults{
-		Version:   "0.0.0",
+		Version:   jujuversion.Current.String(),
 		GitCommit: jimmversion.VersionInfo.GitCommit,
 	})
 }

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -93,7 +93,7 @@ func (r *controllerRoot) modelWithConnection(ctx context.Context, modelTag strin
 // authenticated user has access to. If f returns an error, the iteration
 // will be stopped and the returned error will have the same cause.
 func (r *controllerRoot) doModels(ctx context.Context, f func(context.Context, *mongodoc.Model) error) error {
-	it := r.jem.DB.NewCanReadIter(ctx, r.jem.DB.Models().Find(nil).Sort("_id").Iter())
+	it := r.jem.DB.NewCanReadIter(r.identity, r.jem.DB.Models().Find(nil).Sort("_id").Iter())
 	defer it.Close(ctx)
 
 	for {

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -84,7 +84,6 @@ func init() {
 func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.Entities) jujuparams.MapResults {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.MapResult, len(args.Entities))
 	for i, ent := range args.Entities {
 		err := r.modelWithConnection(
@@ -123,7 +122,6 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Enti
 // ListModelSummaries returns summaries for all the models that that
 // authenticated user has access to. The request parameter is ignored.
 func (r *controllerRoot) ListModelSummaries(ctx context.Context, _ jujuparams.ModelSummariesRequest) (jujuparams.ModelSummaryResults, error) {
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	var results []jujuparams.ModelSummaryResult
 	err := r.doModels(ctx, func(ctx context.Context, model *mongodoc.Model) error {
 		if model.ProviderType == "" {
@@ -216,7 +214,6 @@ func (r *controllerRoot) ListModelSummaries(ctx context.Context, _ jujuparams.Mo
 // ListModels returns the models that the authenticated user
 // has access to. The user parameter is ignored.
 func (r *controllerRoot) ListModels(ctx context.Context, _ jujuparams.Entity) (jujuparams.UserModelList, error) {
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	return r.allModels(ctx)
 }
 
@@ -224,7 +221,6 @@ func (r *controllerRoot) ListModels(ctx context.Context, _ jujuparams.Entity) (j
 func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelInfoResults, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.ModelInfoResult, len(args.Entities))
 	run := parallel.NewRun(maxRequestConcurrency)
 	for i, arg := range args.Entities {
@@ -264,7 +260,6 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelCreateArgs) (info jujuparams.ModelInfo, err error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	err = errgo.Mask(r.createModel(ctx, args, &info),
 		errgo.Is(conv.ErrLocalUser),
 		errgo.Is(params.ErrUnauthorized),
@@ -325,7 +320,6 @@ func (r *controllerRoot) createModel(ctx context.Context, args jujuparams.ModelC
 func (r *controllerRoot) DestroyModelsV4(ctx context.Context, args jujuparams.DestroyModelsParams) (jujuparams.ErrorResults, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.ErrorResult, len(args.Models))
 
 	for i, model := range args.Models {
@@ -353,7 +347,6 @@ func (r *controllerRoot) DestroyModelsV4(ctx context.Context, args jujuparams.De
 func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.ModifyModelAccessRequest) (jujuparams.ErrorResults, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.ErrorResult, len(args.Changes))
 	for i, change := range args.Changes {
 		err := r.modifyModelAccess(ctx, change)
@@ -407,7 +400,6 @@ func (r *controllerRoot) modifyModelAccess(ctx context.Context, change jujuparam
 func (r *controllerRoot) DumpModelsV3(ctx context.Context, args jujuparams.DumpModelRequest) jujuparams.StringResults {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.StringResult, len(args.Entities))
 	for i, ent := range args.Entities {
 		err := r.modelWithConnection(
@@ -436,7 +428,6 @@ func (r *controllerRoot) DumpModelsV3(ctx context.Context, args jujuparams.DumpM
 func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entities) jujuparams.MapResults {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.MapResult, len(args.Entities))
 	for i, ent := range args.Entities {
 		err := r.modelWithConnection(
@@ -465,7 +456,6 @@ func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entit
 func (r *controllerRoot) ChangeModelCredential(ctx context.Context, args jujuparams.ChangeModelCredentialsParams) (jujuparams.ErrorResults, error) {
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	results := make([]jujuparams.ErrorResult, len(args.Models))
 	for i, arg := range args.Models {
 		results[i].Error = mapError(r.changeModelCredential(ctx, arg))

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 
-	"github.com/CanonicalLtd/jimm/internal/auth"
 	"github.com/CanonicalLtd/jimm/internal/conv"
 	"github.com/CanonicalLtd/jimm/internal/jujuapi/rpc"
 	"github.com/CanonicalLtd/jimm/params"
@@ -58,7 +57,6 @@ func (r *controllerRoot) DisableUser(jujuparams.Entities) (jujuparams.ErrorResul
 
 // UserInfo implements the UserManager facade's UserInfo method.
 func (r *controllerRoot) UserInfo(ctx context.Context, req jujuparams.UserInfoRequest) (jujuparams.UserInfoResults, error) {
-	ctx = auth.ContextWithIdentity(ctx, r.identity)
 	res := jujuparams.UserInfoResults{
 		Results: make([]jujuparams.UserInfoResult, len(req.Entities)),
 	}


### PR DESCRIPTION
Remove all the remaining uses of IdentityFromContext in favour of having
explicit identity parameters where required.