### PR TITLE
Checkout without shallow to grab tags

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Build local images
         run: make jimm-image
       - name: Upload charm to charmhub
@@ -51,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@master
         with:
           name: jimm-snap


### PR DESCRIPTION
## Description

When building release images, the [logs](https://github.com/canonical/jimm/actions/runs/5611189381) reported `fatal: No annotated tags can describe '737faa2ac819166b49087425b6ea96b1e6b45ac9'.` this is due to the fact that the [checkout action](https://github.com/actions/checkout/tree/v3/) by default, does a shallow clone and does not pull tags. This fixes that.