### PR TITLE
Add trivy image scan for JIMM rock

### DIFF
--- a/.github/workflows/release-server-rock.yaml
+++ b/.github/workflows/release-server-rock.yaml
@@ -32,6 +32,11 @@ jobs:
       - name: Load ROCK into local registry
         run: make load-rock
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.23.0
+        with:
+          image-ref: 'jimm:latest'
+
       - name: Push to github package
         run: |
           new_tag=ghcr.io/canonical/jimm:${{ github.ref_name }}


### PR DESCRIPTION
## Description

This PR adds a step to the release OCI image workflow to perform a scan of the OCI image. See a test run with results [here](https://github.com/kian99/jimm/actions/runs/9806580992/job/27078614786).

Fixes [CSS-9381](https://warthogs.atlassian.net/browse/CSS-9381)

[CSS-9381]: https://warthogs.atlassian.net/browse/CSS-9381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ