### PR TITLE
CSS-7031 Make jaas snap ci/cd

### DIFF
--- a/.github/workflows/jaas-snap-release.yaml
+++ b/.github/workflows/jaas-snap-release.yaml
@@ -1,0 +1,14 @@
+name: Release jimmctl snap
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v3*'
+
+jobs:
+  build-and-release:
+    uses: ./.github/workflows/snap-release.yaml
+    with:
+      folder: jaas
+      release-channel: 3/edge

--- a/.github/workflows/jimmctl-snap-release.yaml
+++ b/.github/workflows/jimmctl-snap-release.yaml
@@ -1,0 +1,15 @@
+name: Release jimmctl snap
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v3*'
+
+jobs:
+  build-and-release:
+    uses: ./.github/workflows/snap-release.yaml
+    with:
+      folder: jimmctl
+      release-channel: 3/edge
+

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,10 +1,14 @@
-name: Release jimmctl snap
+name: Release snap
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-      - 'v3*'
+  workflow_call:
+    inputs:
+      folder:
+        required: true
+        type: string
+      release-channel:
+        required: true
+        type: string
 
 # Note this workflow requires a Github secret to provide auth against snapstore.
 # snapcraft export-login --snaps=PACKAGE_NAME --acls package_access,package_push,package_update,package_release exported.txt
@@ -23,7 +27,7 @@ jobs:
     - name: scripts
       run: |
         mkdir -p ./snap
-        cp ./snaps/jimmctl/snapcraft.yaml ./snap/
+        cp ./snaps/${{ inputs.folder }}/snapcraft.yaml ./snap/
     - uses: snapcore/action-build@v1
       id: snapcraft
     - uses: actions/upload-artifact@v2
@@ -44,5 +48,4 @@ jobs:
       with:
         store_login: ${{ secrets.STORE_LOGIN }}
         snap: ${{needs.build.outputs.snap}}
-        release: '3/edge'
-
+        release: '${{ inputs.release-channel }}'

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: juju-jaas
+name: jaas
 summary: JAAS plugin
 description: Juju plugin for providing JAAS functionality to the Juju CLI.
 version: git


### PR DESCRIPTION
## Description

Includes changes from #1149.

This PR (see the changes in the last commit), introduces a reusable workflow for building and pushing a Snap. Essentially the same workflow that was used to build and push the jimmctl snap can be used for the JAAS snap. Instead of copy-pasting it, I've made the workflow reusable and called it from both the jimmctl snap workflow and the JAAS snap workflow.

Note that the branch "3" does not exist yet for the JAAS snap, but I will be requesting it shortly.

Fixes CSS-7031