### PR TITLE
internal/jujuapi: add JIMM facade methods

### DIFF
--- a/api/jimm.go
+++ b/api/jimm.go
@@ -31,6 +31,12 @@ func (c *Client) AddController(req *params.AddControllerRequest) (params.Control
 	return info, err
 }
 
+// DisableControllerUUIDMasking disables UUID the masking of the real
+// controller UUID with JIMM's UUID in those response.
+func (c *Client) DisableControllerUUIDMasking() error {
+	return c.caller.APICall("JIMM", 3, "", "DisableControllerUUIDMasking", nil, nil)
+}
+
 // ListControllers returns controller info for all controllers known to
 // JIMM.
 func (c *Client) ListControllers() ([]params.ControllerInfo, error) {
@@ -39,8 +45,19 @@ func (c *Client) ListControllers() ([]params.ControllerInfo, error) {
 	return resp.Controllers, err
 }
 
-// DisableControllerUUIDMasking disables UUID the masking of the real
-// controller UUID with JIMM's UUID in those response.
-func (c *Client) DisableControllerUUIDMasking() error {
-	return c.caller.APICall("JIMM", 3, "", "DisableControllerUUIDMasking", nil, nil)
+// RemoveController removes a controller from the JAAS system. Only
+// controllers that are unavailable can be removed, unless force is used.
+// The return value contains the details of the controller that was
+// removed.
+func (c *Client) RemoveController(req *params.RemoveControllerRequest) (params.ControllerInfo, error) {
+	var info params.ControllerInfo
+	err := c.caller.APICall("JIMM", 3, "", "RemoveController", req, &info)
+	return info, err
+}
+
+// SetControllerDeprecated sets the deprecated status of a controller.
+func (c *Client) SetControllerDeprecated(req *params.SetControllerDeprecatedRequest) (params.ControllerInfo, error) {
+	var info params.ControllerInfo
+	err := c.caller.APICall("JIMM", 3, "", "SetControllerDeprecated", req, &info)
+	return info, err
 }

--- a/api/params/errors.go
+++ b/api/params/errors.go
@@ -1,0 +1,7 @@
+// Copyright 2020 Canonical Ltd.
+
+package params
+
+const (
+	CodeStillAlive = "still alive"
+)

--- a/api/params/params.go
+++ b/api/params/params.go
@@ -76,8 +76,26 @@ type ControllerInfo struct {
 	Status jujuparams.EntityStatus `json:"status"`
 }
 
-// ListControllersResponse is the response that is sent in a
+// A ListControllersResponse is the response that is sent in a
 // ListControllers method.
 type ListControllersResponse struct {
 	Controllers []ControllerInfo `json:"controllers"`
+}
+
+// A RemoveControllerRequest is the request that is sent in a
+// RemoveController method.
+type RemoveControllerRequest struct {
+	Name  string `json:"name"`
+	Force bool   `json:"force"`
+}
+
+// A SetControllerDeprecatedRequest is the request this is sent in a
+// SetControllerDeprecated method.
+type SetControllerDeprecatedRequest struct {
+	// Name is the name of the controller to set deprecated.
+	Name string `json:"name"`
+
+	// Deprecated specifies whether the controller should be set to
+	// deprecated or not.
+	Deprecated bool `json:"deprecated"`
 }

--- a/internal/jem/modelmanager_test.go
+++ b/internal/jem/modelmanager_test.go
@@ -136,7 +136,7 @@ var createModelTests = []struct {
 	user:  "bob",
 	params: jem.CreateModelParams{
 		Path:           params.EntityPath{"bob", ""},
-		ControllerPath: params.EntityPath{"alice", "dummy-1"},
+		ControllerPath: params.EntityPath{jemtest.ControllerAdmin, "dummy-1"},
 		Credential: mongodoc.CredentialPath{
 			Cloud: "dummy",
 			EntityPath: mongodoc.EntityPath{

--- a/internal/jemtest/jemtest.go
+++ b/internal/jemtest/jemtest.go
@@ -155,7 +155,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.JEMSuite.SetUpTest(c)
 
 	s.Controller = mongodoc.Controller{
-		Path: params.EntityPath{User: "alice", Name: "dummy-1"},
+		Path: params.EntityPath{User: ControllerAdmin, Name: "dummy-1"},
 	}
 	s.AddController(c, &s.Controller)
 

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/rpc/jsoncodec"
 	"gopkg.in/errgo.v1"
 
+	apiparams "github.com/CanonicalLtd/jimm/api/params"
 	"github.com/CanonicalLtd/jimm/internal/apiconn"
 	"github.com/CanonicalLtd/jimm/internal/auth"
 	"github.com/CanonicalLtd/jimm/internal/conv"
@@ -42,6 +43,7 @@ var errorCodes = map[error]string{
 	params.ErrUnauthorized:        jujuparams.CodeUnauthorized,
 	params.ErrCloudRegionRequired: jujuparams.CodeCloudRegionRequired,
 	params.ErrIncompatibleClouds:  jujuparams.CodeIncompatibleClouds,
+	params.ErrStillAlive:          apiparams.CodeStillAlive,
 	errNotImplemented:             jujuparams.CodeNotImplemented,
 }
 

--- a/internal/v2/api_test.go
+++ b/internal/v2/api_test.go
@@ -78,7 +78,7 @@ var unauthorizedTests = []struct {
 	about:  "get controller as non-owner",
 	asUser: "other",
 	method: "GET",
-	path:   "/v2/controller/alice/dummy-1",
+	path:   "/v2/controller/controller-admin/dummy-1",
 }, {
 	about:  "new model as non-owner",
 	asUser: "other",
@@ -357,7 +357,7 @@ func (s *APISuite) TestAddControllerDuplicate(c *gc.C) {
 			Public:         true,
 		},
 	})
-	c.Assert(err, gc.ErrorMatches, "Put http://.*/v2/controller/alice/dummy-1: already exists")
+	c.Assert(err, gc.ErrorMatches, "Put http://.*/v2/controller/controller-admin/dummy-1: already exists")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrAlreadyExists)
 }
 
@@ -1042,12 +1042,12 @@ func (s *APISuite) TestNewModelUnauthorized(c *gc.C) {
 func (s *APISuite) TestListController(c *gc.C) {
 	ctx := context.Background()
 
-	c0 := mongodoc.Controller{Path: params.EntityPath{"alice", "dummy-0"}}
+	c0 := mongodoc.Controller{Path: params.EntityPath{jemtest.ControllerAdmin, "dummy-0"}}
 	s.AddController(c, &c0)
 	unavailableTime := time.Now()
 	err := s.JEM.SetControllerUnavailableAt(ctx, s.Controller.Path, unavailableTime)
 	c.Assert(err, gc.Equals, nil)
-	c2 := mongodoc.Controller{Path: params.EntityPath{"alice", "dummy-2"}}
+	c2 := mongodoc.Controller{Path: params.EntityPath{jemtest.ControllerAdmin, "dummy-2"}}
 	s.AddController(c, &c2)
 	err = s.JEM.SetControllerUnavailableAt(ctx, c2.Path, unavailableTime.Add(time.Second))
 	c.Assert(err, gc.Equals, nil)
@@ -1581,7 +1581,7 @@ func (s *APISuite) TestMissingModels(c *gc.C) {
 			Cloud:      "dummy",
 			Region:     "dummy-region",
 			Status:     "available",
-			Controller: "alice/dummy-1",
+			Controller: jemtest.ControllerAdmin + "/dummy-1",
 		}},
 	})
 }
@@ -1593,5 +1593,5 @@ func (s *APISuite) TestMissingModelsNotAuthorized(c *gc.C) {
 		EntityPath: s.Controller.Path,
 	})
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrUnauthorized)
-	c.Assert(err, gc.ErrorMatches, `Get http://.*/v2/controller/alice/dummy-1/missing-models: admin access required`)
+	c.Assert(err, gc.ErrorMatches, `Get http://.*/v2/controller/controller-admin/dummy-1/missing-models: admin access required`)
 }


### PR DESCRIPTION
Add RemoveController and SetControllerDeprecated methods to the v3 JIMM
facade to facilite deprecating and removing controllers. These are
features currently only available through the /v2 HTTP API.