### PR TITLE
CSS-1582 Fix for the AddModel cleanup.

### DIFF
--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -331,8 +331,11 @@ func (b *modelBuilder) Cleanup() {
 	if b.model == nil {
 		return
 	}
-	if derr := b.jimm.Database.DeleteModel(b.ctx, b.model); derr != nil {
-		zapctx.Error(b.ctx, "failed to delete model", zap.String("model", b.model.Name), zap.String("owner", b.model.Owner.Username), zaputil.Error(derr))
+	// the model should be deleted from the database regardless of the request
+	// context expiration
+	ctx := context.Background()
+	if derr := b.jimm.Database.DeleteModel(ctx, b.model); derr != nil {
+		zapctx.Error(ctx, "failed to delete model", zap.String("model", b.model.Name), zap.String("owner", b.model.Owner.Username), zaputil.Error(derr))
 	}
 }
 

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/jsoncodec"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	requestTimeout        = 10 * time.Second
+	requestTimeout        = 30 * time.Second
 	maxRequestConcurrency = 10
 	pingTimeout           = 90 * time.Second
 )


### PR DESCRIPTION
## Description

In case our request to create a model on the controller times out,
we try to delete the model from JIMM's DB. Since we were using
the expired context, the call to delete the model would fail.

Also increased request timeout to 30s as we've seen slower
responses from Juju controllers.
## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
