### PR TITLE
Ensure all workflows use correct go version

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true 
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
       - name: Build local images
         run: make jimm-image
       - name: Upload charm to charmhub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,11 +62,9 @@ jobs:
     # So if the compose returns with exit code 0 then the JIMM server successfully started.
     steps:
       - uses: actions/checkout@v4
-      # Specify a specific version of Go until GH runners no longer comes with anything below 1.21
-      - name: Setup Go 1.21.x
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.x'
+          go-version-file: 'go.mod'
       - name: Pull candid repo for test environment
         run: |
           git clone https://github.com/canonical/candid.git ./tmp/candid


### PR DESCRIPTION
## Description

Follow up fix to our broken release workflow. The error [here](https://github.com/canonical/jimm/actions/runs/7128056186/job/19442244365#step:3:6) indicates the go version on the runner is older than that specified in go.mod. 
This PR ensures all workflows that use go run the `setup-go` action to ensure they are using Go version specified in go.mod.