### PR TITLE
Refactored test setup in env.go

### DIFF
--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -244,7 +244,7 @@ controllers:
     region: test-region
     priority: 1
 `)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	cr, err := s.Database.FindRegion(ctx, "testp", "test-region")
 	c.Assert(err, qt.IsNil)
@@ -363,7 +363,7 @@ controllers:
     region: test-region-2
     priority: 1
 `)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	cl := dbmodel.Cloud{
 		Name: "test-cloud-1",

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -281,7 +281,7 @@ func (s *dbSuite) TestForEachCloudCredential(c *qt.C) {
 	env := jimmtest.ParseEnvironment(c, forEachCloudCredentialEnv)
 	err := s.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	for _, test := range forEachCloudCredentialTests {
 		c.Run(test.name, func(c *qt.C) {

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -241,7 +241,7 @@ func (s *dbSuite) TestForEachController(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachControllerEnv)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	testError := errors.E("test error")
 	err = s.Database.ForEachController(ctx, func(controller *dbmodel.Controller) error {
@@ -426,9 +426,9 @@ func (s *dbSuite) TestForEachControllerModel(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachControllerModelEnv)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
-	ctl := env.Controller("test").DBObject(c, *s.Database, nil)
+	ctl := env.Controller("test").DBObject(c, *s.Database)
 	testError := errors.E("test error")
 	err = s.Database.ForEachControllerModel(ctx, &ctl, func(_ *dbmodel.Model) error {
 		return testError

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -537,7 +537,7 @@ func (s *dbSuite) TestForEachModel(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachModelEnv)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	testError := errors.E("test error")
 	err = s.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
@@ -623,7 +623,7 @@ func (s *dbSuite) TestGetModelsByUUID(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testGetModelsByUUIDEnv)
-	env.PopulateDB(c, *s.Database, nil)
+	env.PopulateDB(c, *s.Database)
 
 	modelUUIDs := []string{
 		"00000002-0000-0000-0000-000000000001",

--- a/internal/jimm/applicationoffer_test.go
+++ b/internal/jimm/applicationoffer_test.go
@@ -2685,7 +2685,6 @@ func TestListApplicationOffers(t *testing.T) {
 	err = db.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 	env := jimmtest.ParseEnvironment(c, listApplicationsTestEnv)
-	env.PopulateDB(c, db, client)
 
 	j := &jimm.JIMM{
 		UUID:          uuid.NewString(),
@@ -2840,7 +2839,7 @@ func TestListApplicationOffers(t *testing.T) {
 			},
 		},
 	}
-
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), db, client)
 	tuples := []openfga.Tuple{{
 		Object:   ofganames.ConvertTag(names.NewUserTag("alice@external")),
 		Relation: ofganames.AdministratorRelation,
@@ -2881,7 +2880,7 @@ func TestListApplicationOffers(t *testing.T) {
 	err = client.AddRelation(context.Background(), tuples...)
 	c.Assert(err, qt.IsNil)
 
-	u := env.User("alice@external").DBObject(c, db, client)
+	u := env.User("alice@external").DBObject(c, db)
 	_, err = j.ListApplicationOffers(ctx, openfga.NewUser(&u, client))
 	c.Assert(err, qt.ErrorMatches, `at least one filter must be specified`)
 

--- a/internal/jimm/cloud_test.go
+++ b/internal/jimm/cloud_test.go
@@ -613,10 +613,9 @@ func TestAddHostedCloud(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, addHostedCloudTestEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.AddHostedCloud(ctx, user, names.NewCloudTag(test.cloudName), test.cloud, false)
@@ -894,10 +893,9 @@ func TestAddCloudToController(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, addHostedCloudTestEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			// Note that the force flag has no effect here because the Juju responses are mocked.
@@ -1054,9 +1052,9 @@ func TestGrantCloudAccess(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(tt.username).DBObject(c, j.Database, client)
+			dbUser := env.User(tt.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.GrantCloudAccess(ctx, user, names.NewCloudTag(tt.cloud), names.NewUserTag(tt.targetUsername), tt.access)
@@ -1354,7 +1352,7 @@ func TestRevokeCloudAccess(t *testing.T) {
 
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 			if tt.extraInitialTuples != nil && len(tt.extraInitialTuples) > 0 {
 				err = client.AddRelation(ctx, tt.extraInitialTuples...)
@@ -1369,7 +1367,7 @@ func TestRevokeCloudAccess(t *testing.T) {
 				}
 			}
 
-			dbUser := env.User(tt.username).DBObject(c, j.Database, client)
+			dbUser := env.User(tt.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.RevokeCloudAccess(ctx, user, names.NewCloudTag(tt.cloud), names.NewUserTag(tt.targetUsername), tt.access)
@@ -1507,9 +1505,9 @@ func TestRemoveCloud(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.RemoveCloud(ctx, user, names.NewCloudTag(test.cloud))
@@ -1747,9 +1745,9 @@ func TestUpdateCloud(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			tag := names.NewCloudTag(test.cloud)
@@ -1941,9 +1939,9 @@ func TestRemoveFromControllerCloud(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.RemoveCloudFromController(ctx, user, test.controllerName, names.NewCloudTag(test.cloud))

--- a/internal/jimm/cloudcredential_test.go
+++ b/internal/jimm/cloudcredential_test.go
@@ -834,9 +834,8 @@ users:
 
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
-	u := env.User("alice@external").DBObject(c, j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
+	u := env.User("alice@external").DBObject(c, j.Database)
 	user := openfga.NewUser(&u, client)
 	_, err = j.UpdateCloudCredential(ctx, user, jimm.UpdateCloudCredentialArgs{
 		CredentialTag: names.NewCloudCredentialTag("test-cloud/bob@external/test"),
@@ -1481,8 +1480,8 @@ func TestForEachUserCloudCredential(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
-			u := env.User(test.username).DBObject(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
+			u := env.User(test.username).DBObject(c, j.Database)
 
 			var credentials []string
 			if test.f == nil {
@@ -1601,14 +1600,13 @@ func TestGetCloudCredentialAttributes(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
-			u := env.User("bob@external").DBObject(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
+			u := env.User("bob@external").DBObject(c, j.Database)
 			userBob := openfga.NewUser(&u, client)
 			cred, err := j.GetCloudCredential(ctx, userBob, names.NewCloudCredentialTag("test-cloud/bob@external/cred-1"))
 			c.Assert(err, qt.IsNil)
 
-			u = env.User(test.username).DBObject(c, j.Database, client)
+			u = env.User(test.username).DBObject(c, j.Database)
 			userTest := openfga.NewUser(&u, client)
 			attr, redacted, err := j.GetCloudCredentialAttributes(ctx, userTest, cred, test.hidden)
 			if test.expectError != "" {
@@ -1654,9 +1652,9 @@ func TestCloudCredentialAttributeStore(t *testing.T) {
   regions:
   - name: test-region
 `)
-	env.PopulateDB(c, j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-	u := env.User("alice@external").DBObject(c, j.Database, client)
+	u := env.User("alice@external").DBObject(c, j.Database)
 	user := openfga.NewUser(&u, client)
 	args := jimm.UpdateCloudCredentialArgs{
 		CredentialTag: names.NewCloudCredentialTag("test/alice@external/cred-1"),

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -413,7 +413,7 @@ func TestEarliestControllerVersion(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, testEarliestControllerVersionEnv)
-	env.PopulateDB(c, j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 	v, err := j.EarliestControllerVersion(ctx)
 	c.Assert(err, qt.Equals, nil)
@@ -913,10 +913,9 @@ func TestImportModel(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, testImportModelEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 			err = j.ImportModel(ctx, user, test.controllerName, names.NewModelTag(test.modelUUID), test.newOwner)
 			if test.expectedError == "" {
@@ -1014,10 +1013,9 @@ func TestSetControllerConfig(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, testControllerConfigEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 			err = j.SetControllerConfig(ctx, user, test.args)
 			if test.expectedError == "" {
@@ -1090,13 +1088,12 @@ func TestGetControllerConfig(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, testImportModelEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbSuperuser := env.User("alice@external").DBObject(c, j.Database, client)
+			dbSuperuser := env.User("alice@external").DBObject(c, j.Database)
 			superuser := openfga.NewUser(&dbSuperuser, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.SetControllerConfig(ctx, superuser, jujuparams.ControllerConfigSet{
@@ -1241,10 +1238,9 @@ func TestUpdateMigratedModel(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, testUpdateMigratedModelEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.UpdateMigratedModel(ctx, user, test.model, test.targetController)
@@ -1295,10 +1291,9 @@ func TestGetControllerAccess(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, testGetControllerAccessEnv)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-	dbUser := env.User("alice@external").DBObject(c, j.Database, client)
+	dbUser := env.User("alice@external").DBObject(c, j.Database)
 	alice := openfga.NewUser(&dbUser, client)
 
 	access, err := j.GetJimmControllerAccess(ctx, alice, names.NewUserTag("alice@external"))
@@ -1313,7 +1308,7 @@ func TestGetControllerAccess(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Check(access, qt.Equals, "login")
 
-	dbUser = env.User("bob@external").DBObject(c, j.Database, client)
+	dbUser = env.User("bob@external").DBObject(c, j.Database)
 	alice = openfga.NewUser(&dbUser, client)
 	access, err = j.GetJimmControllerAccess(ctx, alice, names.NewUserTag("bob@external"))
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/jimm_test.go
+++ b/internal/jimm/jimm_test.go
@@ -215,8 +215,7 @@ func TestListControllers(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, testListCoControllersEnv)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 	tests := []struct {
 		about               string
@@ -225,19 +224,19 @@ func TestListControllers(t *testing.T) {
 		expectedError       string
 	}{{
 		about: "superuser can list controllers",
-		user:  env.User("alice@external").DBObject(c, j.Database, client),
+		user:  env.User("alice@external").DBObject(c, j.Database),
 		expectedControllers: []dbmodel.Controller{
-			env.Controller("test1").DBObject(c, j.Database, client),
-			env.Controller("test2").DBObject(c, j.Database, client),
-			env.Controller("test3").DBObject(c, j.Database, client),
+			env.Controller("test1").DBObject(c, j.Database),
+			env.Controller("test2").DBObject(c, j.Database),
+			env.Controller("test3").DBObject(c, j.Database),
 		},
 	}, {
 		about:         "add-model user can not list controllers",
-		user:          env.User("bob@external").DBObject(c, j.Database, client),
+		user:          env.User("bob@external").DBObject(c, j.Database),
 		expectedError: "unauthorized",
 	}, {
 		about:         "user withouth access rights cannot list controllers",
-		user:          env.User("eve@external").DBObject(c, j.Database, client),
+		user:          env.User("eve@external").DBObject(c, j.Database),
 		expectedError: "unauthorized",
 	}}
 
@@ -300,8 +299,7 @@ func TestSetControllerDeprecated(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, testSetControllerDeprecatedEnv)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 	tests := []struct {
 		about         string
@@ -310,15 +308,15 @@ func TestSetControllerDeprecated(t *testing.T) {
 		expectedError string
 	}{{
 		about:      "superuser can deprecate a controller",
-		user:       env.User("alice@external").DBObject(c, j.Database, client),
+		user:       env.User("alice@external").DBObject(c, j.Database),
 		deprecated: true,
 	}, {
 		about:      "superuser can deprecate a controller",
-		user:       env.User("alice@external").DBObject(c, j.Database, client),
+		user:       env.User("alice@external").DBObject(c, j.Database),
 		deprecated: false,
 	}, {
 		about:         "user withouth access rights cannot deprecate a controller",
-		user:          env.User("eve@external").DBObject(c, j.Database, client),
+		user:          env.User("eve@external").DBObject(c, j.Database),
 		expectedError: "unauthorized",
 		deprecated:    true,
 	}}
@@ -444,15 +442,14 @@ func TestRemoveController(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, removeControllerTestEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			if test.unavailableSince != nil {
 				// make the controller unavailable
-				controller := env.Controller("controller-1").DBObject(c, j.Database, client)
+				controller := env.Controller("controller-1").DBObject(c, j.Database)
 				controller.UnavailableSince = sql.NullTime{
 					Valid: true,
 					Time:  *test.unavailableSince,
@@ -612,10 +609,9 @@ func TestFullModelStatus(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, fullModelStatusTestEnv)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.user).DBObject(c, j.Database, client)
+			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			status, err := j.FullModelStatus(ctx, user, names.NewModelTag(test.modelUUID), nil)

--- a/internal/jimm/model_status_parser_test.go
+++ b/internal/jimm/model_status_parser_test.go
@@ -433,7 +433,7 @@ func TestQueryModelsJq(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, crossModelQueryEnv)
-	env.PopulateDB(c, j.Database, nil)
+	env.PopulateDB(c, j.Database)
 
 	modelUUIDs := []string{
 		"10000000-0000-0000-0000-000000000000",

--- a/internal/jimm/model_test.go
+++ b/internal/jimm/model_test.go
@@ -824,10 +824,9 @@ func TestAddModel(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			args := jimm.ModelCreateArgs{}
@@ -1170,8 +1169,7 @@ func TestModelInfo(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 			dbUser := &dbmodel.User{
 				Username: test.username,
@@ -1312,10 +1310,9 @@ func TestModelStatus(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			ms, err := j.ModelStatus(context.Background(), user, names.NewModelTag(test.uuid))
@@ -1466,10 +1463,9 @@ func TestForEachUserModel(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, forEachModelTestEnv)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-	dbUser := env.User("bob@external").DBObject(c, j.Database, client)
+	dbUser := env.User("bob@external").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, client)
 
 	var res []jujuparams.ModelSummaryResult
@@ -1606,10 +1602,9 @@ func TestForEachModel(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	env := jimmtest.ParseEnvironment(c, forEachModelTestEnv)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-	dbUser := env.User("bob@external").DBObject(c, j.Database, client)
+	dbUser := env.User("bob@external").DBObject(c, j.Database)
 	bob := openfga.NewUser(&dbUser, client)
 
 	err = j.ForEachModel(ctx, bob, func(_ *dbmodel.Model, _ jujuparams.UserAccessPermission) error {
@@ -1618,7 +1613,7 @@ func TestForEachModel(t *testing.T) {
 	c.Check(err, qt.ErrorMatches, `unauthorized`)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeUnauthorized)
 
-	dbUser = env.User("alice@external").DBObject(c, j.Database, client)
+	dbUser = env.User("alice@external").DBObject(c, j.Database)
 	alice := openfga.NewUser(&dbUser, client)
 
 	var models []string
@@ -1877,9 +1872,9 @@ func TestGrantModelAccess(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(tt.username).DBObject(c, j.Database, client)
+			dbUser := env.User(tt.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.GrantModelAccess(ctx, user, names.NewModelTag(tt.uuid), names.NewUserTag(tt.targetUsername), jujuparams.UserAccessPermission(tt.access))
@@ -2596,7 +2591,7 @@ func TestRevokeModelAccess(t *testing.T) {
 			}
 			err = j.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
 			if tt.extraInitialTuples != nil && len(tt.extraInitialTuples) > 0 {
 				err = client.AddRelation(ctx, tt.extraInitialTuples...)
@@ -2611,7 +2606,7 @@ func TestRevokeModelAccess(t *testing.T) {
 				}
 			}
 
-			dbUser := env.User(tt.username).DBObject(c, j.Database, client)
+			dbUser := env.User(tt.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.RevokeModelAccess(ctx, user, names.NewModelTag(tt.uuid), names.NewUserTag(tt.targetUsername), jujuparams.UserAccessPermission(tt.access))
@@ -2784,10 +2779,9 @@ func TestDestroyModel(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.DestroyModel(ctx, user, names.NewModelTag(test.uuid), test.destroyStorage, test.force, test.maxWait, test.timeout)
@@ -2911,10 +2905,9 @@ func TestDumpModel(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			s, err := j.DumpModel(ctx, user, names.NewModelTag(test.uuid), test.simplified)
@@ -3025,10 +3018,9 @@ func TestDumpModelDB(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			dump, err := j.DumpModelDB(ctx, user, names.NewModelTag(test.uuid))
@@ -3145,10 +3137,9 @@ func TestValidateModelUpgrade(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.ValidateModelUpgrade(ctx, user, names.NewModelTag(test.uuid), test.force)
@@ -3367,10 +3358,9 @@ func TestUpdateModelCredential(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			env := jimmtest.ParseEnvironment(c, test.env)
-			env.PopulateDB(c, j.Database, client)
-			env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-			dbUser := env.User(test.username).DBObject(c, j.Database, client)
+			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, client)
 
 			err = j.ChangeModelCredential(
@@ -3484,10 +3474,9 @@ controllers:
     priority: 1
 `
 	env := jimmtest.ParseEnvironment(c, envDefinition)
-	env.PopulateDB(c, j.Database, client)
-	env.AddJIMMRelations(c, j.ResourceTag(), j.Database, client)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, client)
 
-	dbUser := env.User("alice@external").DBObject(c, j.Database, client)
+	dbUser := env.User("alice@external").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, client)
 
 	controller := dbmodel.Controller{

--- a/internal/jimm/watcher_test.go
+++ b/internal/jimm/watcher_test.go
@@ -576,7 +576,7 @@ func TestWatcher(t *testing.T) {
 			env := jimmtest.ParseEnvironment(c, testWatcherEnv)
 			err := w.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, w.Database, nil)
+			env.PopulateDB(c, w.Database)
 
 			if test.initDB != nil {
 				test.initDB(c, w.Database)
@@ -736,7 +736,7 @@ func TestModelSummaryWatcher(t *testing.T) {
 			env := jimmtest.ParseEnvironment(c, testWatcherEnv)
 			err := w.Database.Migrate(ctx, false)
 			c.Assert(err, qt.IsNil)
-			env.PopulateDB(c, w.Database, nil)
+			env.PopulateDB(c, w.Database)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -782,7 +782,7 @@ func TestWatcherSetsControllerUnavailable(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testWatcherEnv)
 	err := w.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, w.Database, nil)
+	env.PopulateDB(c, w.Database)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -846,7 +846,7 @@ func TestWatcherRemoveDyingModelsOnStartup(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testWatcherEnv)
 	err := w.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, w.Database, nil)
+	env.PopulateDB(c, w.Database)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -948,7 +948,7 @@ func TestWatcherIgnoreDeltasForModelsFromIncorrectController(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testWatcherIgnoreDeltasForModelsFromIncorrectControllerEnv)
 	err := w.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, w.Database, nil)
+	env.PopulateDB(c, w.Database)
 
 	m1 := dbmodel.Model{
 		UUID: sql.NullString{


### PR DESCRIPTION
## Description

Based on #1083 

I noticed in my previous PRs that the setup of test resources in env.go was inconsistent, this PR aims to address that.

- Changed env.go so that the PopulateDB function only populates the DB and added PopulateDBAndPermissions to populate the DB and OpenFGA permissions. This clarifies when a test needs only database objects versus when a test needs database objects and permissions.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests