### PR TITLE
Revert "backports changes back to feature-rebac (#1003)"

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -166,8 +166,10 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 	return nil
 }
 
-func (d *Database) FetchModelsByUUID(ctx context.Context, modelUUIDs []string) ([]dbmodel.Model, error) {
-	const op = errors.Op("db.ForEachModel")
+// GetModelsByUUID retrieves a list of models where the model UUIDs are in
+// the provided modelUUIDs slice.
+func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) ([]dbmodel.Model, error) {
+	const op = errors.Op("db.GetModelsByUUID")
 
 	if err := d.ready(); err != nil {
 		return nil, errors.E(op, err)

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -720,7 +720,7 @@ func (s *dbSuite) TestForEachModel(c *qt.C) {
 	})
 }
 
-const testFetchModelsByUUIDEnv = `clouds:
+const testGetModelsByUUIDEnv = `clouds:
 - name: test
   type: test
   regions:
@@ -770,21 +770,21 @@ models:
     access: admin
 `
 
-func TestFetchModelsByUUIDlUnconfiguredDatabase(t *testing.T) {
+func TestGetModelsByUUIDlUnconfiguredDatabase(t *testing.T) {
 	c := qt.New(t)
 
 	var d db.Database
-	_, err := d.FetchModelsByUUID(context.Background(), nil)
+	_, err := d.GetModelsByUUID(context.Background(), nil)
 	c.Check(err, qt.ErrorMatches, `database not configured`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
 }
 
-func (s *dbSuite) TestFetchModelsByUUID(c *qt.C) {
+func (s *dbSuite) TestGetModelsByUUID(c *qt.C) {
 	ctx := context.Background()
 	err := s.Database.Migrate(context.Background(), true)
 	c.Assert(err, qt.Equals, nil)
 
-	env := jimmtest.ParseEnvironment(c, testFetchModelsByUUIDEnv)
+	env := jimmtest.ParseEnvironment(c, testGetModelsByUUIDEnv)
 	env.PopulateDB(c, *s.Database, nil)
 
 	modelUUIDs := []string{
@@ -792,7 +792,7 @@ func (s *dbSuite) TestFetchModelsByUUID(c *qt.C) {
 		"00000002-0000-0000-0000-000000000002",
 		"00000002-0000-0000-0000-000000000003",
 	}
-	models, err := s.Database.FetchModelsByUUID(ctx, modelUUIDs)
+	models, err := s.Database.GetModelsByUUID(ctx, modelUUIDs)
 	c.Assert(err, qt.IsNil)
 	sort.Slice(models, func(i, j int) bool {
 		return models[i].UUID.String < models[j].UUID.String

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -505,7 +505,7 @@ func (r *controllerRoot) CrossModelQuery(ctx context.Context, req apiparams.Cros
 	for i, uuid := range modelUUIDs {
 		modelUUIDs[i] = strings.Split(uuid, ":")[1]
 	}
-	models, err := r.jimm.Database.FetchModelsByUUID(ctx, modelUUIDs)
+	models, err := r.jimm.Database.GetModelsByUUID(ctx, modelUUIDs)
 	if err != nil {
 		return apiparams.CrossModelQueryResponse{}, errors.E(op, errors.Code("failed to get models for user"))
 	}


### PR DESCRIPTION
## Description

Reverts #1003 the backport introduced a regression where we query Postgres for user access to models instead of OpenFGA. I think the best way forward is simply to revert the commit, which is all this PR does.

Fixes [CSS-5254](https://warthogs.atlassian.net/browse/CSS-5254)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[CSS-5254]: https://warthogs.atlassian.net/browse/CSS-5254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ