### PR TITLE
Remove addition of ObjType type

### DIFF
--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -43,28 +43,6 @@ var (
 // NB: Add any new relations from the above to this slice.
 var allRelations = []cofga.Relation{MemberRelation, AdministratorRelation, ControllerRelation, ModelRelation, ConsumerRelation, ReaderRelation, WriterRelation, CanAddModelRelation, AuditLogViewerRelation, NoRelation}
 
-// Object Types
-var (
-	// ModelType represents a model object.
-	ModelType ObjType = "model"
-	// ApplicationOfferType represents an application offer object.
-	ApplicationOfferType ObjType = "applicationoffer"
-	// CloudType represents a cloud object.
-	CloudType ObjType = "cloud"
-	// ControllerType represents a controller object.
-	ControllerType ObjType = "controller"
-	// GroupType represents a group object.
-	GroupType ObjType = "group"
-	// UserType represents a user object.
-	UserType ObjType = "user"
-)
-
-type ObjType string
-
-func (o ObjType) String() string {
-	return string(o)
-}
-
 // Tag represents an entity tag as used by JIMM in OpenFGA.
 type Tag = cofga.Entity
 

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -34,6 +34,22 @@ type Kind = cofga.Kind
 // Relation holds the type of tag relation.
 type Relation = cofga.Relation
 
+// Object Kinds
+var (
+	// ModelType represents a model object.
+	ModelType Kind = "model"
+	// ApplicationOfferType represents an application offer object.
+	ApplicationOfferType Kind = "applicationoffer"
+	// CloudType represents a cloud object.
+	CloudType Kind = "cloud"
+	// ControllerType represents a controller object.
+	ControllerType Kind = "controller"
+	// GroupType represents a group object.
+	GroupType Kind = "group"
+	// UserType represents a user object.
+	UserType Kind = "user"
+)
+
 // OFGAClient contains convenient utility methods for interacting
 // with OpenFGA from OUR usecase. It wraps the provided pre-generated client
 // from OpenFGA.
@@ -80,15 +96,11 @@ func (o *OFGAClient) getRelatedObjects(ctx context.Context, tuple Tuple, pageSiz
 // must NOT include the ID, i.e.,
 //
 //   - "group:" vs "group:mygroup", where "mygroup" is the ID and the correct objType would be "group".
-func (o *OFGAClient) listObjects(ctx context.Context, user string, relation string, objType string, contextualTuples []Tuple) (objectIds []Tag, err error) {
-	userEntity, err := cofga.ParseEntity(user)
-	if err != nil {
-		return nil, err
-	}
+func (o *OFGAClient) listObjects(ctx context.Context, user *Tag, relation Relation, objType Kind, contextualTuples []Tuple) (objectIds []Tag, err error) {
 	entities, err := o.cofgaClient.FindAccessibleObjectsByRelation(ctx, Tuple{
-		Object:   &userEntity,
-		Relation: cofga.Relation(relation),
-		Target:   &Tag{Kind: cofga.Kind(objType)},
+		Object:   user,
+		Relation: relation,
+		Target:   &Tag{Kind: objType},
 	}, contextualTuples...)
 	if err != nil {
 		return nil, err
@@ -107,7 +119,7 @@ func (o *OFGAClient) RemoveRelation(ctx context.Context, tuples ...Tuple) error 
 }
 
 // ListObjects returns all object IDs of <objType> that a user has the relation <relation> to.
-func (o *OFGAClient) ListObjects(ctx context.Context, user string, relation string, objType string, contextualTuples []Tuple) ([]Tag, error) {
+func (o *OFGAClient) ListObjects(ctx context.Context, user *Tag, relation Relation, objType Kind, contextualTuples []Tuple) ([]Tag, error) {
 	return o.listObjects(ctx, user, relation, objType, contextualTuples)
 }
 

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -443,7 +443,7 @@ func (s *openFGATestSuite) TestListObjectsWithContextualTuples(c *gc.C) {
 		}
 	}
 
-	ids, err := s.ofgaClient.ListObjects(ctx, "user:alice", "reader", "model", []openfga.Tuple{
+	ids, err := s.ofgaClient.ListObjects(ctx, ofganames.ConvertTag(names.NewUserTag("alice")), "reader", "model", []openfga.Tuple{
 		{
 			Object:   ofganames.ConvertTag(names.NewUserTag("alice")),
 			Relation: ofganames.ReaderRelation,
@@ -532,7 +532,7 @@ func (s *openFGATestSuite) TestListObjectsWithPeristedTuples(c *gc.C) {
 		}...,
 	), gc.Equals, nil)
 
-	ids, err := s.ofgaClient.ListObjects(ctx, "user:alice", "reader", "model", nil)
+	ids, err := s.ofgaClient.ListObjects(ctx, ofganames.ConvertTag(names.NewUserTag("alice")), "reader", "model", nil)
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(cmp.Equal(
 		ids,

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -237,7 +237,7 @@ func (u *User) UnsetApplicationOfferAccess(ctx context.Context, resource names.A
 
 // ListModels returns a slice of model UUIDs that this user has the relation <relation> to.
 func (u *User) ListModels(ctx context.Context, relation ofga.Relation) ([]string, error) {
-	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()).String(), relation.String(), ofganames.ModelType.String(), nil)
+	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ModelType, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (u *User) ListModels(ctx context.Context, relation ofga.Relation) ([]string
 
 // ListApplicationOffers returns a slice of application offer UUIDs that a user has the relation <relation> to.
 func (u *User) ListApplicationOffers(ctx context.Context, relation ofga.Relation) ([]string, error) {
-	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()).String(), relation.String(), ofganames.ApplicationOfferType.String(), nil)
+	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ApplicationOfferType, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

A previous PR added a type for OpenFGA calls that was unnecessary. This PR refactors those changes.

- Remove addition of ObjType type in favour of using already existing Kind type

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests