### PR TITLE
cmd/jimmctl: add --public-address parameter

### DIFF
--- a/cmd/jimmctl/cmd/controllerinfo_test.go
+++ b/cmd/jimmctl/cmd/controllerinfo_test.go
@@ -73,3 +73,56 @@ public-address: controller1.example.com
 username: test-user
 `)
 }
+
+func (s *controllerInfoSuite) TestControllerInfoSpecifiedPublicAddress(c *gc.C) {
+	s.ClientStore.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		APIEndpoints: []string{"127.0.0.1:17070"},
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	s.ClientStore.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+
+	dir, err := ioutil.TempDir("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(s.ClientStore), "--public-address=controller2.example.com", "controller-1", fname)
+	c.Assert(err, gc.IsNil)
+
+	data, err := ioutil.ReadFile(fname)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Matches, `api-addresses:
+- 127.0.0.1:17070
+name: controller-1
+password: super-secret-password
+public-address: controller2.example.com
+username: test-user
+`)
+}


### PR DESCRIPTION
Allow the public-address to be overridden with a command line parameter
when generating controller info.