### PR TITLE
CSS-4546 - Backport ci/cd and supporting files

### DIFF
--- a/.github/workflows/charm-build.yaml
+++ b/.github/workflows/charm-build.yaml
@@ -1,0 +1,21 @@
+name: Charm Build
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-charm:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        charm-type: ["jimm","jimm-k8s"]
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow
+      - run: sudo snap install charmcraft --channel=2.x/stable --classic
+      - run: sudo charmcraft pack --project-dir ./charms/${{ matrix.charm-type }} --destructive-mode --verbosity=trace
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.charm-type }}-charm
+          path: ./*.charm
+          if-no-files-found: error

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -1,0 +1,68 @@
+name: Release to latest/edge
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+# Note this workflow requires a Github secret to provide auth against charmhub.
+# This can be generated with the following command
+# charmcraft login --export=secrets.auth --charm=<charm-name> --permission=package-manage --permission=package-view --channel=latest/edge --ttl=999999999
+
+jobs:
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
+  charm-tests:
+    uses: ./.github/workflows/charm-test.yaml
+  snap-build:
+    uses: ./.github/workflows/snap.yaml
+
+  release-k8s-charm:
+    name: Release k8s charm
+    needs:
+      - ci-tests
+      - charm-tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build local images
+        run: make jimm-image
+      - name: Upload charm to charmhub
+        uses: kian99/charming-actions/upload-charm@add-local-image-option
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "v1/edge"
+          charm-path: "./charms/jimm-k8s"
+          local-image: "true"
+
+  release-machine-charm:
+    name: Release machine charm
+    needs:
+      - ci-tests
+      - charm-tests
+      - snap-build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@master
+        with:
+          name: jimm-snap
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --channel=2.x/stable
+      - name: Publish Charm Resource
+        run: charmcraft upload-resource juju-jimm jimm-snap --filepath ./jimm-snap
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.3.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "v1/edge"
+          charm-path: "./charms/jimm"

--- a/.github/workflows/charm-test.yaml
+++ b/.github/workflows/charm-test.yaml
@@ -1,0 +1,79 @@
+name: Charm Test
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - charms/**
+
+jobs:
+  charm-build:
+    uses: ./.github/workflows/charm-build.yaml
+
+  lint:
+    # Delete this if statement once charms are updated and include tox.
+    if: ${{ 1 }} == ${{ 2 }} 
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        charm-type: ["jimm","jimm-k8s"]
+    defaults:
+      run:
+        working-directory: ./charms/${{ matrix.charm-type }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+  unit-tests:
+    # Delete this if statement once charms are updated and include tox.
+    if: ${{ 1 }} == ${{ 2 }} 
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        charm-type: ["jimm","jimm-k8s"]
+    defaults:
+      run:
+        working-directory: ./charms/${{ matrix.charm-type }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
+  # TODO(Kian): Fix this
+  # integration-tests:
+  #   name: Integration tests
+  #   needs:
+  #     - charm-build
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     charm-type: "jimm-k8s"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Setup operator environment
+  #       uses: charmed-kubernetes/actions-operator@main
+  #       with:
+  #         juju-channel: 2.9/stable
+  #         provider: microk8s
+  #         microk8s-addons: "ingress storage dns rbac registry"
+  #         channel: 1.27/stable
+  #     # Download the charm from the build to speed up integration tests.
+  #     - uses: actions/download-artifact@master
+  #       with:
+  #         name: jimm-k8s-charm
+  #         path: ./charms/${{ env.charm-type }}
+  #     - name: Create OCI Image
+  #       run: make push-microk8s
+  #     - name: Install tox
+  #       run: python -m pip install tox
+  #     - name: Integration tests
+  #       run: tox -e integration -- --localCharm
+  #       working-directory: ./charms/${{ env.charm-type }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,63 +1,56 @@
 name: CI
 on:
   pull_request:
+  workflow_call:
   workflow_dispatch:
-env:
-  GH_AUTH: ${{ secrets.GH_AUTH }}
-  GH_USER: ${{ secrets.GH_USER }}
 
 jobs:
-  lint:
-    runs-on: ubuntu-20.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/setupgo118amd64
-        with:
-          user: ${{ secrets.GH_USER }}
-          pat: ${{ secrets.GH_AUTH }}
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
-          skip-pkg-cache: true
-          skip-build-cache: true
+  # lint:
+  #   runs-on: ubuntu-20.04
+  #   continue-on-error: true
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: ./.github/workflows/setupgo118amd64
+  #     - name: golangci-lint
+  #       uses: golangci/golangci-lint-action@v3
+  #       with:
+  #         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+  #         version: latest
+  #         skip-pkg-cache: true
+  #         skip-build-cache: true
 
   build_test:
     name: Build and Test
-    #    needs:
-    #      - lint
     runs-on: ubuntu-20.04
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/workflows/setupgo118amd64
       - name: Install dependencies
-        run: sudo apt-get update -y && sudo apt-get install -y gcc git-core gnupg
+        run: sudo apt-get update -y && sudo apt-get install -y gcc git-core gnupg build-essential
       - name: Remove installed mongodb
         run: sudo apt purge mongodb-org && sudo apt autoremove
       - run: sudo snap install juju-db --channel 4.4/stable
-      - name: Install vault
-        run: sudo snap install vault --classic
-      - uses: ./.github/workflows/setupgo118amd64
+      - name: Pull candid repo for test environment
+        run: |
+          git clone https://github.com/canonical/candid.git ./tmp/candid
+          cd ./tmp/candid
+          DOCKER_BUILDKIT=1 \
+          docker build \
+          --cache-from candid:latest \
+          . -f ./Dockerfile -t candid
+          docker image ls candid
+      - name: Add volume files
+        run: |
+          touch ./local/vault/approle.json
+          touch ./local/vault/roleid.txt
+      - name: Start test environment
+        run: docker compose up -d
       - name: Build and Test
         run: go test -mod readonly ./...
         env:
-          JIMM_DSN: postgresql://postgres:password@localhost:5432/jimm
+          JIMM_DSN: postgresql://jimm:jimm@localhost:5432/jimm
           PGHOST: localhost
-          PGPASSWORD: password
+          PGPASSWORD: jimm
           PGSSLMODE: disable
-          PGUSER: postgres
+          PGUSER: jimm
           PGPORT: 5432

--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -1,9 +1,6 @@
 name: BuildOCIImage
 on:
   workflow_dispatch:
-env:
-  GH_USER: ${{ secrets.GH_USER }}
-  GH_AUTH: ${{ secrets.GH_AUTH }}
 
 jobs:
   candid-oci-image:
@@ -12,9 +9,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: git fetch --prune --unshallow
       - uses: ./.github/workflows/setupgo118amd64
-        with:
-          user: ${{ secrets.GH_USER }}
-          pat: ${{ secrets.GH_AUTH }}
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Setup version and commit
@@ -29,12 +23,8 @@ jobs:
           target: deploy-env
           tags: candid:latest
           build-args: |
-            AUTH_TYPE=pat
             GIT_COMMIT=${{ env.GIT_COMMIT }}
             VERSION=${{ env.VERSION }}
-          secrets: |
-            "ghuser=${{ env.GH_USER }}"
-            "ghpat=${{ env.GH_AUTH }}"
           outputs: |
             type=docker,dest=candid-image.tar
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,5 +1,6 @@
 name: BuildSnap
 on:
+  workflow_call:
   workflow_dispatch:
 env:
   GH_AUTH: ${{ secrets.GH_AUTH }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,12 @@
 /version/commit.txt
 /version/version.txt
 /tmp
-/local/vault/approle.yaml
+/local/vault/approle.json
+local/vault/approle.json
+local/vault/roleid.txt
+
+*.crt
+*.key
+*.csr
+jimmctl
+qa-controller

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,12 @@ RUN bash < <(curl -SL -v https://raw.githubusercontent.com/moovweb/gvm/${GVM_VER
     gvm use go$(cat go.mod | sed -n "/^go/p" | cut -d ' ' -f 2)  --default
 
 
-FROM build as build-with-github-auth
-ARG AUTH_TYPE
+FROM build as build-env
 ARG GIT_COMMIT
 ARG VERSION
 WORKDIR /usr/src/jimm
 SHELL ["/bin/bash", "-c"]
 COPY . .
-RUN --mount=type=secret,id=ghuser \
-    --mount=type=secret,id=ghpat \ 
-    --mount=type=ssh \ 
-    if [ "$AUTH_TYPE" = "pat" ]; then \
-    echo "machine github.com login $(cat /run/secrets/ghuser) password $(cat /run/secrets/ghpat)" > $HOME/.netrc && \
-    echo "PAT auth selected"; \
-    elif [ "$AUTH_TYPE" = "ssh" ]; then \
-    git config --global user.name $(cat /run/secrets/ghuser) && \
-    mkdir -p -m 0600 ~/.ssh && \
-    echo $(ssh-keyscan github.com) >> ~/.ssh/known_hosts && \
-    git config --global --add url."git@github.com:".insteadOf "https://github.com/" && \
-    echo "SSH auth selected"; \
-    fi
 RUN echo "${GIT_COMMIT}" | tee ./version/commit.txt
 RUN echo "${VERSION}" | tee ./version/version.txt
 RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go mod vendor
@@ -40,8 +26,8 @@ RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go build -o jimmsrv -race 
 FROM ${DOCKER_REGISTRY}ubuntu:20.04 AS deploy-env
 RUN apt-get -qq update && apt-get -qq install -y ca-certificates postgresql-client
 WORKDIR /root/
-COPY --from=build-with-github-auth /usr/src/jimm/jimmsrv .
-COPY --from=build-with-github-auth /usr/src/jimm/internal/dbmodel/sql ./sql/
+COPY --from=build-env /usr/src/jimm/jimmsrv .
+COPY --from=build-env /usr/src/jimm/internal/dbmodel/sql ./sql/
 ENTRYPOINT [ "./jimmsrv" ]
 CMD ["./config.yaml"]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,38 +1,62 @@
 version: "3.9"
 
 services:
+  traefik:
+    image: "traefik:2.9"
+    container_name: traefik
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8089:8080"
+    volumes:
+      - ./local/traefik/traefik.yaml:/etc/traefik/traefik.yaml
+      - ./local/traefik/certs:/certs/
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: 
+        - CMD
+        - traefik
+        - healthcheck
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    
   jimm:
     image: cosmtrek/air
+    profiles: ["dev"]
+    # extra_hosts:
+    # - "host.docker.internal:host-gateway"
     # working_dir value has to be the same of mapped volume
+    hostname: jimm.localhost
     working_dir: /jimm
     container_name: jimmy
     ports:
-      - 17070:8080
+      - 17070:80
     environment:
-      JIMM_UUID: "diglett-123-diglett-456-diglett"
+      JIMM_UUID: "3217dbc9-8ea9-4381-9e97-01eab0b3f6bb"
       JIMM_DSN: "postgresql://jimm:jimm@db/jimm"
       CANDID_URL: "http://0.0.0.0:8081" # For external client redirects (in the case of compose and running outside)
       # Hardcoded pre-generated key, see ./local/candid/config.yaml
       CANDID_PUBLIC_KEY: "CIdWcEUN+0OZnKW9KwruRQnQDY/qqzVdD30CijwiWCk="
       # Not needed for local test (yet).
       # BAKERY_AGENT_FILE: ""
-      JIMM_ADMINS: "jimm"
+      JIMM_ADMINS: "jimm@candid.localhost"
       VAULT_ADDR: "http://vault:8200"
       VAULT_PATH: "/jimm-kv/"
-      VAULT_SECRET_FILE: "/vault/approle.yaml"
+      VAULT_SECRET_FILE: "/vault/approle.json"
       VAULT_AUTH_PATH: "/auth/approle/login"
-      # Where we gonna grab this?...
       # JIMM_DASHBOARD_LOCATION: ""
-      JIMM_DNS_NAME: "127.0.0.1:17070"
+      JIMM_DNS_NAME: "jimm.localhost"
       JIMM_WATCH_CONTROLLERS: ""
-      JIMM_LISTEN_ADDR: "0.0.0.0:8080"
+      JIMM_LISTEN_ADDR: "0.0.0.0:80"
       JIMM_TEST_PGXDSN: ""
       TEST_LOGGING_CONFIG: ""
     volumes:
       - ./:/jimm/
-      - ./local/vault/approle.yaml:/vault/approle.yaml:rw
+      - ./local/vault/approle.json:/vault/approle.json:rw
+      - ./local/vault/roleid.txt:/vault/roleid.txt:rw
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8080" ]
+      test: [ "CMD", "curl", "http://jimm.localhost:80" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -81,7 +105,8 @@ services:
       - ./local/vault/vault.hcl:/vault/config/vault.hcl
       - ./local/vault/init.sh:/vault/init.sh
       - ./local/vault/policy.hcl:/vault/policy.hcl
-      - ./local/vault/approle.yaml:/vault/approle.yaml
+      - ./local/vault/approle.json:/vault/approle.json
+      - ./local/vault/roleid.txt:/vault/roleid.txt:rw
     command: /vault/init.sh
     depends_on:
       db:
@@ -105,30 +130,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:8081/debug/status" ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  migrateopenfga:
-    image: openfga/openfga:latest
-    container_name: migrateopenfga
-    command: migrate --datastore-engine postgres --datastore-uri 'postgresql://jimm:jimm@db/jimm?sslmode=disable'
-    depends_on:
-      db:
-        condition: service_healthy
-
-  openfga:
-    image: openfga/openfga:latest
-    container_name: openfga
-    command: run --datastore-engine postgres --datastore-uri 'postgresql://jimm:jimm@db/jimm?sslmode=disable'
-    ports:
-      - 8080:8080
-      - 3000:3000
-    depends_on:
-      migrateopenfga:
-        condition: service_completed_successfully
-    healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8080/healthz" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/local/traefik/certs/certs.sh
+++ b/local/traefik/certs/certs.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# A simple script to setup TLS for JIMM when running locally with compose.
+# Please make sure you run this in the ./certs directory.
+
+rm -f ca.crt ca.key server.key server.crt
+
+# Gen CA
+openssl \
+    req \
+    -x509 \
+    -nodes \
+    -days 36500 \
+    -newkey rsa:4096 \
+    -keyout ca.key \
+    -out ca.crt \
+    -subj '/CN=localhost/C=UK/ST=Diglett/L=Diglett/O=Canonical'
+chmod 400 ./ca.key
+
+# Server CSR & Server key
+openssl \
+    req \
+    -nodes \
+    -new \
+    -newkey rsa:4096 \
+    -keyout server.key \
+    -out server.csr \
+    -subj '/CN=jalidy/C=UK/ST=Diglett/L=Diglett/O=JALIDY'
+
+# Server cert
+openssl \
+    x509 \
+    -req \
+    -in server.csr \
+    -days 36500 \
+    -CA ca.crt \
+    -CAkey ca.key \
+    -CAcreateserial \
+    -out server.crt \
+    -extensions v3_req \
+    -extfile ./san.conf
+    
+rm server.csr
+
+sudo cp ca.crt /usr/local/share/ca-certificates
+sudo update-ca-certificates

--- a/local/traefik/certs/san.conf
+++ b/local/traefik/certs/san.conf
@@ -1,0 +1,6 @@
+
+[v3_req]
+subjectKeyIdentifier = hash
+basicConstraints     = critical,CA:false
+subjectAltName       = DNS:jimm.localhost,IP:127.0.0.1
+keyUsage             = critical,digitalSignature,keyEncipherment

--- a/local/traefik/traefik.yaml
+++ b/local/traefik/traefik.yaml
@@ -1,0 +1,57 @@
+## STATIC CONFIG
+
+# shows you a log msg if a newer image tag can be used
+global:
+  checkNewVersion: true
+
+# log default is ERROR, but WARN is more helpful
+log:
+  level: WARN
+  # level: INFO
+
+# enable dashboard on 8080 with NO AUTH
+api:
+  insecure: true
+  dashboard: true
+
+# enable ping so the `traefik healthcheck` works
+ping: {}
+
+# auto-proxy containers if they have proper labels
+# and also use this file for dynamic config (tls)
+providers:
+  docker:
+    exposedByDefault: false
+    watch: true
+  file:
+    filename: /etc/traefik/traefik.yaml
+    watch: true
+
+# listen on 80/443, and redirect all 80 to 443 via 301
+entryPoints:
+  web:
+    address: :80
+    # comment out these lins if you don't want to redirect everything
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: :443
+
+
+## DYNAMIC CONFIG
+tls:
+  certificates:
+    - certFile: /certs/server.crt
+      keyFile: /certs/server.key
+
+# when troubleshooting certs, enable this so traefik doesn't use 
+# its own self-signed. By default if it can't find a matching
+# cert, it'll just create its own which will cause cert warnings
+# in browser and can be confusing to troubleshoot
+  # options:
+    # default:
+      # sniStrict: true

--- a/local/vault/init.sh
+++ b/local/vault/init.sh
@@ -47,6 +47,8 @@ echo "Enabling KV at policy path /jimm-kv"
 echo "/jimm-kv accessible by policy jimm-app"
 vault secrets enable -path /jimm-kv kv
 echo "Creating approle auth file."
-VAULT_TOKEN=$JIMM_SECRET_WRAPPED vault unwrap > /vault/approle.yaml
+VAULT_TOKEN=$JIMM_SECRET_WRAPPED vault unwrap > /vault/approle_tmp.yaml
+echo "$JIMM_ROLE_ID" > /vault/roleid.txt
 
+jq ".data.role_id = \"$JIMM_ROLE_ID\"" /vault/approle_tmp.yaml > /vault/approle.json
 wait

--- a/local/vault/policy.hcl
+++ b/local/vault/policy.hcl
@@ -1,3 +1,7 @@
-path "/jimm-kv" {
-capabilities = ["create", "read", "update", "delete", "list"]
+path "jimm-kv/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "secret/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
 }

--- a/local/vault/vault.hcl
+++ b/local/vault/vault.hcl
@@ -6,9 +6,3 @@ storage "postgresql" {
 # Reachable here: http://localhost:8200/ui/
 ui = true
 
-# We handle this via server flags, see init.sh.
-// api_addr = "0.0.0.0:8200"
-// listener "tcp" {
-//     address     = "0.0.0.0:8200"
-//     tls_disable = true
-// }


### PR DESCRIPTION
## Description

This is an alternative to #961, here only the Github workflows have been backported from `feature-rebac` along with any changes needed to get the CI/CD working (which unfortunately were fairly numerous).

For a rundown of what's changed and why,
- Added/updated Github workflow files.
- Dockerfile update to remove the need to supply git credentials (used as part of the docker compose)
- Docker compose updated with Traefik and Vault tweaks.
- /local/vault setup files added to work with the compose changes
- /local/traefik setup files added to work with the compose changes
- Makefile tweaks for added targets and for removing the need to specify building Candid with git credentials.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests