### PR TITLE
Support running on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM ubuntu:20.04 as build-env
 ARG GIT_COMMIT
 ARG VERSION
 ARG GO_VERSION
+ARG ARCH
 WORKDIR /usr/src/jimm
 SHELL ["/bin/bash", "-c"]
 COPY . .
 RUN apt update && apt install wget gcc -y
-RUN wget -L "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-RUN tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
+RUN wget -L "https://golang.org/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz"
+RUN tar -C /usr/local -xzf "go${GO_VERSION}.linux-${ARCH}.tar.gz"
 ENV PATH="${PATH}:/usr/local/go/bin"
 RUN echo "${GIT_COMMIT}" | tee ./version/commit.txt
 RUN echo "${VERSION}" | tee ./version/version.txt

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PROJECT := github.com/canonical/jimm
 GIT_COMMIT := $(shell git rev-parse --verify HEAD)
 GIT_VERSION := $(shell git describe --abbrev=0 --dirty)
 GO_VERSION := $(shell go list -f {{.GoVersion}} -m)
+ARCH := $(shell dpkg --print-architecture)
 
 ifeq ($(shell uname -p | sed -r 's/.*(x86|armel|armhf).*/golang/'), golang)
 	GO_C := golang
@@ -86,6 +87,7 @@ jimm-image:
 	--build-arg="GIT_COMMIT=$(GIT_COMMIT)" \
 	--build-arg="VERSION=$(GIT_VERSION)" \
 	--build-arg="GO_VERSION=$(GO_VERSION)" \
+	--build-arg="ARCH=$(ARCH)" \
 	--tag jimm:latest .
 
 jimm-snap:

--- a/local/vault/init.sh
+++ b/local/vault/init.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Grab JQ for ease of use.
-wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64
+ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-$ARCH
 chmod +x ./jq
 cp jq /usr/bin
 


### PR DESCRIPTION
## Description

Support running inside a multipass on ARM.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

Note: [this PR](https://github.com/canonical/candid/pull/197) will need to land so that you can get past the `make pull/candid` step.
- Launch a multipass container on an ARM host.
- Check out this branch.
- Follow the [setup instructions](https://github.com/canonical/jimm/blob/feature-rebac/local/README.md#starting-the-environment).
- The `docker compose --profile dev up` step should complete successfully (you should be able to run `make get-local-auth` and get a response).

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->