### PR TITLE
internal/jujuclient: create a juju client for JIMM

### DIFF
--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -49,9 +49,9 @@ type Controller struct {
 	// agent version.
 	AgentVersion string
 
-	// HostPorts holds the known addresses on which the controller is
+	// Addresses holds the known addresses on which the controller is
 	// listening.
-	HostPorts HostPorts
+	Addresses Strings
 
 	// UnavailableSince records the time that this controller became
 	// unavailable, if it has.

--- a/internal/dbmodel/controller_test.go
+++ b/internal/dbmodel/controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CanonicalLtd/jimm/internal/dbmodel"
 	qt "github.com/frankban/quicktest"
-	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/names/v4"
 )
 
@@ -38,26 +37,7 @@ func TestController(t *testing.T) {
 		AdminPassword: "pw",
 		CACertificate: "ca-cert",
 		PublicAddress: "controller.example.com:443",
-		HostPorts: [][]jujuparams.HostPort{{{
-			Address: jujuparams.Address{
-				Value:           "1.1.1.1",
-				Type:            "t1",
-				Scope:           "s1",
-				SpaceName:       "sp1",
-				ProviderSpaceID: "psp1",
-			},
-			Port: 1,
-		}, {
-			Address: jujuparams.Address{
-				Value: "2.2.2.2",
-			},
-			Port: 2,
-		}}, {{
-			Address: jujuparams.Address{
-				Value: "3.3.3.3",
-			},
-			Port: 3,
-		}}},
+		Addresses:     dbmodel.Strings{"1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"},
 	}
 	result := db.Create(&ctl)
 	c.Assert(result.Error, qt.IsNil)

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	jujuparams "github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/version"
+	"github.com/juju/names/v4"
 
 	"github.com/CanonicalLtd/jimm/internal/db"
 	"github.com/CanonicalLtd/jimm/internal/dbmodel"
@@ -24,9 +25,9 @@ func TestAddController(t *testing.T) {
 
 	now := time.Now().UTC().Round(time.Millisecond)
 	api := &jimmtest.API{
-		Clouds_: func(context.Context) (map[string]jujuparams.Cloud, error) {
-			clouds := map[string]jujuparams.Cloud{
-				"cloud-aws": jujuparams.Cloud{
+		Clouds_: func(context.Context) (map[names.CloudTag]jujuparams.Cloud, error) {
+			clouds := map[names.CloudTag]jujuparams.Cloud{
+				names.NewCloudTag("aws"): jujuparams.Cloud{
 					Type:             "ec2",
 					AuthTypes:        []string{"userpass"},
 					Endpoint:         "https://example.com",
@@ -59,7 +60,7 @@ func TestAddController(t *testing.T) {
 						},
 					},
 				},
-				"cloud-k8s": jujuparams.Cloud{
+				names.NewCloudTag("k8s"): jujuparams.Cloud{
 					Type:      "kubernetes",
 					AuthTypes: []string{"userpass"},
 					Endpoint:  "https://k8s.example.com",
@@ -70,8 +71,8 @@ func TestAddController(t *testing.T) {
 			}
 			return clouds, nil
 		},
-		CloudInfo_: func(_ context.Context, tag string, ci *jujuparams.CloudInfo) error {
-			if tag != "cloud-k8s" {
+		CloudInfo_: func(_ context.Context, tag names.CloudTag, ci *jujuparams.CloudInfo) error {
+			if tag.Id() != "k8s" {
 				c.Errorf("CloudInfo called for unexpected cloud %q", tag)
 				return errors.E("unexpected cloud")
 			}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -6,8 +6,11 @@ package jimm
 
 import (
 	"context"
+	"time"
 
 	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/CanonicalLtd/jimm/internal/db"
 	"github.com/CanonicalLtd/jimm/internal/dbmodel"
@@ -45,7 +48,7 @@ type Authenticator interface {
 // dial dials the controller and model specified by the given Controller
 // and ModelTag. If no Dialer has been configured then an error with a
 // code of CodeConnectionFailed will be returned.
-func (j *JIMM) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag string) (API, error) {
+func (j *JIMM) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error) {
 	if j == nil || j.Dialer == nil {
 		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
 	}
@@ -60,22 +63,119 @@ type Dialer interface {
 	// dialing the controller the UUID, AgentVersion and HostPorts fields
 	// in the given controller should be updated to the values provided
 	// by the controller.
-	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag string) (API, error)
+	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error)
 }
 
 // An API is the interface JIMM uses to access the API on a controller.
 type API interface {
+	// AddCloud adds a new cloud.
+	AddCloud(context.Context, names.CloudTag, jujuparams.Cloud) error
+
+	// CheckCredentialModels checks that an updated credential can be used
+	// with the associated models.
+	CheckCredentialModels(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error)
+
 	// Close closes the API connection.
-	Close()
+	Close() error
+
+	// Cloud fetches the cloud data for the given cloud.
+	Cloud(context.Context, names.CloudTag, *jujuparams.Cloud) error
 
 	// CloudInfo fetches the cloud information for the cloud with the given
 	// tag.
-	CloudInfo(ctx context.Context, tag string, ci *jujuparams.CloudInfo) error
+	CloudInfo(context.Context, names.CloudTag, *jujuparams.CloudInfo) error
 
 	// Clouds returns the set of clouds supported by the controller.
-	Clouds(context.Context) (map[string]jujuparams.Cloud, error)
+	Clouds(context.Context) (map[names.CloudTag]jujuparams.Cloud, error)
 
 	// ControllerModelSummary fetches the model summary of the model on the
 	// controller that hosts the controller machines.
 	ControllerModelSummary(context.Context, *jujuparams.ModelSummary) error
+
+	// CreateModel creates a new model.
+	CreateModel(context.Context, *jujuparams.ModelCreateArgs, *jujuparams.ModelInfo) error
+
+	// DestroyApplicationOffer destroys an application offer.
+	DestroyApplicationOffer(context.Context, string, bool) error
+
+	// DestroyModel destroys a model.
+	DestroyModel(context.Context, names.ModelTag, *bool, *bool, *time.Duration) error
+
+	// FindApplicationOffers finds application offers that match the
+	// filter.
+	FindApplicationOffers(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error)
+
+	// GetApplicationOffer completes the given ApplicationOfferAdminDetails
+	// structure.
+	GetApplicationOffer(context.Context, *jujuparams.ApplicationOfferAdminDetails) error
+
+	// GetApplicationOfferConsumeDetails gets the details required to
+	// consume an application offer
+	GetApplicationOfferConsumeDetails(context.Context, names.UserTag, *jujuparams.ConsumeOfferDetails, bakery.Version) error
+
+	// GrantApplicationOfferAccess grants access to an application offer to
+	// a user.
+	GrantApplicationOfferAccess(context.Context, string, names.UserTag, jujuparams.OfferAccessPermission) error
+
+	// GrantCloudAccess grants cloud access to a user.
+	GrantCloudAccess(context.Context, names.CloudTag, names.UserTag, string) error
+
+	// GrantJIMMModelAdmin makes the JIMM user an admin on a model.
+	GrantJIMMModelAdmin(context.Context, names.ModelTag) error
+
+	// GrantModelAccess grants model access to a user.
+	GrantModelAccess(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
+
+	// ListApplicationOffers lists application offers that match the
+	// filter.
+	ListApplicationOffers(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error)
+
+	// ModelInfo fetches a model's ModelInfo.
+	ModelInfo(context.Context, *jujuparams.ModelInfo) error
+
+	// ModelStatus fetches a model's ModelStatus.
+	ModelStatus(context.Context, *jujuparams.ModelStatus) error
+
+	// ModelSummaryWatcherNext returns the next set of model summaries from
+	// the watcher.
+	ModelSummaryWatcherNext(context.Context, string) ([]jujuparams.ModelAbstract, error)
+
+	// ModelSummaryWatcherStop stops a model summary watcher.
+	ModelSummaryWatcherStop(context.Context, string) error
+
+	// Offer creates a new application-offer.
+	Offer(context.Context, jujuparams.AddApplicationOffer) error
+
+	// RemoveCloud removes a cloud.
+	RemoveCloud(context.Context, names.CloudTag) error
+
+	// RevokeApplicationOfferAccess revokes access to an application offer
+	// from a user.
+	RevokeApplicationOfferAccess(context.Context, string, names.UserTag, jujuparams.OfferAccessPermission) error
+
+	// RevokeCloudAccess revokes cloud access from a user.
+	RevokeCloudAccess(context.Context, names.CloudTag, names.UserTag, string) error
+
+	// RevokeCredential revokes a credential.
+	RevokeCredential(context.Context, names.CloudCredentialTag) error
+
+	// RevokeModelAccess revokes model access from a user.
+	RevokeModelAccess(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
+
+	// SupportsCheckCredentialModels returns true if the
+	// CheckCredentialModels method can be used.
+	SupportsCheckCredentialModels() bool
+
+	// SupportsModelSummaryWatcher returns true if the connection supports
+	// a ModelSummaryWatcher.
+	SupportsModelSummaryWatcher() bool
+
+	// UpdateCredential updates a credential.
+	UpdateCredential(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error)
+
+	// ValidateModelUpgrade validates that a model can be upgraded.
+	ValidateModelUpgrade(context.Context, names.ModelTag, bool) error
+
+	// WatchAllModelSummaries creates a ModelSummaryWatcher.
+	WatchAllModelSummaries(context.Context) (string, error)
 }

--- a/internal/jujuclient/applicationoffers.go
+++ b/internal/jujuclient/applicationoffers.go
@@ -1,0 +1,202 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient
+
+import (
+	"context"
+
+	jujuerrors "github.com/juju/errors"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// Offer creates a new ApplicationOffer on the controller. Offer uses the
+// Offer procedure on the ApplicationOffers facade version 2.
+func (c Connection) Offer(ctx context.Context, offer jujuparams.AddApplicationOffer) error {
+	const op = errors.Op("jujuclient.Offer")
+	args := jujuparams.AddApplicationOffers{
+		Offers: []jujuparams.AddApplicationOffer{offer},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 2, "", "Offer", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// ListApplicationOffers lists ApplicationOffers on the controller matching
+// the given filters. ListApplicationOffers uses the ListApplicationOffers
+// procedure on the ApplicationOffers facade version 2.
+func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error) {
+	const op = errors.Op("jujuclient.ListApplicationOffers")
+	args := jujuparams.OfferFilters{
+		Filters: filters,
+	}
+
+	var resp jujuparams.QueryApplicationOffersResults
+	err := c.conn.APICall("ApplicationOffers", 2, "", "ListApplicationOffers", &args, &resp)
+	if err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	return resp.Results, nil
+}
+
+// FindApplicationOffers finds ApplicationOffers on the controller matching
+// the given filters. FindApplicationOffers uses the FindApplicationOffers
+// procedure on the ApplicationOffers facade version 2.
+func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error) {
+	const op = errors.Op("jujuclient.FindApplicationOffers")
+	args := jujuparams.OfferFilters{
+		Filters: filters,
+	}
+
+	var resp jujuparams.QueryApplicationOffersResults
+	err := c.conn.APICall("ApplicationOffers", 2, "", "FindApplicationOffers", &args, &resp)
+	if err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	return resp.Results, nil
+}
+
+// GetApplicationOffer retrives the details of the specified
+// ApplicationOffer. The given ApplicationOfferAdminDetails must specify an
+// OfferURL the rest of the structure will be filled in by the API request.
+// GetApplicationOffer uses the ApplicationOffers procedure on the
+// ApplicationOffers facade version 2.
+func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.ApplicationOfferAdminDetails) error {
+	const op = errors.Op("jujuclient.GetApplicationOffer")
+	args := jujuparams.OfferURLs{
+		OfferURLs: []string{info.OfferURL},
+	}
+
+	resp := jujuparams.ApplicationOffersResults{
+		Results: make([]jujuparams.ApplicationOfferResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 2, "", "ApplicationOffers", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	*info = *resp.Results[0].Result
+	return nil
+}
+
+// GrantApplicationOfferAccess grants the specified permission to the
+// given user on the given application offer. GrantApplicationOfferAccess
+// uses the ModifyOfferAccess procedure on the ApplicationOffers facade
+// version 2.
+func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
+	const op = errors.Op("jujuclient.GrantApplicationOfferAccess")
+	args := jujuparams.ModifyOfferAccessRequest{
+		Changes: []jujuparams.ModifyOfferAccess{{
+			UserTag:  user.String(),
+			Action:   jujuparams.GrantOfferAccess,
+			Access:   access,
+			OfferURL: offerURL,
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 2, "", "ModifyOfferAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// RevokeApplicationOfferAccess revokes the specified permission from the
+// given user on the given application offer. RevokeApplicationOfferAccess
+// uses the ModifyOfferAccess procedure on the ApplicationOffers facade
+// version 1.
+func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
+	const op = errors.Op("jujuclient.RevokeApplicationOfferAccess")
+	args := jujuparams.ModifyOfferAccessRequest{
+		Changes: []jujuparams.ModifyOfferAccess{{
+			UserTag:  user.String(),
+			Action:   jujuparams.RevokeOfferAccess,
+			Access:   access,
+			OfferURL: offerURL,
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 2, "", "ModifyOfferAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// DestroyApplicationOffer destroys the given application offer.
+// DestroyApplicationOffer uses the DestroyOffers procedure
+// from the ApplicationOffers facade version 2.
+func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, force bool) error {
+	const op = errors.Op("jujuclient.DestroyApplicationOffer")
+	args := jujuparams.DestroyApplicationOffers{
+		OfferURLs: []string{offer},
+		Force:     force,
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 2, "", "DestroyOffers", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// GetApplicationOfferConsumeDetails retrieves the details needed to
+// consume an application offer. The given ConsumeOfferDetails structure
+// must include an Offer.OfferURL and the rest of the structure will be
+// filled in by the API call. GetApplicationOfferConsumeDetails uses the
+// GetConsumeDetails procedure on the ApplicationOffers facade version 3.
+func (c Connection) GetApplicationOfferConsumeDetails(ctx context.Context, user names.UserTag, info *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
+	const op = errors.Op("jujuclient.GetApplicationOfferConsumeDetails")
+	args := jujuparams.ConsumeOfferDetailsArg{
+		OfferURLs: jujuparams.OfferURLs{
+			OfferURLs:     []string{info.Offer.OfferURL},
+			BakeryVersion: v,
+		},
+		UserTag: user.String(),
+	}
+
+	resp := jujuparams.ConsumeOfferDetailsResults{
+		Results: make([]jujuparams.ConsumeOfferDetailsResult, 1),
+	}
+	err := c.conn.APICall("ApplicationOffers", 3, "", "GetConsumeDetails", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	*info = resp.Results[0].ConsumeOfferDetails
+	return nil
+}

--- a/internal/jujuclient/applicationoffers_test.go
+++ b/internal/jujuclient/applicationoffers_test.go
@@ -1,0 +1,692 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"context"
+	"sort"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+
+	"github.com/CanonicalLtd/jimm/internal/conv"
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
+)
+
+type applicationoffersSuite struct {
+	jujuclientSuite
+
+	modelInfo jujuparams.ModelInfo
+}
+
+var _ = gc.Suite(&applicationoffersSuite{})
+
+func (s *applicationoffersSuite) SetUpTest(c *gc.C) {
+	s.jujuclientSuite.SetUpTest(c)
+
+	ctx := context.Background()
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: conv.ToUserTag("test-user@external").String(),
+	}, &s.modelInfo)
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *applicationoffersSuite) TestOffer(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot add application offer "test-offer": application offer already exists`)
+}
+
+func (s *applicationoffersSuite) TestOfferError(c *gc.C) {
+	err := s.API.Offer(context.Background(), jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			"url": "url",
+		},
+	})
+	c.Check(err, gc.ErrorMatches, `getting offered application test-app: application "test-app" not found`)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersError(c *gc.C) {
+	_, err := s.API.ListApplicationOffers(context.Background(), nil)
+	c.Assert(err, gc.ErrorMatches, `at least one offer filter is required`)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersNoOffers(c *gc.C) {
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.ListApplicationOffers(context.Background(), []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersMatching(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.DeepEquals, []jujuparams.ApplicationOfferAdminDetails{info})
+}
+
+func (s *applicationoffersSuite) TestListApplicationOffersNoMatch(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName:       owner.Id(),
+		ModelName:       s.modelInfo.Name,
+		ApplicationName: "no-such-app",
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersError(c *gc.C) {
+	_, err := s.API.FindApplicationOffers(context.Background(), nil)
+	c.Assert(err, gc.ErrorMatches, `at least one offer filter is required`)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersNoOffers(c *gc.C) {
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.FindApplicationOffers(context.Background(), []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersMatching(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.FindApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.DeepEquals, []jujuparams.ApplicationOfferAdminDetails{info})
+}
+
+func (s *applicationoffersSuite) TestFindApplicationOffersNoMatch(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.FindApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName:       owner.Id(),
+		ModelName:       s.modelInfo.Name,
+		ApplicationName: "no-such-app",
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Check(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOffer(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	sort.Slice(info.Users, func(i, j int) bool {
+		return info.Users[i].UserName < info.Users[j].UserName
+	})
+	c.Check(info.CharmURL, gc.Matches, `cs:quantal/wordpress-[0-9]*`)
+	info.CharmURL = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.modelInfo.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+				Limit:     0,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName:    "admin",
+				DisplayName: "admin",
+				Access:      string(jujuparams.OfferAdminAccess),
+			}, {
+				UserName: "everyone@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+	})
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferNotFound(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = "test-user@external/test-model.test-offer"
+	err := s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.ErrorMatches, `application offer "test-user@external/test-model.test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestGrantApplicationOfferAccess(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err = s.API.GrantApplicationOfferAccess(ctx, offerURL, names.NewUserTag("test-user-2@external"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = offerURL
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	sort.Slice(info.Users, func(i, j int) bool {
+		return info.Users[i].UserName < info.Users[j].UserName
+	})
+	c.Check(info.CharmURL, gc.Matches, `cs:quantal/wordpress-[0-9]*`)
+	info.CharmURL = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.modelInfo.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+				Limit:     0,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName:    "admin",
+				DisplayName: "admin",
+				Access:      string(jujuparams.OfferAdminAccess),
+			}, {
+				UserName: "everyone@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}, {
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferConsumeAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+	})
+}
+
+func (s *applicationoffersSuite) TestGrantApplicationOfferAccessNotFound(c *gc.C) {
+	ctx := context.Background()
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err := s.API.GrantApplicationOfferAccess(ctx, offerURL, names.NewUserTag("test-user-2@external"), jujuparams.OfferConsumeAccess)
+	c.Check(err, gc.ErrorMatches, `application offer "test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestRevokeApplicationOfferAccess(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err = s.API.GrantApplicationOfferAccess(ctx, offerURL, names.NewUserTag("test-user-2@external"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ApplicationOfferAdminDetails
+	info.OfferURL = offerURL
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	sort.Slice(info.Users, func(i, j int) bool {
+		return info.Users[i].UserName < info.Users[j].UserName
+	})
+	c.Check(info.CharmURL, gc.Matches, `cs:quantal/wordpress-[0-9]*`)
+	info.CharmURL = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.modelInfo.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+				Limit:     0,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName:    "admin",
+				DisplayName: "admin",
+				Access:      string(jujuparams.OfferAdminAccess),
+			}, {
+				UserName: "everyone@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}, {
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferConsumeAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+	})
+
+	err = s.API.RevokeApplicationOfferAccess(ctx, offerURL, names.NewUserTag("test-user-2@external"), jujuparams.OfferConsumeAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.GetApplicationOffer(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.OfferUUID, gc.Not(gc.Equals), "")
+	info.OfferUUID = ""
+	sort.Slice(info.Users, func(i, j int) bool {
+		return info.Users[i].UserName < info.Users[j].UserName
+	})
+	c.Check(info.CharmURL, gc.Matches, `cs:quantal/wordpress-[0-9]*`)
+	info.CharmURL = ""
+	c.Check(info, jc.DeepEquals, jujuparams.ApplicationOfferAdminDetails{
+		ApplicationOfferDetails: jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.modelInfo.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+				Limit:     0,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName:    "admin",
+				DisplayName: "admin",
+				Access:      string(jujuparams.OfferAdminAccess),
+			}, {
+				UserName: "everyone@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}, {
+				UserName: "test-user-2@external",
+				Access:   string(jujuparams.OfferReadAccess),
+			}},
+		},
+		ApplicationName: "test-app",
+	})
+}
+
+func (s *applicationoffersSuite) TestRevokeApplicationOfferAccessNotFound(c *gc.C) {
+	ctx := context.Background()
+	offerURL := "test-user@external/test-model.test-offer"
+
+	err := s.API.RevokeApplicationOfferAccess(ctx, offerURL, names.NewUserTag("test-user-2@external"), jujuparams.OfferConsumeAccess)
+	c.Check(err, gc.ErrorMatches, `application offer "test-offer" not found`)
+}
+
+func (s *applicationoffersSuite) TestDestroyApplicationOffer(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	owner, err := names.ParseUserTag(s.modelInfo.OwnerTag)
+	c.Assert(err, gc.Equals, nil)
+	offers, err := s.API.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 1)
+
+	offerURL := "test-user@external/test-model.test-offer"
+	err = s.API.DestroyApplicationOffer(ctx, offerURL, false)
+	c.Assert(err, gc.Equals, nil)
+
+	offers, err = s.API.ListApplicationOffers(ctx, []jujuparams.OfferFilter{{
+		OwnerName: owner.Id(),
+		ModelName: s.modelInfo.Name,
+	}})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(offers, gc.HasLen, 0)
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferConsumeDetails(c *gc.C) {
+	modelState, err := s.StatePool.Get(s.modelInfo.UUID)
+	c.Assert(err, gc.Equals, nil)
+	defer modelState.Release()
+	f := factory.NewFactory(modelState.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+	ep, err := app.Endpoint("url")
+	c.Assert(err, gc.Equals, nil)
+
+	ctx := context.Background()
+	err = s.API.Offer(ctx, jujuparams.AddApplicationOffer{
+		ModelTag:        names.NewModelTag(s.modelInfo.UUID).String(),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints: map[string]string{
+			ep.Name: ep.Name,
+		},
+	})
+	c.Assert(err, gc.Equals, nil)
+
+	var info jujuparams.ConsumeOfferDetails
+	info.Offer = &jujuparams.ApplicationOfferDetails{
+		OfferURL: "test-user@external/test-model.test-offer",
+	}
+	err = s.API.GetApplicationOfferConsumeDetails(ctx, names.NewUserTag("test-user@external"), &info, bakery.Version2)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(info.Offer.OfferUUID, gc.Not(gc.Equals), "")
+	info.Offer.OfferUUID = ""
+	c.Check(info.Macaroon, gc.Not(gc.IsNil))
+	info.Macaroon = nil
+	lessF := func(a, b jujuparams.OfferUserDetails) bool {
+		return a.UserName < b.UserName
+	}
+	c.Check(info, jemtest.CmpEquals(cmpopts.SortSlices(lessF)), jujuparams.ConsumeOfferDetails{
+		Offer: &jujuparams.ApplicationOfferDetails{
+			SourceModelTag:         names.NewModelTag(s.modelInfo.UUID).String(),
+			OfferURL:               "test-user@external/test-model.test-offer",
+			OfferName:              "test-offer",
+			ApplicationDescription: "A pretty popular blog engine",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+				Limit:     0,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName:    "admin",
+				DisplayName: "admin",
+				Access:      "admin",
+			}, {
+				UserName:    "everyone@external",
+				DisplayName: "",
+				Access:      "read",
+			}, {
+				UserName: "test-user@external",
+				Access:   "admin",
+			}},
+		},
+		ControllerInfo: &jujuparams.ExternalControllerInfo{
+			ControllerTag: names.NewControllerTag(s.ControllerConfig.ControllerUUID()).String(),
+			Addrs:         s.APIInfo(c).Addrs,
+			CACert:        s.APIInfo(c).CACert,
+		},
+	})
+}
+
+func (s *applicationoffersSuite) TestGetApplicationOfferConsumeDetailsNotFound(c *gc.C) {
+	var info jujuparams.ConsumeOfferDetails
+	info.Offer = &jujuparams.ApplicationOfferDetails{
+		OfferURL: "test-user@external/test-model.test-offer",
+	}
+	err := s.API.GetApplicationOfferConsumeDetails(context.Background(), names.NewUserTag("test-user@external"), &info, bakery.Version2)
+	c.Check(err, gc.ErrorMatches, `application offer "test-user@external/test-model.test-offer" not found`)
+}

--- a/internal/jujuclient/cloud.go
+++ b/internal/jujuclient/cloud.go
@@ -1,0 +1,295 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient
+
+import (
+	"context"
+
+	jujuerrors "github.com/juju/errors"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	"go.uber.org/zap"
+
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/zapctx"
+)
+
+// SupportsCheckCredentialModels reports whether the controller supports
+// the Cloud.CheckCredentialsModels, Cloud.RevokeCredentialsCheckModels,
+// and Cloud.UpdateCredentialsCheckModels methods.
+func (c Connection) SupportsCheckCredentialModels() bool {
+	return c.hasFacadeVersion("Cloud", 3)
+}
+
+// CheckCredentialModels checks that the given credential would be
+// accepted as a valid credential by all models currently using that
+// credential. This method uses the CheckCredentialsModel procedure on
+// the Cloud facade version 3. Any error that represents a Juju API
+// failure will be of type *APIError.
+func (c Connection) CheckCredentialModels(_ context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+	const op = errors.Op("jujuclient.CheckCredentialModels")
+	in := jujuparams.TaggedCredentials{
+		Credentials: []jujuparams.TaggedCredential{cred},
+	}
+
+	out := jujuparams.UpdateCredentialResults{
+		Results: make([]jujuparams.UpdateCredentialResult, 1),
+	}
+	if err := c.conn.APICall("Cloud", 3, "", "CheckCredentialsModels", &in, &out); err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	if out.Results[0].Error != nil {
+		return nil, errors.E(op, out.Results[0].Error)
+	}
+	return out.Results[0].Models, nil
+}
+
+// UpdateCredential updates the given credential on the controller. The
+// credential will always be upgraded if possible irrespective of whether
+// it will break existing models (this is a forced update). If the caller
+// wants to check that a credential will work with existing models then
+// CheckCredentialModels should be used first.
+//
+// This method will call the first available procedure from:
+//     - Cloud(7).UpdateCredentialsCheckModels
+//     - Cloud(3).UpdateCredentialsCheckModels
+//     - Cloud(1).UpdateCredentials
+//
+// Any error that represents a Juju API failure will be of type
+// *APIError.
+func (c Connection) UpdateCredential(_ context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+	const op = errors.Op("jujuclient.UpdateCredential")
+	creds := jujuparams.TaggedCredentials{
+		Credentials: []jujuparams.TaggedCredential{cred},
+	}
+
+	update := jujuparams.UpdateCredentialArgs{
+		Credentials: creds.Credentials,
+		Force:       true,
+	}
+
+	out := jujuparams.UpdateCredentialResults{
+		Results: make([]jujuparams.UpdateCredentialResult, 1),
+	}
+	if c.hasFacadeVersion("Cloud", 7) {
+		if err := c.conn.APICall("Cloud", 7, "", "UpdateCredentialsCheckModels", &update, &out); err != nil {
+			return nil, errors.E(op, jujuerrors.Cause(err))
+		}
+	} else if c.hasFacadeVersion("Cloud", 3) {
+		if err := c.conn.APICall("Cloud", 3, "", "UpdateCredentialsCheckModels", &update, &out); err != nil {
+			return nil, errors.E(op, jujuerrors.Cause(err))
+		}
+	} else {
+		// Cloud(1).UpdateCredentials actually returns
+		// jujuparams.ErrorResults rather than
+		// jujuparams.UpdateCredentialsResults, but the former will still
+		// unmarshal correctly into the latter so there is no need to use
+		// a different response type.
+		if err := c.conn.APICall("Cloud", 1, "", "UpdateCredentials", &creds, &out); err != nil {
+			return nil, errors.E(op, jujuerrors.Cause(err))
+		}
+	}
+	if out.Results[0].Error != nil {
+		return nil, errors.E(op, out.Results[0].Error)
+	}
+	return out.Results[0].Models, nil
+}
+
+// RevokeCredential removes the given credential on the controller. The
+// credential will always be removed irrespective of whether it will
+// break existing models (this is a forced revoke). If the caller wants
+// to check that removing the credential will break existing models then
+// CheckCredentialModels should be used first.
+//
+// This method will call the first available procedure from:
+//     - Cloud(3).RevokeCredentialsCheckModels
+//     - Cloud(1).RevokeCredentials
+//
+// Any error that represents a Juju API failure will be of type
+// *APIError.
+func (c Connection) RevokeCredential(_ context.Context, cred names.CloudCredentialTag) error {
+	const op = errors.Op("jujuclient.RevokeCredential")
+	out := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	if c.SupportsCheckCredentialModels() {
+		in := jujuparams.RevokeCredentialArgs{
+			Credentials: []jujuparams.RevokeCredentialArg{{
+				Tag:   cred.String(),
+				Force: true,
+			}},
+		}
+		if err := c.conn.APICall("Cloud", 3, "", "RevokeCredentialsCheckModels", &in, &out); err != nil {
+			return errors.E(op, jujuerrors.Cause(err))
+		}
+	} else {
+		in := jujuparams.Entities{
+			Entities: []jujuparams.Entity{{
+				Tag: cred.String(),
+			}},
+		}
+		if err := c.conn.APICall("Cloud", 1, "", "RevokeCredentials", &in, &out); err != nil {
+			return errors.E(op, jujuerrors.Cause(err))
+		}
+	}
+	if out.Results[0].Error != nil {
+		return errors.E(op, out.Results[0].Error)
+	}
+	return nil
+}
+
+// Cloud retrieves information about the given cloud. Cloud uses the
+// Cloud procedure on the Cloud facade version 1.
+func (c Connection) Cloud(ctx context.Context, tag names.CloudTag, cloud *jujuparams.Cloud) error {
+	const op = errors.Op("jujuclient.Cloud")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: tag.String(),
+		}},
+	}
+	resp := jujuparams.CloudResults{
+		Results: []jujuparams.CloudResult{{
+			Cloud: cloud,
+		}},
+	}
+	if err := c.conn.APICall("Cloud", 1, "", "Cloud", &args, &resp); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// Clouds retrieves information about all available clouds. Clouds uses the
+// Clouds procedure on the Cloud facade version 1.
+func (c Connection) Clouds(ctx context.Context) (map[names.CloudTag]jujuparams.Cloud, error) {
+	const op = errors.Op("jujuclient.Clouds")
+	var resp jujuparams.CloudsResult
+	if err := c.conn.APICall("Cloud", 1, "", "Clouds", nil, &resp); err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+
+	clouds := make(map[names.CloudTag]jujuparams.Cloud, len(resp.Clouds))
+	for cloudTag, cloud := range resp.Clouds {
+		tag, err := names.ParseCloudTag(cloudTag)
+		if err != nil {
+			zapctx.Warn(ctx, "controller returned invalid cloud tag", zap.String("tag", cloudTag))
+			continue
+		}
+		clouds[tag] = cloud
+	}
+	return clouds, nil
+}
+
+// AddCloud adds the given cloud to a controller with the given name.
+// AddCloud uses the AddCloud procedure on the Cloud facade version 2.
+func (c Connection) AddCloud(ctx context.Context, tag names.CloudTag, cloud jujuparams.Cloud) error {
+	const op = errors.Op("jujuclient.AddCloud")
+	args := jujuparams.AddCloudArgs{
+		Cloud: cloud,
+		Name:  tag.Id(),
+	}
+	if err := c.conn.APICall("Cloud", 2, "", "AddCloud", &args, nil); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	return nil
+}
+
+// RemoveCloud removes the given cloud from the controller. RemoveCloud
+// uses the RemoveClouds procedure on the Cloud facade version 2.
+func (c Connection) RemoveCloud(ctx context.Context, tag names.CloudTag) error {
+	const op = errors.Op("jujuclient.RemoveCloud")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: tag.String(),
+		}},
+	}
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	if err := c.conn.APICall("Cloud", 2, "", "RemoveClouds", &args, &resp); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// GrantCloudAccess gives the given user the given access level on the
+// given cloud. GrantCloudAccess uses the ModifyCloudAccess procedure on
+// the Cloud facade version 3.
+func (c Connection) GrantCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
+	const op = errors.Op("jujuclient.GrantCloudAccess")
+	args := jujuparams.ModifyCloudAccessRequest{
+		Changes: []jujuparams.ModifyCloudAccess{{
+			UserTag:  userTag.String(),
+			Action:   jujuparams.GrantCloudAccess,
+			Access:   access,
+			CloudTag: cloudTag.String(),
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("Cloud", 3, "", "ModifyCloudAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// RevokeCloudAccess revokes the given access level on the given cloud from
+// the given user. RevokeCloudAccess uses the ModifyCloudAccess procedure
+// on the Cloud facade version 3.
+func (c Connection) RevokeCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
+	const op = errors.Op("jujuclient.RevokeCloudAccess")
+	args := jujuparams.ModifyCloudAccessRequest{
+		Changes: []jujuparams.ModifyCloudAccess{{
+			UserTag:  userTag.String(),
+			Action:   jujuparams.RevokeCloudAccess,
+			Access:   access,
+			CloudTag: cloudTag.String(),
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("Cloud", 3, "", "ModifyCloudAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// CloudInfo retrieves information about the cloud with the given name.
+// CloudInfo uses the CloudInfo procedure on the Cloud facade version 2.
+func (c Connection) CloudInfo(_ context.Context, tag names.CloudTag, ci *jujuparams.CloudInfo) error {
+	const op = errors.Op("jujuclient.CloudInfo")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{Tag: tag.String()}},
+	}
+
+	resp := jujuparams.CloudInfoResults{
+		Results: []jujuparams.CloudInfoResult{{
+			Result: ci,
+		}},
+	}
+	err := c.conn.APICall("Cloud", 2, "", "CloudInfo", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}

--- a/internal/jujuclient/cloud_test.go
+++ b/internal/jujuclient/cloud_test.go
@@ -1,0 +1,195 @@
+package jujuclient_test
+
+import (
+	"context"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type cloudSuite struct {
+	jujuclientSuite
+}
+
+var _ = gc.Suite(&cloudSuite{})
+
+func (s *cloudSuite) TestSupportsCheckCredentialsModels(c *gc.C) {
+	c.Assert(s.API.SupportsCheckCredentialModels(), gc.Equals, true)
+}
+
+func (s *cloudSuite) TestCheckCredentialModels(c *gc.C) {
+	cred := jujuparams.TaggedCredential{
+		Tag: names.NewCloudCredentialTag("dummy/admin/pw1").String(),
+		Credential: jujuparams.CloudCredential{
+			AuthType: "userpass",
+			Attributes: map[string]string{
+				"username": "alibaba",
+				"password": "open sesame",
+			},
+		},
+	}
+
+	models, err := s.API.CheckCredentialModels(context.Background(), cred)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(models, gc.HasLen, 0)
+}
+
+func (s *cloudSuite) TestUpdateCredential(c *gc.C) {
+	cred := jujuparams.TaggedCredential{
+		Tag: names.NewCloudCredentialTag("dummy/admin/pw1").String(),
+		Credential: jujuparams.CloudCredential{
+			AuthType: "userpass",
+			Attributes: map[string]string{
+				"username": "alibaba",
+				"password": "open sesame",
+			},
+		},
+	}
+
+	models, err := s.API.UpdateCredential(context.Background(), cred)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(models, gc.HasLen, 0)
+
+	cred.Credential.AuthType = "bad-type"
+
+	models, err = s.API.UpdateCredential(context.Background(), cred)
+	c.Assert(err, gc.ErrorMatches, `updating cloud credentials: validating credential "dummy/admin/pw1" for cloud "dummy": supported auth-types \["empty" "userpass"\], "bad-type" not supported`)
+	c.Assert(models, gc.HasLen, 0)
+}
+
+func (s *cloudSuite) TestRevokeCredential(c *gc.C) {
+	tag := names.NewCloudCredentialTag("dummy/admin/pw1")
+	cred := jujuparams.TaggedCredential{
+		Tag: tag.String(),
+		Credential: jujuparams.CloudCredential{
+			AuthType: "userpass",
+			Attributes: map[string]string{
+				"username": "alibaba",
+				"password": "open sesame",
+			},
+		},
+	}
+
+	models, err := s.API.UpdateCredential(context.Background(), cred)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(models, gc.HasLen, 0)
+
+	err = s.API.RevokeCredential(context.Background(), tag)
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *cloudSuite) TestClouds(c *gc.C) {
+	clouds, err := s.API.Clouds(context.Background())
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(clouds, jc.DeepEquals, map[names.CloudTag]jujuparams.Cloud{
+		names.NewCloudTag("dummy"): jujuparams.Cloud{
+			Type:             "dummy",
+			AuthTypes:        []string{"empty", "userpass"},
+			Endpoint:         "dummy-endpoint",
+			IdentityEndpoint: "dummy-identity-endpoint",
+			StorageEndpoint:  "dummy-storage-endpoint",
+			Regions: []jujuparams.CloudRegion{{
+				Name:             "dummy-region",
+				Endpoint:         "dummy-endpoint",
+				IdentityEndpoint: "dummy-identity-endpoint",
+				StorageEndpoint:  "dummy-storage-endpoint",
+			}},
+		},
+	})
+}
+
+func (s *cloudSuite) TestCloud(c *gc.C) {
+	ctx := context.Background()
+
+	clouds, err := s.API.Clouds(ctx)
+	c.Assert(err, gc.Equals, nil)
+
+	var cloud jujuparams.Cloud
+	err = s.API.Cloud(ctx, names.NewCloudTag("dummy"), &cloud)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(cloud, jc.DeepEquals, clouds[names.NewCloudTag("dummy")])
+}
+
+func (s *cloudSuite) TestAddCloud(c *gc.C) {
+	cloud := jujuparams.Cloud{
+		Type:      "kubernetes",
+		AuthTypes: []string{"empty"},
+	}
+
+	ctx := context.Background()
+
+	err := s.API.AddCloud(ctx, names.NewCloudTag("dummy"), cloud)
+	c.Assert(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeAlreadyExists)
+
+	err = s.API.AddCloud(ctx, names.NewCloudTag("test-cloud"), cloud)
+	c.Assert(err, gc.Equals, nil)
+
+	clouds, err := s.API.Clouds(ctx)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(clouds[names.NewCloudTag("test-cloud")], jc.DeepEquals, jujuparams.Cloud{
+		Type:      "kubernetes",
+		AuthTypes: []string{"empty"},
+		Regions: []jujuparams.CloudRegion{{
+			Name: "default",
+		}},
+	})
+}
+
+func (s *cloudSuite) TestRemoveCloud(c *gc.C) {
+	cloud := jujuparams.Cloud{
+		Type:      "kubernetes",
+		AuthTypes: []string{"empty"},
+	}
+
+	ctx := context.Background()
+
+	err := s.API.RemoveCloud(ctx, names.NewCloudTag("test-cloud"))
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+
+	err = s.API.AddCloud(ctx, names.NewCloudTag("test-cloud"), cloud)
+	c.Assert(err, gc.Equals, nil)
+
+	clouds, err := s.API.Clouds(ctx)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Assert(clouds[names.NewCloudTag("test-cloud")], jc.DeepEquals, jujuparams.Cloud{
+		Type:      "kubernetes",
+		AuthTypes: []string{"empty"},
+		Regions: []jujuparams.CloudRegion{{
+			Name: "default",
+		}},
+	})
+
+	err = s.API.RemoveCloud(ctx, names.NewCloudTag("test-cloud"))
+	c.Assert(err, gc.Equals, nil)
+
+	clouds, err = s.API.Clouds(ctx)
+	c.Assert(err, gc.Equals, nil)
+
+	_, ok := clouds[names.NewCloudTag("test-cloud")]
+	c.Assert(ok, gc.Equals, false)
+}
+
+func (s *cloudSuite) TestGrantCloudAccess(c *gc.C) {
+	err := s.API.GrantCloudAccess(context.Background(), names.NewCloudTag("no-such-cloud"), names.NewUserTag("user@external"), "add-model")
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	err = s.API.GrantCloudAccess(context.Background(), names.NewCloudTag("dummy"), names.NewUserTag("user@external"), "add-model")
+	c.Check(err, gc.Equals, nil)
+}
+
+func (s *cloudSuite) TestRevokeCloudAccess(c *gc.C) {
+	err := s.API.RevokeCloudAccess(context.Background(), names.NewCloudTag("no-such-cloud"), names.NewUserTag("user@external"), "add-model")
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	err = s.API.GrantCloudAccess(context.Background(), names.NewCloudTag("dummy"), names.NewUserTag("user@external"), "admin")
+	c.Assert(err, gc.Equals, nil)
+	err = s.API.RevokeCloudAccess(context.Background(), names.NewCloudTag("dummy"), names.NewUserTag("user@external"), "admin")
+	c.Check(err, gc.Equals, nil)
+	err = s.API.RevokeCloudAccess(context.Background(), names.NewCloudTag("dummy"), names.NewUserTag("user@external"), "add-model")
+	c.Check(err, gc.Equals, nil)
+	err = s.API.RevokeCloudAccess(context.Background(), names.NewCloudTag("dummy"), names.NewUserTag("user@external"), "add-model")
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+}

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Canonical Ltd.
+
+// Package jujuclient is the client JIMM uses to connect to juju
+// controllers. The jujuclient uses the juju RPC API directly using
+// API-native types, mostly those coming from github.com/juju/names and
+// github.com/juju/juju/apiserver/params. The rationale for this being that
+// as JIMM both sends and receives messages accross this API it should
+// perform as little format conversion as possible.
+package jujuclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/names/v4"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/jimm"
+)
+
+// A Dialer is an implementation of a jimm.Dialer that adapts a juju API
+// connection to provide a jimm API.
+type Dialer struct{}
+
+// Dial implements jimm.Dialer.
+func (Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (jimm.API, error) {
+	const op = errors.Op("jujuclient.Dial")
+
+	info := api.Info{
+		CACert:   ctl.CACertificate,
+		ModelTag: modelTag,
+		Tag:      names.NewUserTag(ctl.AdminUser),
+		Password: ctl.AdminPassword,
+	}
+	if ctl.PublicAddress != "" {
+		info.Addrs = []string{ctl.PublicAddress}
+	}
+	info.Addrs = append(info.Addrs, ctl.Addresses...)
+	dialOpts := api.DialOpts{}
+	if dl, ok := ctx.Deadline(); ok {
+		t := time.Now()
+		if !t.Before(dl) {
+			return nil, errors.E(op, errors.CodeConnectionFailed, ctx.Err())
+		}
+		dialOpts.Timeout = dl.Sub(t)
+	}
+	conn, err := api.Open(&info, dialOpts)
+	if err != nil {
+		return nil, errors.E(op, errors.CodeConnectionFailed, err)
+	}
+	ctl.SetTag(conn.ControllerTag())
+	v, ok := conn.ServerVersion()
+	if ok {
+		ctl.AgentVersion = v.String()
+	}
+	for _, hps := range conn.APIHostPorts() {
+		for _, hp := range hps {
+			ctl.Addresses = append(ctl.Addresses, hp.String())
+		}
+	}
+	return Connection{conn: conn}, nil
+}
+
+// A Connection is a connection to a juju controller. Connection methods
+// are generally thin wrappers around juju RPC calls, although there are
+// some more JIMM specific operations. The RPC calls prefer to use the
+// earliest facade versions that support all the required data, but will
+// fall-back to earlier versions with slightly degraded functionality if
+// possible.
+type Connection struct {
+	conn api.Connection
+}
+
+// Close closes the connection.
+func (c Connection) Close() error {
+	return c.conn.Close()
+}
+
+// hasFacadeVersion returns whether the connection supports the given
+// facade at the given version.
+func (c Connection) hasFacadeVersion(facade string, version int) bool {
+	for _, v := range c.conn.AllFacadeVersions()[facade] {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jujuclient/dial_test.go
+++ b/internal/jujuclient/dial_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"context"
+
+	jujuversion "github.com/juju/juju/version"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
+	"github.com/CanonicalLtd/jimm/internal/jimm"
+	"github.com/CanonicalLtd/jimm/internal/jujuclient"
+)
+
+type jujuclientSuite struct {
+	jemtest.JujuConnSuite
+
+	Dialer jimm.Dialer
+	API    jimm.API
+}
+
+func (s *jujuclientSuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+
+	s.Dialer = jujuclient.Dialer{}
+	var err error
+	info := s.APIInfo(c)
+	ctl := dbmodel.Controller{
+		Name:          s.ControllerConfig.ControllerName(),
+		CACertificate: info.CACert,
+		AdminUser:     info.Tag.Id(),
+		AdminPassword: info.Password,
+		Addresses:     dbmodel.Strings(info.Addrs),
+	}
+	s.API, err = s.Dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *jujuclientSuite) TearDownTest(c *gc.C) {
+	if s.API != nil {
+		err := s.API.Close()
+		s.API = nil
+		c.Assert(err, gc.Equals, nil)
+	}
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+type dialSuite struct {
+	jujuclientSuite
+}
+
+var _ = gc.Suite(&dialSuite{})
+
+func (s *dialSuite) TestDial(c *gc.C) {
+	info := s.APIInfo(c)
+	ctl := dbmodel.Controller{
+		Name:          s.ControllerConfig.ControllerName(),
+		CACertificate: info.CACert,
+		AdminUser:     info.Tag.Id(),
+		AdminPassword: info.Password,
+		PublicAddress: info.Addrs[0],
+	}
+	api, err := s.Dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Assert(err, gc.Equals, nil)
+	defer api.Close()
+	c.Check(ctl.UUID, gc.Equals, "deadbeef-1bad-500d-9000-4b1d0d06f00d")
+	c.Check(ctl.AgentVersion, gc.Equals, jujuversion.Current.String())
+	c.Check(ctl.Addresses, jc.DeepEquals, dbmodel.Strings(info.Addrs))
+}

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -1,0 +1,336 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient
+
+import (
+	"context"
+	"time"
+
+	jujuerrors "github.com/juju/errors"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/names/v4"
+
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// CreateModel creates a new model as specified by the given model
+// specification. If the model is created successfully then the model
+// document passed in will be updated with the model information returned
+// from the Create model call. If there is an error returned it will be
+// of type *APIError. CreateModel uses the Create model procedure on the
+// ModelManager facade version 2.
+func (c Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreateArgs, info *jujuparams.ModelInfo) error {
+	const op = errors.Op("jujuclient.CreateModel")
+	if err := c.conn.APICall("ModelManager", 2, "", "CreateModel", args, info); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	return nil
+}
+
+// ModelInfo retrieves information about a model from the controller. The
+// given info structure must specify a UUID, the rest will be filled out
+// from the controller response. If an error is returned by the Juju API
+// then the resulting error response will be of type *APIError. ModelInfo
+// will use the ModelInfo procedure from the ModelManager version 8
+// facade if it is available, falling back to version 3.
+func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) error {
+	const op = errors.Op("jujuclient.ModelInfo")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: names.NewModelTag(info.UUID).String(),
+		}},
+	}
+
+	resp := jujuparams.ModelInfoResults{
+		Results: []jujuparams.ModelInfoResult{{
+			Result: info,
+		}},
+	}
+	var err error
+	if c.hasFacadeVersion("ModelManager", 8) {
+		err = c.conn.APICall("ModelManager", 8, "", "ModelInfo", &args, &resp)
+	} else {
+		err = c.conn.APICall("ModelManager", 3, "", "ModelInfo", &args, &resp)
+	}
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// GrantJIMMModelAdmin ensures that the JIMM user is an admin level user
+// of the given model. This is a specialized wrapper around
+// ModifyModelAccess to be used when bootstrapping a model. Any error
+// that is returned from the API will be of type *APIError.
+// GrantJIMMModelAdmin uses the ModifyModelAccess procedure on the
+// ModelManager facade version 2.
+func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
+	const op = errors.Op("jujuclient.GrantJIMMModelAdmin")
+	args := jujuparams.ModifyModelAccessRequest{
+		Changes: []jujuparams.ModifyModelAccess{{
+			UserTag:  c.conn.AuthTag().String(),
+			Action:   jujuparams.GrantModelAccess,
+			Access:   jujuparams.ModelAdminAccess,
+			ModelTag: tag.String(),
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	if err := c.conn.APICall("ModelManager", 2, "", "ModifyModelAccess", &args, &resp); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// DumpModel dumps debugging details for the given model. DumpModel uses
+// the DumpModels method on the ModelManager facade version 2.
+func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+	const op = errors.Op("jujuclient.DumpModel")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: tag.String(),
+		}},
+	}
+
+	resp := jujuparams.MapResults{
+		Results: make([]jujuparams.MapResult, 1),
+	}
+	if err := c.conn.APICall("ModelManager", 2, "", "DumpModels", &args, &resp); err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return nil, errors.E(op, resp.Results[0].Error)
+	}
+	return resp.Results[0].Result, nil
+}
+
+// DumpModelV3 dumps debugging details for the given model into the given
+// . If the simplied dump is requested then a simplified dump is
+// returned. DumpModelV3 uses the DumpModels method on the ModelManager
+// facade version 3.
+func (c Connection) DumpModelV3(ctx context.Context, tag names.ModelTag, simplified bool) (string, error) {
+	const op = errors.Op("jujuclient.DumpModelV3")
+	args := jujuparams.DumpModelRequest{
+		Entities: []jujuparams.Entity{{
+			Tag: tag.String(),
+		}},
+		Simplified: simplified,
+	}
+
+	resp := jujuparams.StringResults{
+		Results: make([]jujuparams.StringResult, 1),
+	}
+	if err := c.conn.APICall("ModelManager", 3, "", "DumpModels", &args, &resp); err != nil {
+		return "", errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return "", errors.E(op, resp.Results[0].Error)
+	}
+	return resp.Results[0].Result, nil
+}
+
+// DumpModelDB dumps the controller database entry given model.
+// DumpModelDB uses the DumpModelsDB method on the ModelManager facade
+// version 2.
+func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+	const op = errors.Op("jujuclient.DumpModelDB")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: tag.String(),
+		}},
+	}
+
+	resp := jujuparams.MapResults{
+		Results: make([]jujuparams.MapResult, 1),
+	}
+	if err := c.conn.APICall("ModelManager", 2, "", "DumpModelsDB", &args, &resp); err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return nil, errors.E(op, resp.Results[0].Error)
+	}
+	return resp.Results[0].Result, nil
+}
+
+// GrantModelAccess gives the given user the given access level on the
+// given model. GrantModelAccess uses the ModifyModelAccess procedure
+// on the ModelManager facade version 2.
+func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
+	const op = errors.Op("jujuclient.GrantModelAccess")
+	args := jujuparams.ModifyModelAccessRequest{
+		Changes: []jujuparams.ModifyModelAccess{{
+			UserTag:  userTag.String(),
+			Action:   jujuparams.GrantModelAccess,
+			Access:   access,
+			ModelTag: modelTag.String(),
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ModelManager", 2, "", "ModifyModelAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// RevokeModelAccess removes the given access level from the given user on
+// the given model. Revoke ModelAccess uses the ModifyModelAccess procedure
+// on the ModelManager facade version 2.
+func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
+	const op = errors.Op("jujuclient.RevokeModelAccess")
+	args := jujuparams.ModifyModelAccessRequest{
+		Changes: []jujuparams.ModifyModelAccess{{
+			UserTag:  userTag.String(),
+			Action:   jujuparams.RevokeModelAccess,
+			Access:   access,
+			ModelTag: modelTag.String(),
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ModelManager", 2, "", "ModifyModelAccess", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// ControllerModelSummary retrieves the ModelSummary for the controller
+// model. ControllerModelSummary uses the ListModelSummaries procedure on
+// the ModelManager facade version 4.
+func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelSummary) error {
+	const op = errors.Op("jujuclient.ControllerModelSummary")
+	args := jujuparams.ModelSummariesRequest{
+		UserTag: c.conn.AuthTag().String(),
+		All:     true,
+	}
+	var resp jujuparams.ModelSummaryResults
+	err := c.conn.APICall("ModelManager", 4, "", "ListModelSummaries", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	for _, r := range resp.Results {
+		if r.Result != nil && r.Result.IsController {
+			*ms = *r.Result
+			return nil
+		}
+	}
+	return errors.E(op, "controller model not found", errors.CodeNotFound)
+}
+
+// ValidateModelUpgrade validates if a model is allowed to perform an upgrade. It
+// uses ValidateModelUpgrades on the ModelManager facade version 9.
+func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelTag, force bool) error {
+	const op = errors.Op("jujuclient.ValidateModelUpgrade")
+	args := jujuparams.ValidateModelUpgradeParams{
+		Models: []jujuparams.ValidateModelUpgradeParam{{
+			ModelTag: model.String(),
+		}},
+		Force: force,
+	}
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	err := c.conn.APICall("ModelManager", 9, "", "ValidateModelUpgrades", &args, &resp)
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// DestroyModel starts the destruction of the given model. This method uses
+// the highest available method from:
+//
+//  - ModelManager(7).DestroyModels
+//  - ModelManager(4).DestroyModels
+//  - ModelManager(2).DestroyModels
+func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStorage *bool, force *bool, maxWait *time.Duration) error {
+	const op = errors.Op("jujuclient.DestroyModel")
+	args := jujuparams.DestroyModelsParams{
+		Models: []jujuparams.DestroyModelParams{{
+			ModelTag:       tag.String(),
+			DestroyStorage: destroyStorage,
+			Force:          force,
+			MaxWait:        maxWait,
+		}},
+	}
+
+	resp := jujuparams.ErrorResults{
+		Results: make([]jujuparams.ErrorResult, 1),
+	}
+	var err error
+	switch {
+	case c.hasFacadeVersion("ModelManager", 7):
+		err = c.conn.APICall("ModelManager", 7, "", "DestroyModels", &args, &resp)
+	case c.hasFacadeVersion("ModelManager", 4):
+		err = c.conn.APICall("ModelManager", 4, "", "DestroyModels", &args, &resp)
+	default:
+		err = c.conn.APICall("ModelManager", 2, "", "DestroyModels",
+			&jujuparams.Entities{Entities: []jujuparams.Entity{{Tag: tag.String()}}},
+			&resp,
+		)
+	}
+
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	return nil
+}
+
+// ModelStatus retrieves the status of a model from the controller. The
+// given status structure must specify a ModelTag, the rest will be filled
+// out from the controller response. If an error is returned by the Juju
+// API then the resulting error response will be of type *APIError.
+// ModelStatus will use the ModelStatus procedure from the ModelManager
+// version 4 facade if it is available, falling back to version 2.
+func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelStatus) error {
+	const op = errors.Op("jujuclient.ModelStatus")
+	args := jujuparams.Entities{
+		Entities: []jujuparams.Entity{{
+			Tag: status.ModelTag,
+		}},
+	}
+
+	resp := jujuparams.ModelStatusResults{
+		Results: make([]jujuparams.ModelStatus, 1),
+	}
+	var err error
+	if c.hasFacadeVersion("ModelManager", 4) {
+		err = c.conn.APICall("ModelManager", 4, "", "ModelStatus", &args, &resp)
+	} else {
+		err = c.conn.APICall("ModelManager", 2, "", "ModelStatus", &args, &resp)
+	}
+	if err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	if resp.Results[0].Error != nil {
+		return errors.E(op, resp.Results[0].Error)
+	}
+	*status = resp.Results[0]
+	return nil
+}

--- a/internal/jujuclient/modelmanager_test.go
+++ b/internal/jujuclient/modelmanager_test.go
@@ -1,0 +1,256 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	jujuparams "github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jimm/internal/jemtest"
+)
+
+type modelmanagerSuite struct {
+	jujuclientSuite
+}
+
+var _ = gc.Suite(&modelmanagerSuite{})
+
+func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(info.UUID, gc.Not(gc.Equals), "")
+	c.Check(info.CloudTag, gc.Equals, names.NewCloudTag("dummy").String())
+	c.Check(info.CloudRegion, gc.Equals, "dummy-region")
+	c.Check(info.DefaultSeries, gc.Equals, "focal")
+	c.Check(string(info.Life), gc.Equals, "alive")
+	c.Check(string(info.Status.Status), gc.Equals, "available")
+	c.Check(info.Status.Data, gc.IsNil)
+	c.Check(info.Status.Since.After(time.Now().Add(-10*time.Second)), gc.Equals, true)
+	c.Check(info.Type, gc.Equals, "iaas")
+	c.Check(info.ProviderType, gc.Equals, "dummy")
+}
+
+func (s *modelmanagerSuite) TestCreateModelError(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+		CloudTag: names.NewCloudTag("nosuchcloud").String(),
+	}, &info)
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `cloud "nosuchcloud" not found, expected one of \["dummy"\] \(not found\)`)
+}
+
+func (s *modelmanagerSuite) TestGrantJIMMModelAdmin(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.GrantJIMMModelAdmin(ctx, names.NewModelTag(info.UUID))
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ModelInfo(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	var access jujuparams.UserAccessPermission
+	for _, u := range info.Users {
+		if u.UserName == s.APIInfo(c).Tag.Id() {
+			access = u.Access
+		}
+	}
+	c.Check(access, gc.Equals, jujuparams.ModelAdminAccess)
+}
+
+func (s *modelmanagerSuite) TestGrantJIMMModelAdminError(c *gc.C) {
+	ctx := context.Background()
+
+	err := s.API.GrantJIMMModelAdmin(ctx, names.NewModelTag("00000000-0000-0000-0000-000000000000"))
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `could not lookup model: model "00000000-0000-0000-0000-000000000000" not found`)
+}
+
+func (s *modelmanagerSuite) TestModelInfo(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	mi := jujuparams.ModelInfo{
+		UUID: info.UUID,
+	}
+	err = s.API.ModelInfo(ctx, &mi)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(mi, jc.DeepEquals, info)
+}
+
+func (s *modelmanagerSuite) TestModelInfoError(c *gc.C) {
+	ctx := context.Background()
+
+	mi := jujuparams.ModelInfo{
+		UUID: "00000000-0000-0000-0000-000000000000",
+	}
+	err := s.API.ModelInfo(ctx, &mi)
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeUnauthorized)
+	c.Check(err, gc.ErrorMatches, `permission denied`)
+}
+
+func (s *modelmanagerSuite) TestGrantRevokeModel(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.GrantModelAccess(ctx, names.NewModelTag(info.UUID), names.NewUserTag("test-user-2@external"), jujuparams.ModelReadAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ModelInfo(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	lessf := func(a, b jujuparams.ModelUserInfo) bool {
+		return a.UserName < b.UserName
+	}
+	c.Check(info.Users, jemtest.CmpEquals(cmpopts.SortSlices(lessf)), []jujuparams.ModelUserInfo{{
+		UserName:    "test-user@external",
+		DisplayName: "test-user",
+		Access:      "admin",
+	}, {
+		UserName: "test-user-2@external",
+		Access:   "read",
+	}})
+
+	err = s.API.RevokeModelAccess(ctx, names.NewModelTag(info.UUID), names.NewUserTag("test-user-2@external"), jujuparams.ModelReadAccess)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ModelInfo(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(info.Users, jemtest.CmpEquals(cmpopts.SortSlices(lessf)), []jujuparams.ModelUserInfo{{
+		UserName:    "test-user@external",
+		DisplayName: "test-user",
+		Access:      "admin",
+	}})
+}
+
+func (s *modelmanagerSuite) TestGrantModelAccessError(c *gc.C) {
+	ctx := context.Background()
+
+	err := s.API.GrantModelAccess(ctx, names.NewModelTag("00000000-0000-0000-0000-000000000000"), names.NewUserTag("test-user-2"), jujuparams.ModelReadAccess)
+
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `could not lookup model: model "00000000-0000-0000-0000-000000000000" not found`)
+}
+
+func (s *modelmanagerSuite) TestRevokeModelAccessError(c *gc.C) {
+	ctx := context.Background()
+
+	err := s.API.RevokeModelAccess(ctx, names.NewModelTag("00000000-0000-0000-0000-000000000000"), names.NewUserTag("test-user-2"), jujuparams.ModelReadAccess)
+
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `could not lookup model: model "00000000-0000-0000-0000-000000000000" not found`)
+}
+
+func (s *modelmanagerSuite) TestValidateModelUpgrade(c *gc.C) {
+	ctx := context.Background()
+
+	args := jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}
+	var info jujuparams.ModelInfo
+
+	err := s.API.CreateModel(ctx, &args, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ValidateModelUpgrade(ctx, names.NewModelTag(info.UUID), true)
+	c.Assert(err, gc.Equals, nil)
+
+	uuid := utils.MustNewUUID().String()
+	err = s.API.ValidateModelUpgrade(ctx, names.NewModelTag(uuid), false)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("model %q not found", uuid))
+}
+
+func (s *modelmanagerSuite) TestDestroyModel(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.DestroyModel(ctx, names.NewModelTag(info.UUID), nil, nil, nil)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ModelInfo(ctx, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(info.Life, gc.Equals, life.Dying)
+}
+
+func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
+	ctx := context.Background()
+
+	var info jujuparams.ModelInfo
+	err := s.API.CreateModel(ctx, &jujuparams.ModelCreateArgs{
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("test-user@external").String(),
+	}, &info)
+	c.Assert(err, gc.Equals, nil)
+
+	status := jujuparams.ModelStatus{
+		ModelTag: names.NewModelTag(info.UUID).String(),
+	}
+	err = s.API.ModelStatus(ctx, &status)
+	c.Assert(err, gc.Equals, nil)
+
+	c.Check(status, jc.DeepEquals, jujuparams.ModelStatus{
+		ModelTag: names.NewModelTag(info.UUID).String(),
+		Life:     info.Life,
+		Type:     info.Type,
+		OwnerTag: info.OwnerTag,
+	})
+}
+
+func (s *modelmanagerSuite) TestModelStatusError(c *gc.C) {
+	ctx := context.Background()
+
+	status := jujuparams.ModelStatus{
+		ModelTag: names.NewModelTag("00000000-0000-0000-0000-000000000000").String(),
+	}
+	err := s.API.ModelStatus(ctx, &status)
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `model "00000000-0000-0000-0000-000000000000" not found`)
+}

--- a/internal/jujuclient/modelsummarywatcher.go
+++ b/internal/jujuclient/modelsummarywatcher.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient
+
+import (
+	"context"
+
+	jujuerrors "github.com/juju/errors"
+	jujuparams "github.com/juju/juju/apiserver/params"
+
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// SupportsModelSummaryWatcher reports whether the controller supports
+// the Controller.WatchAllModelSummaries method.
+func (c Connection) SupportsModelSummaryWatcher() bool {
+	return c.hasFacadeVersion("Controller", 9)
+}
+
+// WatchAllModelSummaries initialises a new AllModelSummaryWatcher. On
+// success the watcher ID is returned. If an error is returned it will be
+// of type *APIError. This uses the WatchAllModelSummaries method on the
+// Controller facade version 9.
+func (c Connection) WatchAllModelSummaries(_ context.Context) (string, error) {
+	const op = errors.Op("jujuclient.WatchAllModelSummaries")
+	var resp jujuparams.SummaryWatcherID
+	if err := c.conn.APICall("Controller", 9, "", "WatchAllModelSummaries", nil, &resp); err != nil {
+		return "", errors.E(op, jujuerrors.Cause(err))
+	}
+	return resp.WatcherID, nil
+}
+
+// ModelSummaryWatcherNext receives the next set of results from the
+// model summary watcher with the given id. If an error is returned it
+// will be of type *APIError. This uses the Next method on the
+// ModelSummaryWatcher facade version 1.
+func (c Connection) ModelSummaryWatcherNext(_ context.Context, id string) ([]jujuparams.ModelAbstract, error) {
+	const op = errors.Op("jujuclient.ModelSummaryWatcherNext")
+	var resp jujuparams.SummaryWatcherNextResults
+	if err := c.conn.APICall("ModelSummaryWatcher", 1, id, "Next", nil, &resp); err != nil {
+		return nil, errors.E(op, jujuerrors.Cause(err))
+	}
+	return resp.Models, nil
+}
+
+// ModelSummaryWatcherStop stops the
+// model summary watcher with the given id. If an error is returned it
+// will be of type *APIError. This uses the Stop method on the
+// ModelSummaryWatcher facade version 1.
+func (c Connection) ModelSummaryWatcherStop(_ context.Context, id string) error {
+	const op = errors.Op("jujuclient.ModelSummaryWatcherStop")
+	if err := c.conn.APICall("ModelSummaryWatcher", 1, id, "Stop", nil, nil); err != nil {
+		return errors.E(op, jujuerrors.Cause(err))
+	}
+	return nil
+}

--- a/internal/jujuclient/modelsummarywatcher_test.go
+++ b/internal/jujuclient/modelsummarywatcher_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"context"
+
+	jujuparams "github.com/juju/juju/apiserver/params"
+	gc "gopkg.in/check.v1"
+)
+
+type modelSummaryWatcherSuite struct {
+	jujuclientSuite
+}
+
+var _ = gc.Suite(&modelSummaryWatcherSuite{})
+
+func (s *modelSummaryWatcherSuite) TestSupportsWatchAllModelSummaries(c *gc.C) {
+	c.Assert(s.API.SupportsModelSummaryWatcher(), gc.Equals, true)
+}
+
+func (s *modelSummaryWatcherSuite) TestWatchAllModelSummaries(c *gc.C) {
+	ctx := context.Background()
+
+	id, err := s.API.WatchAllModelSummaries(ctx)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(id, gc.Not(gc.Equals), "")
+
+	err = s.API.ModelSummaryWatcherStop(ctx, id)
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *modelSummaryWatcherSuite) TestModelSummaryWatcherNext(c *gc.C) {
+	ctx := context.Background()
+
+	id, err := s.API.WatchAllModelSummaries(ctx)
+	c.Assert(err, gc.Equals, nil)
+
+	_, err = s.API.ModelSummaryWatcherNext(ctx, id)
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.API.ModelSummaryWatcherStop(ctx, id)
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *modelSummaryWatcherSuite) TestModelSummaryWatcherNextError(c *gc.C) {
+	_, err := s.API.ModelSummaryWatcherNext(context.Background(), "invalid-watcher")
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `watcher id: invalid-watcher: unknown watcher id \(not found\)`)
+}
+
+func (s *modelSummaryWatcherSuite) TestModelSummaryWatcherStopError(c *gc.C) {
+	err := s.API.ModelSummaryWatcherStop(context.Background(), "invalid-watcher")
+	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeNotFound)
+	c.Check(err, gc.ErrorMatches, `watcher id: invalid-watcher: unknown watcher id \(not found\)`)
+}

--- a/internal/jujuclient/package_test.go
+++ b/internal/jujuclient/package_test.go
@@ -1,0 +1,13 @@
+// Copyright 2015 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t)
+}


### PR DESCRIPTION
The new internal/jujuclient package is an adaptation of the apiconn
package for use by the new relational database architecture. This has
greatly increased the definition of jimm.API.