### PR TITLE
internal/jujuapi: support GetControllerAccess API

### DIFF
--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -369,7 +369,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "alice@external",
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "admin",
@@ -377,7 +377,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "bob@external",
 		User: dbmodel.User{
 			Username:         "bob@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "add-model",
@@ -385,7 +385,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "charlie@external",
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "add-model",
@@ -401,7 +401,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "alice@external",
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "admin",
@@ -409,7 +409,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "bob@external",
 		User: dbmodel.User{
 			Username:         "bob@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "admin",
@@ -417,7 +417,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "charlie@external",
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "add-model",
@@ -433,7 +433,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "alice@external",
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "admin",
@@ -441,7 +441,7 @@ func (s *dbSuite) TestUpdateUserCloudAccess(c *qt.C) {
 		Username: "charlie@external",
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		CloudName: "test-hosted",
 		Access:    "add-model",

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -566,19 +566,19 @@ func (s *dbSuite) TestUpdateUserModelAccess(c *qt.C) {
 	c.Check(m.Users, jimmtest.DBObjectEquals, []dbmodel.UserModelAccess{{
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "admin",
 	}, {
 		User: dbmodel.User{
 			Username:         "bob@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "write",
 	}, {
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "read",
 	}})
@@ -592,19 +592,19 @@ func (s *dbSuite) TestUpdateUserModelAccess(c *qt.C) {
 	c.Check(m.Users, jimmtest.DBObjectEquals, []dbmodel.UserModelAccess{{
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "admin",
 	}, {
 		User: dbmodel.User{
 			Username:         "bob@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "read",
 	}, {
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "read",
 	}})
@@ -618,13 +618,13 @@ func (s *dbSuite) TestUpdateUserModelAccess(c *qt.C) {
 	c.Check(m.Users, jimmtest.DBObjectEquals, []dbmodel.UserModelAccess{{
 		User: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "admin",
 	}, {
 		User: dbmodel.User{
 			Username:         "charlie@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Access: "read",
 	}})

--- a/internal/db/user_test.go
+++ b/internal/db/user_test.go
@@ -45,7 +45,7 @@ func (s *dbSuite) TestGetUser(c *qt.C) {
 	}
 	err = s.Database.GetUser(ctx, &u)
 	c.Assert(err, qt.IsNil)
-	c.Check(u.ControllerAccess, qt.Equals, "add-model")
+	c.Check(u.ControllerAccess, qt.Equals, "login")
 
 	u2 := dbmodel.User{
 		Username: u.Username,
@@ -82,7 +82,7 @@ func (s *dbSuite) TestUpdateUser(c *qt.C) {
 	}
 	err = s.Database.GetUser(ctx, &u)
 	c.Assert(err, qt.IsNil)
-	c.Check(u.ControllerAccess, qt.Equals, "add-model")
+	c.Check(u.ControllerAccess, qt.Equals, "login")
 
 	u.ControllerAccess = "superuser"
 	u.Models = []dbmodel.UserModelAccess{{
@@ -306,7 +306,7 @@ models:
 			},
 			Owner: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Controller: dbmodel.Controller{
 				Name:        "test",
@@ -327,13 +327,13 @@ models:
 			Users: []dbmodel.UserModelAccess{{
 				User: dbmodel.User{
 					Username:         "alice@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				Access: "admin",
 			}, {
 				User: dbmodel.User{
 					Username:         "bob@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				Access: "write",
 			}},
@@ -348,7 +348,7 @@ models:
 			},
 			Owner: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Controller: dbmodel.Controller{
 				Name:        "test",
@@ -369,13 +369,13 @@ models:
 			Users: []dbmodel.UserModelAccess{{
 				User: dbmodel.User{
 					Username:         "alice@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				Access: "admin",
 			}, {
 				User: dbmodel.User{
 					Username:         "bob@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				Access: "read",
 			}},

--- a/internal/dbmodel/sql/postgres/0_0.sql
+++ b/internal/dbmodel/sql/postgres/0_0.sql
@@ -88,7 +88,7 @@ CREATE TABLE users (
 	display_name TEXT NOT NULL,
 	last_login TIMESTAMP WITH TIME ZONE,
 	disabled BOOLEAN,
-	controller_access TEXT NOT NULL DEFAULT 'add-model',
+	controller_access TEXT NOT NULL DEFAULT 'login',
 	audit_log_access TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX idx_users_deleted_at ON users (deleted_at);

--- a/internal/dbmodel/sql/sqlite/0_0.sql
+++ b/internal/dbmodel/sql/sqlite/0_0.sql
@@ -88,7 +88,7 @@ CREATE TABLE users (
 	display_name TEXT NOT NULL,
 	last_login DATETIME,
 	disabled INTEGER,
-	controller_access TEXT NOT NULL DEFAULT 'add-model',
+	controller_access TEXT NOT NULL DEFAULT 'login',
 	audit_log_access TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX idx_users_deleted_at ON users (deleted_at);

--- a/internal/dbmodel/user.go
+++ b/internal/dbmodel/user.go
@@ -34,7 +34,7 @@ type User struct {
 
 	// ControllerAccess is the access level this user has on the JIMM
 	// controller. By default all users have "add-model" access.
-	ControllerAccess string `gorm:"not null;default:'add-model'"`
+	ControllerAccess string `gorm:"not null;default:'login'"`
 
 	// AuditLogAccess is the access level this user has on the JIMM audit
 	// log.

--- a/internal/dbmodel/user_test.go
+++ b/internal/dbmodel/user_test.go
@@ -30,7 +30,7 @@ func TestUser(t *testing.T) {
 	result = db.Create(&u1)
 	c.Assert(result.Error, qt.IsNil)
 	c.Check(result.RowsAffected, qt.Equals, int64(1))
-	c.Check(u1.ControllerAccess, qt.Equals, "add-model")
+	c.Check(u1.ControllerAccess, qt.Equals, "login")
 
 	var u2 dbmodel.User
 	result = db.Where("username = ?", "bob@external").First(&u2)

--- a/internal/jimm/applicationoffer_test.go
+++ b/internal/jimm/applicationoffer_test.go
@@ -2263,7 +2263,7 @@ func TestUpdateOffer(t *testing.T) {
 				Username: "eve@external",
 				User: dbmodel.User{
 					Username:         "eve@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				ApplicationOfferID: 1,
 				Access:             "admin",
@@ -2271,7 +2271,7 @@ func TestUpdateOffer(t *testing.T) {
 				Username: "bob@external",
 				User: dbmodel.User{
 					Username:         "bob@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				ApplicationOfferID: 1,
 				Access:             "consume",
@@ -2279,7 +2279,7 @@ func TestUpdateOffer(t *testing.T) {
 				Username: "fred@external",
 				User: dbmodel.User{
 					Username:         "fred@external",
-					ControllerAccess: "add-model",
+					ControllerAccess: "login",
 				},
 				ApplicationOfferID: 1,
 				Access:             "read",
@@ -2431,7 +2431,7 @@ func TestFindApplicationOffers(t *testing.T) {
 			Username: "eve@external",
 			User: dbmodel.User{
 				Username:         "eve@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			ApplicationOfferID: 1,
 			Access:             "admin",
@@ -2439,7 +2439,7 @@ func TestFindApplicationOffers(t *testing.T) {
 			Username: "bob@external",
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			ApplicationOfferID: 1,
 			Access:             "consume",
@@ -2447,7 +2447,7 @@ func TestFindApplicationOffers(t *testing.T) {
 			Username: "fred@external",
 			User: dbmodel.User{
 				Username:         "fred@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			ApplicationOfferID: 1,
 			Access:             "read",

--- a/internal/jimm/cloud.go
+++ b/internal/jimm/cloud.go
@@ -204,7 +204,7 @@ func (j *JIMM) AddHostedCloud(ctx context.Context, u *dbmodel.User, tag names.Cl
 		return err
 	}
 
-	if u.ControllerAccess != "add-model" && u.ControllerAccess != "superuser" {
+	if u.ControllerAccess != "login" && u.ControllerAccess != "superuser" {
 		return fail(errors.E(op, errors.CodeUnauthorized, "unauthorized"))
 	}
 

--- a/internal/jimm/cloud_test.go
+++ b/internal/jimm/cloud_test.go
@@ -97,7 +97,7 @@ func TestGetCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "admin",
@@ -115,7 +115,7 @@ func TestGetCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "add-model",
@@ -159,7 +159,7 @@ func TestGetCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "admin",
@@ -177,7 +177,7 @@ func TestGetCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "add-model",
@@ -292,7 +292,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "admin",
@@ -310,7 +310,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "add-model",
@@ -436,7 +436,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "admin",
@@ -454,7 +454,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-1",
 			Access:    "add-model",
@@ -479,7 +479,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-2",
 			Access:    "add-model",
@@ -497,7 +497,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         auth.Everyone,
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-2",
 			Access:    "add-model",
@@ -522,7 +522,7 @@ func TestForEachCloud(t *testing.T) {
 					UpdatedAt: now,
 				},
 				Username:         auth.Everyone,
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test-cloud-3",
 			Access:    "add-model",
@@ -569,8 +569,6 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
-- username: charlie@external
   controller-access: login
 `
 
@@ -648,26 +646,12 @@ var addHostedCloudTests = []struct {
 			Username: "bob@external",
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "new-cloud",
 			Access:    "admin",
 		}},
 	},
-}, {
-	name:      "UserWithoutAccess",
-	username:  "charlie@external",
-	cloudName: "new-cloud",
-	cloud: jujuparams.Cloud{
-		Type:             "kubernetes",
-		HostCloudRegion:  "test-provider/test-region",
-		AuthTypes:        []string{"empty", "userpass"},
-		Endpoint:         "https://example.com",
-		IdentityEndpoint: "https://example.com/identity",
-		StorageEndpoint:  "https://example.com/storage",
-	},
-	expectError:     `unauthorized`,
-	expectErrorCode: errors.CodeUnauthorized,
 }, {
 	name:      "CloudWithReservedName",
 	username:  "bob@external",
@@ -932,7 +916,7 @@ var grantCloudAccessTests = []struct {
 			Username: "alice@external",
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "admin",
@@ -940,7 +924,7 @@ var grantCloudAccessTests = []struct {
 			Username: "bob@external",
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "add-model",
@@ -1113,7 +1097,7 @@ var revokeCloudAccessTests = []struct {
 			Username: "alice@external",
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "admin",
@@ -1121,7 +1105,7 @@ var revokeCloudAccessTests = []struct {
 			Username: "bob@external",
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "add-model",
@@ -1129,7 +1113,7 @@ var revokeCloudAccessTests = []struct {
 			Username: "charlie@external",
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "add-model",
@@ -1174,7 +1158,7 @@ var revokeCloudAccessTests = []struct {
 			Username: "alice@external",
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "admin",
@@ -1182,7 +1166,7 @@ var revokeCloudAccessTests = []struct {
 			Username: "charlie@external",
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "add-model",
@@ -1559,7 +1543,7 @@ var updateCloudTests = []struct {
 			Username: "bob@external",
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			CloudName: "test",
 			Access:    "admin",

--- a/internal/jimm/jimm_test.go
+++ b/internal/jimm/jimm_test.go
@@ -183,7 +183,7 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 - username: eve@external
   controller-access: "no-access"
 `
@@ -262,7 +262,7 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 - username: eve@external
   controller-access: "no-access"
 `
@@ -340,7 +340,7 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 - username: eve@external
   controller-access: "no-access"
 controllers:
@@ -495,7 +495,7 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 - username: eve@external
   controller-access: "no-access"
 controllers:

--- a/internal/jimm/model_test.go
+++ b/internal/jimm/model_test.go
@@ -240,7 +240,7 @@ machines:
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-2",
@@ -290,7 +290,7 @@ machines:
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}},
@@ -371,7 +371,7 @@ machines:
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-2",
@@ -421,7 +421,7 @@ machines:
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}},
@@ -460,7 +460,7 @@ users:
 - username: alice@external
   controller-access: superuser
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 `[1:],
 	updateCredential: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
 		return nil, nil
@@ -507,7 +507,7 @@ machines:
 		},
 		Owner: dbmodel.User{
 			Username:         "bob@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-2",
@@ -594,9 +594,9 @@ controllers:
     priority: 2
 users:
 - username: alice@external
-  controller-access: add-model
+  controller-access: login
 - username: bob@external
-  controller-access: add-model
+  controller-access: login
 `[1:],
 	updateCredential: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
 		return nil, nil
@@ -1760,7 +1760,7 @@ var grantModelAccessTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -1781,19 +1781,19 @@ var grantModelAccessTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}, {
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}},
@@ -1956,7 +1956,7 @@ var revokeModelAccessTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -1977,19 +1977,19 @@ var revokeModelAccessTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}, {
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}},
@@ -2021,7 +2021,7 @@ var revokeModelAccessTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -2042,19 +2042,19 @@ var revokeModelAccessTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "read",
 		}, {
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}},
@@ -2086,7 +2086,7 @@ var revokeModelAccessTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -2107,13 +2107,13 @@ var revokeModelAccessTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}},
@@ -2145,7 +2145,7 @@ var revokeModelAccessTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -2166,13 +2166,13 @@ var revokeModelAccessTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "bob@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}},
@@ -2816,7 +2816,7 @@ var updateModelCredentialTests = []struct {
 		},
 		Owner: dbmodel.User{
 			Username:         "alice@external",
-			ControllerAccess: "add-model",
+			ControllerAccess: "login",
 		},
 		Controller: dbmodel.Controller{
 			Name:        "controller-1",
@@ -2837,13 +2837,13 @@ var updateModelCredentialTests = []struct {
 		Users: []dbmodel.UserModelAccess{{
 			User: dbmodel.User{
 				Username:         "alice@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "admin",
 		}, {
 			User: dbmodel.User{
 				Username:         "charlie@external",
-				ControllerAccess: "add-model",
+				ControllerAccess: "login",
 			},
 			Access: "write",
 		}},

--- a/internal/jimm/user_test.go
+++ b/internal/jimm/user_test.go
@@ -64,7 +64,7 @@ func TestAuthenticate(t *testing.T) {
 		Model:            u.Model,
 		Username:         "bob@external",
 		DisplayName:      "Bob",
-		ControllerAccess: "add-model",
+		ControllerAccess: "login",
 		LastLogin: sql.NullTime{
 			Time:  now,
 			Valid: true,

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -173,6 +173,31 @@ func (s *controllerSuite) TestControllerVersion(c *gc.C) {
 	})
 }
 
+func (s *controllerSuite) TestControllerAccess(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	client := controllerapi.NewClient(conn)
+	access, err := client.GetControllerAccess("alice@external")
+	c.Assert(err, gc.Equals, nil)
+	c.Check(string(access), gc.Equals, "superuser")
+
+	access, err = client.GetControllerAccess("bob@external")
+	c.Assert(err, gc.Equals, nil)
+	c.Check(string(access), gc.Equals, "login")
+
+	conn = s.open(c, nil, "bob")
+	defer conn.Close()
+
+	client = controllerapi.NewClient(conn)
+	access, err = client.GetControllerAccess("bob@external")
+	c.Assert(err, gc.Equals, nil)
+	c.Check(string(access), gc.Equals, "login")
+
+	_, err = client.GetControllerAccess("alice@external")
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+}
+
 type watcherSuite struct {
 	websocketSuite
 }

--- a/internal/jujuapi/usermanager_test.go
+++ b/internal/jujuapi/usermanager_test.go
@@ -104,7 +104,7 @@ func (s *usermanagerSuite) TestUserInfoWithDomain(c *gc.C) {
 	c.Assert(users[0], jc.DeepEquals, jujuparams.UserInfo{
 		Username:    "alice@mydomain",
 		DisplayName: "alice",
-		Access:      "add-model",
+		Access:      "login",
 	})
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -91,7 +91,7 @@ func TestAuthenticator(t *testing.T) {
 
 	c.Check(conn.ControllerTag(), qt.Equals, names.NewControllerTag("6acf4fd8-32d6-49ea-b4eb-dcb9d1590c11"))
 	c.Check(conn.AuthTag(), qt.Equals, names.NewUserTag("bob@external"))
-	c.Check(conn.ControllerAccess(), qt.Equals, "add-model")
+	c.Check(conn.ControllerAccess(), qt.Equals, "login")
 }
 
 func TestVault(t *testing.T) {


### PR DESCRIPTION
Implement the Controller.GetControllerAccess API. As part of investigating
this it turns out that add-model isn't a valid controller access level
so make the defautl level login instead.