### PR TITLE
PoC Simple Connector 

### DIFF
--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -12,31 +12,37 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"net/http"
-	"net/url"
-	"sort"
-	"sync/atomic"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
-	"github.com/juju/juju/api/base"
-	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/connector"
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
-	"gopkg.in/httprequest.v1"
 
 	"github.com/canonical/jimm/internal/dbmodel"
 	"github.com/canonical/jimm/internal/errors"
 	"github.com/canonical/jimm/internal/jimm"
 	"github.com/canonical/jimm/internal/jimmjwx"
-	"github.com/canonical/jimm/internal/rpc"
 )
 
-const (
-	// JIMM claims to be a 3.2.4 client.
-	jujuClientVersion = "3.2.4"
-)
+func getJujuApiConnection(config connector.SimpleConfig, dialOpts func(do *api.DialOpts)) (api.Connection, error) {
+	connr, err := connector.NewSimple(config, dialOpts)
+	if err != nil {
+		return nil, err
+	}
+	connr.Info.SkipLogin = false
+
+	conn, err := connr.Connect()
+	return conn, err
+}
+
+func getAddrAndPort(addr string) (string, int, error) {
+	addrSplit := strings.Split(addr, ":")
+	addrAddr := addrSplit[0]
+	addrPort, err := strconv.Atoi(addrSplit[1])
+	return addrAddr, addrPort, err
+}
 
 // A Dialer is an implementation of a jimm.Dialer that adapts a juju API
 // connection to provide a jimm API.
@@ -44,7 +50,7 @@ type Dialer struct {
 	JWTService *jimmjwx.JWTService
 }
 
-func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, p map[string]string) (*jujuparams.LoginRequest, error) {
+func (d *Dialer) getJwt(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, p map[string]string) (string, error) {
 	// JIMM is automatically given all required permissions
 	permissions := p
 	if permissions == nil {
@@ -61,270 +67,116 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 		Access:     permissions,
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return "", errors.E(err)
 	}
 	jwtString := base64.StdEncoding.EncodeToString(jwt)
 
-	return &jujuparams.LoginRequest{
-		AuthTag:       names.NewUserTag("admin").String(),
-		ClientVersion: jujuClientVersion,
-		Token:         jwtString,
-	}, nil
+	return jwtString, nil
 }
 
 // Dial implements jimm.Dialer.
 func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, requiredPermissions map[string]string) (jimm.API, error) {
 	const op = errors.Op("jujuclient.Dial")
 
-	conn, err := rpc.Dial(ctx, ctl, modelTag, "")
-	if err != nil {
-		return nil, err
+	// Parse the controller host ports into a normal api address string format
+	apiAddresses := make([]string, 0)
+	for _, hps := range ctl.Addresses {
+		for _, hp := range hps {
+			apiAddresses = append(apiAddresses, fmt.Sprintf("%s:%d", hp.Value, hp.Port))
+		}
 	}
-	if conn == nil {
-		return nil, errors.E(op, errors.CodeConnectionFailed, err)
-	}
-	client := rpc.NewClient(conn)
 
-	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, requiredPermissions)
+	jwt, err := d.getJwt(
+		ctx,
+		ctl,
+		modelTag,
+		requiredPermissions,
+	)
+	if err != nil {
+		//TODO
+	}
+
+	authTag := names.NewUserTag("admin").String()
+
+	dialOptions := func(do *api.DialOpts) {
+		//this is set as a const above, in case we need to use it elsewhere to manage connection timings
+		do.Timeout = 0
+		//default is 2 seconds, as we are changing the overall timeout it makes sense to reduce this as well
+		do.RetryDelay = 1 * time.Second
+		// IDK what im even doing
+		do.LoginProvider = api.NewJWTLoginProvider(
+			authTag,
+			jwt,
+		)
+	}
+
+	jujuConn, err := getJujuApiConnection(connector.SimpleConfig{
+		ControllerAddresses: apiAddresses,
+		Username:            ctl.AdminIdentityName,
+		CACert:              ctl.CACertificate,
+		ModelUUID:           modelTag.Id(),
+	}, dialOptions)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
 
-	var res jujuparams.LoginResult
-	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
-		client.Close()
-		return nil, errors.E(op, errors.CodeConnectionFailed, "authentication failed", err)
+	serverVersion, versionSet := jujuConn.ServerVersion()
+	if versionSet == false {
+		// What do we do? This means server reported 0
+		// and as such it isn't set... Otherwise all is OK.
 	}
+	ctl.AgentVersion = serverVersion.String()
 
-	ct, err := names.ParseControllerTag(res.ControllerTag)
-	if err == nil {
-		ctl.SetTag(ct)
+	c := Connection{
+		jujuConn,
+		authTag,
 	}
-	if res.ServerVersion != "" {
-		ctl.AgentVersion = res.ServerVersion
-	}
-	ctl.Addresses = dbmodel.HostPorts(res.Servers)
-	facades := make(map[string]bool)
-	bestFacadeVersions := make(map[string]int)
-	for _, fv := range res.Facades {
-		sort.Sort(sort.Reverse(sort.IntSlice(fv.Versions)))
-		bestFacadeVersions[fv.Name] = fv.Versions[0]
-		for _, v := range fv.Versions {
-			facades[fmt.Sprintf("%s\x1f%d", fv.Name, v)] = true
-		}
-	}
-	zapctx.Error(ctx, "facades", zap.Any("version", bestFacadeVersions))
-
-	monitorC := make(chan struct{})
-	broken := new(uint32)
-	go pinger(client, monitorC, broken)
-	return &Connection{
-		ctx:                ctx,
-		client:             client,
-		userTag:            loginRequest.AuthTag,
-		facadeVersions:     facades,
-		bestFacadeVersions: bestFacadeVersions,
-		monitorC:           monitorC,
-		broken:             broken,
-		dialer:             d,
-		ctl:                ctl,
-		mt:                 modelTag,
-	}, nil
+	return c, nil
 }
 
-const pingTimeout = 15 * time.Second
-const pingInterval = 30 * time.Second
-
-// pinger runs in the background ensuring the client connection is kept alive.
-func pinger(client *rpc.Client, doneC <-chan struct{}, broken *uint32) {
-	doPing := func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
-		defer cancel()
-		if err := client.Call(ctx, "Pinger", 1, "", "Ping", nil, nil); err != nil {
-			zapctx.Error(ctx, "connection failed", zap.Error(err))
-			return false
-		}
-		return true
-	}
-
-	t := time.NewTimer(pingInterval)
-	defer t.Stop()
-	for {
-		select {
-		case <-doneC:
-			atomic.StoreUint32(broken, 1)
-			return
-		case <-t.C:
-			if !doPing() {
-				atomic.StoreUint32(broken, 1)
-				return
-			}
-		}
-	}
-}
-
-// A Connection is a connection to a juju controller. Connection methods
-// are generally thin wrappers around juju RPC calls, although there are
-// some more JIMM specific operations. The RPC calls prefer to use the
-// most recent facade versions that support all the required data, but will
-// fall-back to earlier versions with slightly degraded functionality if
-// possible.
+// Ale8k: We try v2 this shizz
 type Connection struct {
-	ctx                context.Context
-	client             *rpc.Client
-	userTag            string
-	facadeVersions     map[string]bool
-	bestFacadeVersions map[string]int
-
-	monitorC chan struct{}
-	broken   *uint32
-
-	dialer      *Dialer
-	redialCount atomic.Int32
-	ctl         *dbmodel.Controller
-	mt          names.ModelTag
+	api.Connection
+	// Preventing refactor but probably doesn't belong here
+	// this should be stored on a struct dedicated to user connections
+	// upon a successful dial, not in "Connection", which so happens
+	// to also be an implementation of jimm.API
+	userTag string
 }
 
-// Close closes the connection.
-func (c *Connection) Close() error {
-	close(c.monitorC)
-	return c.client.Close()
+func (c *Connection) Call(
+	ctx context.Context,
+	facade string,
+	version int,
+	id,
+	method string,
+	args,
+	resp interface{},
+) error {
+	return c.APICall(facade, version, id, method, args, resp)
 }
 
-// IsBroken returns true if the connection has failed.
-func (c *Connection) IsBroken() bool {
-	if atomic.LoadUint32(c.broken) != 0 {
-		return true
-	}
-	return c.client.IsBroken()
+func (c *Connection) CallHighestFacadeVersion(
+	ctx context.Context,
+	facade string,
+	versions []int,
+	id,
+	method string,
+	args,
+	resp interface{},
+) error {
+	bestVersion := c.BestFacadeVersion(facade)
+	return c.APICall(
+		facade,
+		bestVersion,
+		"",
+		method,
+		args,
+		resp,
+	)
 }
 
-func (c *Connection) RootHTTPClient() (*httprequest.Client, error) {
-	return c.HTTPClient()
-}
-
-// hasFacadeVersion returns whether the connection supports the given
-// facade at the given version.
+// not needed anymore but just preventing a refactor for now
 func (c *Connection) hasFacadeVersion(facade string, version int) bool {
-	return c.facadeVersions[fmt.Sprintf("%s\x1f%d", facade, version)]
-}
-
-func (c *Connection) redial(ctx context.Context, requiredPermissions map[string]string) error {
-	const op = errors.Op("jujuclient.redial")
-	dialCount := c.redialCount.Add(1)
-	if dialCount > 10 {
-		return errors.E(op, "dial count exceeded")
-	}
-	api, err := c.dialer.Dial(ctx, c.ctl, c.mt, requiredPermissions)
-	if err != nil {
-		return errors.E(op, err)
-	}
-	if err = c.Close(); err != nil {
-		return errors.E(op, err)
-	}
-	conn := api.(*Connection)
-	c.client = conn.client
-	c.userTag = conn.userTag
-	c.facadeVersions = conn.facadeVersions
-	c.monitorC = conn.monitorC
-	c.broken = conn.broken
-	return nil
-}
-
-// Call makes an RPC call to the server. Call sends the request message to
-// the server and waits for the response to be returned or the context to
-// be canceled.
-func (c *Connection) Call(ctx context.Context, facade string, version int, id, method string, args, resp interface{}) error {
-	err := c.client.Call(ctx, facade, version, id, method, args, resp)
-	if err != nil {
-		if rpcErr, ok := err.(*rpc.Error); ok {
-			// if we get a permission check required error, we redial the controller
-			// and amend permissions to include any required permissions as
-			// JIMM should be allowed to access anything in the JIMM system.
-			if rpcErr.Code == rpc.PermissionCheckRequiredErrorCode {
-				requiredPermissions := make(map[string]string)
-				for k, v := range rpcErr.Info {
-					vString, ok := v.(string)
-					if !ok {
-						return errors.E(fmt.Sprintf("expected %T, received %T", vString, v))
-					}
-					requiredPermissions[k] = vString
-				}
-				if err = c.redial(ctx, requiredPermissions); err != nil {
-					return err
-				}
-
-				return c.Call(ctx, facade, version, id, method, args, resp)
-			}
-		}
-		return err
-	}
-	return nil
-}
-
-// CallHighestFacadeVersion calls the specified method on the highest supported version of
-// the facade.
-func (c *Connection) CallHighestFacadeVersion(ctx context.Context, facade string, versions []int, id, method string, args, resp interface{}) error {
-	sort.Sort(sort.Reverse(sort.IntSlice(versions)))
-
-	for _, version := range versions {
-		if c.hasFacadeVersion(facade, version) {
-			return c.Call(ctx, facade, version, id, method, args, resp)
-		}
-	}
-	return errors.E(fmt.Sprintf("facade %v version %v not supported", facade, versions))
-}
-
-// BestFacadeVersion returns the newest version of 'objType' that this
-// client can use with the current API server.
-func (c *Connection) BestFacadeVersion(facade string) int {
-	return c.bestFacadeVersions[facade]
-}
-
-// ModelTag returns the tag of the model the client is connected
-// to if there is one. It returns false for a controller-only connection.
-func (c *Connection) ModelTag() (names.ModelTag, bool) {
-	return c.mt, c.mt.Id() != ""
-}
-
-// HTTPClient returns a httprequest.Client that can be used
-// to make HTTP requests to the API. URLs passed to the client
-// will be made relative to the API host and the current model.
-func (c *Connection) HTTPClient() (*httprequest.Client, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
-}
-
-// BakeryClient returns the bakery client for this connection.
-func (c *Connection) BakeryClient() base.MacaroonDischarger {
-	return httpbakery.NewClient()
-}
-
-// APICall makes a call to the API server with the given object type,
-// id, request and parameters. The response is filled in with the
-// call's result if the call is successful.
-func (c *Connection) APICall(objType string, version int, id, request string, params, response interface{}) error {
-	return c.Call(c.ctx, objType, version, id, request, params, response)
-}
-
-// Context returns the standard context for this connection.
-func (c *Connection) Context() context.Context {
-	return c.ctx
-}
-
-// ConnectStream connects to the given HTTP websocket
-// endpoint path (interpreted relative to the receiver's
-// model) and returns the resulting connection.
-// The given parameters are used as URL query values
-// when making the initial HTTP request.
-func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
-}
-
-// ConnectControllerStream connects to the given HTTP websocket
-// endpoint path and returns the resulting connection. The given
-// values are used as URL query values when making the initial
-// HTTP request. Headers passed in will be added to the HTTP
-// request.
-func (c *Connection) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+	return c.Connection.BestFacadeVersion(facade) >= version
 }

--- a/internal/jujuclient/modelsummarywatcher.go
+++ b/internal/jujuclient/modelsummarywatcher.go
@@ -37,7 +37,7 @@ func (c Connection) WatchAllModelSummaries(ctx context.Context) (string, error) 
 func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]jujuparams.ModelAbstract, error) {
 	const op = errors.Op("jujuclient.ModelSummaryWatcherNext")
 	var resp jujuparams.SummaryWatcherNextResults
-	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Next", nil, &resp); err != nil {
+	if err := c.Call(ctx, "ModelSummaryWatcher", 1, id, "Next", nil, &resp); err != nil {
 		return nil, errors.E(op, jujuerrors.Cause(err))
 	}
 	return resp.Models, nil
@@ -49,7 +49,7 @@ func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]j
 // ModelSummaryWatcher facade version 1.
 func (c Connection) ModelSummaryWatcherStop(ctx context.Context, id string) error {
 	const op = errors.Op("jujuclient.ModelSummaryWatcherStop")
-	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Stop", nil, nil); err != nil {
+	if err := c.Call(ctx, "ModelSummaryWatcher", 1, id, "Stop", nil, nil); err != nil {
 		return errors.E(op, jujuerrors.Cause(err))
 	}
 	return nil


### PR DESCRIPTION
This PoC enables the removal of our *Connection struct in favour of Juju's api.Connection. The benefits of this are as follows:

- DRY code
- Can track juju's changes better
- Enables use of their client libraries
- Better enables upgrades as our client version maps directly to juju clis client versions and should we begin using juju's apiclients, enables better mapping of params and juju version compatibility

If we are to try utilise Juju and track it properly, then we should be using their libraries where possible. This is a phase 1 of the removal of jujuclient within JIMM. In my tests this seemed to work fine, bar two issues.

- I'm not 100% sure the new "CallHighestFacadeVersion" is 1-2-1 the same as how it was done previously, due to the fact our custom implementation had access to the "state" (which is actually just a *Connection), and could access private fields, i.e., the facade versions upon login.
- We often dial with just a public address, but the simple connector won't allow for this, in the dial tests you can see it maps the addrs over to make the test pass.

Some interesting details to note about how Juju works on connections:
- Websocket established and a "state" (aka *Connection) is created
- Login called sent (via a provider)
- Login provider is expected to update the state (i.e., current facade versions)
- Internal state is NOT exposed
Interestingly though, on our *Connection, we had one field different, the auth tag. Which I've left a comment explaining this is probably the wrong place and the way we use this in a jimm.API interface should really be called Connection/State, to match juju. I also don't think we need to store the auth tag on the state as we always login as an admin to controllers via the JWT. Essentially meaning we don't even require our own connection struct. I kept it as-is though for the PoC.

Finally, to make this work I vendored and added a JWT login provider. This provider is here:
```go
package api

import (
	"context"

	"github.com/juju/errors"
	"github.com/juju/juju/api/base"
	"github.com/juju/juju/rpc/params"
	"github.com/juju/names/v5"
	"github.com/juju/version/v2"
)

func NewJWTLoginProvider(
	authTag string,
	jwt string,
) *jwtLoginProvider {
	return &jwtLoginProvider{
		AuthTag: authTag,
		JWT:     jwt,
	}
}

type jwtLoginProvider struct {
	AuthTag string
	JWT     string
}

func (jlp *jwtLoginProvider) Login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {
	var result params.LoginResult
	loginRequest := &params.LoginRequest{
		AuthTag: names.NewUserTag(jlp.AuthTag).String(),
		Token:   jlp.JWT,
	}

	err := caller.APICall("Admin", 3, "", "Login", loginRequest, &result)
	if err != nil {
		return nil, errors.Trace(err)
	}

	var controllerAccess string
	var modelAccess string
	var tag names.Tag
	if result.UserInfo != nil {
		tag, err = names.ParseTag(result.UserInfo.Identity)
		if err != nil {
			return nil, errors.Trace(err)
		}
		controllerAccess = result.UserInfo.ControllerAccess
		modelAccess = result.UserInfo.ModelAccess
	}
	servers := params.ToMachineHostsPorts(result.Servers)
	serverVersion, err := version.Parse(result.ServerVersion)
	if err != nil {
		return nil, errors.Trace(err)
	}
	lrp := &LoginResultParams{
		tag:              tag,
		modelTag:         result.ModelTag,
		controllerTag:    result.ControllerTag,
		servers:          servers,
		publicDNSName:    result.PublicDNSName,
		facades:          result.Facades,
		modelAccess:      modelAccess,
		controllerAccess: controllerAccess,
		serverVersion:    serverVersion,
	}
	return lrp, nil
}
```

So for this change to work for us, this provider will need proposing to juju.

We can discuss this further in Madrid on Tuesday during the session.