### PR TITLE
serve dashboard at /

### DIFF
--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -22,6 +22,9 @@ options:
     description: |
       Whitespace separated list of candid users (or groups) that are
       made controller admins by default.
+  dns-name:
+    type: string
+    description: Public DNS hostname that JIMM is being served from.
   log-level:
     type: string
     description: |

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -82,6 +82,7 @@ class JimmCharm(SystemdCharm):
             "admins": self.config.get('controller-admins', ''),
             "bakery_agent_file": self._bakery_agent_file(),
             "candid_url": self.config.get('candid-url'),
+            "dns_name": self.config.get('dns-name'),
             "log_level": self.config.get('log-level'),
             "uuid": self.config.get('uuid')
         }

--- a/charm/templates/jimm.env
+++ b/charm/templates/jimm.env
@@ -4,5 +4,8 @@ JIMM_ADMINS={{admins}}
 {% if dashboard_location %}
 JIMM_DASHBOARD_LOCATION={{dashboard_location}}
 {% endif %}
+{% if dns_name %}
+JIMM_DNS_NAME={{dns_name}}
+{% endif %}
 JIMM_LOG_LEVEL={{log_level}}
 JIMM_UUID={{uuid}}

--- a/charm/tests/test_charm.py
+++ b/charm/tests/test_charm.py
@@ -130,6 +130,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({
             "candid-url": "https://candid.example.com",
             "controller-admins": "user1 user2 group1",
+            "dns-name": "jimm.example.com",
             "log-level": "debug",
             "uuid": "caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa",
         })
@@ -137,14 +138,16 @@ class TestCharm(unittest.TestCase):
         with open(config_file) as f:
             lines = f.readlines()
         os.unlink(config_file)
-        self.assertEqual(len(lines), 8)
+        self.assertEqual(len(lines), 11)
         self.assertEqual(lines[0].strip(), "BAKERY_AGENT_FILE=")
         self.assertEqual(lines[1].strip(), "CANDID_URL=https://candid.example.com")
         self.assertEqual(lines[2].strip(), "JIMM_ADMINS=user1 user2 group1")
         self.assertEqual(lines[4].strip(),
                          "JIMM_DASHBOARD_LOCATION=" + self.tempdir.name + "/dashboard")
-        self.assertEqual(lines[6].strip(), "JIMM_LOG_LEVEL=debug")
-        self.assertEqual(lines[7].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
+        self.assertEqual(lines[7].strip(),
+                         "JIMM_DNS_NAME=" + "jimm.example.com")
+        self.assertEqual(lines[9].strip(), "JIMM_LOG_LEVEL=debug")
+        self.assertEqual(lines[10].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
 
     def test_config_changed_ready(self):
         config_file = os.path.join(self.harness.charm.charm_dir, 'jimm.env')
@@ -160,14 +163,14 @@ class TestCharm(unittest.TestCase):
         with open(config_file) as f:
             lines = f.readlines()
         os.unlink(config_file)
-        self.assertEqual(len(lines), 8)
+        self.assertEqual(len(lines), 9)
         self.assertEqual(lines[0].strip(), "BAKERY_AGENT_FILE=")
         self.assertEqual(lines[1].strip(), "CANDID_URL=https://candid.example.com")
         self.assertEqual(lines[2].strip(), "JIMM_ADMINS=user1 user2 group1")
         self.assertEqual(lines[4].strip(),
                          "JIMM_DASHBOARD_LOCATION=" + self.tempdir.name + "/dashboard")
-        self.assertEqual(lines[6].strip(), "JIMM_LOG_LEVEL=info")
-        self.assertEqual(lines[7].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
+        self.assertEqual(lines[7].strip(), "JIMM_LOG_LEVEL=info")
+        self.assertEqual(lines[8].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
 
     def test_config_changed_with_agent(self):
         config_file = os.path.join(self.harness.charm.charm_dir, 'jimm.env')
@@ -189,13 +192,14 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(os.path.exists(config_file))
         with open(config_file) as f:
             lines = f.readlines()
-        self.assertEqual(len(lines), 6)
+        self.assertEqual(len(lines), 7)
         self.assertEqual(lines[0].strip(),
                          "BAKERY_AGENT_FILE=" + self.harness.charm._agent_filename)
         self.assertEqual(lines[1].strip(), "CANDID_URL=https://candid.example.com")
         self.assertEqual(lines[2].strip(), "JIMM_ADMINS=user1 user2 group1")
-        self.assertEqual(lines[4].strip(), "JIMM_LOG_LEVEL=info")
-        self.assertEqual(lines[5].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
+        self.assertEqual(lines[5].strip(), "JIMM_LOG_LEVEL=info")
+        self.assertEqual(lines[6].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
+
         self.harness.charm._agent_filename = \
             os.path.join(self.tempdir.name, "no-such-dir", "agent.json")
         self.harness.update_config({
@@ -208,12 +212,12 @@ class TestCharm(unittest.TestCase):
         })
         with open(config_file) as f:
             lines = f.readlines()
-        self.assertEqual(len(lines), 6)
+        self.assertEqual(len(lines), 7)
         self.assertEqual(lines[0].strip(), "BAKERY_AGENT_FILE=")
         self.assertEqual(lines[1].strip(), "CANDID_URL=https://candid.example.com")
         self.assertEqual(lines[2].strip(), "JIMM_ADMINS=user1 user2 group1")
-        self.assertEqual(lines[4].strip(), "JIMM_LOG_LEVEL=info")
-        self.assertEqual(lines[5].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
+        self.assertEqual(lines[5].strip(), "JIMM_LOG_LEVEL=info")
+        self.assertEqual(lines[6].strip(), "JIMM_UUID=caaa4ba4-e2b5-40dd-9bf3-2bd26d6e17aa")
 
     def test_leader_elected(self):
         leader_file = os.path.join(self.harness.charm.charm_dir, 'jimm-leader.env')

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -50,6 +50,7 @@ func start(ctx context.Context, s *service.Service) error {
 		VaultAuthPath:     os.Getenv("VAULT_AUTH_PATH"),
 		VaultPath:         os.Getenv("VAULT_PATH"),
 		DashboardLocation: os.Getenv("JIMM_DASHBOARD_LOCATION"),
+		PublicDNSName:     os.Getenv("JIMM_DNS_NAME"),
 	})
 	if err != nil {
 		return err

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -69,6 +69,7 @@ func (r *controllerRoot) Login(ctx context.Context, req jujuparams.LoginRequest)
 		aui.LastConnection = &u.LastLogin.Time
 	}
 	return jujuparams.LoginResult{
+		PublicDNSName: r.params.PublicDNSName,
 		UserInfo:      &aui,
 		ControllerTag: names.NewControllerTag(r.params.ControllerUUID).String(),
 		Facades:       facades,

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -20,6 +20,10 @@ type Params struct {
 	// IdentityLocation holds the URL of the thrid-party identiry
 	// provider.
 	IdentityLocation string
+
+	// PublicDNSName is the name to advertise as the public address of
+	// the juju controller.
+	PublicDNSName string
 }
 
 // APIHandler returns an http Handler for the /api endpoint.


### PR DESCRIPTION
The juju dashboard expects to the run at the root of the server. This also
updates the login response to publish the public DNS name of the server.