### PR TITLE
internal/jujuapi: audit methods in JIMM facade

### DIFF
--- a/api/jimm.go
+++ b/api/jimm.go
@@ -37,6 +37,21 @@ func (c *Client) DisableControllerUUIDMasking() error {
 	return c.caller.APICall("JIMM", 3, "", "DisableControllerUUIDMasking", nil, nil)
 }
 
+// FindAuditEvents finds audit events that match the requested filters.
+func (c *Client) FindAuditEvents(req *params.FindAuditEventsRequest) (params.AuditEvents, error) {
+	var resp params.AuditEvents
+	if err := c.caller.APICall("JIMM", 3, "", "FindAuditEvents", req, &resp); err != nil {
+		return params.AuditEvents{}, err
+	}
+	return resp, nil
+}
+
+// GrantAuditLogAccess grants the given access to the audit log to the
+// given user.
+func (c *Client) GrantAuditLogAccess(req *params.AuditLogAccessRequest) error {
+	return c.caller.APICall("JIMM", 3, "", "GrantAuditLogAccess", req, nil)
+}
+
 // ListControllers returns controller info for all controllers known to
 // JIMM.
 func (c *Client) ListControllers() ([]params.ControllerInfo, error) {
@@ -53,6 +68,12 @@ func (c *Client) RemoveController(req *params.RemoveControllerRequest) (params.C
 	var info params.ControllerInfo
 	err := c.caller.APICall("JIMM", 3, "", "RemoveController", req, &info)
 	return info, err
+}
+
+// RevokeAuditLogAccess revokes the given access to the audit log from the
+// given user.
+func (c *Client) RevokeAuditLogAccess(req *params.AuditLogAccessRequest) error {
+	return c.caller.APICall("JIMM", 3, "", "RevokeAuditLogAccess", req, nil)
 }
 
 // SetControllerDeprecated sets the deprecated status of a controller.

--- a/api/params/params.go
+++ b/api/params/params.go
@@ -2,7 +2,11 @@
 
 package params
 
-import jujuparams "github.com/juju/juju/apiserver/params"
+import (
+	"time"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+)
 
 // An AddControllerRequest is the request sent when adding a new controller
 // to JIMM.
@@ -33,6 +37,60 @@ type AddControllerRequest struct {
 	// Password contains the password that JIMM should use to connect to
 	// the controller.
 	Password string `json:"password"`
+}
+
+// AuditLogAccessRequest is the request used to modify a user's access
+// to the audit log.
+type AuditLogAccessRequest struct {
+	// UserTag is the user who's audit-log access is being modified.
+	UserTag string `json:"user-tag"`
+
+	// Level is the access level being granted or revoked. The only access
+	// level is "read".
+	Level string `json:"level"`
+}
+
+const (
+	// AuditActionCreate is the Action value in an audit entry that
+	// creates an entity.
+	AuditActionCreate = "create"
+
+	// AuditActionDelete is the Action value in an audit entry that
+	// deletes an entity.
+	AuditActionDelete = "delete"
+
+	// AuditActionGrant is the Action value in an audit entry that
+	// grants access to an entity.
+	AuditActionGrant = "grant"
+
+	// AuditActionRevoke is the Action value in an audit entry that
+	// revokes access from an entity.
+	AuditActionRevoke = "revoke"
+)
+
+// An AuditEvent is an event in the audit log.
+type AuditEvent struct {
+	// Time is the time of the audit event.
+	Time time.Time `json:"time"`
+
+	// Tag contains the tag of the entity the event is for.
+	Tag string `json:"tag"`
+
+	// UserTag contains the user tag of authenticated user that performed
+	// the action.
+	UserTag string `json:"user-tag"`
+
+	// Action contains the action that occured on the entity.
+	Action string `json:"action"`
+
+	// Params contains additional details for the audit entry. The contents
+	// will vary depending on the action and the entity.
+	Params map[string]string `json:"params"`
+}
+
+// An AuditEvents contains events from the audit log.
+type AuditEvents struct {
+	Events []AuditEvent `json:"events"`
 }
 
 // A ControllerInfo describes a controller on a JIMM system.
@@ -74,6 +132,35 @@ type ControllerInfo struct {
 	// Status contains the current status of the controller. The status
 	// will either be "available", "deprecated", or "unavailable".
 	Status jujuparams.EntityStatus `json:"status"`
+}
+
+// A FindAuditEventsRequest finds audit events that match the specified
+// query.
+type FindAuditEventsRequest struct {
+	// After is used to filter the event log to only contain events that
+	// happened after a certain time. If this is specified it must contain
+	// an RFC3339 encoded time value.
+	After string `json:"after,omitempty"`
+
+	// Before is used to filter the event log to only contain events that
+	// happened before a certain time. If this is specified it must contain
+	// an RFC3339 encoded time value.
+	Before string `json:"before,omitempty"`
+
+	// Tag is used to filter the event log to only contain events that
+	// occured to a particular entity.
+	Tag string `json:"tag,omitempty"`
+
+	// UserTag is used to filter the event log to only contain events that
+	// were performed by a particular authenticated user.
+	UserTag string `json:"user-tag,omitempty"`
+
+	// Action is used to filter the event log to only contain events that
+	// perform a particular action.
+	Action string `json:"action,omitempty"`
+
+	// Limit is the maximum number of audit events to return.
+	Limit int64 `json:"limit,omitempty"`
 }
 
 // A ListControllersResponse is the response that is sent in a

--- a/internal/dbmodel/audit.go
+++ b/internal/dbmodel/audit.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// An AuditLogEntry is an entry in the audit log.
+type AuditLogEntry struct {
+	gorm.Model
+
+	// Time contains the time that the event happened.
+	Time time.Time `gorm:"index"`
+
+	// Tag is the tag of the entity that this audit entry is for.
+	Tag string `gorm:"index"`
+
+	// UserTag is the tag of the user the performed the action.
+	UserTag string `gorm:"index"`
+
+	// Action is the type of event that this audit entry is for.
+	Action string `gorm:"index"`
+
+	// Params contains the event-specific params for the audit entry.
+	Params StringMap
+}

--- a/internal/dbmodel/audit_test.go
+++ b/internal/dbmodel/audit_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel_test
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/names/v4"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
+
+func TestAuditLogEntry(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(t, &dbmodel.AuditLogEntry{})
+
+	ale := dbmodel.AuditLogEntry{
+		Time:    time.Now(),
+		Tag:     names.NewModelTag("00000001-0000-0000-0000-0000-000000000008").String(),
+		UserTag: names.NewUserTag("bob@external").String(),
+		Action:  "created",
+		Params:  dbmodel.StringMap{"a": "b", "c": "d"},
+	}
+	c.Assert(db.Create(&ale).Error, qt.IsNil)
+
+	var ale2 dbmodel.AuditLogEntry
+	c.Assert(db.First(&ale2).Error, qt.IsNil)
+	c.Check(ale2, qt.DeepEquals, ale)
+}

--- a/internal/dbmodel/user.go
+++ b/internal/dbmodel/user.go
@@ -35,6 +35,10 @@ type User struct {
 	// controller. By default all users have "add-model" access.
 	ControllerAccess string `gorm:"not null;default:'add-model'"`
 
+	// AuditLogAccess is the access level this user has on the JIMM audit
+	// log.
+	AuditLogAccess string `gorm:"not null;default:''"`
+
 	// Clouds are the clouds accessible to this user.
 	Clouds []UserCloudAccess
 


### PR DESCRIPTION
Implement access to the audit log in the JIMM facade. The API has been
implemented based on the future relational world, as has the dbmodel
definition, however the implementation uses the current audit log. This
causes a slight disconnect in the implementation. This will be resolved
when the relational data stores are fully implemented.

The current RPC methods are restricted to controller-admin users only.
This is more restrictive than the current HTTP based audit log. This
will be resolved when the relational data store is wired up.