### PR TITLE
internal/monitor: count cores

### DIFF
--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -95,6 +95,9 @@ func (s *modelManagerSuite) TestListModelSummaries(c *gc.C) {
 		}, {
 			Entity: "cores",
 			Count:  0,
+		}, {
+			Entity: "units",
+			Count:  0,
 		}},
 		AgentVersion: &jujuversion.Current,
 		Type:         "iaas",
@@ -119,6 +122,9 @@ func (s *modelManagerSuite) TestListModelSummaries(c *gc.C) {
 			Count:  0,
 		}, {
 			Entity: "cores",
+			Count:  0,
+		}, {
+			Entity: "units",
 			Count:  0,
 		}},
 		AgentVersion: &jujuversion.Current,
@@ -181,6 +187,9 @@ func (s *modelManagerSuite) TestListModelSummariesWitouthControllerUUIDMasking(c
 		}, {
 			Entity: "cores",
 			Count:  0,
+		}, {
+			Entity: "units",
+			Count:  0,
 		}},
 		AgentVersion: &jujuversion.Current,
 		Type:         "iaas",
@@ -205,6 +214,9 @@ func (s *modelManagerSuite) TestListModelSummariesWitouthControllerUUIDMasking(c
 			Count:  0,
 		}, {
 			Entity: "cores",
+			Count:  0,
+		}, {
+			Entity: "units",
 			Count:  0,
 		}},
 		AgentVersion: &jujuversion.Current,
@@ -1666,6 +1678,9 @@ func (s *caasModelManagerSuite) TestListCAASModelSummaries(c *gc.C) {
 			Count:  0,
 		}, {
 			Entity: "cores",
+			Count:  0,
+		}, {
+			Entity: "units",
 			Count:  0,
 		}},
 		AgentVersion: &jujuversion.Current,

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/utils/parallel"
 	"go.uber.org/zap"
 	"gopkg.in/errgo.v1"
@@ -454,6 +455,10 @@ type modelInfo struct {
 	// changed holds information about what's changed
 	// in the model since the last set of deltas.
 	changed modelChange
+
+	// machineHardware holds a map from a machine Id to the machine's
+	// hardware characteristics.
+	machineHardware map[string]*instance.HardwareCharacteristics
 }
 
 func (info *modelInfo) adjustCount(kind params.EntityCount, n int) {
@@ -466,6 +471,23 @@ func (info *modelInfo) adjustCount(kind params.EntityCount, n int) {
 func (info *modelInfo) setInfo(modelInfo *jujuparams.ModelUpdate) {
 	info.changed |= infoChange
 	info.info = modelInfo
+}
+
+func (info *modelInfo) setMachineHardware(id string, hw *instance.HardwareCharacteristics) int {
+	getCores := func(h *instance.HardwareCharacteristics) int {
+		if h == nil || h.CpuCores == nil {
+			return 0
+		}
+		return int(*h.CpuCores)
+	}
+	oldCount := getCores(info.machineHardware[id])
+	newCount := getCores(hw)
+	if hw == nil {
+		delete(info.machineHardware, id)
+	} else {
+		info.machineHardware[id] = hw
+	}
+	return newCount - oldCount
 }
 
 func newWatcherState(ctx context.Context, j jemInterface, ctlPath params.EntityPath) *watcherState {
@@ -516,9 +538,14 @@ func (w *watcherState) addDelta(ctx context.Context, d jujuparams.Delta) error {
 		// TODO for top level machines, increment instance count?
 		delta := w.adjustCount(&w.stats.MachineCount, d)
 		w.modelInfo(e.ModelUUID).adjustCount(params.MachineCount, delta)
+		var coreDelta int
 		if d.Removed {
+			coreDelta = w.modelInfo(e.ModelUUID).setMachineHardware(e.Id, nil)
 			e.Life = "dead"
+		} else {
+			coreDelta = w.modelInfo(e.ModelUUID).setMachineHardware(e.Id, e.HardwareCharacteristics)
 		}
+		w.modelInfo(e.ModelUUID).adjustCount(params.CoreCount, coreDelta)
 		w.runner.Do(func() error {
 			return w.jem.UpdateMachineInfo(ctx, w.ctlPath, e)
 		})
@@ -547,10 +574,12 @@ func (w watcherState) modelInfo(uuid string) *modelInfo {
 			// update the counts even if no entities are created.
 			changed: ^0,
 			counts: map[params.EntityCount]int{
+				params.CoreCount:        0,
 				params.UnitCount:        0,
 				params.MachineCount:     0,
 				params.ApplicationCount: 0,
 			},
+			machineHardware: make(map[string]*instance.HardwareCharacteristics),
 		}
 		w.models[uuid] = info
 	}

--- a/internal/monitor/internal_test.go
+++ b/internal/monitor/internal_test.go
@@ -1352,12 +1352,12 @@ func (s *internalSuite) controllerStats(c *gc.C, ctlPath params.EntityPath) mong
 
 // modelStats holds the aspects of a model updated by the monitor.
 type modelStats struct {
-	life                                      string
-	status                                    string
-	message                                   string
-	hasConfig                                 bool
-	hasStatusSince                            bool
-	unitCount, machineCount, applicationCount int
+	life                                                 string
+	status                                               string
+	message                                              string
+	hasConfig                                            bool
+	hasStatusSince                                       bool
+	unitCount, machineCount, applicationCount, coreCount int
 }
 
 func (s *internalSuite) modelStats(c *gc.C, modelPath params.EntityPath) modelStats {
@@ -1378,6 +1378,7 @@ func (s *internalSuite) modelStats(c *gc.C, modelPath params.EntityPath) modelSt
 		unitCount:        modelDoc.Counts[params.UnitCount].Current,
 		machineCount:     modelDoc.Counts[params.MachineCount].Current,
 		applicationCount: modelDoc.Counts[params.ApplicationCount].Current,
+		coreCount:        modelDoc.Counts[params.CoreCount].Current,
 	}
 	if modelDoc.Info == nil {
 		return ms

--- a/params/params.go
+++ b/params/params.go
@@ -451,6 +451,7 @@ const (
 	ApplicationCount      EntityCount = "applications"
 	MachineCount          EntityCount = "machines"
 	ApplicationOfferCount EntityCount = "application-offers"
+	CoreCount             EntityCount = "cores"
 )
 
 // Count records information about a changing count of


### PR DESCRIPTION
Count cpu cores when processing MachineInfo data to save recalculating
it on every request.

Note: I couldn't find a way to convince the dummy provider to send
MachineInfo including cores so this can't be automatically tested.