### PR TITLE
add go cache to v3 branch to make it available to child branch

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,13 +1,9 @@
 name: Cache on default branch
-on:
-  push:
-    branches:
-      - v3
-  
+on: push
 
 jobs:
   go_cache:
-    name: Install And Cache Go dependencies
+    name: Install And Cache Go Dependencies and Build Artifacts
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -21,6 +17,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      
-      - name: Build and Test
-        run: go mod tidy
+
+      - name: Build
+        run: go build ./...


### PR DESCRIPTION
## Description

Following [GitHub Doc](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) we discovered cache is not shared between child branches and prs.

We need to build the cache in the parent branch to make it available to child branch.
This should improve the cache hit ratio even for newly created PRs.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->