### PR TITLE
Allow adding a model with implicit cloud.

### DIFF
--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -861,18 +861,16 @@ var createModelTests = []struct {
 	credentialTag: "cloudcred-" + jimmtest.TestCloudName + "_bob@canonical.com_cred1",
 	expectError:   `"not-a-cloud-tag" is not a valid tag \(bad request\)`,
 }, {
-	about:         "no cloud tag",
-	name:          "model-8",
-	ownerTag:      names.NewUserTag("bob@canonical.com").String(),
-	cloudTag:      "",
-	credentialTag: "cloudcred-" + jimmtest.TestCloudName + "_bob@canonical.com_cred1",
-	expectError:   `no cloud specified for model; please specify one`,
-}, {
 	about:    "no credential tag selects unambigous creds",
 	name:     "model-8",
 	ownerTag: names.NewUserTag("bob@canonical.com").String(),
 	cloudTag: names.NewCloudTag(jimmtest.TestCloudName).String(),
 	region:   jimmtest.TestCloudRegionName,
+}, {
+	about:         "success - without a cloud tag",
+	name:          "model-9",
+	ownerTag:      names.NewUserTag("bob@canonical.com").String(),
+	credentialTag: "cloudcred-" + jimmtest.TestCloudName + "_bob@canonical.com_cred",
 }}
 
 func (s *modelManagerSuite) TestCreateModel(c *gc.C) {


### PR DESCRIPTION
If the user does not specify which cloud to add the model to and only one cloud is known to JIMM, we will select that cloud and continue instead of returning an error.

## Description

The what and why - include a summary of the change, describe what it does, and include relevant motivation and context.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->