### PR TITLE
Less defers in charm

### DIFF
--- a/charms/jimm-k8s/src/charm.py
+++ b/charms/jimm-k8s/src/charm.py
@@ -74,8 +74,9 @@ LOG_FILE = "/var/log/jimm"
 PROMETHEUS_PORT = 8080
 
 
-class DeferRequiredError(Exception):
-    """Used to indicate to the calling function that an event should be deferred."""
+class DeferError(Exception):
+    """Used to indicate to the calling function that an event could be deferred
+    if the hook needs to be retried."""
 
     pass
 
@@ -322,7 +323,7 @@ class JimmOperatorCharm(CharmBase):
             else:
                 logger.info("workload not ready - returning")
                 return
-        except DeferRequiredError:
+        except DeferError:
             logger.info("workload container not ready - deferring")
             event.defer()
             return
@@ -351,7 +352,7 @@ class JimmOperatorCharm(CharmBase):
             logger.info("failed to stop the jimm service: {}".format(e))
         try:
             self._ready()
-        except DeferRequiredError:
+        except DeferError:
             logger.info("workload not ready")
             return
 
@@ -363,7 +364,7 @@ class JimmOperatorCharm(CharmBase):
             return
         try:
             self._ready()
-        except DeferRequiredError:
+        except DeferError:
             logger.info("workload not ready")
             return
 
@@ -434,7 +435,7 @@ class JimmOperatorCharm(CharmBase):
                 self.unit.status = WaitingStatus("stopped")
             return True
         else:
-            raise DeferRequiredError
+            raise DeferError
 
     def _get_network_address(self, event):
         return str(self.model.get_binding(event.relation).network.egress_subnets[0].network_address)


### PR DESCRIPTION
## Description

Most hooks in jimm's k8s charm end up calling the `_update_workload` function and usually end up deferred because if jimm doesn't have all it's config/relations it will report that the service is not ready and defer the event, but these hooks have already done their primary task of setting up some config or value in state so they should complete gracefully and eventually the service will start when the necessary config/relations have been provided.

We also do a check in the `update_status` hook that runs periodically to modify the unit's state to reflect whether the service is running or not, but if the unit is in an error state this ends up overriding the error and the user can no longer `juju resolve jimm/0` to retry the failed hook. So we skip running the check if the unit is in the error state.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests