### PR TITLE
ApplicatonOffer consume fix.

### DIFF
--- a/internal/dbmodel/applicationoffer.go
+++ b/internal/dbmodel/applicationoffer.go
@@ -69,7 +69,10 @@ func (o *ApplicationOffer) SetTag(t names.ApplicationOfferTag) {
 // UserAccess returns the access level for the specified user.
 func (o *ApplicationOffer) UserAccess(u *User) string {
 	for _, ou := range o.Users {
-		if u.Username == ou.Username {
+		// NOTE (alesstimec) remove this once juju decides that
+		// users are allowed to have upper case characters in
+		// usernames (see https://bugs.launchpad.net/juju/+bug/1959584)
+		if strings.ToLower(u.Username) == strings.ToLower(ou.Username) {
 			return ou.Access
 		}
 	}

--- a/internal/jimm/applicationoffer.go
+++ b/internal/jimm/applicationoffer.go
@@ -165,7 +165,6 @@ func (j *JIMM) GetApplicationOfferConsumeDetails(ctx context.Context, user *dbmo
 	if accessLevel == "" {
 		accessLevel = offer.UserAccess(&dbmodel.User{Username: auth.Everyone})
 	}
-
 	switch accessLevel {
 	case string(jujuparams.OfferAdminAccess):
 	case string(jujuparams.OfferConsumeAccess):


### PR DESCRIPTION
## Description

This fix accounts for the fact that juju lowercases all usernames, which is wrong, to say the least. Until they fix this issue, we will be lowercasing both usernames when comparing for application offer access.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->