### PR TITLE
internal/jimm: implement adding controllers

### DIFF
--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -39,8 +39,7 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 		db = db.Where("name = ?", controller.Name)
 	}
 
-	// TODO (ashipika): think about model preloading - is it needed?
-	if err := db.Preload("Models", "is_controller = true").First(&controller).Error; err != nil {
+	if err := db.Preload("CloudRegions").First(&controller).Error; err != nil {
 		return errors.E(op, dbError(err))
 	}
 	return nil

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -66,14 +66,14 @@ func (s *dbSuite) TestGetController(c *qt.C) {
 	}
 	err = s.Database.GetController(context.Background(), &dbController)
 	c.Assert(err, qt.Equals, nil)
-	c.Assert(dbController, qt.DeepEquals, controller)
+	c.Assert(dbController, qt.CmpEquals(cmpopts.EquateEmpty()), controller)
 
 	dbController = dbmodel.Controller{
 		Name: controller.Name,
 	}
 	err = s.Database.GetController(context.Background(), &dbController)
 	c.Assert(err, qt.Equals, nil)
-	c.Assert(dbController, qt.DeepEquals, controller)
+	c.Assert(dbController, qt.CmpEquals(cmpopts.EquateEmpty()), controller)
 
 	dbController = dbmodel.Controller{
 		Name: "no such controller",
@@ -188,7 +188,5 @@ func (s *dbSuite) TestGetControllerWithModels(c *qt.C) {
 	controller.Models = []dbmodel.Model{
 		models[0],
 	}
-	c.Assert(dbController, qt.CmpEquals(cmpopts.IgnoreFields(dbmodel.Controller{}, "Models")), controller)
-	c.Assert(dbController.Models, qt.HasLen, 1)
-	c.Assert(dbController.Models[0].UUID, qt.Equals, models[0].UUID)
+	c.Assert(dbController, qt.CmpEquals(cmpopts.IgnoreFields(dbmodel.Controller{}, "Models"), cmpopts.EquateEmpty()), controller)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -102,7 +102,9 @@ type Code string
 const (
 	CodeAlreadyExists       Code = jujuparams.CodeAlreadyExists
 	CodeBadRequest          Code = jujuparams.CodeBadRequest
+	CodeConnectionFailed    Code = "connection failed"
 	CodeNotFound            Code = jujuparams.CodeNotFound
+	CodeNotImplemented      Code = jujuparams.CodeNotImplemented
 	CodeServerConfiguration Code = "server configuration"
 	CodeUnauthorized        Code = jujuparams.CodeUnauthorized
 	CodeUpgradeInProgress   Code = jujuparams.CodeUpgradeInProgress

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -1,0 +1,151 @@
+// Copyright 2020 Canonical Ltd.
+
+package jimm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	"go.uber.org/zap"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/zapctx"
+)
+
+// AddController adds the specified controller to JIMM. Only
+// controller-admin level users may add new controllers. If the user adding
+// the controller is not authorized then an error with a code of
+// CodeUnauthorized will be returned. If there already exists a controller
+// with the same name as the controller being added then an error with a
+// code of CodeAlreasyExists will be returned. If the controller cannot be
+// contacted then an error with a code of CodeConnectionFailed will be
+// returned.
+func (j *JIMM) AddController(ctx context.Context, u *dbmodel.User, ctl *dbmodel.Controller) error {
+	const op = errors.Op("jimm.AddController")
+	if u.ControllerAccess != "superuser" {
+		return errors.E(op, errors.CodeUnauthorized, "cannot add controller")
+	}
+
+	api, err := j.dial(ctx, ctl, "")
+	if err != nil {
+		return errors.E(op, err)
+	}
+	defer api.Close()
+
+	var ms jujuparams.ModelSummary
+	if err := api.ControllerModelSummary(ctx, &ms); err != nil {
+		return errors.E(op, err)
+	}
+	// TODO(mhilton) add the controller model?
+
+	clouds, err := api.Clouds(ctx)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	for tag, cld := range clouds {
+		ctx := zapctx.WithFields(ctx, zap.String("tag", tag))
+		ct, err := names.ParseCloudTag(tag)
+		if err != nil {
+			zapctx.Error(ctx, "cannot parse cloud tag - skipping", zap.Error(err))
+			continue
+		}
+		cloud := dbmodel.Cloud{
+			Name:             ct.Id(),
+			Type:             cld.Type,
+			HostCloudRegion:  cld.HostCloudRegion,
+			AuthTypes:        dbmodel.Strings(cld.AuthTypes),
+			Endpoint:         cld.Endpoint,
+			IdentityEndpoint: cld.IdentityEndpoint,
+			StorageEndpoint:  cld.StorageEndpoint,
+			CACertificates:   dbmodel.Strings(cld.CACertificates),
+			Config:           dbmodel.Map(cld.Config),
+			Users: []dbmodel.UserCloudAccess{{
+				User: dbmodel.User{
+					// "everyone@external" represents all authenticated
+					// users.
+					Username:    "everyone@external",
+					DisplayName: "everyone",
+				},
+				Access: "add-model",
+			}},
+		}
+		// If this cloud is not the one used by the controller model then
+		// it is only available to a subset of users.
+		if tag != ms.CloudTag {
+			var err error
+			cloud.Users, err = cloudUsers(ctx, api, tag)
+			if err != nil {
+				// If there is an error getting the users, log the failure
+				// but carry on, this will prevent anyone trying to add a
+				// cloud with the same name. The user access can be fixed
+				// later.
+				zapctx.Error(ctx, "cannot get cloud users", zap.Error(err))
+			}
+		}
+
+		for _, r := range cld.Regions {
+			cr := dbmodel.CloudRegion{
+				CloudName:        cloud.Name,
+				Name:             r.Name,
+				Endpoint:         r.Endpoint,
+				IdentityEndpoint: r.IdentityEndpoint,
+				StorageEndpoint:  r.StorageEndpoint,
+				Config:           dbmodel.Map(cld.RegionConfig[r.Name]),
+			}
+			cloud.Regions = append(cloud.Regions, cr)
+		}
+
+		if err := j.Database.SetCloud(ctx, &cloud); err != nil {
+			return errors.E(op, errors.Code(""), fmt.Sprintf("cannot load controller cloud %q", cloud.Name), err)
+		}
+
+		for _, cr := range cloud.Regions {
+			priority := dbmodel.CloudRegionControllerPrioritySupported
+			if tag == ms.CloudTag && cr.Name == ms.CloudRegion {
+				priority = dbmodel.CloudRegionControllerPriorityDeployed
+			}
+			ctl.CloudRegions = append(ctl.CloudRegions, dbmodel.CloudRegionControllerPriority{
+				CloudRegionID: cr.ID,
+				Priority:      uint(priority),
+			})
+		}
+	}
+
+	if err := j.Database.AddController(ctx, ctl); err != nil {
+		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+			return errors.E(op, err, fmt.Sprintf("controller %q already exists", ctl.Name))
+		}
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+// cloudUsers determines the users that can access a cloud.
+func cloudUsers(ctx context.Context, api API, tag string) ([]dbmodel.UserCloudAccess, error) {
+	const op = errors.Op("jimm.cloudUsers")
+	var ci jujuparams.CloudInfo
+	if err := api.CloudInfo(ctx, tag, &ci); err != nil {
+		return nil, errors.E(op, err)
+	}
+	var users []dbmodel.UserCloudAccess
+	for _, u := range ci.Users {
+		if strings.Index(u.UserName, "@") < 0 {
+			// If the username doesn't contain an "@" the user is local
+			// to the controller and we don't want to propagate it.
+			continue
+		}
+		users = append(users, dbmodel.UserCloudAccess{
+			User: dbmodel.User{
+				Username:    u.UserName,
+				DisplayName: u.DisplayName,
+			},
+			Access: u.Access,
+		})
+	}
+	return users, nil
+}

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -1,0 +1,149 @@
+// Copyright 2020 Canonical Ltd.
+
+package jimm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/version"
+
+	"github.com/CanonicalLtd/jimm/internal/db"
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/jimm"
+	"github.com/CanonicalLtd/jimm/internal/jimmtest"
+)
+
+func TestAddController(t *testing.T) {
+	c := qt.New(t)
+
+	now := time.Now().UTC().Round(time.Millisecond)
+	api := &jimmtest.API{
+		Clouds_: func(context.Context) (map[string]jujuparams.Cloud, error) {
+			clouds := map[string]jujuparams.Cloud{
+				"cloud-aws": jujuparams.Cloud{
+					Type:             "ec2",
+					AuthTypes:        []string{"userpass"},
+					Endpoint:         "https://example.com",
+					IdentityEndpoint: "https://identity.example.com",
+					StorageEndpoint:  "https://storage.example.com",
+					Regions: []jujuparams.CloudRegion{{
+						Name:             "eu-west-1",
+						Endpoint:         "https://eu-west-1.example.com",
+						IdentityEndpoint: "https://eu-west-1.identity.example.com",
+						StorageEndpoint:  "https://eu-west-1.storage.example.com",
+					}, {
+						Name:             "eu-west-2",
+						Endpoint:         "https://eu-west-2.example.com",
+						IdentityEndpoint: "https://eu-west-2.identity.example.com",
+						StorageEndpoint:  "https://eu-west-2.storage.example.com",
+					}},
+					CACertificates: []string{"CA CERT 1", "CA CERT 2"},
+					Config: map[string]interface{}{
+						"A": "a",
+						"B": 0xb,
+					},
+					RegionConfig: map[string]map[string]interface{}{
+						"eu-west-1": map[string]interface{}{
+							"B": 0xb0,
+							"C": "C",
+						},
+						"eu-west-2": map[string]interface{}{
+							"B": 0xb1,
+							"D": "D",
+						},
+					},
+				},
+				"cloud-k8s": jujuparams.Cloud{
+					Type:      "kubernetes",
+					AuthTypes: []string{"userpass"},
+					Endpoint:  "https://k8s.example.com",
+					Regions: []jujuparams.CloudRegion{{
+						Name: "default",
+					}},
+				},
+			}
+			return clouds, nil
+		},
+		CloudInfo_: func(_ context.Context, tag string, ci *jujuparams.CloudInfo) error {
+			if tag != "cloud-k8s" {
+				c.Errorf("CloudInfo called for unexpected cloud %q", tag)
+				return errors.E("unexpected cloud")
+			}
+			ci.Type = "kubernetes"
+			ci.AuthTypes = []string{"userpass"}
+			ci.Endpoint = "https://k8s.example.com"
+			ci.Regions = []jujuparams.CloudRegion{{
+				Name: "default",
+			}}
+			ci.Users = []jujuparams.CloudUserInfo{{
+				UserName:    "alice@external",
+				DisplayName: "Alice",
+				Access:      "admin",
+			}, {
+				UserName:    "bob@external",
+				DisplayName: "Bob",
+				Access:      "add-model",
+			}}
+			return nil
+		},
+		ControllerModelSummary_: func(_ context.Context, ms *jujuparams.ModelSummary) error {
+			ms.Name = "controller"
+			ms.UUID = "5fddf0ed-83d5-47e8-ae7b-a4b27fc04a9f"
+			ms.Type = "iaas"
+			ms.ControllerUUID = jimmtest.DefaultControllerUUID
+			ms.IsController = true
+			ms.ProviderType = "ec2"
+			ms.DefaultSeries = "warty"
+			ms.CloudTag = "cloud-aws"
+			ms.CloudRegion = "eu-west-1"
+			ms.OwnerTag = "user-admin"
+			ms.Life = "alive"
+			ms.Status = jujuparams.EntityStatus{
+				Status: "available",
+			}
+			ms.UserAccess = "admin"
+			ms.AgentVersion = &version.Current
+			return nil
+		},
+	}
+
+	j := &jimm.JIMM{
+		Database: db.Database{
+			DB: jimmtest.MemoryDB(c, func() time.Time { return now }),
+		},
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	}
+
+	ctx := context.Background()
+	err := j.Database.Migrate(ctx, false)
+	c.Assert(err, qt.IsNil)
+
+	u := dbmodel.User{
+		Username:         "alice@external",
+		ControllerAccess: "superuser",
+	}
+
+	ctl := dbmodel.Controller{
+		Name:          "test-controller",
+		AdminUser:     "admin",
+		AdminPassword: "5ecret",
+		PublicAddress: "example.com:443",
+	}
+	err = j.AddController(context.Background(), &u, &ctl)
+	c.Assert(err, qt.IsNil)
+
+	ctl2 := dbmodel.Controller{
+		Name: "test-controller",
+	}
+	err = j.Database.GetController(ctx, &ctl2)
+	c.Assert(err, qt.IsNil)
+	c.Check(ctl2, qt.CmpEquals(cmpopts.EquateEmpty()), ctl)
+}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CanonicalLtd/jimm/internal/db"
 	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
 )
 
 // A JIMM provides the buisness logic for managing resources in the JAAS
@@ -28,6 +29,10 @@ type JIMM struct {
 	// authenticating with the API. If this is not specified then all
 	// authentication requests are considered to have failed.
 	Authenticator Authenticator
+
+	// Dialer is the API dialer JIMM uses to contact juju controllers. if
+	// this is not configured all connection attempts will fail.
+	Dialer Dialer
 }
 
 // An Authenticator authenticates login requests.
@@ -35,4 +40,42 @@ type Authenticator interface {
 	// Authenticate processes the given LoginRequest and returns the user
 	// that has authenticated.
 	Authenticate(ctx context.Context, req *jujuparams.LoginRequest) (*dbmodel.User, error)
+}
+
+// dial dials the controller and model specified by the given Controller
+// and ModelTag. If no Dialer has been configured then an error with a
+// code of CodeConnectionFailed will be returned.
+func (j *JIMM) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag string) (API, error) {
+	if j == nil || j.Dialer == nil {
+		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
+	}
+	return j.Dialer.Dial(ctx, ctl, modelTag)
+}
+
+// A Dialer provides a connection to a controller.
+type Dialer interface {
+	// Dial creates an API connection to a controller. If the given
+	// model-tag is non-zero the connection will be to that model,
+	// otherwise the connection is to the controller. After sucessfully
+	// dialing the controller the UUID, AgentVersion and HostPorts fields
+	// in the given controller should be updated to the values provided
+	// by the controller.
+	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag string) (API, error)
+}
+
+// An API is the interface JIMM uses to access the API on a controller.
+type API interface {
+	// Close closes the API connection.
+	Close()
+
+	// CloudInfo fetches the cloud information for the cloud with the given
+	// tag.
+	CloudInfo(ctx context.Context, tag string, ci *jujuparams.CloudInfo) error
+
+	// Clouds returns the set of clouds supported by the controller.
+	Clouds(context.Context) (map[string]jujuparams.Cloud, error)
+
+	// ControllerModelSummary fetches the model summary of the model on the
+	// controller that hosts the controller machines.
+	ControllerModelSummary(context.Context, *jujuparams.ModelSummary) error
 }

--- a/internal/jimmtest/api.go
+++ b/internal/jimmtest/api.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Canonical Ltd.
+
+package jimmtest
+
+import (
+	"context"
+	"sync/atomic"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/version"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/jimm"
+)
+
+// DefaultControllerUUID is the controller UUID returned by Dialer if
+// the is no configured controller UUID.
+const DefaultControllerUUID = "982b16d9-a945-4762-b684-fd4fd885aa10"
+
+// A Dialer is a jimm.Dialer that either returns an error if Err is
+// non-zero, or returns the value of API. The number of open API
+// connections is tracked.
+type Dialer struct {
+	// API contains the API implementation to return, if Err is nil.
+	API jimm.API
+
+	// Err contains the error to return when a Dial is attempted.
+	Err error
+
+	// UUID is the UUID of the connected controller, if this is not set
+	// then DefaultControllerUUID will be used.
+	UUID string
+
+	// AgentVersion contains the juju-agent version to the report to the
+	// controller connection. If this is empty the version of the linked
+	// juju is used.
+	AgentVersion string
+
+	// HostPorts contains the HostPorts to set on the controller.
+	HostPorts dbmodel.HostPorts
+
+	open int64
+}
+
+// Dialer implements jimm.Dialer.
+func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ string) (jimm.API, error) {
+	if d.Err != nil {
+		return nil, d.Err
+	}
+	atomic.AddInt64(&d.open, 1)
+	ctl.UUID = d.UUID
+	if ctl.UUID == "" {
+		ctl.UUID = DefaultControllerUUID
+	}
+	ctl.AgentVersion = d.AgentVersion
+	if ctl.AgentVersion == "" {
+		ctl.AgentVersion = version.Current.String()
+	}
+	ctl.HostPorts = d.HostPorts
+	return apiWrapper{
+		API:  d.API,
+		open: &d.open,
+	}, nil
+}
+
+// IsClosed returns true if all opened connections have been closed.
+func (d *Dialer) IsClosed() bool {
+	return atomic.LoadInt64(&d.open) == 0
+}
+
+// apiWrapper is the API implementation used by Dialer to track usage.
+type apiWrapper struct {
+	jimm.API
+	open *int64
+}
+
+// Close closes the API and decrements the open count.
+func (w apiWrapper) Close() {
+	atomic.AddInt64(w.open, -1)
+	w.API.Close()
+}
+
+// API is a default implementation of the jimm.API interface. Every method
+// has a corresponding function field. Whenever the method is called it
+// will delegate to the requested function or if the function is nil return
+// a NotImplemented error.
+type API struct {
+	Close_                  func()
+	CloudInfo_              func(context.Context, string, *jujuparams.CloudInfo) error
+	Clouds_                 func(context.Context) (map[string]jujuparams.Cloud, error)
+	ControllerModelSummary_ func(context.Context, *jujuparams.ModelSummary) error
+}
+
+func (a *API) Close() {
+	if a.Close_ == nil {
+		return
+	}
+	a.Close_()
+}
+
+func (a *API) CloudInfo(ctx context.Context, tag string, ci *jujuparams.CloudInfo) error {
+	if a.CloudInfo_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.CloudInfo_(ctx, tag, ci)
+}
+
+func (a *API) Clouds(ctx context.Context) (map[string]jujuparams.Cloud, error) {
+	if a.Clouds_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return a.Clouds_(ctx)
+}
+
+func (a *API) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelSummary) error {
+	if a.ControllerModelSummary_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.ControllerModelSummary_(ctx, ms)
+}
+
+var _ jimm.API = &API{}


### PR DESCRIPTION
Support adding controllers to the system. This introduces the system
JIMM will use for contacting controllers to perform API requests, along
with support for testing those API requests.