### PR TITLE
internal/dashboard: serve the dashboard from the root

### DIFF
--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -74,10 +74,14 @@ options:
     type: string
     description: Domain to log all users in to.
   dbname:
-     default: "jem"
-     type: string
-     description: MongoDB database name to use.
+    default: "jem"
+    type: string
+    description: MongoDB database name to use.
   juju-dashboard-location:
     default: ""
     type: string
     description: URL of the Juju Dashboard for this controller.
+  public-dns-name:
+    default: ""
+    type: string
+    description: Public DNS hostname of the JIMM service.

--- a/charm/hooks/config-changed
+++ b/charm/hooks/config-changed
@@ -30,6 +30,7 @@ def config_changed():
         "logging-level",
         "max-mgo-sessions",
         "metering-location",
+        "public-dns-name",
     ]
 
     admins = [admin.strip() for admin in config['controller-admins'].split(",")]
@@ -60,7 +61,7 @@ def config_changed():
         config_js_path = os.path.join(dashboard_path(), 'config.js')
         dashboard_context = {
             'base_controller_url': app_config['controller-url'],
-            'base_app_url': '/dashboard/',
+            'base_app_url': '/',
             'identity_provider_available': str(len(app_config['identity-location']) != 0).lower(),
         }
         templating.render(

--- a/cmd/jemd/main.go
+++ b/cmd/jemd/main.go
@@ -152,6 +152,7 @@ func startServer(ctx context.Context, eg *errgroup.Group, conf *config.Config) e
 		JujuDashboardLocation: conf.JujuDashboardLocation,
 		VaultClient:           vaultClient,
 		VaultPath:             conf.Vault.KVPath,
+		PublicDNSName:         conf.PublicDNSName,
 	}
 
 	server, err := jem.NewServer(ctx, cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	MaxPubsubConcurrency  int               `yaml:"max-pubsub-concurrency"`
 	JujuDashboardLocation string            `yaml:"juju-dashboard-location"`
 	Vault                 VaultConfig       `yaml:"vault"`
+	PublicDNSName         string            `yaml:"public-dns-name"`
 }
 
 // A VaultConfig contains the configuration settings for a vault server

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,6 +104,7 @@ vault:
   approle-role-id: 00000000-0000-0000-0000-000000000000
   approle-secret-id: 00000000-0000-0000-0000-000000000001
   kv-path: /kv/jimm
+public-dns-name: jimm.example.com
 `
 
 func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error) {
@@ -163,6 +164,7 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 			ApproleSecretID: "00000000-0000-0000-0000-000000000001",
 			KVPath:          "/kv/jimm",
 		},
+		PublicDNSName: "jimm.example.com",
 	})
 }
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	dashboardPathPrefix = "dashboard"
+	dashboardPath = "/dashboard"
 )
 
 // Register registers a http handler the serves Juju Dashboard
@@ -58,8 +58,10 @@ func Register(ctx context.Context, router *httprouter.Router, dashboardLocation 
 		switch fi.Name() {
 		case "index.html":
 			// Use index.html to serve anything we don't otherwise know about.
-			router.GET("/"+dashboardPathPrefix, serveFile)
-			router.GET("/"+dashboardPathPrefix+"/*anything", serveFile)
+			router.GET(dashboardPath, serveFile)
+			router.NotFound = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				http.ServeFile(w, req, path)
+			})
 		case "config.js":
 			// Ignore any config.js file, use a rendered one instead.
 		case "config.js.go":
@@ -69,7 +71,7 @@ func Register(ctx context.Context, router *httprouter.Router, dashboardLocation 
 			}
 			var buf bytes.Buffer
 			err = tmpl.Execute(&buf, map[string]interface{}{
-				"baseAppURL":                "/" + dashboardPathPrefix + "/",
+				"baseAppURL":                "/",
 				"identityProviderAvailable": true,
 				"isJuju":                    false,
 			})

--- a/internal/db/dqlite_test.go
+++ b/internal/db/dqlite_test.go
@@ -3,7 +3,7 @@
 // go-dqlite only works properly if the go-sqlite3 package is built with
 // the libsqlite3 tag.
 // +build libsqlite3
-//go:build !libsqlite3
+//go:build libsqlite3
 
 package db_test
 

--- a/internal/jemserver/server.go
+++ b/internal/jemserver/server.go
@@ -117,6 +117,9 @@ type Params struct {
 
 	// VaultPath is the root path in the vault for JIMM's secrets.
 	VaultPath string
+
+	// PublicDNSName contains the DNS hostname of the JIMM service.
+	PublicDNSName string
 }
 
 // HandlerParams are the parameters used to initialize a handler.

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -75,6 +75,7 @@ func (r *controllerRoot) Login(ctx context.Context, req jujuparams.LoginRequest)
 		ControllerTag: names.NewControllerTag(r.params.ControllerUUID).String(),
 		Facades:       facades,
 		ServerVersion: srvVersion.String(),
+		PublicDNSName: r.params.PublicDNSName,
 	}, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -101,6 +101,9 @@ type ServerParams struct {
 
 	// VaultPath is the root path in the vault for JIMM's secrets.
 	VaultPath string
+
+	// PublicDNSName contains the DNS hostname of the JIMM service.
+	PublicDNSName string
 }
 
 // HandleCloser represents an HTTP handler that can


### PR DESCRIPTION
The juju dashboard works best when served from the server root. Also
include the PublicDNSName in the login response so that the juju
dashboard command.