### PR TITLE
CSS-6774 rework auth model

### DIFF
--- a/local/openfga/authorisation_model.fga
+++ b/local/openfga/authorisation_model.fga
@@ -3,15 +3,15 @@ model
 
 type applicationoffer
   relations
-    define administrator: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator from model
-    define consumer: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator
+    define administrator: [user, user:*, group#member] or administrator from model
+    define consumer: [user, user:*, group#member] or administrator
     define model: [model]
-    define reader: [serviceaccount, serviceaccount:*, user, user:*, group#member] or consumer
+    define reader: [user, user:*, group#member] or consumer
 
 type cloud
   relations
-    define administrator: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator from controller
-    define can_addmodel: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator
+    define administrator: [user, user:*, group#member] or administrator from controller
+    define can_addmodel: [user, user:*, group#member] or administrator
     define controller: [controller]
 
 type controller
@@ -26,13 +26,13 @@ type group
 
 type model
   relations
-    define administrator: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator from controller
+    define administrator: [user, user:*, group#member] or administrator from controller
     define controller: [controller]
-    define reader: [serviceaccount, serviceaccount:*, user, user:*, group#member] or writer
-    define writer: [serviceaccount, serviceaccount:*, user, user:*, group#member] or administrator
+    define reader: [user, user:*, group#member] or writer
+    define writer: [user, user:*, group#member] or administrator
 
 type user
 
 type serviceaccount
   relations
-    define administator: [serviceaccount, serviceaccount:*, user, user:*, group#member]
+    define administator: [user, user:*, group#member]

--- a/local/openfga/authorisation_model.json
+++ b/local/openfga/authorisation_model.json
@@ -7,13 +7,6 @@
                     "administrator": {
                         "directly_related_user_types": [
                             {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
-                            {
                                 "type": "user"
                             },
                             {
@@ -28,13 +21,6 @@
                     },
                     "consumer": {
                         "directly_related_user_types": [
-                            {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
                             {
                                 "type": "user"
                             },
@@ -57,13 +43,6 @@
                     },
                     "reader": {
                         "directly_related_user_types": [
-                            {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
                             {
                                 "type": "user"
                             },
@@ -139,13 +118,6 @@
                     "administrator": {
                         "directly_related_user_types": [
                             {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
-                            {
                                 "type": "user"
                             },
                             {
@@ -160,13 +132,6 @@
                     },
                     "can_addmodel": {
                         "directly_related_user_types": [
-                            {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
                             {
                                 "type": "user"
                             },
@@ -344,13 +309,6 @@
                     "administrator": {
                         "directly_related_user_types": [
                             {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
-                            {
                                 "type": "user"
                             },
                             {
@@ -373,13 +331,6 @@
                     "reader": {
                         "directly_related_user_types": [
                             {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
-                            {
                                 "type": "user"
                             },
                             {
@@ -394,13 +345,6 @@
                     },
                     "writer": {
                         "directly_related_user_types": [
-                            {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
                             {
                                 "type": "user"
                             },
@@ -478,13 +422,6 @@
                 "relations": {
                     "administator": {
                         "directly_related_user_types": [
-                            {
-                                "type": "serviceaccount"
-                            },
-                            {
-                                "type": "serviceaccount",
-                                "wildcard": {}
-                            },
                             {
                                 "type": "user"
                             },


### PR DESCRIPTION
## Description

This PR changes the auth model to remove service accounts from the places where it was mirroring users. Going forward service accounts, when authenticated will be created as identities within JIMM with the resource tag of `user-`. The reason the resource tag remains as `user-` instead of `identity-` is because Juju expects incoming users to have a tag of `user-` and our OpenFGA tags are coupled to Juju resource tags.

Partially addresses CSS-6774

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests