### PR TITLE
Ensure snap release workflow has access to necessary secrets

### DIFF
--- a/.github/workflows/jaas-snap-release.yaml
+++ b/.github/workflows/jaas-snap-release.yaml
@@ -12,3 +12,4 @@ jobs:
     with:
       folder: jaas
       release-channel: 3/edge
+    secrets: inherit

--- a/.github/workflows/jimmctl-snap-release.yaml
+++ b/.github/workflows/jimmctl-snap-release.yaml
@@ -12,4 +12,5 @@ jobs:
     with:
       folder: jimmctl
       release-channel: 3/edge
+    secrets: inherit
 

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -9,6 +9,10 @@ on:
       release-channel:
         required: true
         type: string
+    secrets:
+      STORE_LOGIN:
+        required: true
+
 
 # Note this workflow requires a Github secret to provide auth against snapstore.
 # snapcraft export-login --snaps=PACKAGE_NAME --acls package_access,package_push,package_update,package_release exported.txt
@@ -47,6 +51,5 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        store_login: ${{ secrets.STORE_LOGIN }}
         snap: ${{needs.build.outputs.snap}}
         release: '${{ inputs.release-channel }}'


### PR DESCRIPTION
## Description

The snap release workflow is triggered by other workflows through the `workflow_call` key. These workflows do not have access that the original workflow had access to, instead they must be explicitly passed, see more [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow).