### PR TITLE
Fix/mod cache action

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,5 +1,9 @@
 name: Cache on default branch
-on: push
+on:
+  push:
+    branches:
+      - v3
+      - "feature*"
 
 jobs:
   go_cache:


### PR DESCRIPTION
## Description

Fix:
- trigger the cache action only on specific branch (v3, feature*). This is to avoid triggering the cache action in our private fork too many times
- go build command requires some files to succeed

> The nuance with github actions cache is:
- every branch inherits the **default** branch cache
- the pr inherits the base branch cache


Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->