### PR TITLE
internal/db: rework the Database object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/vault/api v1.0.5-0.20200709165743-f98572ac11c9
+	github.com/jackc/pgconn v1.7.0
 	github.com/jackc/pgx/v4 v4.9.0
 	github.com/juju/aclstore v0.0.0-20180706073322-7fc1cdaacf01
 	github.com/juju/charm/v8 v8.0.0-20200925052646-bb021a575610

--- a/internal/db/application_offer.go
+++ b/internal/db/application_offer.go
@@ -10,31 +10,31 @@ import (
 )
 
 // AddApplicationOffer stores the application offer information.
-func (d Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
+func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
 	const op = errors.Op("db.AddApplicationOffer")
-	if err := d.ready(op); err != nil {
-		return err
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
 	}
 	db := d.DB.WithContext(ctx)
 
 	result := db.Create(offer)
 	if result.Error != nil {
-		return errors.E(op, errorCode(result.Error))
+		return errors.E(op, dbError(result.Error))
 	}
 	return nil
 }
 
 // UpdateApplicationOffer updates the application offer information.
-func (d Database) UpdateApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
+func (d *Database) UpdateApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
 	const op = errors.Op("db.UpdateApplicationOffer")
-	if err := d.ready(op); err != nil {
-		return err
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
 	}
 	db := d.DB.WithContext(ctx)
 
 	result := db.Model(offer).Updates(offer)
 	if result.Error != nil {
-		return errors.E(op, errorCode(result.Error))
+		return errors.E(op, dbError(result.Error))
 	}
 
 	if err := d.GetApplicationOffer(ctx, offer); err != nil {
@@ -46,31 +46,31 @@ func (d Database) UpdateApplicationOffer(ctx context.Context, offer *dbmodel.App
 
 // GetApplicationOffer returns application offer information based on the
 // offer UUID.
-func (d Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
+func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
 	const op = errors.Op("db.GetApplicationOffer")
-	if err := d.ready(op); err != nil {
-		return err
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
 	}
 	db := d.DB.WithContext(ctx)
 
 	result := db.Where("uuid = ?", offer.UUID).Preload("Users").First(&offer)
 	if result.Error != nil {
-		return errors.E(op, errorCode(result.Error))
+		return errors.E(op, dbError(result.Error))
 	}
 	return nil
 }
 
 // DeleteApplicationOffer deletes the application offer.
-func (d Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
+func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) error {
 	const op = errors.Op("db.DeleteApplicationOffer")
-	if err := d.ready(op); err != nil {
-		return err
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
 	}
 	db := d.DB.WithContext(ctx)
 
 	result := db.Delete(offer)
 	if result.Error != nil {
-		return errors.E(op, errorCode(result.Error))
+		return errors.E(op, dbError(result.Error))
 	}
 	return nil
 }

--- a/internal/db/application_offer_test.go
+++ b/internal/db/application_offer_test.go
@@ -32,7 +32,7 @@ type testEnvironment struct {
 	model      dbmodel.Model
 }
 
-func initTestEnvironment(c *qt.C, db db.Database) testEnvironment {
+func initTestEnvironment(c *qt.C, db *db.Database) testEnvironment {
 	err := db.Migrate(context.Background(), true)
 	c.Assert(err, qt.Equals, nil)
 
@@ -209,7 +209,7 @@ func (s *dbSuite) TestGetApplicationOffer(c *qt.C) {
 		UUID: "00000000-0000-0000-0000-000000000002",
 	}
 	err = s.Database.GetApplicationOffer(context.Background(), &dbOffer)
-	c.Assert(err, qt.ErrorMatches, "not found")
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 func (s *dbSuite) TestUpdateApplicationOffer(c *qt.C) {
@@ -264,7 +264,6 @@ func (s *dbSuite) TestUpdateApplicationOffer(c *qt.C) {
 	}
 	err = s.Database.UpdateApplicationOffer(context.Background(), &offer3)
 	c.Assert(err, qt.Not(qt.IsNil))
-
 }
 
 func (s *dbSuite) TestDeleteApplicationOffer(c *qt.C) {
@@ -285,5 +284,5 @@ func (s *dbSuite) TestDeleteApplicationOffer(c *qt.C) {
 		Users: nil,
 	}
 	err = s.Database.GetApplicationOffer(context.Background(), &dbOffer)
-	c.Assert(err, qt.ErrorMatches, "not found")
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -24,16 +24,26 @@ type Database struct {
 	// to the current database version. The value of migrated should always
 	// be read using atomic.LoadUint32 and will contain a 0 if the
 	// migration is yet to be run, or 1 if it has been run successfully.
-	migrated *uint32
+	migrated uint32
 }
 
-// NewDatabase creates a new Database using the given gorm.DB to store the
-// data.
-func NewDatabase(db *gorm.DB) Database {
-	return Database{
-		DB:       db,
-		migrated: new(uint32),
+// Transaction starts a new transaction using the database. This allows
+// a set of changes to be performed as a single atomic unit. All of the
+// transaction steps should be performed in the given function, if this
+// function returns an error then all changes in the transaction will be
+// aborted and the error returned. Transactions may be nested.
+//
+// Attempting to start a transaction on an unmigrated database will result
+// in an error with a code of errors.CodeUpgradeInProgress.
+func (d *Database) Transaction(f func(*Database) error) error {
+	if err := d.ready(); err != nil {
+		return err
 	}
+	return d.DB.Transaction(func(tx *gorm.DB) error {
+		d := *d
+		d.DB = tx
+		return f(&d)
+	})
 }
 
 // Migrate migrates the configured database to have the structure required
@@ -45,23 +55,23 @@ func NewDatabase(db *gorm.DB) Database {
 // then the migration will be performed no matter what the current version
 // is. The force parameter should only be set when the migration is
 // initiated by a user request.
-func (d Database) Migrate(ctx context.Context, force bool) error {
+func (d *Database) Migrate(ctx context.Context, force bool) error {
 	const op = errors.Op("db.Migrate")
-	if d.DB == nil {
+	if d == nil || d.DB == nil {
 		return errors.E(op, errors.CodeServerConfiguration, "database not configured")
 	}
 	db := d.DB.WithContext(ctx)
 	if err := db.AutoMigrate(&dbmodel.Version{}); err != nil {
-		return errors.E(op, errorCode(err), err)
+		return errors.E(op, dbError(err))
 	}
 	v := dbmodel.Version{Component: dbmodel.Component}
 	if err := db.FirstOrCreate(&v).Error; err != nil {
-		return errors.E(op, errorCode(err), err)
+		return errors.E(op, dbError(err))
 	}
 	if dbmodel.Major == v.Major && dbmodel.Minor <= v.Minor {
 		// The database is already at, or past, our current version.
 		// Nothing to do.
-		atomic.StoreUint32(d.migrated, 1)
+		atomic.StoreUint32(&d.migrated, 1)
 		return nil
 	}
 	if v.Major != dbmodel.Major && !force && v.Major != 0 {
@@ -86,26 +96,26 @@ func (d Database) Migrate(ctx context.Context, force bool) error {
 		&dbmodel.UserModelAccess{},
 	)
 	if err != nil {
-		return errors.E(op, errorCode(err), err)
+		return errors.E(op, dbError(err))
 	}
 
 	v.Major = dbmodel.Major
 	v.Minor = dbmodel.Minor
 	if err := db.Save(&v).Error; err != nil {
-		return errors.E(op, errorCode(err), err)
+		return errors.E(op, dbError(err))
 	}
-	atomic.StoreUint32(d.migrated, 1)
+	atomic.StoreUint32(&d.migrated, 1)
 	return nil
 }
 
 // ready checks that the database is ready to accept requests. An error is
 // returned if the database is not yet initialised.
-func (d Database) ready(op errors.Op) error {
-	if d.DB == nil {
-		return errors.E(op, errors.CodeServerConfiguration, "database not configured")
+func (d *Database) ready() error {
+	if d == nil || d.DB == nil {
+		return errors.E(errors.CodeServerConfiguration, "database not configured")
 	}
-	if atomic.LoadUint32(d.migrated) == 0 {
-		return errors.E(op, errors.CodeUpgradeInProgress)
+	if atomic.LoadUint32(&d.migrated) == 0 {
+		return errors.E(errors.CodeUpgradeInProgress)
 	}
 	return nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -9,18 +9,17 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/CanonicalLtd/jimm/internal/db"
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
 	"github.com/CanonicalLtd/jimm/internal/errors"
 )
 
 // dbSuite contains a suite of database tests that are run against
 // different database engines.
 type dbSuite struct {
-	Database db.Database
+	Database *db.Database
 }
 
 func (s *dbSuite) TestMigrate(c *qt.C) {
-	c.Parallel()
-
 	// Migrate from an empty database should work.
 	err := s.Database.Migrate(context.Background(), false)
 	c.Assert(err, qt.IsNil)
@@ -38,4 +37,37 @@ func TestMigrateUnconfiguredDatabase(t *testing.T) {
 	err := database.Migrate(context.Background(), false)
 	c.Check(err, qt.ErrorMatches, `database not configured`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func TestTransactionUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var database db.Database
+	err := database.Transaction(func(d *db.Database) error {
+		return errors.E("unexpected function call")
+	})
+	c.Check(err, qt.ErrorMatches, `database not configured`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func (s *dbSuite) TestTransaction(c *qt.C) {
+	err := s.Database.Transaction(func(d *db.Database) error {
+		return errors.E("unexpected function call")
+	})
+	c.Check(err, qt.ErrorMatches, `upgrade in progress`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
+
+	err = s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.Transaction(func(d *db.Database) error {
+		c.Check(d, qt.Not(qt.Equals), s.Database)
+		return d.GetUser(context.Background(), &dbmodel.User{Username: "bob@external"})
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.Transaction(func(d *db.Database) error {
+		return errors.E("test error")
+	})
+	c.Check(err, qt.ErrorMatches, `test error`)
 }

--- a/internal/db/dqlite_test.go
+++ b/internal/db/dqlite_test.go
@@ -56,5 +56,5 @@ func (s *dqliteSuite) Init(c *qt.C) {
 	// expected.
 	err = gdb.Exec("PRAGMA foreign_keys=ON").Error
 	c.Assert(err, qt.IsNil)
-	s.dbSuite.Database = db.NewDatabase(gdb)
+	s.dbSuite.Database = &db.Database{DB: gdb}
 }

--- a/internal/db/pgx_test.go
+++ b/internal/db/pgx_test.go
@@ -79,5 +79,5 @@ func (s *postgresSuite) Init(c *qt.C) {
 	}
 	gdb, err := gorm.Open(postgres.New(pCfg), &cfg)
 	c.Assert(err, qt.IsNil)
-	s.dbSuite.Database = db.NewDatabase(gdb)
+	s.dbSuite.Database = &db.Database{DB: gdb}
 }

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -35,5 +35,5 @@ func (s *sqliteSuite) Init(c *qt.C) {
 	// expected.
 	err = gdb.Exec("PRAGMA foreign_keys=ON").Error
 	c.Assert(err, qt.IsNil)
-	s.dbSuite.Database = db.NewDatabase(gdb)
+	s.dbSuite.Database = &db.Database{DB: gdb}
 }

--- a/internal/db/user_test.go
+++ b/internal/db/user_test.go
@@ -4,6 +4,7 @@ package db_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -41,6 +42,60 @@ func (s *dbSuite) TestGetUser(c *qt.C) {
 	err = s.Database.GetUser(ctx, &u)
 	c.Assert(err, qt.IsNil)
 	c.Check(u.ControllerAccess, qt.Equals, "add-model")
+
+	u2 := dbmodel.User{
+		Username: u.Username,
+	}
+	err = s.Database.GetUser(ctx, &u2)
+	c.Assert(err, qt.IsNil)
+	c.Check(u2, qt.DeepEquals, u)
+}
+
+func TestUpdateUserUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var d db.Database
+	err := d.UpdateUser(context.Background(), &dbmodel.User{})
+	c.Check(err, qt.ErrorMatches, `database not configured`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func (s *dbSuite) TestUpdateUser(c *qt.C) {
+	ctx := context.Background()
+	err := s.Database.UpdateUser(ctx, &dbmodel.User{})
+	c.Check(err, qt.ErrorMatches, `upgrade in progress`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
+
+	err = s.Database.Migrate(ctx, false)
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.UpdateUser(ctx, &dbmodel.User{})
+	c.Check(err, qt.ErrorMatches, `invalid username ""`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	u := dbmodel.User{
+		Username: "bob@external",
+	}
+	err = s.Database.GetUser(ctx, &u)
+	c.Assert(err, qt.IsNil)
+	c.Check(u.ControllerAccess, qt.Equals, "add-model")
+
+	u.ControllerAccess = "superuser"
+	u.Models = []dbmodel.UserModelAccess{{
+		Model_: dbmodel.Model{
+			Name:  "model-1",
+			Owner: u,
+			UUID: sql.NullString{
+				String: "00000001-0000-0000-0000-0000-00000000001",
+				Valid:  true,
+			},
+		},
+		Access: "admin",
+	}}
+	err = s.Database.UpdateUser(ctx, &u)
+	c.Assert(err, qt.IsNil)
+
+	u.Models = nil
 
 	u2 := dbmodel.User{
 		Username: u.Username,


### PR DESCRIPTION
Change the Database object such that the zero value is, somewhat, useful
removing the need for a constructor. Also add a Transaction method to
allow Database operations to be run in transactions.