### PR TITLE
CSS-737 Fix application-offer permissions logic

### DIFF
--- a/internal/db/applicationoffer_test.go
+++ b/internal/db/applicationoffer_test.go
@@ -389,11 +389,11 @@ func (s *dbSuite) TestFindApplicationOffers(c *qt.C) {
 		},
 		expectedOffers: []dbmodel.ApplicationOffer{offer2, offer3},
 	}, {
-		about: "filter by first user ",
+		about: "filter by model admin user",
 		filters: []db.ApplicationOfferFilter{
 			db.ApplicationOfferFilterByUser(env.u.Username),
 		},
-		expectedOffers: []dbmodel.ApplicationOffer{offer1, offer2},
+		expectedOffers: []dbmodel.ApplicationOffer{offer1, offer2, offer3},
 	}, {
 		about: "filter by user - not found",
 		filters: []db.ApplicationOfferFilter{


### PR DESCRIPTION
The application-offer permissions logic was inconsistent and buggy:
1. A controller superuser or model admin could (theoretically) grant/revoke access to an offer, but they were not able to find the offer.
2. A bug in the model fetching logic meant the model admins couldn't actually perform the above.
3. Unit tests were not capturing the bugs above.

This PR fixes all issues, such that now either a controller superuser, a user that has admin rights on the model, or admin access to the offer can find the offer and all its user, and can grant or revoke access from said offer, or delete the offer completely.

I also edited the tests so that they capture the above issues as well.