### PR TITLE
internal/jujuapi: include correct units count in model summary

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -181,6 +181,7 @@ func preloadModel(prefix string, db *gorm.DB) *gorm.DB {
 	db = db.Preload(prefix + "CloudCredential")
 	db = db.Preload(prefix + "Applications")
 	db = db.Preload(prefix + "Machines")
+	db = db.Preload(prefix + "Units")
 	db = db.Preload(prefix + "Users").Preload(prefix + "Users.User")
 
 	return db

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -241,13 +241,12 @@ func (m Model) ToJujuModelSummary() jujuparams.ModelSummary {
 	ms.OwnerTag = m.Owner.Tag().String()
 	ms.Life = life.Value(m.Life)
 	ms.Status = m.Status.ToJujuEntityStatus()
-	var machines, cores, units int64
+	var machines, cores int64
 	for _, mach := range m.Machines {
 		machines += 1
 		if mach.Hardware.CPUCores.Valid {
 			cores += int64(mach.Hardware.CPUCores.Uint64)
 		}
-		units += int64(len(mach.Units))
 	}
 	ms.Counts = []jujuparams.ModelEntityCount{{
 		Entity: jujuparams.Machines,
@@ -257,7 +256,7 @@ func (m Model) ToJujuModelSummary() jujuparams.ModelSummary {
 		Count:  cores,
 	}, {
 		Entity: jujuparams.Units,
-		Count:  units,
+		Count:  int64(len(m.Units)),
 	}}
 
 	// JIMM doesn't store information about Migrations so this is omitted.

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -611,6 +611,12 @@ func TestImportModel(t *testing.T) {
 					Info:   "test-message",
 				},
 			}},
+			Units: []dbmodel.Unit{{
+				ApplicationName: "app-1",
+				MachineID:       "machine-1",
+				Name:            "app-1/1",
+				Life:            "starting",
+			}},
 			Users: []dbmodel.UserModelAccess{{
 				User: dbmodel.User{
 					Username:         "alice@external",

--- a/internal/jimm/watcher_test.go
+++ b/internal/jimm/watcher_test.go
@@ -567,6 +567,7 @@ var watcherTests = []struct {
 		model.Controller = dbmodel.Controller{}
 		model.Applications = nil
 		model.Machines = nil
+		model.Units = nil
 		model.Users = nil
 		c.Check(model, jimmtest.DBObjectEquals, dbmodel.Model{
 			UUID: sql.NullString{
@@ -636,6 +637,7 @@ var watcherTests = []struct {
 		model.Controller = dbmodel.Controller{}
 		model.Applications = nil
 		model.Machines = nil
+		model.Units = nil
 		model.Users = nil
 		c.Check(model, jimmtest.DBObjectEquals, dbmodel.Model{
 			UUID: sql.NullString{


### PR DESCRIPTION
Retrieve units when retrieving a model to correctly count them for the
model summary.