### PR TITLE
Cleanup db during tests

### DIFF
--- a/internal/cmdtest/jimmsuite.go
+++ b/internal/cmdtest/jimmsuite.go
@@ -49,6 +49,8 @@ type JimmCmdSuite struct {
 	OFGAClient  *openfga.OFGAClient
 	COFGAClient *cofga.Client
 	COFGAParams *cofga.OpenFGAParams
+
+	databaseName string
 }
 
 func (s *JimmCmdSuite) SetUpTest(c *gc.C) {
@@ -67,6 +69,9 @@ func (s *JimmCmdSuite) SetUpTest(c *gc.C) {
 	s.COFGAParams = cofgaParams
 
 	s.Params = jimmtest.NewTestJimmParams(&jimmtest.GocheckTester{C: c})
+	dsn, err := url.Parse(s.Params.DSN)
+	c.Assert(err, gc.Equals, nil)
+	s.databaseName = strings.Replace(dsn.Path, "/", "", -1)
 	s.Params.PublicDNSName = u.Host
 	s.Params.ControllerAdmins = []string{"admin"}
 	s.Params.OpenFGAParams = service.OpenFGAParams{
@@ -142,6 +147,14 @@ func (s *JimmCmdSuite) TearDownTest(c *gc.C) {
 	if s.JIMM != nil && s.JIMM.Database.DB != nil {
 		if err := s.JIMM.Database.Close(); err != nil {
 			c.Logf("failed to close database connections at tear down: %s", err)
+		}
+	}
+	// Only delete the DB after closing connections to it.
+	_, skip_cleanup := os.LookupEnv("NO_DB_CLEANUP")
+	if !skip_cleanup {
+		err := jimmtest.DeleteDatabase(s.databaseName)
+		if err != nil {
+			c.Logf("failed to delete database (%s): %s", s.databaseName, err)
 		}
 	}
 	s.JujuConnSuite.TearDownTest(c)

--- a/internal/jimmtest/suite.go
+++ b/internal/jimmtest/suite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -63,6 +64,7 @@ type JIMMSuite struct {
 	Server         *httptest.Server
 	cancel         context.CancelFunc
 	deviceFlowChan chan string
+	databaseName   string
 }
 
 func (s *JIMMSuite) SetUpTest(c *gc.C) {
@@ -70,7 +72,8 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 	s.OFGAClient, s.COFGAClient, s.COFGAParams, err = SetupTestOFGAClient(c.TestName())
 	c.Assert(err, gc.IsNil)
 
-	pgdb := PostgresDB(GocheckTester{c}, nil)
+	pgdb, databaseName := PostgresDBWithDbName(GocheckTester{c}, nil)
+	s.databaseName = databaseName
 
 	// Setup OpenFGA.
 	s.JIMM = &jimm.JIMM{
@@ -149,6 +152,14 @@ func (s *JIMMSuite) TearDownTest(c *gc.C) {
 	}
 	if err := s.JIMM.Database.Close(); err != nil {
 		c.Logf("failed to close database connections at tear down: %s", err)
+	}
+	// Only delete the DB after closing connections to it.
+	_, skip_cleanup := os.LookupEnv("NO_DB_CLEANUP")
+	if !skip_cleanup {
+		err := DeleteDatabase(s.databaseName)
+		if err != nil {
+			c.Logf("failed to delete database (%s): %s", s.databaseName, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds a mechanism to cleanup/skip-cleanup of the database created for a test. When running tests in CI, tests have started [failing](https://github.com/canonical/jimm/actions/runs/10219381062/job/28277516569) with errors about no disk space. When investigating by SSHing into a test runner, it was found this was indeed the problem.

Github runners have a lot of pre-installed tools and [the docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners) mention that the public runners only have 14GB of disk to use. After JIMM's Docker compose is started (where images like Keycloak are ~800 MB on its own) and other tools like the juju-db are installed, there is not much space left. Each Postgres test DB also takes a fair amount of space, when I checked, JIMM's Postgresql volume was using 4+ GB. 

In this PR we cleanup test databases after they are created. If you want to keep a test DB around for debugging purposes, I've added a env var `NO_DB_CLEANUP` that can be set to skip cleanup.