### PR TITLE
Fixes password used when adding a controller to JIMM

### DIFF
--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -110,7 +110,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 		if u != "" {
 			username = u
 		}
-		if password != "" {
+		if p != "" {
 			password = p
 		}
 	}


### PR DESCRIPTION
## Description

Fixes a bug when adding a controller to JIMM, when dialling a controller we pass in a dbmodel.Controller which might have a username and password. We then check if the controller details are in Vault, if they are we use that instead, however we were checking the wrong variable.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests