### PR TITLE
Allow querying groups by UUID

### DIFF
--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -519,10 +519,13 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 			"Resolving JIMM tags to Juju tags for tag kind: group",
 			zap.String("group-name", trailer),
 		)
-		entry := &dbmodel.GroupEntry{
-			Name: trailer,
+		var entry dbmodel.GroupEntry
+		if resourceUUID != "" {
+			entry.UUID = resourceUUID
+		} else if trailer != "" {
+			entry.Name = trailer
 		}
-		err := db.GetGroup(ctx, entry)
+		err := db.GetGroup(ctx, &entry)
 		if err != nil {
 			return nil, errors.E(fmt.Sprintf("group %s not found", trailer))
 		}

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -636,7 +636,11 @@ func TestResolveTupleObjectMapsGroups(t *testing.T) {
 	}
 	err = j.Database.GetGroup(ctx, group)
 	c.Assert(err, qt.IsNil)
+	// Test resolution via name and via UUID.
 	tag, err := jimm.ResolveTag(j.UUID, &j.Database, "group-"+group.Name+"#member")
+	c.Assert(err, qt.IsNil)
+	c.Assert(tag, qt.DeepEquals, ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation))
+	tag, err = jimm.ResolveTag(j.UUID, &j.Database, "group-"+group.UUID+"#member")
 	c.Assert(err, qt.IsNil)
 	c.Assert(tag, qt.DeepEquals, ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation))
 }

--- a/pkg/names/group.go
+++ b/pkg/names/group.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	validGroupName      = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9._-]{4,}[a-zA-Z0-9]$")
+	validGroupName      = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9._-]+[a-zA-Z0-9]$")
 	validGroupIdSnippet = `^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}((#|\z)[a-z]+)?$`
 	validGroupId        = regexp.MustCompile(validGroupIdSnippet)
 )

--- a/pkg/names/group_test.go
+++ b/pkg/names/group_test.go
@@ -121,8 +121,14 @@ func TestIsValidGroupName(t *testing.T) {
 		name:             "",
 		expectedValidity: false,
 	}, {
-		name:             "short",
+		name:             "no",
 		expectedValidity: false,
+	}, {
+		name:             "foo",
+		expectedValidity: true,
+	}, {
+		name:             "short",
+		expectedValidity: true,
 	}, {
 		name:             "short1",
 		expectedValidity: true,


### PR DESCRIPTION
## Description

This PR allows a user to reference JIMM groups by UUID much like we do for application-offers, models, controllers, etc.

Fixes [CSS-9900](https://warthogs.atlassian.net/browse/CSS-9900)

As a drive-by fix I noticed our group validation regex enforces group names to be at least 6 characters long. I've reduced that to 3. 

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[CSS-9900]: https://warthogs.atlassian.net/browse/CSS-9900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ