### PR TITLE
Refactor JWKS cache

### DIFF
--- a/cmd/jimmctl/cmd/jimmsuite_test.go
+++ b/cmd/jimmctl/cmd/jimmsuite_test.go
@@ -94,8 +94,6 @@ func (s *jimmSuite) SetUpTest(c *gc.C) {
 
 	s.HTTP.StartTLS()
 
-	s.Service.RegisterJwksCache(ctx)
-
 	// NOW we can set up the  juju conn suites
 	s.ControllerConfigAttrs = map[string]interface{}{
 		"login-token-refresh-url": u.String() + "/.well-known/jwks.json",

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -70,10 +70,6 @@ func start(ctx context.Context, s *service.Service) error {
 	if _, ok := os.LookupEnv("INSECURE_SECRET_STORAGE"); ok {
 		insecureSecretStorage = true
 	}
-	insecureJwksLookup := false
-	if _, ok := os.LookupEnv("INSECURE_JWKS_LOOKUP"); ok {
-		insecureJwksLookup = true
-	}
 	jimmsvc, err := jimm.NewService(ctx, jimm.Params{
 		ControllerUUID:    os.Getenv("JIMM_UUID"),
 		DSN:               os.Getenv("JIMM_DSN"),
@@ -101,7 +97,6 @@ func start(ctx context.Context, s *service.Service) error {
 		MacaroonExpiryDuration:        macaroonExpiryDuration,
 		JWTExpiryDuration:             jwtExpiryDuration,
 		InsecureSecretStorage:         insecureSecretStorage,
-		InsecureJwksLookup:            insecureJwksLookup,
 	})
 	if err != nil {
 		return err
@@ -134,7 +129,6 @@ func start(ctx context.Context, s *service.Service) error {
 		httpsrv.Shutdown(ctx)
 	})
 	s.Go(httpsrv.ListenAndServe)
-	jimmsvc.RegisterJwksCache(ctx)
 	zapctx.Info(ctx, "Successfully started JIMM server")
 	return nil
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,6 @@ services:
       VAULT_PATH: "/jimm-kv/"
       VAULT_SECRET_FILE: "/vault/approle.json"
       VAULT_AUTH_PATH: "/auth/approle/login"
-      INSECURE_JWKS_LOOKUP: "enabled"
       # Note: By default we should use Vault as that is the primary means of secret storage.
       # INSECURE_SECRET_STORAGE: "enabled"
       # JIMM_DASHBOARD_LOCATION: ""

--- a/go.mod
+++ b/go.mod
@@ -49,10 +49,9 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20230626224747-e794b9370d49
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/itchyny/gojq v0.12.12
 	github.com/juju/charm/v11 v11.0.2
-	github.com/juju/clock v1.0.3
-	github.com/juju/retry v1.0.0
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/stretchr/testify v1.8.4
@@ -192,6 +191,7 @@ require (
 	github.com/juju/aclstore/v2 v2.1.0 // indirect
 	github.com/juju/ansiterm v1.0.0 // indirect
 	github.com/juju/blobstore/v3 v3.0.2 // indirect
+	github.com/juju/clock v1.0.3 // indirect
 	github.com/juju/collections v1.0.4 // indirect
 	github.com/juju/description/v4 v4.0.11 // indirect
 	github.com/juju/featureflag v1.0.0 // indirect
@@ -217,6 +217,7 @@ require (
 	github.com/juju/pubsub/v2 v2.0.0 // indirect
 	github.com/juju/ratelimit v1.0.2 // indirect
 	github.com/juju/replicaset/v3 v3.0.1 // indirect
+	github.com/juju/retry v1.0.0 // indirect
 	github.com/juju/rfc/v2 v2.0.0 // indirect
 	github.com/juju/romulus v1.0.0 // indirect
 	github.com/juju/schema v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/jimmtest/suite.go
+++ b/internal/jimmtest/suite.go
@@ -124,10 +124,8 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 	s.JIMM.JWTService = jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
 		Host:   u.Host,
 		Store:  s.JIMM.CredentialStore,
-		Secure: false,
 		Expiry: time.Minute,
 	})
-	s.JIMM.JWTService.RegisterJWKSCache(ctx, s.Server.Client())
 	s.JIMM.Dialer = &jujuclient.Dialer{
 		JWTService: s.JIMM.JWTService,
 	}


### PR DESCRIPTION
## Description

Refactor the JWKS cache away from the jwk.Cache object which caches an HTTP response and forces JIMM to make an HTTP call to itself. Instead, we use a cache with a TTL and fetch the JWK set from Vault periodically (currently set to 1h) with a frequency much higher than the cache refresh interval.

For the cache I've chosen to go with Hashicorp expirable LRU cache (the same as used on Livepatch, thanks @mina1460 for pointing this out). If we want to move to a different cache this would be very straightforward.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests