### PR TITLE
Remove service from ROCK

### DIFF
--- a/cmd/jaas/cmd/listserviceaccountcredentials.go
+++ b/cmd/jaas/cmd/listserviceaccountcredentials.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	listServiceCredentialsCommandDoc = `
-list-credentials lists the cloud credentials belonging to a service account.
+list-service-account-credentials lists the cloud credentials belonging to a service account.
 
 This command only shows credentials uploaded to the controller that belong to the service account.
 Client-side credentials should be managed via the juju credentials command.

--- a/cmd/jaas/cmd/updatecredentials.go
+++ b/cmd/jaas/cmd/updatecredentials.go
@@ -23,12 +23,12 @@ import (
 
 var (
 	updateCredentialsCommandDoc = `
-update-credentials command updates the credentials associated with a service account.
+update-service-account-credentials command updates the credentials associated with a service account.
 This will add the credentials to JAAS if they were not found.
 `
 
 	updateCredentialsCommandExamples = `
-    juju update-service-account-credentials update-credentials 00000000-0000-0000-0000-000000000000 aws credential-name
+    juju update-service-account-credentials 00000000-0000-0000-0000-000000000000 aws credential-name
 `
 )
 

--- a/rocks/jimm.yaml
+++ b/rocks/jimm.yaml
@@ -10,22 +10,6 @@ license: GPL-3.0
 platforms:
     amd64:
 
-services:
-    server:
-        summary: JIMM
-        description: |
-            JIMM is a Juju controller, used in conjunction with the JaaS dashboard to provide a seamless way
-            to manage models, regardless of where their controllers reside or what cloud they may be running on.
-        startup: enabled
-        override: replace
-        command: jimmsrv
-        on-success: ignore
-        on-failure: restart
-        backoff-delay: 1s
-        backoff-factor: 2
-        backoff-limit: 10s
-        kill-delay: 10s
-
 parts:
     ca-certs:
         plugin: nil


### PR DESCRIPTION
## Description

This PR removes the `service` keyword from the JIMM rock. Additionally, it also fixes some help text in the JAAS cli.

There is a service called `server` in the ROCK that causes the image to attempt to start a service called `server` when the k8s charm is deployed using the ROCK. But the charm already creates it's own service called "jimm". The `server` service also doesn't have any environment variables used for config and fails to start. We could either rename the service to "jimm" so that the charm replaces the service definition with whatever it wants or, as I've done here for the purposes of removing any confusion, remove the service entirely.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests