### PR TITLE
CSS-2764 Added AddGroup method to the JIMM facade.

### DIFF
--- a/api/jimm.go
+++ b/api/jimm.go
@@ -112,3 +112,8 @@ func (c *Client) ImportModel(req *params.ImportModelRequest) error {
 func (c *Client) UpdateMigratedModel(req *params.UpdateMigratedModelRequest) error {
 	return c.caller.APICall("JIMM", 3, "", "UpdateMigratedModel", req, nil)
 }
+
+// AddGroup adds the group to JIMM.
+func (c *Client) AddGroup(req *params.AddGroupRequest) error {
+	return c.caller.APICall("JIMM", 4, "", "AddGroup", req, nil)
+}

--- a/api/params/params.go
+++ b/api/params/params.go
@@ -237,3 +237,18 @@ type ImportModelRequest struct {
 	// ModelTag is the tag of the model that is to be imported.
 	ModelTag string `json:"model-tag"`
 }
+
+// AddGroupRequest holds a request to add a group.
+type AddGroupRequest struct {
+	// Name holds the name of the group.
+	Name string `json:"name"`
+}
+
+// RenameGroupRequest holds a request to rename a group.
+type RenameGroupRequest struct {
+	// Name holds the name of the group.
+	Name string `json:"name"`
+
+	// NewName holds the new name of the group.
+	NewName string `json:"new-name"`
+}

--- a/cmd/jimmctl/cmd/auth.go
+++ b/cmd/jimmctl/cmd/auth.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Canonical Ltd.
+
+package cmd
+
+import (
+	jujucmd "github.com/juju/cmd/v3"
+)
+
+var authDoc = `
+auth enables users to manage authorisation model used by JIMM.
+`
+
+func NewAuthCommand() *jujucmd.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(jujucmd.SuperCommandParams{
+		Name:    "auth",
+		Doc:     authDoc,
+		Purpose: "Authorisation model management.",
+	})
+	cmd.Register(NewGroupCommand())
+
+	return cmd
+}

--- a/cmd/jimmctl/cmd/export_test.go
+++ b/cmd/jimmctl/cmd/export_test.go
@@ -181,3 +181,15 @@ func NewImportCloudCredentialsCommandForTesting(store jujuclient.ClientStore, bC
 
 	return modelcmd.WrapBase(cmd)
 }
+
+func NewAddGroupCommandForTesting(store jujuclient.ClientStore, bClient *httpbakery.Client) cmd.Command {
+	cmd := &addGroupCommand{
+		store: store,
+		dialOpts: &jujuapi.DialOpts{
+			InsecureSkipVerify: true,
+			BakeryClient:       bClient,
+		},
+	}
+
+	return modelcmd.WrapBase(cmd)
+}

--- a/cmd/jimmctl/cmd/group.go
+++ b/cmd/jimmctl/cmd/group.go
@@ -1,0 +1,106 @@
+// Copyright 2021 Canonical Ltd.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	jujucmdv3 "github.com/juju/cmd/v3"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/CanonicalLtd/jimm/api"
+	apiparams "github.com/CanonicalLtd/jimm/api/params"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+var (
+	groupDoc = `
+	group command enables group management for jimm
+`
+
+	addGroupDoc = `
+	add-group command adds group to jimm.
+
+	Example:
+		jimmctl auth group add <name> 
+`
+)
+
+// NewGroupCommand returns a command for group management.
+func NewGroupCommand() *jujucmdv3.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(jujucmdv3.SuperCommandParams{
+		Name:    "group",
+		Doc:     groupDoc,
+		Purpose: "Group management.",
+	})
+	cmd.Register(newAddGroupCommand())
+
+	return cmd
+}
+
+// newAddGroupCommand returns a command to add a group.
+func newAddGroupCommand() cmd.Command {
+	cmd := &addGroupCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addGroupCommand adds a group.
+type addGroupCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name string
+}
+
+func (c *addGroupCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "add",
+		Purpose: "Add group to jimm",
+		Doc:     addGroupDoc,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *addGroupCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("group name not specified")
+	}
+	c.name, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *addGroupCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	params := apiparams.AddGroupRequest{
+		Name: c.name,
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.AddGroup(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}

--- a/cmd/jimmctl/cmd/group_test.go
+++ b/cmd/jimmctl/cmd/group_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Canonical Ltd.
+
+package cmd_test
+
+import (
+	"context"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/jimm/cmd/jimmctl/cmd"
+)
+
+type groupSuite struct {
+	jimmSuite
+}
+
+var _ = gc.Suite(&groupSuite{})
+
+func (s *groupSuite) TestAddGroupSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.userBakeryClient("alice")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore, bClient), "test-group")
+	c.Assert(err, gc.IsNil)
+
+	group, err := s.jimmSuite.JIMM.Database.GetGroup(context.TODO(), "test-group")
+	c.Assert(err, gc.IsNil)
+	c.Assert(group.ID, gc.Equals, uint(1))
+	c.Assert(group.Name, gc.Equals, "test-group")
+}
+
+func (s *groupSuite) TestAddGroup(c *gc.C) {
+	// bob is not superuser
+	bClient := s.userBakeryClient("bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore, bClient), "test-group")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jimmctl/main.go
+++ b/cmd/jimmctl/main.go
@@ -34,6 +34,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jimmcmd.Register(cmd.NewUpdateMigratedModelCommand())
 	jimmcmd.Register(cmd.NewAddCloudToControllerCommand())
 	jimmcmd.Register(cmd.NewRemoveCloudFromControllerCommand())
+	jimmcmd.Register(cmd.NewAuthCommand())
 	return jimmcmd
 }
 

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Canonical Ltd.
+
+package db
+
+import (
+	"context"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+// AddGroup adds a new group.
+func (d *Database) AddGroup(ctx context.Context, name string) error {
+	const op = errors.Op("db.AddGroup")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+	ge := dbmodel.GroupEntry{
+		Name: name,
+	}
+
+	if err := d.DB.WithContext(ctx).Create(&ge).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// GetGroup returns a GroupEntry with the specified name.
+func (d *Database) GetGroup(ctx context.Context, name string) (*dbmodel.GroupEntry, error) {
+	const op = errors.Op("db.GetGroup")
+	if err := d.ready(); err != nil {
+		return nil, errors.E(op, err)
+	}
+	ge := dbmodel.GroupEntry{
+		Name: name,
+	}
+
+	if err := d.DB.WithContext(ctx).First(&ge).Error; err != nil {
+		return nil, errors.E(op, dbError(err))
+	}
+	return &ge, nil
+}
+
+// UpdateGroup updates the group identified by its ID.
+func (d *Database) UpdateGroup(ctx context.Context, group *dbmodel.GroupEntry) error {
+	const op = errors.Op("db.UpdateGroup")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+	if group.ID == 0 {
+		return errors.E(errors.CodeNotFound)
+	}
+	if err := d.DB.WithContext(ctx).Save(group).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -1,0 +1,95 @@
+// Copyright 2021 Canonical Ltd.
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/CanonicalLtd/jimm/internal/db"
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+	"github.com/CanonicalLtd/jimm/internal/errors"
+)
+
+func TestAddGroupUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var d db.Database
+	err := d.AddGroup(context.Background(), "test-group")
+	c.Check(err, qt.ErrorMatches, `database not configured`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func (s *dbSuite) TestAddGroup(c *qt.C) {
+	ctx := context.Background()
+
+	err := s.Database.AddGroup(ctx, "test-group")
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
+
+	err = s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.AddGroup(ctx, "test-group")
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.AddGroup(ctx, "test-group")
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeAlreadyExists)
+
+	ge := dbmodel.GroupEntry{
+		Name: "test-group",
+	}
+	tx := s.Database.DB.First(&ge)
+	c.Assert(tx.Error, qt.IsNil)
+	c.Assert(ge.ID, qt.Equals, uint(1))
+	c.Assert(ge.Name, qt.Equals, "test-group")
+}
+
+func (s *dbSuite) TestGetGroup(c *qt.C) {
+	_, err := s.Database.GetGroup(context.Background(), "test-group")
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
+
+	err = s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	_, err = s.Database.GetGroup(context.Background(), "test-group")
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	err = s.Database.AddGroup(context.TODO(), "test-group")
+	c.Assert(err, qt.IsNil)
+
+	ge, err := s.Database.GetGroup(context.Background(), "test-group")
+	c.Check(err, qt.IsNil)
+	c.Assert(ge.ID, qt.Equals, uint(1))
+	c.Assert(ge.Name, qt.Equals, "test-group")
+}
+
+func (s *dbSuite) TestUpdateGroup(c *qt.C) {
+	err := s.Database.UpdateGroup(context.Background(), &dbmodel.GroupEntry{})
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
+
+	err = s.Database.Migrate(context.Background(), false)
+	c.Assert(err, qt.IsNil)
+
+	ge := &dbmodel.GroupEntry{
+		Name: "test-group",
+	}
+
+	err = s.Database.UpdateGroup(context.Background(), ge)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	err = s.Database.AddGroup(context.Background(), "test-group")
+	c.Assert(err, qt.IsNil)
+
+	ge1, err := s.Database.GetGroup(context.Background(), "test-group")
+	c.Assert(err, qt.IsNil)
+
+	ge1.Name = "renamed-group"
+	err = s.Database.UpdateGroup(context.Background(), ge1)
+	c.Check(err, qt.IsNil)
+
+	ge2, err := s.Database.GetGroup(context.Background(), "renamed-group")
+	c.Check(err, qt.IsNil)
+	c.Assert(ge2, qt.DeepEquals, ge1)
+}

--- a/internal/dbmodel/group.go
+++ b/internal/dbmodel/group.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel
+
+import (
+	"gorm.io/gorm"
+)
+
+// A GroupEntry holds information about a user group.
+type GroupEntry struct {
+	gorm.Model
+
+	// Name holds the name of the group.
+	Name string `gorm:"index;column:name"`
+}
+
+// TableName overrides the table name gorm will use to find
+// GroupEntry records.
+func (GroupEntry) TableName() string {
+	return "groups"
+}

--- a/internal/dbmodel/group_test.go
+++ b/internal/dbmodel/group_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Canonical Ltd.
+
+package dbmodel_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/CanonicalLtd/jimm/internal/dbmodel"
+)
+
+func TestGroupEntry(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(t)
+
+	ge := dbmodel.GroupEntry{
+		Name: "test-group-1",
+	}
+	c.Assert(db.Create(&ge).Error, qt.IsNil)
+	c.Assert(ge.ID, qt.Equals, uint(1))
+
+	ge1 := dbmodel.GroupEntry{
+		Name: "test-group-1",
+	}
+	c.Assert(db.Create(&ge1).Error, qt.ErrorMatches, "UNIQUE constraint failed: groups.name")
+
+	var ge2 dbmodel.GroupEntry
+	c.Assert(db.First(&ge2).Error, qt.IsNil)
+	c.Check(ge2, qt.DeepEquals, ge)
+
+	ge3 := dbmodel.GroupEntry{
+		Name: "test-group-1",
+	}
+	result := db.First(&ge3)
+	c.Assert(result.Error, qt.IsNil)
+	c.Assert(ge3, qt.DeepEquals, ge)
+}

--- a/internal/dbmodel/sql/postgres/0_0.sql
+++ b/internal/dbmodel/sql/postgres/0_0.sql
@@ -273,4 +273,15 @@ CREATE TABLE IF NOT EXISTS root_keys (
 CREATE INDEX IF NOT EXISTS idx_root_keys_created_at ON root_keys (created_at);
 CREATE INDEX IF NOT EXISTS idx_root_keys_expires ON root_keys (expires);
 
+CREATE TABLE IF NOT EXISTS groups (
+	id BIGSERIAL PRIMARY KEY,
+	created_at TIMESTAMP WITH TIME ZONE,
+	updated_at TIMESTAMP WITH TIME ZONE,
+	deleted_at TIMESTAMP WITH TIME ZONE,
+	name TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_group_deleted_at ON groups (deleted_at);
+CREATE INDEX IF NOT EXISTS idx_group_name ON groups (group_name);
+
 UPDATE versions SET major=1, minor=0 WHERE component='jimmdb';
+

--- a/internal/dbmodel/sql/sqlite/0_0.sql
+++ b/internal/dbmodel/sql/sqlite/0_0.sql
@@ -54,8 +54,7 @@ CREATE TABLE controllers (
 	updated_at DATETIME,
 	deleted_at DATETIME,
 	name TEXT NOT NULL UNIQUE,
-	uuid TEXT NOT NULL,
-	admin_user TEXT NOT NULL,
+	uuid TEXT NOT NULL,admin_user TEXT NOT NULL,
 	admin_password TEXT NOT NULL,
 	ca_certificate TEXT NOT NULL,
 	public_address TEXT NOT NULL,
@@ -271,5 +270,15 @@ CREATE TABLE root_keys (
 
 CREATE INDEX idx_root_keys_created_at ON root_keys (created_at);
 CREATE INDEX idx_root_keys_expires ON root_keys (expires);
+
+CREATE TABLE groups (
+	id INTEGER PRIMARY KEY,
+	created_at DATETIME,
+	updated_at DATETIME,
+	deleted_at DATETIME,
+	name TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX idx_group_deleted_at ON groups (deleted_at);
 
 UPDATE versions SET major=1, minor=0 WHERE component='jimmdb';

--- a/internal/jimmtest/openfga.go
+++ b/internal/jimmtest/openfga.go
@@ -3,8 +3,10 @@
 package jimmtest
 
 import (
+	"net/http"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/CanonicalLtd/jimm/internal/errors"
 )
@@ -19,6 +21,28 @@ func StartOpenFGA() error {
 	openFGACmd = exec.Command("openfga", "run", "--http-addr", "0.0.0.0:8082")
 	if err := openFGACmd.Start(); err != nil {
 		return err
+	}
+
+	ping := func() error {
+		resp, err := http.Get("http://127.0.0.1:8082/healthz")
+		if err != nil {
+			return errors.E(err, "health ping failed")
+		}
+		if resp.StatusCode != http.StatusOK {
+			return errors.E("health ping failed")
+		}
+		return nil
+	}
+	var err error
+	for i := 0; i < 10; i++ {
+		err = ping()
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		return errors.E("failed to start openfga")
 	}
 	return nil
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -35,6 +35,7 @@ func init() {
 		updateMigratedModelMethod := rpc.Method(r.UpdateMigratedModel)
 		addCloudToControllerMethod := rpc.Method(r.AddCloudToController)
 		removeCloudFromControllerMethod := rpc.Method(r.RemoveCloudFromController)
+		addGroupMethod := rpc.Method(r.AddGroup)
 
 		r.AddMethod("JIMM", 2, "DisableControllerUUIDMasking", disableControllerUUIDMaskingMethod)
 		r.AddMethod("JIMM", 2, "ListControllers", listControllersMethod)
@@ -53,7 +54,22 @@ func init() {
 		r.AddMethod("JIMM", 3, "AddCloudToController", addCloudToControllerMethod)
 		r.AddMethod("JIMM", 3, "RemoveCloudFromController", removeCloudFromControllerMethod)
 
-		return []int{2, 3}
+		r.AddMethod("JIMM", 4, "AddController", addControllerMethod)
+		r.AddMethod("JIMM", 4, "DisableControllerUUIDMasking", disableControllerUUIDMaskingMethod)
+		r.AddMethod("JIMM", 4, "FindAuditEvents", findAuditEventsMethod)
+		r.AddMethod("JIMM", 4, "FullModelStatus", fullModelStatusMethod)
+		r.AddMethod("JIMM", 4, "GrantAuditLogAccess", grantAuditLogAccessMethod)
+		r.AddMethod("JIMM", 4, "ImportModel", importModelMethod)
+		r.AddMethod("JIMM", 4, "ListControllers", listControllersV3Method)
+		r.AddMethod("JIMM", 4, "RemoveController", removeControllerMethod)
+		r.AddMethod("JIMM", 4, "RevokeAuditLogAccess", revokeAuditLogAccessMethod)
+		r.AddMethod("JIMM", 4, "SetControllerDeprecated", setControllerDeprecatedMethod)
+		r.AddMethod("JIMM", 4, "UpdateMigratedModel", updateMigratedModelMethod)
+		r.AddMethod("JIMM", 4, "AddCloudToController", addCloudToControllerMethod)
+		r.AddMethod("JIMM", 4, "RemoveCloudFromController", removeCloudFromControllerMethod)
+		r.AddMethod("JIMM", 4, "AddGroup", addGroupMethod)
+
+		return []int{2, 3, 4}
 	}
 }
 
@@ -437,6 +453,34 @@ func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apip
 		return errors.E(op, err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.RemoveCloudFromController(ctx, r.user, req.ControllerName, ct); err != nil {
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+// AddGroup adds a group to JIMM.
+func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupRequest) error {
+	const op = errors.Op("jujuapi.AddGroup")
+	if r.user.ControllerAccess != "superuser" {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	if err := r.jimm.Database.AddGroup(ctx, req.Name); err != nil {
+		zapctx.Error(ctx, "failed to add group", zaputil.Error(err))
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+// RenameGroup renames a group.
+func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGroupRequest) error {
+	const op = errors.Op("jujuapi.RenameGroup")
+	if r.user.ControllerAccess != "superuser" {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	if err := r.jimm.Database.AddGroup(ctx, req.Name); err != nil {
+		zapctx.Error(ctx, "failed to add group", zaputil.Error(err))
 		return errors.E(op, err)
 	}
 	return nil

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -610,3 +610,15 @@ func (s *jimmSuite) TestRemoveCloudFromController(c *gc.C) {
 	_, err = s.JIMM.GetCloud(context.Background(), &u, names.NewCloudTag("test-cloud"))
 	c.Assert(err, gc.ErrorMatches, `cloud "test-cloud" not found`)
 }
+
+func (s *jimmSuite) TestAddGroup(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+	err := client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
+	c.Assert(err, gc.ErrorMatches, ".*already exists.*")
+}


### PR DESCRIPTION
## Description

- Adds the AddGroup method to the JIMM facade.
- Adds methods to persist group information.
- Added CLI with skeleton for other auth commands

In OpenFGA groups will be referenced by their ID - this will enable us to support renaming groups (group name changes, ID remains the same).

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->