### PR TITLE
internal/jimm: add cloud management commands

### DIFF
--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -147,3 +147,40 @@ func (d *Database) FindRegion(ctx context.Context, providerType, name string) (*
 	}
 	return &region, nil
 }
+
+// UpdateUserCloudAccess updates the given UserCloudAccess record. If the
+// specified access is changed to "" (no access) then the record is
+// removed.
+func (d *Database) UpdateUserCloudAccess(ctx context.Context, a *dbmodel.UserCloudAccess) error {
+	const op = errors.Op("db.UpdateUserCloudAccess")
+
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	db := d.DB.WithContext(ctx)
+	if a.Access == "" {
+		db = db.Delete(a)
+	} else {
+		db = db.Save(a)
+	}
+	if db.Error != nil {
+		return errors.E(op, dbError(db.Error))
+	}
+	return nil
+}
+
+// DeleteCloud deletes the given cloud.
+func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) error {
+	const op = errors.Op("db.DeleteCloud")
+
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Delete(c).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/dbmodel/cloud.go
+++ b/internal/dbmodel/cloud.go
@@ -153,7 +153,7 @@ type CloudRegion struct {
 
 	// Cloud is the cloud this region belongs to.
 	CloudName string `gorm:"uniqueIndex:idx_cloud_region_cloud_name_name"`
-	Cloud     Cloud  `gorm:"foreignKey:CloudName;references:Name"`
+	Cloud     Cloud  `gorm:"foreignKey:CloudName;references:Name;constraint:OnDelete:CASCADE"`
 
 	// Name is the name of the region.
 	Name string `gorm:"not null;uniqueIndex:idx_cloud_region_cloud_name_name"`

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -98,11 +98,11 @@ type CloudRegionControllerPriority struct {
 
 	// CloudRegion is the cloud-region this pertains to.
 	CloudRegionID uint
-	CloudRegion   CloudRegion
+	CloudRegion   CloudRegion `gorm:"constraint:OnDelete:CASCADE"`
 
 	// Controller is the controller this pertains to.
 	ControllerID uint
-	Controller   Controller
+	Controller   Controller `gorm:"constraint:OnDelete:CASCADE"`
 
 	// Priority is the priority with which this controller should be
 	// chosen when deploying to a cloud-region.

--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -891,7 +891,7 @@ func (j *JIMM) ValidateModelUpgrade(ctx context.Context, u *dbmodel.User, mt nam
 // with the code CodeNotFound is returned. If the given user does not have
 // admin access to the model then an error with the code CodeUnauthorized
 // is returned. If there is an error connecting to the controller hosting
-// the model then ther returned error will have the same code as the error
+// the model then the returned error will have the same code as the error
 // returned from the dial operation. If the given function returns an error
 // that error will be returned with the code unmasked.
 func (j *JIMM) doModelAdmin(ctx context.Context, u *dbmodel.User, mt names.ModelTag, f func(*dbmodel.Model, API) error) error {


### PR DESCRIPTION
Support granting and revoking access to hosted (kubernetes) clouds. Also
support removing hosted clouds.