### PR TITLE
Fix dial controller and monitoring

### DIFF
--- a/internal/jimm/watcher.go
+++ b/internal/jimm/watcher.go
@@ -138,7 +138,7 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 		if !updateController {
 			return
 		}
-		if uerr := w.Database.UpdateController(ctx, ctl); err != nil {
+		if uerr := w.Database.UpdateController(ctx, ctl); uerr != nil {
 			zapctx.Error(ctx, "cannot set controller available", zap.Error(uerr))
 		}
 		// Note (alesstimec) This channel is only available in tests.

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -113,7 +113,7 @@ var (
 		Name:      "errors_total",
 		Help:      "The number of monitoring errors found.",
 	}, []string{"controller"})
-	WebsocketRequestDuration = promauto.NewSummaryVec(prometheus.SummaryOpts{
+	WebsocketRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "jimm",
 		Subsystem: "websocket",
 		Name:      "request_duration_seconds",


### PR DESCRIPTION
## Description

Two minor fixes:
- Use the correct error value in the watcher DialController function.
- Use a Histogram instead of a Summary in our monitoring of websocket request duration.