### PR TITLE
Workflow fix - 2

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -19,7 +19,7 @@ jobs:
       - run: sudo snap install snapcraft --channel=7.x/stable --classic
       - run: mkdir -p snap
       - run: cp ./snaps/jimm/snapcraft.yaml ./snap/snapcraft.yaml
-      - run: snapcraft --destructive-mode --output jimm.snap
+      - run: snapcraft snap --destructive-mode --output jimm.snap
       - uses: actions/upload-artifact@v3
         with:
           name: jimm-snap


### PR DESCRIPTION
## Description

Another fix for the Snap build. Running `snapcraft` is the same as `snapcraft snap` but without specifying the `snap` bit the `--output` parameter is not recognised.