### PR TITLE
New github workflow to check signed commits

### DIFF
--- a/.github/workflows/assert-signed-commits.yaml
+++ b/.github/workflows/assert-signed-commits.yaml
@@ -1,0 +1,15 @@
+name: Check signed commits in PR 
+on: 
+    pull_request_target:
+    pull_request:
+
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1


### PR DESCRIPTION
## Description

To meet Canonical repo policy and to prepare for JIMM going open-source soon, we need to start enforcing signed commits. it is a low effort step to set it up and get up and running with it. Without enforcing it on PRs, we will never start signing everything. 


start with this guide to generate a new gpg key (bonus if you use ElGamal algorithm for the key, because he is an Egyptian mathematician)
https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key

Then add it to your GitHub account:
https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account

and configure git to use it when committing 
https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key

Or if you like SSH more than GPG (acting like if I know the difference):

Follow the steps below to set up commit signing with ssh-agent:

[Generate an SSH key and add it to ssh-agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
[Add the SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
[Configure git to use your SSH key for commit signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

