### PR TITLE
internal/jem: credential auth-check consistency

### DIFF
--- a/internal/apiconn/cloud.go
+++ b/internal/apiconn/cloud.go
@@ -107,7 +107,7 @@ func (c *Conn) UpdateCredential(_ context.Context, cred *mongodoc.Credential) ([
 //
 // Any error that represents a Juju API failure will be of type
 // *APIError.
-func (c *Conn) RevokeCredential(_ context.Context, path params.CredentialPath) error {
+func (c *Conn) RevokeCredential(_ context.Context, path mongodoc.CredentialPath) error {
 	var out jujuparams.ErrorResults
 	if c.SupportsCheckCredentialModels() {
 		in := jujuparams.RevokeCredentialArgs{

--- a/internal/apiconn/cloud_test.go
+++ b/internal/apiconn/cloud_test.go
@@ -126,7 +126,7 @@ func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(models, gc.HasLen, 0)
 
-	err = s.conn.RevokeCredential(context.Background(), cred.Path.ToParams())
+	err = s.conn.RevokeCredential(context.Background(), cred.Path)
 	c.Assert(err, gc.Equals, nil)
 }
 

--- a/internal/conv/cred.go
+++ b/internal/conv/cred.go
@@ -9,6 +9,7 @@ import (
 
 	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/names/v4"
+	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
 	"github.com/CanonicalLtd/jimm/params"
@@ -16,19 +17,38 @@ import (
 
 // ToCloudCredentialTag creates a juju cloud credential tag from the given
 // CredentialPath.
-func ToCloudCredentialTag(p params.CredentialPath) names.CloudCredentialTag {
+func ToCloudCredentialTag(p mongodoc.CredentialPath) names.CloudCredentialTag {
 	if p.IsZero() {
 		return names.CloudCredentialTag{}
 	}
-	user := ToUserTag(p.User)
+	user := ToUserTag(params.User(p.User))
 	return names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", p.Cloud, user.Id(), p.Name))
+}
+
+// FromCloudCredentialTag creates a CredentialPath from the given juju
+// cloud credential tag.
+func FromCloudCredentialTag(t names.CloudCredentialTag) (mongodoc.CredentialPath, error) {
+	if t.IsZero() {
+		return mongodoc.CredentialPath{}, nil
+	}
+	user, err := FromUserTag(t.Owner())
+	if err != nil {
+		return mongodoc.CredentialPath{}, errgo.Mask(err, errgo.Is(ErrLocalUser))
+	}
+	return mongodoc.CredentialPath{
+		Cloud: t.Cloud().Id(),
+		EntityPath: mongodoc.EntityPath{
+			User: string(user),
+			Name: t.Name(),
+		},
+	}, nil
 }
 
 // ToTaggedCredential converts the given mongodoc.Credential to a
 // jujuparams.TaggedCredential.
 func ToTaggedCredential(cred *mongodoc.Credential) jujuparams.TaggedCredential {
 	return jujuparams.TaggedCredential{
-		Tag: ToCloudCredentialTag(cred.Path.ToParams()).String(),
+		Tag: ToCloudCredentialTag(cred.Path).String(),
 		Credential: jujuparams.CloudCredential{
 			AuthType:   string(cred.Type),
 			Attributes: cred.Attributes,

--- a/internal/conv/cred_test.go
+++ b/internal/conv/cred_test.go
@@ -3,13 +3,14 @@
 package conv_test
 
 import (
-	gc "gopkg.in/check.v1"
-
 	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/jimm/internal/conv"
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
-	"github.com/CanonicalLtd/jimm/params"
 )
 
 type credSuite struct{}
@@ -17,21 +18,79 @@ type credSuite struct{}
 var _ = gc.Suite(&credSuite{})
 
 func (s *credSuite) TestToCloudCredentialTag(c *gc.C) {
-	cp1 := params.CredentialPath{
+	cp1 := mongodoc.CredentialPath{
 		Cloud: "dummy",
-		User:  "alice",
-		Name:  "cred",
+		EntityPath: mongodoc.EntityPath{
+			User: "alice",
+			Name: "cred",
+		},
 	}
-	cp2 := params.CredentialPath{
+	cp2 := mongodoc.CredentialPath{
 		Cloud: "dummy",
-		User:  "alice@domain",
-		Name:  "cred",
+		EntityPath: mongodoc.EntityPath{
+			User: "alice@domain",
+			Name: "cred",
+		},
 	}
-	var cp3 params.CredentialPath
+	var cp3 mongodoc.CredentialPath
 
 	c.Assert(conv.ToCloudCredentialTag(cp1).String(), gc.Equals, "cloudcred-dummy_alice@external_cred")
 	c.Assert(conv.ToCloudCredentialTag(cp2).String(), gc.Equals, "cloudcred-dummy_alice@domain_cred")
 	c.Assert(conv.ToCloudCredentialTag(cp3).String(), gc.Equals, "")
+}
+
+var fromCloudCredentialTagTests = []struct {
+	tag              string
+	expect           mongodoc.CredentialPath
+	expectError      string
+	expectErrorCause error
+}{{
+	tag: "cloudcred-dummy_alice@external_cred",
+	expect: mongodoc.CredentialPath{
+		Cloud: "dummy",
+		EntityPath: mongodoc.EntityPath{
+			User: "alice",
+			Name: "cred",
+		},
+	},
+}, {
+	tag: "cloudcred-dummy_alice@domain_cred",
+	expect: mongodoc.CredentialPath{
+		Cloud: "dummy",
+		EntityPath: mongodoc.EntityPath{
+			User: "alice@domain",
+			Name: "cred",
+		},
+	},
+}, {
+	tag:              "cloudcred-dummy_alice_cred",
+	expectError:      "unsupported local user",
+	expectErrorCause: conv.ErrLocalUser,
+}, {
+	tag:    "",
+	expect: mongodoc.CredentialPath{},
+}}
+
+func (s *credSuite) TestFromCloudCredentialTag(c *gc.C) {
+	for i, test := range fromCloudCredentialTagTests {
+		c.Logf("test %d. %s", i, test.tag)
+		var tag names.CloudCredentialTag
+		if test.tag != "" {
+			var err error
+			tag, err = names.ParseCloudCredentialTag(test.tag)
+			c.Assert(err, gc.Equals, nil)
+		}
+		path, err := conv.FromCloudCredentialTag(tag)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			if test.expectErrorCause != nil {
+				c.Assert(errgo.Cause(err), gc.Equals, test.expectErrorCause)
+			}
+			continue
+		}
+		c.Assert(err, gc.Equals, nil)
+		c.Check(path, jc.DeepEquals, test.expect)
+	}
 }
 
 func (s *credSuite) TestToTaggedCredential(c *gc.C) {
@@ -50,10 +109,12 @@ func (s *credSuite) TestToTaggedCredential(c *gc.C) {
 		},
 	})
 	c.Assert(tc, gc.DeepEquals, jujuparams.TaggedCredential{
-		Tag: conv.ToCloudCredentialTag(params.CredentialPath{
+		Tag: conv.ToCloudCredentialTag(mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "test-user",
-			Name:  "test-cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "test-user",
+				Name: "test-cred",
+			},
 		}).String(),
 		Credential: jujuparams.CloudCredential{
 			AuthType: "userpass",

--- a/internal/jem/cloud_test.go
+++ b/internal/jem/cloud_test.go
@@ -425,13 +425,15 @@ func (s *cloudSuite) TestRemoveCloudWithModel(c *gc.C) {
 	)
 	c.Assert(err, gc.Equals, nil)
 
-	credpath := params.CredentialPath{
+	credpath := mongodoc.CredentialPath{
 		Cloud: "test-cloud",
-		User:  "bob",
-		Name:  "kubernetes",
+		EntityPath: mongodoc.EntityPath{
+			User: "bob",
+			Name: "kubernetes",
+		},
 	}
-	_, err = s.JEM.UpdateCredential(testContext, &mongodoc.Credential{
-		Path: mongodoc.CredentialPathFromParams(credpath),
+	_, err = s.JEM.UpdateCredential(testContext, id, &mongodoc.Credential{
+		Path: credpath,
 		Type: string(cloud.UserPassAuthType),
 		Attributes: map[string]string{
 			"username": kubetest.Username,

--- a/internal/jem/controller.go
+++ b/internal/jem/controller.go
@@ -321,7 +321,7 @@ func (j *JEM) controllerUpdateCredentials(ctx context.Context, conn *apiconn.Con
 			continue
 		}
 		if cred.Revoked {
-			if err := j.revokeControllerCredential(ctx, conn, ctl.Path, cred.Path.ToParams()); err != nil {
+			if err := j.revokeControllerCredential(ctx, conn, ctl.Path, cred.Path); err != nil {
 				zapctx.Warn(ctx,
 					"cannot revoke credential",
 					zap.Stringer("cred", credPath),

--- a/internal/jem/controller_test.go
+++ b/internal/jem/controller_test.go
@@ -285,7 +285,7 @@ func (s *controllerSuite) TestControllerUpdateCredentials(c *gc.C) {
 
 	// check it was updated on the controller.
 	client := cloudapi.NewClient(conn)
-	creds, err := client.Credentials(conv.ToCloudCredentialTag(cred.Path.ToParams()))
+	creds, err := client.Credentials(conv.ToCloudCredentialTag(cred.Path))
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(creds, jc.DeepEquals, []jujuparams.CloudCredentialResult{{
 		Result: &jujuparams.CloudCredential{
@@ -329,7 +329,7 @@ func (s *controllerSuite) TestConnectMonitor(c *gc.C) {
 
 	// check the credential has been updated.
 	client := cloudapi.NewClient(conn)
-	creds, err := client.Credentials(conv.ToCloudCredentialTag(cred.Path.ToParams()))
+	creds, err := client.Credentials(conv.ToCloudCredentialTag(cred.Path))
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(creds, jc.DeepEquals, []jujuparams.CloudCredentialResult{{
 		Result: &jujuparams.CloudCredential{

--- a/internal/jem/jem_test.go
+++ b/internal/jem/jem_test.go
@@ -238,7 +238,7 @@ func (s *jemSuite) TestWatchAllModelSummaries(c *gc.C) {
 				Admins:     []string{conv.ToUserTag(s.Model.Path.User).Id()},
 				Cloud:      "dummy",
 				Region:     "dummy-region",
-				Credential: conv.ToCloudCredentialTag(s.Model.Credential.ToParams()).Id(),
+				Credential: conv.ToCloudCredentialTag(s.Model.Credential).Id(),
 				Size: jujuparams.ModelSummarySize{
 					Machines:     0,
 					Containers:   0,

--- a/internal/jem/modelmanager.go
+++ b/internal/jem/modelmanager.go
@@ -67,7 +67,7 @@ type CreateModelParams struct {
 
 	// Credential contains the name of the credential to use to
 	// create the model.
-	Credential params.CredentialPath
+	Credential mongodoc.CredentialPath
 
 	// Cloud contains the name of the cloud in which the
 	// model will be created.
@@ -279,7 +279,7 @@ func (j *JEM) createModel(ctx context.Context, p createModelParams, info *jujupa
 		if err := j.credentialAddController(ctx, p.cred, p.controller.Path); err != nil {
 			return errgo.WithCausef(err, errInvalidModelParams, "cannot add credential")
 		}
-		cloudCredentialTag = conv.ToCloudCredentialTag(p.cred.Path.ToParams()).String()
+		cloudCredentialTag = conv.ToCloudCredentialTag(p.cred.Path).String()
 	}
 
 	args := jujuparams.ModelCreateArgs{
@@ -338,9 +338,9 @@ func (j *JEM) createModel(ctx context.Context, p createModelParams, info *jujupa
 // If there's more than one such credential, it returns a params.ErrAmbiguousChoice error.
 //
 // If there are no credentials found, a zero credential path is returned.
-func (j *JEM) selectCredential(ctx context.Context, id identchecker.ACLIdentity, path params.CredentialPath, user params.User, cloud params.Cloud) (*mongodoc.Credential, error) {
+func (j *JEM) selectCredential(ctx context.Context, id identchecker.ACLIdentity, path mongodoc.CredentialPath, user params.User, cloud params.Cloud) (*mongodoc.Credential, error) {
 	if !path.IsZero() {
-		cred := mongodoc.Credential{Path: mongodoc.CredentialPathFromParams(path)}
+		cred := mongodoc.Credential{Path: path}
 		if err := j.GetCredential(ctx, id, &cred); err != nil {
 			return nil, errgo.Mask(err, errgo.Is(params.ErrUnauthorized), errgo.Is(params.ErrNotFound))
 		}
@@ -410,7 +410,7 @@ func (j *JEM) GetModelInfo(ctx context.Context, id identchecker.ACLIdentity, inf
 		info.DefaultSeries = m.DefaultSeries
 		info.CloudTag = conv.ToCloudTag(m.Cloud).String()
 		info.CloudRegion = m.CloudRegion
-		info.CloudCredentialTag = conv.ToCloudCredentialTag(m.Credential.ToParams()).String()
+		info.CloudCredentialTag = conv.ToCloudCredentialTag(m.Credential).String()
 		info.CloudCredentialValidity = nil
 		info.OwnerTag = conv.ToUserTag(m.Path.User).String()
 		info.Life = life.Value(m.Life())
@@ -717,7 +717,7 @@ func (j *JEM) UpdateModelCredential(ctx context.Context, conn *apiconn.Conn, mod
 	}
 
 	client := modelmanager.NewClient(conn)
-	if err := client.ChangeModelCredential(names.NewModelTag(model.UUID), conv.ToCloudCredentialTag(cred.Path.ToParams())); err != nil {
+	if err := client.ChangeModelCredential(names.NewModelTag(model.UUID), conv.ToCloudCredentialTag(cred.Path)); err != nil {
 		return errgo.Mask(err)
 	}
 

--- a/internal/jem/modelmanager_test.go
+++ b/internal/jem/modelmanager_test.go
@@ -102,7 +102,7 @@ var createModelTests = []struct {
 	user                           string
 	params                         jem.CreateModelParams
 	usageSenderAuthorizationErrors []error
-	expectCredential               params.CredentialPath
+	expectCredential               mongodoc.CredentialPath
 	expectError                    string
 	expectErrorCause               error
 }{{
@@ -110,10 +110,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", ""},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud: "dummy",
 	},
@@ -123,10 +125,12 @@ var createModelTests = []struct {
 	params: jem.CreateModelParams{
 		Path:           params.EntityPath{"bob", ""},
 		ControllerPath: params.EntityPath{"alice", "dummy-1"},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud: "dummy",
 	},
@@ -135,10 +139,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", ""},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud:  "dummy",
 		Region: "dummy-region",
@@ -148,10 +154,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", ""},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred2",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred2",
+			},
 		},
 		Cloud: "dummy",
 	},
@@ -162,10 +170,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", "model-1"},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud: "dummy",
 	},
@@ -176,10 +186,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", ""},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud:  "dummy",
 		Region: "not-a-region",
@@ -192,10 +204,12 @@ var createModelTests = []struct {
 		Path:  params.EntityPath{"bob", ""},
 		Cloud: "dummy",
 	},
-	expectCredential: params.CredentialPath{
+	expectCredential: mongodoc.CredentialPath{
 		Cloud: "dummy",
-		User:  "bob",
-		Name:  "cred",
+		EntityPath: mongodoc.EntityPath{
+			User: "bob",
+			Name: "cred",
+		},
 	},
 }, {
 	about: "empty cloud credentials fails with more than one choice",
@@ -218,10 +232,12 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path: params.EntityPath{"bob", ""},
-		Credential: params.CredentialPath{
+		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
-			User:  "bob",
-			Name:  "cred",
+			EntityPath: mongodoc.EntityPath{
+				User: "bob",
+				Name: "cred",
+			},
 		},
 		Cloud: "dummy",
 	},
@@ -271,9 +287,9 @@ func (s *modelManagerSuite) TestCreateModel(c *gc.C) {
 		c.Check(m.Creator, gc.Equals, test.user)
 		c.Check(m.CreationTime.Equal(now), gc.Equals, true)
 		if !test.expectCredential.IsZero() {
-			c.Check(m.Credential, jc.DeepEquals, mongodoc.CredentialPathFromParams(test.expectCredential))
+			c.Check(m.Credential, jc.DeepEquals, test.expectCredential)
 		} else {
-			c.Check(m.Credential, jc.DeepEquals, mongodoc.CredentialPathFromParams(test.params.Credential))
+			c.Check(m.Credential, jc.DeepEquals, test.params.Credential)
 		}
 	}
 }
@@ -295,7 +311,7 @@ func (s *modelManagerSuite) TestCreateModelWithPartiallyCreatedModel(c *gc.C) {
 	err = s.JEM.CreateModel(testContext, jemtest.Bob, jem.CreateModelParams{
 		Path:           params.EntityPath{"bob", "model"},
 		ControllerPath: s.Controller.Path,
-		Credential:     s.Credential.Path.ToParams(),
+		Credential:     s.Credential.Path,
 		Cloud:          "dummy",
 	}, nil)
 	c.Assert(err, gc.Equals, nil)
@@ -312,7 +328,7 @@ func (s *modelManagerSuite) TestCreateModelWithExistingModelInControllerOnly(c *
 	err = s.JEM.CreateModel(testContext, jemtest.Bob, jem.CreateModelParams{
 		Path:           s.Model.Path,
 		ControllerPath: s.Model.Controller,
-		Credential:     s.Model.Credential.ToParams(),
+		Credential:     s.Model.Credential,
 		Cloud:          s.Model.Cloud,
 	}, nil)
 	c.Assert(err, gc.ErrorMatches, `cannot create model: model name in use: api error: failed to create new model: model "model-1" for bob@external already exists \(already exists\)`)

--- a/internal/jem/vault_test.go
+++ b/internal/jem/vault_test.go
@@ -66,7 +66,7 @@ func (s *jemVaultSuite) TestVaultCredentials(c *gc.C) {
 			"password": "test-pass",
 		},
 	}
-	_, err := s.JEM.UpdateCredential(ctx, cred1, 0)
+	_, err := s.JEM.UpdateCredential(ctx, jemtest.Bob, cred1, 0)
 	c.Assert(err, gc.Equals, nil)
 
 	secret, err := s.Params.VaultClient.Logical().Read("test/creds/dummy/bob/test-1")

--- a/internal/jemtest/jemtest.go
+++ b/internal/jemtest/jemtest.go
@@ -113,7 +113,7 @@ func (s *JEMSuite) AddController(c *gc.C, ctl *mongodoc.Controller) {
 
 // UpdateCredential updates the given credential.
 func (s *JEMSuite) UpdateCredential(c *gc.C, cred *mongodoc.Credential) {
-	_, err := s.JEM.UpdateCredential(context.TODO(), cred, jem.CredentialUpdate)
+	_, err := s.JEM.UpdateCredential(context.TODO(), NewIdentity(string(cred.Path.User)), cred, jem.CredentialUpdate)
 	c.Assert(err, gc.Equals, nil)
 }
 
@@ -126,7 +126,7 @@ func (s *JEMSuite) CreateModel(c *gc.C, m *mongodoc.Model, mi *jujuparams.ModelI
 	params := jem.CreateModelParams{
 		Path:           m.Path,
 		ControllerPath: m.Controller,
-		Credential:     m.Credential.ToParams(),
+		Credential:     m.Credential,
 		Cloud:          m.Cloud,
 		Region:         m.CloudRegion,
 	}

--- a/internal/jujuapi/cloud_test.go
+++ b/internal/jujuapi/cloud_test.go
@@ -17,6 +17,7 @@ import (
 	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
 
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
 	"github.com/CanonicalLtd/jimm/internal/mongodoc"
 	"github.com/CanonicalLtd/jimm/params"
 )
@@ -169,7 +170,7 @@ func (s *cloudSuite) TestUserCredentials(c *gc.C) {
 func (s *cloudSuite) TestUserCredentialsWithDomain(c *gc.C) {
 	ctx := context.Background()
 
-	_, err := s.JEM.UpdateCredential(ctx, &mongodoc.Credential{
+	_, err := s.JEM.UpdateCredential(ctx, jemtest.NewIdentity("test@domain"), &mongodoc.Credential{
 		Path: mongodoc.CredentialPath{
 			Cloud: "dummy",
 			EntityPath: mongodoc.EntityPath{

--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -273,7 +273,7 @@ func (s *modelManagerSuite) TestModelInfo(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path).String(),
 			OwnerTag:           names.NewUserTag("bob@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -300,7 +300,7 @@ func (s *modelManagerSuite) TestModelInfo(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -322,7 +322,7 @@ func (s *modelManagerSuite) TestModelInfo(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -352,7 +352,7 @@ func (s *modelManagerSuite) TestModelInfo(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -456,7 +456,7 @@ func (s *modelManagerSuite) TestModelInfoDisableControllerUUIDMasking(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path).String(),
 			OwnerTag:           names.NewUserTag("bob@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -478,7 +478,7 @@ func (s *modelManagerSuite) TestModelInfoDisableControllerUUIDMasking(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -500,7 +500,7 @@ func (s *modelManagerSuite) TestModelInfoDisableControllerUUIDMasking(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -534,7 +534,7 @@ func (s *modelManagerSuite) TestModelInfoDisableControllerUUIDMasking(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -568,7 +568,7 @@ func (s *modelManagerSuite) TestModelInfoDisableControllerUUIDMasking(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential2.Path).String(),
 			OwnerTag:           names.NewUserTag("charlie@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -620,7 +620,7 @@ func (s *modelManagerSuite) TestModelInfoForLegacyModel(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path).String(),
 			OwnerTag:           names.NewUserTag("bob@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -680,7 +680,7 @@ func (s *modelManagerSuite) TestModelInfoForLegacyModelDisableControllerUUIDMask
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path).String(),
 			OwnerTag:           names.NewUserTag("bob@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -810,7 +810,7 @@ func (s *modelManagerSuite) TestModelInfoRequestTimeout(c *gc.C) {
 			ProviderType:       "dummy",
 			CloudTag:           "cloud-dummy",
 			CloudRegion:        "dummy-region",
-			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path.ToParams()).String(),
+			CloudCredentialTag: conv.ToCloudCredentialTag(s.Credential.Path).String(),
 			OwnerTag:           names.NewUserTag("bob@external").String(),
 			Life:               life.Alive,
 			Status: jujuparams.EntityStatus{
@@ -1232,7 +1232,7 @@ func (s *modelManagerSuite) TestChangeModelCredential(c *gc.C) {
 	modelTag := names.NewModelTag(s.Model.UUID)
 	cred := jemtest.EmptyCredential("bob", "cred2")
 	s.UpdateCredential(c, &cred)
-	credTag := conv.ToCloudCredentialTag(cred.Path.ToParams())
+	credTag := conv.ToCloudCredentialTag(cred.Path)
 	client := modelmanager.NewClient(conn)
 	err := client.ChangeModelCredential(modelTag, credTag)
 	c.Assert(err, gc.Equals, nil)

--- a/internal/v2/api.go
+++ b/internal/v2/api.go
@@ -325,7 +325,7 @@ func (h *Handler) NewModel(p httprequest.Params, args *params.NewModel) (*params
 	err = h.jem.CreateModel(p.Context, h.id, jem.CreateModelParams{
 		Path:           modelPath,
 		ControllerPath: ctlPath,
-		Credential:     args.Info.Credential,
+		Credential:     mongodoc.CredentialPathFromParams(args.Info.Credential),
 		Cloud:          lp.cloud,
 		Region:         lp.region,
 		Attributes:     args.Info.Config,
@@ -419,11 +419,7 @@ func (h *Handler) GetModelPerm(p httprequest.Params, arg *params.GetModelPerm) (
 // user, cloud and name. If there is already a credential with that name
 // it is overwritten.
 func (h *Handler) UpdateCredential(p httprequest.Params, arg *params.UpdateCredential) error {
-	// Only the owner can set credentials.
-	if err := auth.CheckIsUser(p.Context, h.id, arg.User); err != nil {
-		return errgo.Mask(err, errgo.Is(params.ErrUnauthorized))
-	}
-	_, err := h.jem.UpdateCredential(p.Context, &mongodoc.Credential{
+	_, err := h.jem.UpdateCredential(p.Context, h.id, &mongodoc.Credential{
 		Path:       mongodoc.CredentialPathFromParams(arg.CredentialPath),
 		Type:       arg.Credential.AuthType,
 		Attributes: arg.Credential.Attributes,


### PR DESCRIPTION
Ensure that auth checks for credentials are consistently made for any
operation that uses them. Also prefer the use of the
mongodoc.CredentialPath type to reduce the amount of required
conversions through the code.