### PR TITLE
Remove extra snap permission from jimmctl snap

### DIFF
--- a/snaps/jimmctl/snapcraft.yaml
+++ b/snaps/jimmctl/snapcraft.yaml
@@ -20,7 +20,6 @@ plugs:
     interface: personal-files
     read:
     - $HOME/.local/share/juju
-    - $HOME/.local/share/juju/cookies
 
 apps:
   jimmctl:


### PR DESCRIPTION
## Description

The jimmctl snap was still failing Snapstore review even though auto-connection of the interface was granted.
From https://forum.snapcraft.io/t/request-for-jimmctl-personal-files-autoconnect/36821/7
>The problem is that your interface is also specifying read access to .local/share/juju/cookies, which isn’t explicitly in the declaration I granted. Fortunately, it’s unnecessary though.
We granted .local/share/juju, which will extends to include the cookies sub-directory anyway, so you can just remove the following line from your snapcraft.yaml and it should pass review and still function correctly.
    - $HOME/.local/share/juju/cookies

This line was added in https://github.com/canonical/jimm/pull/1044 which aimed to address an issue with the jimmctl where it was failing to create a lockfile for something inside $HOME/.local/share/juju/cookies during calls to `jimmctl list-controllers` and potentially other commands. That likely needs revisiting.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests