### PR TITLE
internal/jujuapi: stop the ping timer on connection close

### DIFF
--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -89,6 +89,7 @@ func serveRoot(ctx context.Context, root root, wsConn *websocket.Conn) {
 		zapctx.Info(ctx, "ping timeout, closing connection")
 		conn.Close()
 	})
+	defer t.Stop()
 	root.setPingF(func() { t.Reset(pingTimeout) })
 	conn.Start(ctx)
 	<-conn.Dead()


### PR DESCRIPTION
Ensure the ping timer is stopped when a client closes a connection. This
prevents the timer firing and attempting to close the connection after
the client has already closed the connection.