### PR TITLE
CSS-9575 Use new error for session token login

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -121,6 +121,7 @@ const (
 	CodeServerConfiguration          Code = "server configuration"
 	CodeStillAlive                   Code = apiparams.CodeStillAlive
 	CodeUnauthorized                 Code = jujuparams.CodeUnauthorized
+	CodeInvalidSessionToken          Code = "session token invalid"
 	CodeUpgradeInProgress            Code = jujuparams.CodeUpgradeInProgress
 	CodeFailedToParseTupleKey        Code = "failed to parse tuple object key"
 	CodeFailedToResolveTupleResource Code = "failed resolve resource"

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -153,6 +153,8 @@ type OAuthAuthenticator interface {
 	//
 	// The subject of the token contains the user's email and can be used
 	// for user object creation.
+	// If verification fails, return error with code CodeInvalidSessionToken
+	// to indicate to the client to retry login.
 	VerifySessionToken(token string) (jwt.Token, error)
 
 	// UpdateIdentity updates the database with the display name and access token set for the user.

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -4,7 +4,6 @@ package jujuapi
 
 import (
 	"context"
-	stderrors "errors"
 	"sort"
 
 	"github.com/juju/juju/rpc"
@@ -123,11 +122,8 @@ func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.L
 	// Verify the session token
 	jwtToken, err := authenticationSvc.VerifySessionToken(req.SessionToken)
 	if err != nil {
-		var aerr *auth.AuthenticationError
-		if stderrors.As(err, &aerr) {
-			return aerr.LoginResult, nil
-		}
-		return jujuparams.LoginResult{}, errors.E(op, err, errors.CodeUnauthorized)
+		// Don't replace the error code as it is important for the client, see [OAuthAuthenticator.VerifySessionToken]
+		return jujuparams.LoginResult{}, errors.E(op, err)
 	}
 
 	// Get an OpenFGA user to place on the controllerRoot for this WS

--- a/internal/rpc/proxy.go
+++ b/internal/rpc/proxy.go
@@ -585,6 +585,8 @@ func modifyControllerResponse(msg *message) error {
 // an error
 func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clientResponse *message, controllerMessage *message, err error) {
 	errorFnc := func(err error) (*message, *message, error) {
+		// The error contains specific codes that the client will use to decide
+		// how to proceed if login fails.
 		return nil, nil, err
 	}
 	controllerLoginMessageFnc := func(data []byte) (*message, *message, error) {


### PR DESCRIPTION
## Description

This PR is marked as a draft until https://github.com/juju/juju/pull/17726 lands. **NB**: This change should only land after the Juju PR lands and a new Juju release is made including the change - likely in Juju ~~3.5.3~~ 3.5.4. 

This PR intends to fix a behaviour of the Juju CLI when interacting with JIMM. Copy-pasting from the above PR:

>The current implementation of the Juju CLI uses the sessionTokenLoginProvider to login to JAAS. This login method uses the device code login flow, i.e. it:
>
>Tries to login with the client's session token.
If the error returned is a specific code, it starts the device flow login described below.
>- The server returns a URL where the user must go to login.
>- The server polls the server waiting for the user to login.
>- The server returns a session token to the client.
>- The client tries to login again with the session token.
>
>Currently, the specific error code is CodeUnauthorized. This is a poor choice because it is possible for Juju to return this code as a valid error unrelated to login. In cases like these the user is suddenly asked to login again when in fact they should simply be presented with the error.
>
>This PR changes the expected error to a unique code. The code is only used in tests/the login provider. JAAS will use this error in its implementation.
>
>**NB!** Unfortunately this change will cause a breakage between the Juju CLI and JAAS but because JAAS is not in widespread usage yet, it is better to fix the issue before then.

In JIMM, we ensure that whenever a call to `VerifySessionToken` fails, we return the appropriate error for the client to start the device flow. This handles cases where:
- A user is logging in for the first time and presents an empty session token.
- The user's session token is expired.
- The user has modified their existing session token and it is no longer valid.
- Covers both controller and model level calls, as they both return the error from `VerifySessionToken` direcltly.

Fixes [CSS-9575](https://warthogs.atlassian.net/browse/CSS-9575)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Notes for code reviewers
This PR is marked as a draft until the Juju changes land at which point the Juju dependency in JIMM must be updated. It will likely also require some updates to tests.

[CSS-9575]: https://warthogs.atlassian.net/browse/CSS-9575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ