### PR TITLE
Add two new prometheus counters on the failed/successful  river jobs 

### DIFF
--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -738,22 +738,18 @@ func (j *JIMM) AddModel(ctx context.Context, user *openfga.User, args *ModelCrea
 	})
 	if err != nil {
 		builder.err = err
-		servermon.AddModelFailCount.Inc()
 		return nil, errors.E(err, fmt.Sprintf("failed to insert and wait for the river job, err: %s", err))
 	}
 	model := &dbmodel.Model{
 		ID: builder.model.ID,
 	}
 	if err = j.Database.GetModel(ctx, model); err != nil {
-		servermon.AddModelFailCount.Inc()
 		return nil, errors.E(err, fmt.Sprintf("failed to fetch model information, err: %s", err))
 	}
 	modelInfo, err := j.ModelInfo(ctx, ownerOfgaUser, names.NewModelTag(model.UUID.String))
 	if err != nil {
-		servermon.AddModelFailCount.Inc()
 		return nil, errors.E(err, fmt.Sprintf("failed to read model info, err: %s", err))
 	}
-	servermon.AddModelSuccessCount.Inc()
 	return modelInfo, nil
 }
 

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -10,18 +10,6 @@ import (
 )
 
 var (
-	AddModelFailCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "jem",
-		Subsystem: "jobs",
-		Name: "add_model_fail",
-		Help: "The number of failed add model jobs with after the MaxAttempts",
-	})
-	AddModelSuccessCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "jem",
-		Subsystem: "jobs",
-		Name: "add_model_Success",
-		Help: "The number of successful add model jobs with before the MaxAttempts",
-	})
 	QueryTimeAuditLogCleanUpHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "jem",
 		Name:      "db_query_audit_clean_up_duration_seconds",
@@ -132,6 +120,12 @@ var (
 		Name:      "models_destroyed_count",
 		Help:      "The number of models destroyed.",
 	})
+	FailedJobsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "jem",
+		Subsystem: "jobs",
+		Name:      "failed_jobs",
+		Help:      "The number of failed jobs after retrying for the MaxAttempts",
+	}, []string{"job_kind"})
 	MonitorDeltasReceivedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "jem",
 		Subsystem: "monitor",
@@ -189,8 +183,6 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(AddModelFailCount)	
-	prometheus.MustRegister(AddModelSuccessCount)
 	prometheus.MustRegister(AuthenticationFailCount)
 	prometheus.MustRegister(AuthenticationSuccessCount)
 	prometheus.MustRegister(AuthenticatorPoolGet)
@@ -199,14 +191,15 @@ func init() {
 	prometheus.MustRegister(ConcurrentWebsocketConnections)
 	prometheus.MustRegister(DatabaseFailCount)
 	prometheus.MustRegister(DeployedUnitCount)
+	prometheus.MustRegister(FailedJobsCount)
 	prometheus.MustRegister(LoginFailCount)
 	prometheus.MustRegister(LoginRedirectCount)
 	prometheus.MustRegister(LoginSuccessCount)
 	prometheus.MustRegister(ModelLifetime)
 	prometheus.MustRegister(ModelsCreatedCount)
 	prometheus.MustRegister(ModelsCreatedFailCount)
-	prometheus.MustRegister(MonitorDeltasReceivedCount)
 	prometheus.MustRegister(MonitorDeltaBatchesReceivedCount)
+	prometheus.MustRegister(MonitorDeltasReceivedCount)
 	prometheus.MustRegister(MonitorErrorsCount)
 	prometheus.MustRegister(MonitorLeaseGauge)
 	prometheus.MustRegister(requestDuration)


### PR DESCRIPTION
## Description

River removes cancelled and failed jobs after 1 and 7 days respectively, accordingly, having proper alerting is necessary to take corrective actions as soon as possible. I will follow this with another PR that configures a longer retention period.


## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Do we have tests for our servmon package? 

## Notes for code reviewers
How can I set proper alerting in grafana based on these two new counters? 