### PR TITLE
internal/db: implement root key store

### DIFF
--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Canonical Ltd.
+
+package db
+
+import (
+	"time"
+
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+	"gorm.io/gorm"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// GetKey implements Backing.GetKey.
+func (d *Database) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	const op = errors.Op("db.FindLatestKey")
+
+	if d.DB == nil {
+		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
+	}
+	rk := dbmodel.RootKey{
+		ID: id,
+	}
+	if err := d.DB.First(&rk).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return dbrootkeystore.RootKey{}, bakery.ErrNotFound
+		}
+		return dbrootkeystore.RootKey{}, errors.E(op, err)
+	}
+	return dbrootkeystore.RootKey{
+		Id:      rk.ID,
+		Created: rk.CreatedAt,
+		Expires: rk.Expires,
+		RootKey: rk.RootKey,
+	}, nil
+}
+
+// FindLatestKey implements Backing.FindLatestKey.
+func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	const op = errors.Op("db.FindLatestKey")
+
+	if d.DB == nil {
+		return dbrootkeystore.RootKey{}, nil
+	}
+	db := d.DB.Where("created_at > ?", createdAfter)
+	db = db.Where("expires BETWEEN ? AND ?", expiresAfter, expiresBefore)
+	db = db.Order("created_at DESC")
+	var rk dbmodel.RootKey
+	if err := db.First(&rk).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return dbrootkeystore.RootKey{}, nil
+		}
+		return dbrootkeystore.RootKey{}, errors.E(op, dbError(err))
+	}
+	return dbrootkeystore.RootKey{
+		Id:      rk.ID,
+		Created: rk.CreatedAt,
+		Expires: rk.Expires,
+		RootKey: rk.RootKey,
+	}, nil
+}
+
+// InsertKey implements Backing.InsertKey.
+func (d *Database) InsertKey(key dbrootkeystore.RootKey) error {
+	const op = errors.Op("db.InsertKey")
+
+	if d.DB == nil {
+		return errors.E(op, errors.CodeServerConfiguration, "database not configured")
+	}
+	rk := dbmodel.RootKey{
+		ID:        key.Id,
+		CreatedAt: key.Created,
+		Expires:   key.Expires,
+		RootKey:   key.RootKey,
+	}
+	if err := d.DB.Create(&rk).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/rootkeys_test.go
+++ b/internal/db/rootkeys_test.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Canonical Ltd.
+
+package db_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+
+	"github.com/CanonicalLtd/jimm/internal/db"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+var _ dbrootkeystore.Backing = (*db.Database)(nil)
+
+func TestGetKeyUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var d db.Database
+	_, err := d.GetKey([]byte("test-id"))
+	c.Assert(err, qt.Equals, bakery.ErrNotFound)
+}
+
+func TestInsertKeyUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var d db.Database
+	rk := dbrootkeystore.RootKey{
+		Id:      []byte("test-id"),
+		Created: time.Now().UTC().Round(time.Millisecond),
+		Expires: time.Now().UTC().Round(time.Millisecond).Add(24 * time.Hour),
+		RootKey: []byte("very secret"),
+	}
+	err := d.InsertKey(rk)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func (s *dbSuite) TestInsertKeyGetKey(c *qt.C) {
+	err := s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	_, err = s.Database.GetKey([]byte("test-id"))
+	c.Assert(err, qt.Equals, bakery.ErrNotFound)
+
+	rk := dbrootkeystore.RootKey{
+		Id:      []byte("test-id"),
+		Created: time.Now().UTC().Round(time.Millisecond),
+		Expires: time.Now().UTC().Round(time.Millisecond).Add(24 * time.Hour),
+		RootKey: []byte("very secret"),
+	}
+
+	s.Database.InsertKey(rk)
+
+	rk2, err := s.Database.GetKey([]byte("test-id"))
+	c.Assert(err, qt.IsNil)
+	c.Check(rk2, qt.DeepEquals, rk)
+}
+
+func TestFindLatestKeyUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var d db.Database
+	now := time.Now().UTC().Round(time.Millisecond)
+	rk, err := d.FindLatestKey(now.Add(-24*time.Hour), now.Add(24*time.Hour), now.Add(48*time.Hour))
+	c.Assert(err, qt.IsNil)
+	c.Check(rk, qt.DeepEquals, dbrootkeystore.RootKey{})
+}
+
+func (s *dbSuite) TestFindLatestKey(c *qt.C) {
+	err := s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	now := time.Now().UTC().Round(time.Millisecond)
+
+	// An empty database shouldn't find any keys.
+	rk, err := s.Database.FindLatestKey(now.Add(-24*time.Hour), now.Add(24*time.Hour), now.Add(48*time.Hour))
+	c.Assert(err, qt.IsNil)
+	c.Check(rk, qt.DeepEquals, dbrootkeystore.RootKey{})
+
+	// Add some keys
+	rks := make([]dbrootkeystore.RootKey, 10)
+	for i := 0; i < 10; i++ {
+		var name, key bytes.Buffer
+		fmt.Fprintf(&name, "test-%d", i)
+		fmt.Fprintf(&key, "secret %d", i)
+		rks[i] = dbrootkeystore.RootKey{
+			Id:      name.Bytes(),
+			Created: now.Add(time.Duration(i-10) * time.Hour),
+			Expires: now.Add(time.Duration(i-10+24) * time.Hour),
+			RootKey: key.Bytes(),
+		}
+		err := s.Database.InsertKey(rks[i])
+		c.Assert(err, qt.IsNil)
+	}
+
+	rk, err = s.Database.FindLatestKey(now.Add(-5*time.Hour), now.Add((24-5)*time.Hour), now.Add((24-2)*time.Hour))
+	c.Assert(err, qt.IsNil)
+	c.Check(rk, qt.DeepEquals, rks[8])
+}

--- a/internal/dbmodel/rootkey.go
+++ b/internal/dbmodel/rootkey.go
@@ -1,0 +1,13 @@
+// Copyright 2021 Canoncial Ltd.
+
+package dbmodel
+
+import "time"
+
+// A RootKey is a macaroon root key.
+type RootKey struct {
+	ID        []byte
+	CreatedAt time.Time
+	Expires   time.Time
+	RootKey   []byte
+}

--- a/internal/dbmodel/sql/postgres/0_0.sql
+++ b/internal/dbmodel/sql/postgres/0_0.sql
@@ -364,4 +364,14 @@ CREATE TABLE controller_configs (
 	UNIQUE(name)
 );
 
+CREATE TABLE root_keys (
+	id BYTEA NOT NULL PRIMARY KEY,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+	expires TIMESTAMP WITH TIME ZONE  NOT NULL,
+	root_key BYTEA NOT NULL
+);
+
+CREATE INDEX idx_root_keys_created_at ON root_keys (created_at);
+CREATE INDEX idx_root_keys_expires ON root_keys (expires);
+
 UPDATE versions SET major=1, minor=0 WHERE component='jimmdb';

--- a/internal/dbmodel/sql/sqlite/0_0.sql
+++ b/internal/dbmodel/sql/sqlite/0_0.sql
@@ -363,4 +363,14 @@ CREATE TABLE controller_configs (
 	UNIQUE(name)
 );
 
+CREATE TABLE root_keys (
+	id BLOB NOT NULL PRIMARY KEY,
+	created_at DATETIME NOT NULL,
+	expires DATETIME NOT NULL,
+	root_key BLOB NOT NULL
+);
+
+CREATE INDEX idx_root_keys_created_at ON root_keys (created_at);
+CREATE INDEX idx_root_keys_expires ON root_keys (expires);
+
 UPDATE versions SET major=1, minor=0 WHERE component='jimmdb';


### PR DESCRIPTION
Enhance the database object such that it can be used as a backing database
for a macaroon root key store.