### PR TITLE
CSS-8435 Push images to ghcr

### DIFF
--- a/.github/workflows/publich-oci.yaml
+++ b/.github/workflows/publich-oci.yaml
@@ -1,0 +1,33 @@
+# Publish the OCI image to ghcr
+name: Publish image
+
+on:
+  # Note that when running via workflow_dispatch, the github.ref_name
+  # variable will match the selected branch name used.
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build local images
+        run: make jimm-image
+
+      - name: Push to github package
+        run: |
+          new_tag=ghcr.io/canonical/jimm:${{ github.ref_name }}
+          docker tag jimm:latest $new_tag
+          docker push $new_tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN go build -tags version -o jimmsrv -v ./cmd/jimmsrv
 
 # Define a smaller single process image for deployment
 FROM ${DOCKER_REGISTRY}ubuntu:20.04 AS deploy-env
+LABEL org.opencontainers.image.source=https://github.com/canonical/jimm
+LABEL org.opencontainers.image.description="JIMM server container image"
 RUN apt-get -qq update && apt-get -qq install -y ca-certificates postgresql-client
 WORKDIR /root/
 COPY --from=build-env /usr/src/jimm/jimmsrv .


### PR DESCRIPTION
## Description

This PR adds a Github action that will push JIMM's OCI image to the Github container registry. It triggers on pushed tags and manual runs. I tested it on my fork using both approaches [here](https://github.com/kian99/jimm/actions/runs/8966070613/job/24620832122), [here](https://github.com/kian99/jimm/actions/runs/8966057808/job/24620792980) and [here](https://github.com/kian99/jimm/actions/runs/8965986437).

Fixes [CSS-8435](https://warthogs.atlassian.net/browse/CSS-8435)

[CSS-8435]: https://warthogs.atlassian.net/browse/CSS-8435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ