### PR TITLE
Improve errors and edge case handling in model proxy

### DIFF
--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -266,7 +266,7 @@ func TestProxySockets(t *testing.T) {
 			LoginService:      &mockLoginService{},
 		}
 		err := rpc.ProxySockets(ctx, proxyHelpers)
-		c.Check(err, qt.ErrorMatches, "error reading from (client|controller).*")
+		c.Check(err, qt.IsNil)
 		errChan <- err
 		return err
 	})
@@ -368,7 +368,7 @@ func TestProxySocketsAuditLogs(t *testing.T) {
 			LoginService:      &mockLoginService{},
 		}
 		err := rpc.ProxySockets(ctx, proxyHelpers)
-		c.Check(err, qt.ErrorMatches, `error reading from (client|controller).*`)
+		c.Check(err, qt.IsNil)
 		errChan <- err
 		return err
 	})


### PR DESCRIPTION
## Description

This PR modifies the model proxy to improve the error logging and simplify logic in some edge cases.

The reason for this change was that when running JIMM in a test setup there were constant debug logs about "error reading from client" or "error reading from controller" which were completely expected, every time the client closes the websocket our routines waiting to read from the websocket stop and return. In these cases, there were debug and error level logs which were not necessary because this was the normal mode of operation. 

The first commit in this PR simply makes the client/controller proxy return a nil error when they fail to read from their respective websocket connections.

The second commit in this PR was done after taking a look at whether we could simplify the complicated logic when handling `ctx.Done()` involving a mutex. It was thankfully easy to clean this up because we already handle things gracefully when the client connection is closed so we can simply close the client connection to clean things up.

Finally, I noticed an edge case that wasn't handled and added a test for it. If the connection to the controller was closed unexpectedly, the model proxy would not handle this gracefully. Now if the controller proxy routine ends early, we handle this by stopping the model proxy.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Ran the relevant tests with `-race` and/or `-count=1000`. E.g.
```
go test -race -timeout 30s github.com/canonical/jimm/v3/internal/rpc -count=10
go test -timeout 30s -run ^TestProxySockets$ github.com/canonical/jimm/v3/internal/rpc -count=1000
```
## Notes for code reviewers
I suggest reviewing this PR by each commit individually to see the changes more clearly.