### PR TITLE
remove go setup from smoke test phase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,11 +64,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-
       - name: Add volume files
         run: |
           touch ./local/vault/approle.json


### PR DESCRIPTION
## Description

There way a go setup step in the smoke test phase. This disable the cache in the Build and Test phase because it overrides it with an empty folder.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->