### PR TITLE
internal/jujuapi: support UpdateMigratedModel API

### DIFF
--- a/api/params/params.go
+++ b/api/params/params.go
@@ -186,3 +186,15 @@ type SetControllerDeprecatedRequest struct {
 	// deprecated or not.
 	Deprecated bool `json:"deprecated"`
 }
+
+// UpdateMigratedModelRequest holds a request to check
+// if the specified model has been migrated to the specified controller
+// and update the model accordingly.
+type UpdateMigratedModelRequest struct {
+	// ModelTag holds the tag of the model that has been migrated.
+	ModelTag string `json:"model-tag"`
+
+	// TargetController holds the name of the controller the
+	// model has been migrated to.
+	TargetController string `json:"target-controller"`
+}

--- a/internal/jem/jimmdb/controller.go
+++ b/internal/jem/jimmdb/controller.go
@@ -180,7 +180,10 @@ func controllerQuery(c *mongodoc.Controller) Query {
 	case c == nil:
 		return nil
 	case !c.Path.IsZero():
-		return Eq("path", c.Path)
+		if c.Path.User != "" {
+			return Eq("path", c.Path)
+		}
+		return Eq("path.name", c.Path.Name)
 	case c.UUID != "":
 		return Eq("uuid", c.UUID)
 	default:

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -32,6 +32,7 @@ func init() {
 		revokeAuditLogAccessMethod := rpc.Method(r.RevokeAuditLogAccess)
 		setControllerDeprecatedMethod := rpc.Method(r.SetControllerDeprecated)
 		userModelStatsMethod := rpc.Method(r.UserModelStats)
+		updateMigratedModelMethod := rpc.Method(r.UpdateMigratedModel)
 
 		r.AddMethod("JIMM", 1, "UserModelStats", userModelStatsMethod)
 
@@ -47,6 +48,7 @@ func init() {
 		r.AddMethod("JIMM", 3, "RemoveController", removeControllerMethod)
 		r.AddMethod("JIMM", 3, "RevokeAuditLogAccess", revokeAuditLogAccessMethod)
 		r.AddMethod("JIMM", 3, "SetControllerDeprecated", setControllerDeprecatedMethod)
+		r.AddMethod("JIMM", 3, "UpdateMigratedModel", updateMigratedModelMethod)
 
 		return []int{1, 2, 3}
 	}
@@ -429,4 +431,18 @@ OUTER:
 			Status: "available",
 		}
 	}
+}
+
+// UpdateMigratedModel checks that the model has been migrated to the specified controller
+// and updates internal representation of the model.
+func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.UpdateMigratedModelRequest) error {
+	mt, err := names.ParseModelTag(req.ModelTag)
+	if err != nil {
+		return errgo.WithCausef(err, params.ErrBadRequest, "")
+	}
+	err = r.jem.UpdateMigratedModel(ctx, r.identity, mt, params.Name(req.TargetController))
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrUnauthorized))
+	}
+	return nil
 }


### PR DESCRIPTION
Backport the UpdateMigratedModel API from the sqlstore branch.