### PR TITLE
workflow improvements

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -38,6 +38,7 @@ jobs:
           channel: "2/edge"
           charm-path: "./charms/jimm-k8s"
           local-image: "true"
+          tag-prefix: "v2-k8s"
 
   release-machine-charm:
     name: Release machine charm
@@ -66,3 +67,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "2/edge"
           charm-path: "./charms/jimm"
+          tag-prefix: "v2-k8s"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,11 @@
 name: CI
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'  # Skip this workflow if the only change was inside the .github folder
   workflow_call:
   workflow_dispatch:
+
 
 jobs:
   # lint:

--- a/.github/workflows/ci_skip.yaml
+++ b/.github/workflows/ci_skip.yaml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  pull_request:
+    paths:
+      - '.github/**'  # Run this workflow when the only files changed were any in .github
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Description

The Github action to release a charm has a nice feature to create a tag of the form `revX` whenever it pushes your charm but when you're building multiple charms, this tag can break your CI. This PR makes use of the `tag-prefix` parameter to address this.

Also, to make life easier when making workflow related changes I've limited the CI job to only run when a file has changed outside the .github folder. But we do require in the repo settings that a status check is received so according to [these docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks) I've added a similar check that will simply skip and allow the PR to receive a status check. This can be extended if there are certain folders we want to ignore on CI.