### PR TITLE
internal/jem: allow users to revoke their own access.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/juju/cmd v0.0.0-20200108104440-8e43f3faa5c9
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
-	github.com/juju/juju v0.0.0-20210630005308-95b319ca0ac1
+	github.com/juju/juju v0.0.0-20210708071739-f4b4ab472fc0
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e
 	github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f
 	github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -563,8 +564,8 @@ github.com/juju/idmclient/v2 v2.0.0-20210309081103-6b4a5212f851/go.mod h1:xBoR8o
 github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c h1:bcsSKpMpnzB/mG5HRc3HRoLgUoOy0foC9EoQgS/WqFE=
 github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c/go.mod h1:Z33NTjLML8JqPVeiRJvhZQcbjyrKs5QahQDG35H3cF8=
 github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2/go.mod h1:zUnyTKLoDDJ+56rAYZTpW6ku45aOPpTdghDa1zMEIHw=
-github.com/juju/juju v0.0.0-20210630005308-95b319ca0ac1 h1:ILc0V78IUCx+dOem/a4EINtbBtsHwa3oIL8wlFqOD0o=
-github.com/juju/juju v0.0.0-20210630005308-95b319ca0ac1/go.mod h1:TzbLXVIIgLuK7OZgWwprKCpJgvWA/Qnk+5b0HemjRSI=
+github.com/juju/juju v0.0.0-20210708071739-f4b4ab472fc0 h1:QOH8HiduNG3LkQMbxvQL2s8Uja2GgwE+UlMjWWb/NVE=
+github.com/juju/juju v0.0.0-20210708071739-f4b4ab472fc0/go.mod h1:KOLSTs4TnXepH5Hw4eV4aJwLzsMwjVxvgg2K0gCrk2k=
 github.com/juju/loggo v0.0.0-20150527035839-8477fc936adf/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20160818025724-3b7ece48644d/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
@@ -835,6 +836,7 @@ github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuK
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/oracle/oci-go-sdk v5.7.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
+github.com/packethost/packngo v0.14.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -1012,6 +1014,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200422194213-44a606286825/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/jem/modelmanager.go
+++ b/internal/jem/modelmanager.go
@@ -709,7 +709,12 @@ func (j *JEM) GrantModel(ctx context.Context, id identchecker.ACLIdentity, m *mo
 // RevokeModel revokes the given access for the given user on the given
 // model and updates the JEM database.
 func (j *JEM) RevokeModel(ctx context.Context, id identchecker.ACLIdentity, m *mongodoc.Model, user params.User, access jujuparams.UserAccessPermission) error {
-	if err := j.GetModel(ctx, id, jujuparams.ModelAdminAccess, m); err != nil {
+	requiredAccess := jujuparams.ModelAdminAccess
+	if id.Id() == string(user) {
+		// Always allow a user to revoke their own access.
+		requiredAccess = jujuparams.ModelReadAccess
+	}
+	if err := j.GetModel(ctx, id, requiredAccess, m); err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound), errgo.Is(params.ErrUnauthorized))
 	}
 	u := new(jimmdb.Update)

--- a/internal/jem/modelmanager_test.go
+++ b/internal/jem/modelmanager_test.go
@@ -635,6 +635,24 @@ func (s *modelManagerSuite) TestRevokeModelWrite(c *gc.C) {
 	})
 }
 
+func (s *modelManagerSuite) TestUserCanAlwaysRevokeTheirOwnAccess(c *gc.C) {
+	err := s.JEM.GrantModel(testContext, jemtest.Bob, &s.Model, "alice", "read")
+	c.Assert(err, gc.Equals, nil)
+	model1 := mongodoc.Model{Path: s.Model.Path}
+	err = s.JEM.DB.GetModel(testContext, &model1)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(model1.ACL, jc.DeepEquals, params.ACL{
+		Read:  []string{"alice"},
+		Write: []string{},
+		Admin: []string{},
+	})
+	err = s.JEM.RevokeModel(testContext, jemtest.Alice, &s.Model, "alice", "read")
+	c.Assert(err, gc.Equals, nil)
+	err = s.JEM.DB.GetModel(testContext, &model1)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(model1.ACL, jc.DeepEquals, params.ACL{})
+}
+
 func (s *modelManagerSuite) TestRevokeModelControllerFailure(c *gc.C) {
 	err := s.JEM.GrantModel(testContext, jemtest.Bob, &s.Model, "alice", "write")
 	c.Assert(err, gc.Equals, nil)

--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -1029,6 +1029,34 @@ func (s *modelManagerSuite) TestGrantAndRevokeModel(c *gc.C) {
 	c.Assert(res[0].Error, gc.ErrorMatches, "unauthorized")
 }
 
+func (s *modelManagerSuite) TestUserRevokeOwnAccess(c *gc.C) {
+	conn := s.open(c, nil, "bob")
+	defer conn.Close()
+	client := modelmanager.NewClient(conn)
+
+	conn2 := s.open(c, nil, "charlie")
+	defer conn2.Close()
+	client2 := modelmanager.NewClient(conn2)
+
+	err := client.GrantModel("charlie@external", "read", s.Model.UUID)
+	c.Assert(err, gc.Equals, nil)
+
+	res, err := client2.ModelInfo([]names.ModelTag{names.NewModelTag(s.Model.UUID)})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(res, gc.HasLen, 1)
+	c.Assert(res[0].Error, gc.IsNil)
+	c.Assert(res[0].Result.UUID, gc.Equals, s.Model.UUID)
+
+	err = client2.RevokeModel("charlie@external", "read", s.Model.UUID)
+	c.Assert(err, gc.Equals, nil)
+
+	res, err = client2.ModelInfo([]names.ModelTag{names.NewModelTag(s.Model.UUID)})
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(res, gc.HasLen, 1)
+	c.Assert(res[0].Error, gc.Not(gc.IsNil))
+	c.Assert(res[0].Error, gc.ErrorMatches, "unauthorized")
+}
+
 func (s *modelManagerSuite) TestModifyModelAccessErrors(c *gc.C) {
 	conn := s.open(c, nil, "bob")
 	defer conn.Close()


### PR DESCRIPTION
Users who are not admins can revoke access to the model for themselves,
this allows users to clean up their own model list. This also updates
the linked juju to the 2.9.8 release.