### PR TITLE
internal/dbmodel: add dbmodel version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,8 @@ require (
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/yaml.v2 v2.3.0
+	gorm.io/driver/sqlite v1.1.3
+	gorm.io/gorm v1.20.6
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,10 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -681,6 +685,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.3 h1:j7a/xn1U6TKA/PHHxqZuzh64CdtRc7rU9M+AvkOl5bA=
+github.com/mattn/go-sqlite3 v1.14.3/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mhilton/openid v0.0.0-20150511103207-7922a4e937d8/go.mod h1:Alv076OXc0MA78hV0BTU06FTh1Q9sWKk3Ru20SykbTA=
@@ -1241,6 +1247,11 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/sqlite v1.1.3 h1:BYfdVuZB5He/u9dt4qDpZqiqDJ6KhPqs5QUqsr/Eeuc=
+gorm.io/driver/sqlite v1.1.3/go.mod h1:AKDgRWk8lcSQSw+9kxCJnX/yySj8G3rdwYlU57cB45c=
+gorm.io/gorm v1.20.1/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.20.6 h1:qa7tC1WcU+DBI/ZKMxvXy1FcrlGsvxlaKufHrT2qQ08=
+gorm.io/gorm v1.20.6/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/dbmodel/gorm_test.go
+++ b/internal/dbmodel/gorm_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// gormDB creates a new *gorm.DB for use in tests. The newly created DB
+// will be an in-memory SQLite database that logs to the given test with
+// debug enabled. If any objects are specified the datbase automatically
+// performs the migrations for those objects.
+func gormDB(t testing.TB, objects ...interface{}) *gorm.DB {
+	cfg := gorm.Config{
+		Logger: testLogger{t},
+	}
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &cfg)
+	if err != nil {
+		t.Fatalf("error creating test database: %s", err)
+	}
+	err = db.AutoMigrate(objects...)
+	if err != nil {
+		t.Fatalf("error perform migrations on test database: %s", err)
+	}
+	return db
+}
+
+// A testLogger is a gorm.Logger that is used in tests. It logs everything
+// to the test.
+type testLogger struct {
+	t testing.TB
+}
+
+func (l testLogger) LogMode(_ logger.LogLevel) logger.Interface {
+	return l
+}
+
+func (l testLogger) Info(_ context.Context, fmt string, args ...interface{}) {
+	l.t.Logf(fmt, args...)
+}
+
+func (l testLogger) Warn(_ context.Context, fmt string, args ...interface{}) {
+	l.t.Logf(fmt, args...)
+}
+
+func (l testLogger) Error(_ context.Context, fmt string, args ...interface{}) {
+	l.t.Logf(fmt, args...)
+}
+
+func (l testLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	sql, rows := fc()
+	errS := "<nil>"
+	if err != nil {
+		errS = fmt.Sprintf("%q", err.Error())
+	}
+	l.Info(ctx, "sql:%q rows:%d, error:%s, duration:%0.3fms", sql, rows, errS, float64(time.Since(begin).Microseconds())/10e3)
+}
+
+var _ logger.Interface = testLogger{}

--- a/internal/dbmodel/version.go
+++ b/internal/dbmodel/version.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Canonical Ltd.
+
+// Package dbmodel contains the model objects for the relational storage
+// database.
+package dbmodel
+
+const (
+	// Component is the component name in the version table for th
+	Component = "jimmdb"
+
+	// Major is the major version of the model described in the dbmodel
+	// package. It should be incremented if the database model is modified
+	// in a way that is not backwards-compatible. That is, a column or
+	// table is added or changed in such a way that the default behaviour
+	// that would occur with a previous version of the package would break
+	// the data model. If this is incremented the Minor version should be
+	// reset to 0.
+	Major = 1
+
+	// Minor is the minor version of the model described in the dbmodel
+	// package. It should be incremented for any change made to the
+	// database model from database model in a relesed JIMM.
+	Minor = 0
+)
+
+type Version struct {
+	// Component represents the component that the stored version number
+	// is for. Currently there is only one known component "jimmdb" it
+	// mostly exists for the purposes of there being a primary key on the
+	// database table.
+	Component string `gorm:"primaryKey"`
+
+	// Major is the stored major version.
+	Major int
+
+	// Minor is the stored minor version.
+	Minor int
+}

--- a/internal/dbmodel/version_test.go
+++ b/internal/dbmodel/version_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"gorm.io/gorm"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
+
+func TestVersion(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c, dbmodel.Version{})
+
+	var v0 dbmodel.Version
+	result := db.First(&v0, "component = ?", dbmodel.Component)
+	c.Check(result.Error, qt.Equals, gorm.ErrRecordNotFound)
+
+	v1 := dbmodel.Version{
+		Component: dbmodel.Component,
+		Major:     dbmodel.Major,
+		Minor:     dbmodel.Minor,
+	}
+	result = db.Create(&v1)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(result.RowsAffected, qt.Equals, int64(1))
+
+	var v2 dbmodel.Version
+	result = db.First(&v2, "component = ?", dbmodel.Component)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(v2, qt.DeepEquals, v1)
+
+	v3 := dbmodel.Version{
+		Component: dbmodel.Component,
+		Major:     v1.Major + 1,
+		Minor:     v1.Minor + 1,
+	}
+	result = db.Create(&v3)
+	c.Check(result.Error, qt.ErrorMatches, "UNIQUE constraint failed: versions.component")
+	result = db.Save(&v3)
+	c.Assert(result.Error, qt.IsNil)
+
+	var v4 dbmodel.Version
+	result = db.First(&v4, "component = ?", dbmodel.Component)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(v4, qt.DeepEquals, v3)
+}


### PR DESCRIPTION
This adds the version objects for the new dbmodel. This is mostly about
putting the infrastructure in place for upcoming database developments.

Note that as this package is not referenced from anywhere it will not be
used by, or indeed compiled into, any production software.