### PR TITLE
Fix for the StartJWKSRotator

### DIFF
--- a/service.go
+++ b/service.go
@@ -201,11 +201,19 @@ func (s *Service) PollModels(ctx context.Context) error {
 
 // StartJWKSRotator see internal/jimmjwx/jwks.go for details.
 func (s *Service) StartJWKSRotator(ctx context.Context, checkRotateRequired <-chan time.Time, initialRotateRequiredTime time.Time) error {
+	if s.jimm.JWKService == nil {
+		zapctx.Warn(ctx, "not starting JWKS rotation")
+		return nil
+	}
 	return s.jimm.JWKService.StartJWKSRotator(ctx, checkRotateRequired, initialRotateRequiredTime)
 }
 
 // RegisterJwksCache registers the JWKS Cache with JIMM's JWT service.
 func (s *Service) RegisterJwksCache(ctx context.Context) {
+	if s.jimm.JWTService == nil {
+		zapctx.Warn(ctx, "skipping JWKS cache registration - service not available")
+		return
+	}
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}


### PR DESCRIPTION
## Description

If Vault is not present, we cannot create a JWKS service and JIMM would panic starting the JWKS rotator.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->