### PR TITLE
Add error field to list relations response

### DIFF
--- a/api/params/params.go
+++ b/api/params/params.go
@@ -350,8 +350,9 @@ type ListRelationshipTuplesRequest struct {
 
 // ListRelationshipTuplesResponse holds the response of the ListRelationshipTuples method.
 type ListRelationshipTuplesResponse struct {
-	Tuples            []RelationshipTuple `json:"tuples,omitempty"`
-	ContinuationToken string              `json:"continuation_token,omitempty"`
+	Tuples            []RelationshipTuple `json:"tuples,omitempty" yaml:"tuples,omitempty"`
+	Errors            []string            `json:"errors,omitempty" yaml:"errors,omitempty"`
+	ContinuationToken string              `json:"continuation_token,omitempty" yaml:"continuation_token,omitempty"`
 }
 
 // CrossModelQueryRequest holds the parameters to perform a cross model query against

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -419,7 +419,7 @@ func (j *JIMM) ToJAASTag(ctx context.Context, tag *ofganames.Tag) (string, error
 		}
 		err := j.Database.GetModel(ctx, &model)
 		if err != nil {
-			return "", errors.E(err, "failed to fetch model information")
+			return "", errors.E(err, fmt.Sprintf("failed to fetch model information: %s", model.UUID.String))
 		}
 		modelString := names.ModelTagKind + "-" + model.Controller.Name + ":" + model.OwnerIdentityName + "/" + model.Name
 		if tag.Relation.String() != "" {
@@ -432,7 +432,7 @@ func (j *JIMM) ToJAASTag(ctx context.Context, tag *ofganames.Tag) (string, error
 		}
 		err := j.Database.GetApplicationOffer(ctx, &ao)
 		if err != nil {
-			return "", errors.E(err, "failed to fetch application offer information")
+			return "", errors.E(err, fmt.Sprintf("failed to fetch application offer information: %s", ao.UUID))
 		}
 		aoString := names.ApplicationOfferTagKind + "-" + ao.Model.Controller.Name + ":" + ao.Model.OwnerIdentityName + "/" + ao.Model.Name + "." + ao.Name
 		if tag.Relation.String() != "" {
@@ -445,7 +445,7 @@ func (j *JIMM) ToJAASTag(ctx context.Context, tag *ofganames.Tag) (string, error
 		}
 		err := j.Database.GetGroup(ctx, &group)
 		if err != nil {
-			return "", errors.E(err, "failed to fetch group information")
+			return "", errors.E(err, fmt.Sprintf("failed to fetch group information: %s", group.UUID))
 		}
 		groupString := jimmnames.GroupTagKind + "-" + group.Name
 		if tag.Relation.String() != "" {
@@ -458,7 +458,7 @@ func (j *JIMM) ToJAASTag(ctx context.Context, tag *ofganames.Tag) (string, error
 		}
 		err := j.Database.GetCloud(ctx, &cloud)
 		if err != nil {
-			return "", errors.E(err, "failed to fetch group information")
+			return "", errors.E(err, fmt.Sprintf("failed to fetch cloud information: %s", cloud.Name))
 		}
 		cloudString := names.CloudTagKind + "-" + cloud.Name
 		if tag.Relation.String() != "" {

--- a/internal/jujuapi/access_control_test.go
+++ b/internal/jujuapi/access_control_test.go
@@ -864,6 +864,7 @@ func (s *accessControlSuite) TestListRelationshipTuples(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	// first three tuples created during setup test
 	c.Assert(response.Tuples[12:], jc.DeepEquals, tuples)
+	c.Assert(len(response.Errors), gc.Equals, 0)
 
 	response, err = client.ListRelationshipTuples(&apiparams.ListRelationshipTuplesRequest{
 		Tuple: apiparams.RelationshipTuple{
@@ -872,7 +873,85 @@ func (s *accessControlSuite) TestListRelationshipTuples(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(response.Tuples, jc.DeepEquals, []apiparams.RelationshipTuple{tuples[3]})
+	c.Assert(len(response.Errors), gc.Equals, 0)
+}
 
+func (s *accessControlSuite) TestListRelationshipTuplesAfterDeletingGroup(c *gc.C) {
+	ctx := context.Background()
+	user, _, controller, model, applicationOffer, _, _, client, closeClient := createTestControllerEnvironment(ctx, c, s)
+	defer closeClient()
+
+	err := client.AddGroup(&apiparams.AddGroupRequest{Name: "yellow"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	tuples := []apiparams.RelationshipTuple{{
+		Object:       "group-orange#member",
+		Relation:     "member",
+		TargetObject: "group-yellow",
+	}, {
+		Object:       "user-" + user.Name,
+		Relation:     "member",
+		TargetObject: "group-orange",
+	}, {
+		Object:       "group-yellow#member",
+		Relation:     "administrator",
+		TargetObject: "controller-" + controller.Name,
+	}, {
+		Object:       "group-orange#member",
+		Relation:     "administrator",
+		TargetObject: "applicationoffer-" + controller.Name + ":" + user.Name + "/" + model.Name + "." + applicationOffer.Name,
+	}}
+
+	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = client.RemoveGroup(&apiparams.RemoveGroupRequest{Name: "yellow"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	response, err := client.ListRelationshipTuples(&apiparams.ListRelationshipTuplesRequest{})
+	c.Assert(err, jc.ErrorIsNil)
+	// Create a new slice of tuples excluding the ones we expect to be deleted.
+	newTuples := []apiparams.RelationshipTuple{tuples[1], tuples[3]}
+	// first three tuples created during setup test
+	c.Assert(response.Tuples[12:], jc.DeepEquals, newTuples)
+	c.Assert(len(response.Errors), gc.Equals, 0)
+}
+
+func (s *accessControlSuite) TestListRelationshipTuplesWithMissingGroups(c *gc.C) {
+	ctx := context.Background()
+	_, _, _, _, _, _, _, client, closeClient := createTestControllerEnvironment(ctx, c, s)
+	defer closeClient()
+
+	err := client.AddGroup(&apiparams.AddGroupRequest{Name: "yellow"})
+	c.Assert(err, jc.ErrorIsNil)
+	err = client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	tuples := []apiparams.RelationshipTuple{{
+		Object:       "group-orange#member",
+		Relation:     "member",
+		TargetObject: "group-yellow",
+	}}
+
+	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Delete a group without going through the API.
+	group := &dbmodel.GroupEntry{Name: "yellow"}
+	err = s.JIMM.DB().GetGroup(ctx, group)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.JIMM.DB().RemoveGroup(ctx, group)
+	c.Assert(err, jc.ErrorIsNil)
+
+	response, err := client.ListRelationshipTuples(&apiparams.ListRelationshipTuplesRequest{})
+	c.Assert(err, jc.ErrorIsNil)
+	tupleWithoutDBEntry := tuples[0]
+	tupleWithoutDBEntry.TargetObject = "group:" + group.UUID
+	// first three tuples created during setup test
+	c.Assert(response.Tuples[12], gc.Equals, tupleWithoutDBEntry)
+	c.Assert(response.Errors, gc.DeepEquals, []string{"failed to parse target: failed to fetch group information: " + group.UUID})
 }
 
 func (s *accessControlSuite) TestCheckRelationAsNonAdmin(c *gc.C) {


### PR DESCRIPTION
## Description

This PR partially addresses an issue in `jimmctl auth relation list`. When retrieving OpenFGA tuples, we convert the UUIDs commonly used in the OpenFGA tags back to human readable names. If a tag doesn't exist in the DB it should _theoretically_ have been deleted from OpenFGA but if cleanup failed or the code had a bug that missed some cleanup then currently the `jimmctl auth relation list` command will always fail and return a cryptic error.

This PR changes this behaviour to always return the tuples returned from OpenFGA and adds an `errors` field to the response from `ListRelationshipTuples`. Tests have been added for the API and the CLI.

Partially addresses [CSS-8387](https://warthogs.atlassian.net/browse/CSS-8387)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[CSS-8387]: https://warthogs.atlassian.net/browse/CSS-8387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ