### PR TITLE
internal/jimm: active ping in cached dialer

### DIFF
--- a/internal/jimm/cache_test.go
+++ b/internal/jimm/cache_test.go
@@ -123,7 +123,9 @@ func TestCacheDialerCloseBrokenConnection(t *testing.T) {
 			// connection is good, so won't check for a
 			// failed connection until retrieving it
 			// from the cache.
-			IsBroken_: true,
+			Ping_: func(context.Context) error {
+				return errors.E("ping error")
+			},
 		},
 	}
 	testDialer := &countingDialer{
@@ -138,12 +140,10 @@ func TestCacheDialerCloseBrokenConnection(t *testing.T) {
 
 	api, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
 	c.Assert(err, qt.IsNil)
-	c.Check(api.IsBroken(), qt.Equals, true)
 	err = api.Close()
 	c.Assert(err, qt.IsNil)
 	api2, err := dialer.Dial(context.Background(), &ctl, names.ModelTag{})
 	c.Assert(err, qt.IsNil)
-	c.Check(api2.IsBroken(), qt.Equals, true)
 	err = api2.Close()
 	c.Assert(err, qt.IsNil)
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -193,6 +193,9 @@ type API interface {
 	// Offer creates a new application-offer.
 	Offer(context.Context, jujuparams.AddApplicationOffer) error
 
+	// Ping tests the connection is working.
+	Ping(context.Context) error
+
 	// RemoveCloud removes a cloud.
 	RemoveCloud(context.Context, names.CloudTag) error
 

--- a/internal/jimmtest/api.go
+++ b/internal/jimmtest/api.go
@@ -133,6 +133,7 @@ type API struct {
 	ModelWatcherNext_                  func(ctx context.Context, id string) ([]jujuparams.Delta, error)
 	ModelWatcherStop_                  func(ctx context.Context, id string) error
 	Offer_                             func(context.Context, jujuparams.AddApplicationOffer) error
+	Ping_                              func(context.Context) error
 	RemoveCloud_                       func(context.Context, names.CloudTag) error
 	RevokeApplicationOfferAccess_      func(context.Context, string, names.UserTag, jujuparams.OfferAccessPermission) error
 	RevokeCloudAccess_                 func(context.Context, names.CloudTag, names.UserTag, string) error
@@ -340,6 +341,13 @@ func (a *API) Offer(ctx context.Context, aao jujuparams.AddApplicationOffer) err
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return a.Offer_(ctx, aao)
+}
+
+func (a *API) Ping(ctx context.Context) error {
+	if a.Ping_ == nil {
+		return nil
+	}
+	return a.Ping_(ctx)
 }
 
 func (a *API) RemoveCloud(ctx context.Context, tag names.CloudTag) error {

--- a/internal/jujuclient/ping.go
+++ b/internal/jujuclient/ping.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Canonical Ltd.
+
+package jujuclient
+
+import (
+	"context"
+
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// Ping sends a ping message accross the connection and waits for a
+// response.
+func (c Connection) Ping(ctx context.Context) error {
+	const op = errors.Op("jujuclient.Ping")
+
+	err := c.client.Call(ctx, "Pinger", 1, "", "Ping", nil, nil)
+	if err != nil {
+		err = errors.E(op, err)
+	}
+	return err
+}

--- a/internal/jujuclient/ping_test.go
+++ b/internal/jujuclient/ping_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Canonical Ltd.
+
+package jujuclient_test
+
+import (
+	"context"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/juju/names/v4"
+	gc "gopkg.in/check.v1"
+)
+
+type pingSuite struct {
+	jujuclientSuite
+}
+
+var _ = gc.Suite(&pingSuite{})
+
+func (s *pingSuite) TestPing(c *gc.C) {
+	ctx := context.Background()
+
+	info := s.APIInfo(c)
+	ctl := dbmodel.Controller{
+		Name:          s.ControllerConfig.ControllerName(),
+		CACertificate: info.CACert,
+		AdminUser:     info.Tag.Id(),
+		AdminPassword: info.Password,
+		PublicAddress: info.Addrs[0],
+	}
+	api, err := s.Dialer.Dial(ctx, &ctl, names.ModelTag{})
+	c.Assert(err, gc.Equals, nil)
+	defer api.Close()
+
+	err = api.Ping(ctx)
+	c.Assert(err, gc.Equals, nil)
+}


### PR DESCRIPTION
When retrieving a connection from the connection cache perform an active
ping to test the connection before returning it. The existing, more
passive, IsBroken mechanism is causing failed connections to stay in the
cache and have cascading failures for other operations.