### PR TITLE
internal/jimm: add a connection caching dialer

### DIFF
--- a/internal/jimm/cache.go
+++ b/internal/jimm/cache.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Canonical Ltd.
+
+package jimm
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/juju/names/v4"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
+
+// CacheDialer wraps the given Dialer in a cache that will share controller
+// connections between a number of operations.
+func CacheDialer(d Dialer) Dialer {
+	return &cacheDialer{
+		dialer: d,
+		conns:  make(map[string]cachedAPI),
+	}
+}
+
+// A cacheDialer is a Dialer that caches connections so that the cost of
+// establishing connections is shared by a number of operations attempting
+// to contact a controller.
+type cacheDialer struct {
+	// dialer is used by the CacheDialer to make connections that are
+	// not in the cache.
+	dialer Dialer
+
+	sfg   singleflight.Group
+	mu    sync.Mutex
+	conns map[string]cachedAPI
+}
+
+// Dial implements Dialer.Dial.
+func (d *cacheDialer) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (API, error) {
+	if mt.Id() != "" {
+		// connections to models are rare, so we don't cache them.
+		return d.dialer.Dial(ctx, ctl, mt)
+	}
+	rc := d.sfg.DoChan(ctl.Name, func() (interface{}, error) {
+		return d.dial(ctx, ctl)
+	})
+	select {
+	case r := <-rc:
+		if r.Err != nil {
+			return nil, r.Err
+		}
+		return r.Val.(cachedAPI).Clone(), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (d *cacheDialer) dial(ctx context.Context, ctl *dbmodel.Controller) (interface{}, error) {
+	d.mu.Lock()
+	capi, ok := d.conns[ctl.Name]
+	if ok && !capi.IsBroken() {
+		// connection is still good, return it.
+		d.mu.Unlock()
+		return capi, nil
+	}
+	if ok {
+		// The connection must be broken, evict from the cache.
+		delete(d.conns, ctl.Name)
+	}
+	d.mu.Unlock()
+	if ok {
+		// If the connection was broken, close it.
+		capi.Close()
+	}
+	// We don't have a working connection to the controller, so dial one.
+	api, err := d.dialer.Dial(ctx, ctl, names.ModelTag{})
+	if err != nil {
+		return nil, err
+	}
+	capi = cachedAPI{
+		API:      api,
+		refCount: new(int64),
+		closed:   new(uint32),
+	}
+	atomic.StoreInt64(capi.refCount, 1)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.conns[ctl.Name] = capi
+	return capi, nil
+}
+
+// Close implements io.Closer.
+func (d *cacheDialer) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var firstErr error
+	for k, v := range d.conns {
+		delete(d.conns, k)
+		if err := v.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+type cachedAPI struct {
+	API
+
+	// refCount is the number of open instances of the connection. When
+	// refCount reaches 0 the underlying connection is closed.
+	refCount *int64
+	closed   *uint32
+}
+
+// Close implements API.Close()
+func (a cachedAPI) Close() error {
+	// Protect from closing the same clone multiple times.
+	if !atomic.CompareAndSwapUint32(a.closed, 0, 1) {
+		return nil
+	}
+	if atomic.AddInt64(a.refCount, -1) > 0 {
+		return nil
+	}
+	// There are no references left, close the connection.
+	return a.API.Close()
+}
+
+// Clone creates a clone of the cached API connection.
+func (a cachedAPI) Clone() API {
+	closed := new(uint32)
+	atomic.AddInt64(a.refCount, 1)
+	return cachedAPI{
+		API:      a.API,
+		refCount: a.refCount,
+		closed:   closed,
+	}
+}

--- a/internal/jimm/cache_test.go
+++ b/internal/jimm/cache_test.go
@@ -1,0 +1,197 @@
+// Copyright 2021 Canonical Ltd.
+
+package jimm_test
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/names/v4"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+	"github.com/CanonicalLtd/jimm/internal/jimm"
+	"github.com/CanonicalLtd/jimm/internal/jimmtest"
+)
+
+func TestCacheDialerDialError(t *testing.T) {
+	c := qt.New(t)
+
+	testError := errors.E("test error")
+	testDialer := &jimmtest.Dialer{
+		Err: testError,
+	}
+	dialer := jimm.CacheDialer(testDialer)
+	ctl := dbmodel.Controller{
+		Name: "test-controller",
+	}
+	_, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Check(err, qt.Equals, testError)
+
+	testAPI := jimmtest.API{
+		SupportsCheckCredentialModels_: true,
+	}
+	testDialer.Err = nil
+	testDialer.API = &testAPI
+	api, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Assert(err, qt.IsNil)
+	c.Check(api.SupportsCheckCredentialModels(), qt.Equals, true)
+}
+
+func TestCacheDialerDialModel(t *testing.T) {
+	c := qt.New(t)
+
+	testAPI := jimmtest.API{
+		SupportsCheckCredentialModels_: true,
+	}
+	testDialer := &jimmtest.Dialer{
+		API: &testAPI,
+	}
+	dialer := jimm.CacheDialer(testDialer)
+	ctl := dbmodel.Controller{
+		Name: "test-controller",
+	}
+	mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
+	api, err := dialer.Dial(context.Background(), &ctl, mt)
+	c.Assert(err, qt.IsNil)
+	c.Check(api.SupportsCheckCredentialModels(), qt.Equals, true)
+
+	testAPI2 := jimmtest.API{
+		SupportsModelSummaryWatcher_: true,
+	}
+	testDialer.API = &testAPI2
+	api, err = dialer.Dial(context.Background(), &ctl, mt)
+	c.Assert(err, qt.IsNil)
+	c.Check(api.SupportsModelSummaryWatcher(), qt.Equals, true)
+}
+
+func TestCacheDialerConcurrentConnections(t *testing.T) {
+	c := qt.New(t)
+
+	testDialer := &countingDialer{
+		dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				SupportsCheckCredentialModels_: true,
+			},
+		},
+	}
+	dialer := jimm.CacheDialer(testDialer)
+	ctl := dbmodel.Controller{
+		Name: "test-controller",
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			api, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+			c.Check(err, qt.IsNil)
+			defer api.Close()
+			c.Check(api.SupportsCheckCredentialModels(), qt.Equals, true)
+			// close our API connection twice to ensure the
+			// cache is robust to that.
+			err = api.Close()
+			c.Check(err, qt.IsNil)
+		}()
+	}
+	wg.Wait()
+	// Get a connection from the cache.
+	api, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Check(err, qt.IsNil)
+	c.Check(api.SupportsCheckCredentialModels(), qt.Equals, true)
+	err = api.Close()
+	c.Check(err, qt.IsNil)
+
+	c.Check(atomic.LoadInt64(&testDialer.count), qt.Equals, int64(1))
+	c.Check(testDialer.dialer.(*jimmtest.Dialer).IsClosed(), qt.Equals, false)
+	err = dialer.(io.Closer).Close()
+	c.Check(err, qt.IsNil)
+	c.Check(testDialer.dialer.(*jimmtest.Dialer).IsClosed(), qt.Equals, true)
+}
+
+func TestCacheDialerCloseBrokenConnection(t *testing.T) {
+	c := qt.New(t)
+
+	testAPI := closeCountingAPI{
+		API: &jimmtest.API{
+			// The cache assumes the a newly dialed
+			// connection is good, so won't check for a
+			// failed connection until retrieving it
+			// from the cache.
+			IsBroken_: true,
+		},
+	}
+	testDialer := &countingDialer{
+		dialer: &jimmtest.Dialer{
+			API: &testAPI,
+		},
+	}
+	dialer := jimm.CacheDialer(testDialer)
+	ctl := dbmodel.Controller{
+		Name: "test-controller",
+	}
+
+	api, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Assert(err, qt.IsNil)
+	c.Check(api.IsBroken(), qt.Equals, true)
+	err = api.Close()
+	c.Assert(err, qt.IsNil)
+	api2, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
+	c.Assert(err, qt.IsNil)
+	c.Check(api2.IsBroken(), qt.Equals, true)
+	err = api2.Close()
+	c.Assert(err, qt.IsNil)
+
+	c.Check(atomic.LoadInt64(&testDialer.count), qt.Equals, int64(2))
+	c.Check(atomic.LoadInt64(&testAPI.count), qt.Equals, int64(1))
+}
+
+type countingDialer struct {
+	dialer jimm.Dialer
+	count  int64
+}
+
+func (d *countingDialer) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (jimm.API, error) {
+	atomic.AddInt64(&d.count, 1)
+	return d.dialer.Dial(ctx, ctl, mt)
+}
+
+type closeCountingAPI struct {
+	jimm.API
+	count int64
+}
+
+func (a *closeCountingAPI) Close() error {
+	atomic.AddInt64(&a.count, 1)
+	return a.API.Close()
+}
+
+func TestCacheDialerContextCanceled(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneC := make(chan struct{})
+	dialer := jimm.CacheDialer(dialerFunc(func(context.Context, *dbmodel.Controller, names.ModelTag) (jimm.API, error) {
+		cancel()
+		<-doneC
+		return nil, errors.E("dial error")
+	}))
+	ctl := dbmodel.Controller{
+		Name: "test-controller",
+	}
+	api, err := dialer.Dial(ctx, &ctl, names.ModelTag{})
+	c.Check(err, qt.Equals, context.Canceled)
+	c.Check(api, qt.IsNil)
+	close(doneC)
+}
+
+type dialerFunc func(context.Context, *dbmodel.Controller, names.ModelTag) (jimm.API, error)
+
+func (f dialerFunc) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (jimm.API, error) {
+	return f(ctx, ctl, mt)
+}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -165,6 +165,9 @@ type API interface {
 	// GrantModelAccess grants model access to a user.
 	GrantModelAccess(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
 
+	// IsBroken returns true if the API connection has failed.
+	IsBroken() bool
+
 	// ListApplicationOffers lists application offers that match the
 	// filter.
 	ListApplicationOffers(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error)
@@ -181,6 +184,7 @@ type API interface {
 
 	// ModelSummaryWatcherStop stops a model summary watcher.
 	ModelSummaryWatcherStop(context.Context, string) error
+
 	// Offer creates a new application-offer.
 	Offer(context.Context, jujuparams.AddApplicationOffer) error
 

--- a/internal/jimmtest/api.go
+++ b/internal/jimmtest/api.go
@@ -124,6 +124,7 @@ type API struct {
 	GrantCloudAccess_                  func(context.Context, names.CloudTag, names.UserTag, string) error
 	GrantJIMMModelAdmin_               func(context.Context, names.ModelTag) error
 	GrantModelAccess_                  func(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
+	IsBroken_                          bool
 	ListApplicationOffers_             func(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error)
 	ModelInfo_                         func(context.Context, *jujuparams.ModelInfo) error
 	ModelStatus_                       func(context.Context, *jujuparams.ModelStatus) error
@@ -289,6 +290,10 @@ func (a *API) GrantModelAccess(ctx context.Context, mt names.ModelTag, ut names.
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return a.GrantModelAccess_(ctx, mt, ut, p)
+}
+
+func (a *API) IsBroken() bool {
+	return a.IsBroken_
 }
 
 func (a *API) ListApplicationOffers(ctx context.Context, f []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetails, error) {


### PR DESCRIPTION
Amortize the cost of connecting to controllers by caching the connection
and reusing it where possible.
