### PR TITLE
checkout v4 and get tags

### DIFF
--- a/.github/workflows/charm-build.yaml
+++ b/.github/workflows/charm-build.yaml
@@ -10,7 +10,10 @@ jobs:
       matrix:
         charm-type: ["jimm","jimm-k8s"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - run: git fetch --prune --unshallow
       - run: sudo snap install charmcraft --channel=2.x/stable --classic
       - run: sudo charmcraft pack --project-dir ./charms/${{ matrix.charm-type }} --destructive-mode --verbosity=trace

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -27,9 +27,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true 
       - name: Build local images
         run: make jimm-image
       - name: Upload charm to charmhub
@@ -52,9 +53,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/download-artifact@master
         with:
           name: jimm-snap

--- a/.github/workflows/charm-test.yaml
+++ b/.github/workflows/charm-test.yaml
@@ -21,7 +21,10 @@ jobs:
         working-directory: ./charms/${{ matrix.charm-type }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
@@ -37,7 +40,10 @@ jobs:
         working-directory: ./charms/${{ matrix.charm-type }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests

--- a/.github/workflows/charm.yaml
+++ b/.github/workflows/charm.yaml
@@ -18,7 +18,10 @@ jobs:
   build-charm:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - run: git fetch --prune --unshallow
       - run: sudo snap install charmcraft --channel=2.x/stable --classic
       - run: charmcraft pack --project-dir ./charms/${{ inputs.charm }} --destructive-mode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,10 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -6,7 +6,10 @@ jobs:
   candid-oci-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - run: git fetch --prune --unshallow
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -17,9 +17,10 @@ jobs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        fetch-tags: true
     - name: scripts
       run: |
         mkdir -p ./snap

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -10,7 +10,10 @@ jobs:
   build-snap:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+          fetch-tags: true
       - run: git fetch --prune --unshallow
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## Description
Multiple issues reported issues with fetching tags and latest versions in older actions/checkout version. 
see https://github.com/actions/checkout/pull/579 and https://github.com/actions/checkout/issues/448

Hopefully by migrating to the new checkout v4 and forcing fetch-depth to 0 and asking for fetch-tags can solve the issue. In some cases, I add a separate command to git fetch --tags explicitly which should come at no cost given that tags should already be fetched in the previous steps.

Fixes [CSS-5482](https://warthogs.atlassian.net/browse/CSS-5482)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
we test it and see if it works or not, if not, we add git fetch --tags as a separate step and that should work 

[CSS-5482]: https://warthogs.atlassian.net/browse/CSS-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ