### PR TITLE
internal/jimm: poll models for user connection time updates

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -56,6 +56,7 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 	if os.Getenv("JIMM_WATCH_CONTROLLERS") != "" {
 		s.Go(func() error { return jimmsvc.WatchControllers(ctx) })
+		s.Go(func() error { return jimmsvc.PollModels(ctx) })
 	}
 	s.Go(func() error { return jimmsvc.WatchModelSummaries(ctx) })
 	// TODO(mhilton) access logs?

--- a/internal/jimm/export_test.go
+++ b/internal/jimm/export_test.go
@@ -2,7 +2,11 @@
 
 package jimm
 
-import "github.com/CanonicalLtd/jimm/internal/dbmodel"
+import (
+	"context"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
 
 var (
 	DetermineAccessLevelAfterRevoke = determineAccessLevelAfterRevoke
@@ -12,4 +16,8 @@ var (
 
 func (j *JIMM) AddAuditLogEntry(ale *dbmodel.AuditLogEntry) {
 	j.addAuditLogEntry(ale)
+}
+
+func (w *Watcher) PollControllerModels(ctx context.Context, ctl *dbmodel.Controller) {
+	w.pollControllerModels(ctx, ctl)
 }

--- a/internal/jimm/watcher_test.go
+++ b/internal/jimm/watcher_test.go
@@ -1164,6 +1164,172 @@ func TestWatcherIgnoreDeltasForModelsFromIncorrectController(t *testing.T) {
 	c.Check(m2, qt.DeepEquals, m1)
 }
 
+const pollControllerModelEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+- owner: alice@external
+  name: cred-1
+  cloud: test-cloud
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+- name: model-1
+  type: iaas
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: controller-1
+  default-series: warty
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: alice@external
+  life: alive
+  status:
+    status: available
+    info: "OK!"
+    since: 2020-02-20T20:02:20Z
+  users:
+  - user: alice@external
+    access: admin
+  - user: bob@external
+    access: write
+  - user: charlie@external
+    access: read
+  - user: dawn@external
+    access: read
+- name: model-2
+  type: iaas
+  uuid: 00000002-0000-0000-0000-000000000002
+  controller: controller-1
+  default-series: warty
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: alice@external
+  life: alive
+  status:
+    status: available
+    info: "OK!"
+    since: 2020-02-20T20:02:20Z
+  users:
+  - user: alice@external
+    access: admin
+    last-connection: 2020-02-20T01:02:03Z
+  - user: bob@external
+    access: write
+    last-connection: 2020-02-20T01:02:03Z
+  - user: charlie@external
+    access: read
+    last-connection: 2020-02-20T01:02:03Z
+  - user: dawn@external
+    access: read
+`
+
+func TestPollControllerModel(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t0 := time.Date(2020, time.February, 20, 1, 2, 3, 0, time.UTC)
+	t1 := time.Date(2020, time.February, 20, 2, 2, 3, 0, time.UTC)
+	t2 := time.Date(2020, time.February, 20, 0, 2, 3, 0, time.UTC)
+
+	w := &jimm.Watcher{
+		Database: db.Database{
+			DB: jimmtest.MemoryDB(c, nil),
+		},
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				ModelInfo_: func(_ context.Context, mi *jujuparams.ModelInfo) error {
+					mi.Users = []jujuparams.ModelUserInfo{{
+						UserName: "alice@external",
+						Access:   "admin",
+					}, {
+						UserName:       "bob@external",
+						Access:         "write",
+						LastConnection: &t1,
+					}, {
+						UserName:       "charlie@external",
+						Access:         "read",
+						LastConnection: &t2,
+					}, {
+						UserName: "dawn@external",
+						Access:   "read",
+					}}
+					return nil
+				},
+			},
+		},
+	}
+
+	env := jimmtest.ParseEnvironment(c, pollControllerModelEnv)
+	err := w.Database.Migrate(ctx, false)
+	c.Assert(err, qt.IsNil)
+	env.PopulateDB(c, w.Database)
+
+	ctl := env.Controller("controller-1").DBObject(c, w.Database)
+	w.PollControllerModels(ctx, &ctl)
+
+	m1 := dbmodel.Model{
+		UUID: sql.NullString{
+			String: "00000002-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+	}
+	m2 := dbmodel.Model{
+		UUID: sql.NullString{
+			String: "00000002-0000-0000-0000-000000000002",
+			Valid:  true,
+		},
+	}
+	err = w.Database.GetModel(ctx, &m1)
+	c.Assert(err, qt.IsNil)
+	err = w.Database.GetModel(ctx, &m2)
+	c.Assert(err, qt.IsNil)
+
+	c.Check(m1.Users[0].LastConnection.Valid, qt.Equals, false)
+	c.Check(m1.Users[1].LastConnection.Valid, qt.Equals, true)
+	c.Check(m1.Users[1].LastConnection.Time, qt.Equals, t1)
+	c.Check(m1.Users[2].LastConnection.Valid, qt.Equals, true)
+	c.Check(m1.Users[2].LastConnection.Time, qt.Equals, t2)
+	c.Check(m1.Users[3].LastConnection.Valid, qt.Equals, false)
+	c.Check(m2.Users[0].LastConnection.Valid, qt.Equals, true)
+	c.Check(m2.Users[0].LastConnection.Time, qt.Equals, t0)
+	c.Check(m2.Users[1].LastConnection.Valid, qt.Equals, true)
+	c.Check(m2.Users[1].LastConnection.Time, qt.Equals, t1)
+	c.Check(m2.Users[2].LastConnection.Valid, qt.Equals, true)
+	c.Check(m2.Users[2].LastConnection.Time, qt.Equals, t0)
+	c.Check(m2.Users[3].LastConnection.Valid, qt.Equals, false)
+}
+
+func TestPollModelsStops(t *testing.T) {
+	c := qt.New(t)
+
+	w := &jimm.Watcher{
+		Database: db.Database{
+			DB: jimmtest.MemoryDB(c, nil),
+		},
+	}
+
+	err := w.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	now := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err = w.PollModels(ctx, time.Minute)
+	c.Check(time.Since(now), qt.Satisfies, func(d time.Duration) bool {
+		return d < time.Second
+	})
+	c.Check(err, qt.ErrorMatches, `context deadline exceeded`)
+}
+
 type testPublisher struct {
 	mu       sync.Mutex
 	messages []interface{}

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -60,13 +60,16 @@ func (r *controllerRoot) Login(ctx context.Context, req jujuparams.LoginRequest)
 	if err != nil {
 		return jujuparams.LoginResult{}, errors.E(op, err)
 	}
+	aui := jujuparams.AuthUserInfo{
+		DisplayName:      u.DisplayName,
+		Identity:         u.Tag().String(),
+		ControllerAccess: u.ControllerAccess,
+	}
+	if u.LastLogin.Valid {
+		aui.LastConnection = &u.LastLogin.Time
+	}
 	return jujuparams.LoginResult{
-		UserInfo: &jujuparams.AuthUserInfo{
-			DisplayName: u.DisplayName,
-			Identity:    u.Tag().String(),
-			// TODO(mhilton) work out how to populate LastConnection.
-			ControllerAccess: u.ControllerAccess,
-		},
+		UserInfo:      &aui,
 		ControllerTag: names.NewControllerTag(r.params.ControllerUUID).String(),
 		Facades:       facades,
 		ServerVersion: srvVersion.String(),

--- a/service.go
+++ b/service.go
@@ -136,8 +136,22 @@ func (s *Service) WatchControllers(ctx context.Context) error {
 // the given context is canceled, or there is a fatal error watching model
 // summaries.
 func (s *Service) WatchModelSummaries(ctx context.Context) error {
-	// TODO(mhilton) need to create a way to watch these.
-	return nil
+	w := jimm.Watcher{
+		Database: s.jimm.Database,
+		Dialer:   s.jimm.Dialer,
+	}
+	return w.WatchAllModelSummaries(ctx, 10*time.Minute)
+}
+
+// PollModels regularly polls each known model to get required data not
+// included in the multiwatcher deltas. PollModels finishes when the given
+// context is canceled, or there is a fatal error polling models.
+func (s *Service) PollModels(ctx context.Context) error {
+	w := jimm.Watcher{
+		Database: s.jimm.Database,
+		Dialer:   s.jimm.Dialer,
+	}
+	return w.PollModels(ctx, 10*time.Minute)
 }
 
 // NewService creates a new Service using the given params.
@@ -281,8 +295,7 @@ func newAuthenticator(ctx context.Context, db *db.Database, p Params) (jimm.Auth
 			Key:            key,
 			IdentityClient: auth.IdentityClientV3{IdentityClient: candidClient},
 			Location:       "jimm",
-			// TODO(mhilton) set an appropriate logger.
-			Logger: logger.BakeryLogger{},
+			Logger:         logger.BakeryLogger{},
 		}),
 		ControllerAdmins: p.ControllerAdmins,
 	}, nil


### PR DESCRIPTION
LastConnection is not included in the deltas from juju's watchers,
in order to have reasonably up-to-date values in the database poll the
controllers for this information.

This also enables the model-summary watcher in the JIMM server.