### PR TITLE
internal/dbmodel: add user model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
-	github.com/juju/httprequest v1.0.1
 	github.com/juju/juju v0.0.0-20201102064548-d344015a21e6
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
 	github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31

--- a/internal/dbmodel/user.go
+++ b/internal/dbmodel/user.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel
+
+import (
+	"time"
+
+	"github.com/juju/names/v4"
+	"gorm.io/gorm"
+)
+
+// A User represents a JIMM user.
+type User struct {
+	gorm.Model
+
+	// Username is the username for the user. This is the juju
+	// representation of the username (i.e. with an @external suffix). The
+	// username will have originated at an external identity provider in
+	// JAAS deployments.
+	Username string `gorm:"not null;uniqueIndex"`
+
+	// DisplayName is the displayname of the user.
+	DisplayName string `gorm:"not null"`
+
+	// LastLogin is the time the user last authenticated to the JIMM
+	// server. It will be the zero time if the user has never logged in
+	// to JIMM.
+	LastLogin time.Time
+
+	// Disabled records whether the user has been disabled or not, disabled
+	// users are not allowed to authenticate.
+	Disabled bool `gorm:"not null;default:FALSE"`
+
+	// ControllerAccess is the access level this user has on the JIMM
+	// controller. By default all users have "add-model" access.
+	ControllerAccess string `gorm:"not null;default:'add-model'"`
+}
+
+// Tag returns a names.UserTag for the user.
+func (u User) Tag() names.UserTag {
+	return names.NewUserTag(u.Username)
+}

--- a/internal/dbmodel/user_test.go
+++ b/internal/dbmodel/user_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel_test
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"gorm.io/gorm"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
+
+func TestUser(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c, &dbmodel.User{})
+
+	var u0 dbmodel.User
+	result := db.Where("username = ?", "bob@external").First(&u0)
+	c.Check(result.Error, qt.Equals, gorm.ErrRecordNotFound)
+
+	u1 := dbmodel.User{
+		Username:    "bob@external",
+		DisplayName: "bob",
+	}
+	result = db.Create(&u1)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(result.RowsAffected, qt.Equals, int64(1))
+	c.Check(u1.ControllerAccess, qt.Equals, "add-model")
+
+	var u2 dbmodel.User
+	result = db.Where("username = ?", "bob@external").First(&u2)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(u2, qt.DeepEquals, u1)
+
+	u2.LastLogin = time.Now().UTC().Round(time.Millisecond)
+	result = db.Save(&u2)
+	c.Assert(result.Error, qt.IsNil)
+	var u3 dbmodel.User
+	result = db.Where("username = ?", "bob@external").First(&u3)
+	c.Assert(result.Error, qt.IsNil)
+	c.Check(u3, qt.DeepEquals, u2)
+
+	u4 := dbmodel.User{
+		Username:    "bob@external",
+		DisplayName: "bob",
+	}
+	result = db.Create(&u4)
+	c.Check(result.Error, qt.ErrorMatches, "UNIQUE constraint failed: users.username")
+}
+
+func TestUserTag(t *testing.T) {
+	c := qt.New(t)
+
+	u := dbmodel.User{
+		Username: "bob@external",
+	}
+	c.Check(u.Tag().String(), qt.Equals, "user-bob@external")
+}


### PR DESCRIPTION
Add a model entity to represent a user. JIMM does not currently
reference users except by username in other structures, but in the
relational data model almost all other structures will need to reference
them.