### PR TITLE
Added build tag to include version info in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN echo "${GIT_COMMIT}" | tee ./version/commit.txt
 RUN echo "${VERSION}" | tee ./version/version.txt
 RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go mod vendor
-RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go build -o jimmsrv -race -v -a -mod vendor ./cmd/jimmsrv
+RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go build -tags version -o jimmsrv -v -a -mod vendor ./cmd/jimmsrv
 
 # Define a smaller single process image for deployment
 FROM ${DOCKER_REGISTRY}ubuntu:20.04 AS deploy-env

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/CanonicalLtd/jimm"
+	"github.com/CanonicalLtd/jimm/version"
 )
 
 func main() {
@@ -32,6 +33,10 @@ func main() {
 
 // start initialises the jimmsrv service.
 func start(ctx context.Context, s *service.Service) error {
+	zapctx.Info(ctx, "jimm info",
+		zap.String("version", version.VersionInfo.Version),
+		zap.String("commit", version.VersionInfo.GitCommit),
+	)
 	if logLevel := os.Getenv("JIMM_LOG_LEVEL"); logLevel != "" {
 		if err := zapctx.LogLevel.UnmarshalText([]byte(logLevel)); err != nil {
 			zapctx.Error(ctx, "cannot set log level", zap.Error(err))


### PR DESCRIPTION
## Description

Fix the build of the JIMM binary in the Dockerfile to include version info. Also added a log when the service starts to output the version and commit hash. Removed the `-race` flag since this this binary is part of the production build.

These changes will land in `feature-rebac` in a separate pr when `main` is merged into `feature-rebac`.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests