### PR TITLE
CSS-1121 A fix for jem CreateModel method.

### DIFF
--- a/internal/jem/credential.go
+++ b/internal/jem/credential.go
@@ -356,7 +356,7 @@ func (j *JEM) checkCredentialOnController(ctx context.Context, ctlPath params.En
 // on the models updated.
 func (j *JEM) updateControllerCredential(
 	ctx context.Context,
-	conn *apiconn.Conn,
+	conn ModelCreateAPI,
 	ctlPath params.EntityPath,
 	cred *mongodoc.Credential,
 ) ([]jujuparams.UpdateCredentialModelResult, error) {


### PR DESCRIPTION
If the request context times out (because Juju controller takes too long to
create a model), we would return an error (and JEM would be closed), but
the create model method would continue running in a separate goroutine
still trying to use JEM which was closed - therefore we would see
a panic since JEM was trying to use a nil DB.