### PR TITLE
Add CORS middleware

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -142,6 +142,8 @@ func start(ctx context.Context, s *service.Service) error {
 		return errors.E("jimm session store secret must be at least 64 characters")
 	}
 
+	corsAllowedOrigins := strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), " ")
+
 	jimmsvc, err := jimmsvc.NewService(ctx, jimmsvc.Params{
 		ControllerUUID:    os.Getenv("JIMM_UUID"),
 		DSN:               os.Getenv("JIMM_DSN"),
@@ -167,17 +169,18 @@ func start(ctx context.Context, s *service.Service) error {
 		JWTExpiryDuration:             jwtExpiryDuration,
 		InsecureSecretStorage:         insecureSecretStorage,
 		OAuthAuthenticatorParams: jimmsvc.OAuthAuthenticatorParams{
-			IssuerURL:           issuerURL,
-			ClientID:            clientID,
-			ClientSecret:        clientSecret,
-			Scopes:              scopesParsed,
-			SessionTokenExpiry:  sessionTokenExpiryDuration,
-			SessionCookieMaxAge: sessionCookieMaxAgeInt,
-			JWTSessionKey:       sessionSecretKey,
+			IssuerURL:            issuerURL,
+			ClientID:             clientID,
+			ClientSecret:         clientSecret,
+			Scopes:               scopesParsed,
+			SessionTokenExpiry:   sessionTokenExpiryDuration,
+			SessionCookieMaxAge:  sessionCookieMaxAgeInt,
+			JWTSessionKey:        sessionSecretKey,
+			SecureSessionCookies: secureSessionCookies,
 		},
 		DashboardFinalRedirectURL: os.Getenv("JIMM_DASHBOARD_FINAL_REDIRECT_URL"),
-		SecureSessionCookies:      secureSessionCookies,
 		CookieSessionKey:          []byte(sessionSecretKey),
+		CorsAllowedOrigins:        corsAllowedOrigins,
 	})
 	if err != nil {
 		return err

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -482,4 +483,47 @@ func TestCleanupDoesNotPanic_SessionStoreRelatedCleanups(t *testing.T) {
 	c.Assert(len(svc.GetCleanups()) > 0, qt.IsTrue)
 
 	svc.Cleanup()
+}
+
+func TestCORS(t *testing.T) {
+	c := qt.New(t)
+
+	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
+	c.Assert(err, qt.IsNil)
+	p := jimmtest.NewTestJimmParams(c)
+	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
+	allowedOrigin := "http://my-referrer.com"
+	p.CorsAllowedOrigins = []string{allowedOrigin}
+	p.InsecureSecretStorage = true
+
+	svc, err := jimmsvc.NewService(context.Background(), p)
+	c.Assert(err, qt.IsNil)
+	defer svc.Cleanup()
+
+	srv := httptest.NewServer(svc)
+	c.Cleanup(srv.Close)
+
+	url, err := url.Parse(srv.URL + "/debug/info")
+	c.Assert(err, qt.IsNil)
+	// Invalid origin won't receive CORS headers.
+	req := http.Request{
+		Method: "GET",
+		URL:    url,
+		Header: http.Header{"Origin": []string{"123"}},
+	}
+	response, err := srv.Client().Do(&req)
+	c.Assert(err, qt.IsNil)
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, qt.Equals, http.StatusOK)
+	c.Assert(response.Header.Get("Access-Control-Allow-Credentials"), qt.Equals, "")
+	c.Assert(response.Header.Get("Access-Control-Allow-Origin"), qt.Equals, "")
+
+	// Valid origin should receive CORS headers.
+	req.Header = http.Header{"Origin": []string{allowedOrigin}}
+	response, err = srv.Client().Do(&req)
+	c.Assert(err, qt.IsNil)
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, qt.Equals, http.StatusOK)
+	c.Assert(response.Header.Get("Access-Control-Allow-Credentials"), qt.Equals, "true")
+	c.Assert(response.Header.Get("Access-Control-Allow-Origin"), qt.Equals, allowedOrigin)
 }

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/lestrrat-go/iter v1.0.2
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.16.0
 	gopkg.in/errgo.v1 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -956,8 +956,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
-github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/internal/auth/oauth2.go
+++ b/internal/auth/oauth2.go
@@ -76,6 +76,8 @@ type AuthenticationService struct {
 	sessionTokenExpiry time.Duration
 	// sessionCookieMaxAge holds the max age for session cookies in seconds.
 	sessionCookieMaxAge int
+	// secureCookies decides whether to set the secure flag on cookies.
+	secureCookies bool
 	// jwtSessionKey holds the secret key used for signing/verifying JWT tokens.
 	// According to https://datatracker.ietf.org/doc/html/rfc7518 minimum key lengths are
 	// HSXXX e.g. HS256 - 256 bits, RSA - at least 2048 bits.
@@ -118,6 +120,9 @@ type AuthenticationServiceParams struct {
 
 	// SessionCookieMaxAge holds the max age for session cookies in seconds.
 	SessionCookieMaxAge int
+
+	// SecureCookies decides whether to set the secure flag on cookies.
+	SecureCookies bool
 
 	// JWTSessionKey holds the secret key used for signing/verifying JWT tokens.
 	// See AuthenticationService.JWTSessionKey for more details.
@@ -163,6 +168,7 @@ func NewAuthenticationService(ctx context.Context, params AuthenticationServiceP
 		db:                  params.Store,
 		sessionStore:        params.SessionStore,
 		sessionCookieMaxAge: params.SessionCookieMaxAge,
+		secureCookies:       params.SecureCookies,
 	}, nil
 }
 
@@ -420,13 +426,23 @@ func (as *AuthenticationService) VerifyClientCredentials(ctx context.Context, cl
 	return nil
 }
 
+// sessionCrossOriginSafe sets parameters on the session that allow its use in cross-origin requests.
+// Options are not saved to the database so this must be called whenever a session cookie will be returned to a client.
+//
+// Note browsers require cookies with the same-site policy as 'none' to additionally have the secure flag set.
+func sessionCrossOriginSafe(session *sessions.Session, secure bool) *sessions.Session {
+	session.Options.Secure = secure                  // Ensures only sent with HTTPS
+	session.Options.HttpOnly = false                 // Allow Javascript to read it
+	session.Options.SameSite = http.SameSiteNoneMode // Allow cross-origin requests via Javascript
+	return session
+}
+
 // CreateBrowserSession creates a session and updates the cookie for a browser
 // login callback.
 func (as *AuthenticationService) CreateBrowserSession(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
-	secureCookies bool,
 	email string,
 ) error {
 	const op = errors.Op("auth.AuthenticationService.CreateBrowserSession")
@@ -438,8 +454,7 @@ func (as *AuthenticationService) CreateBrowserSession(
 
 	session.IsNew = true                            // Sets cookie to a fresh new cookie
 	session.Options.MaxAge = as.sessionCookieMaxAge // Expiry in seconds
-	session.Options.Secure = secureCookies          // Ensures only sent with HTTPS
-	session.Options.HttpOnly = false                // Allow Javascript to read it
+	session = sessionCrossOriginSafe(session, as.secureCookies)
 
 	session.Values[SessionIdentityKey] = email
 	if err = session.Save(r, w); err != nil {
@@ -465,6 +480,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	if err != nil {
 		return ctx, errors.E(op, err, "failed to retrieve session")
 	}
+	session = sessionCrossOriginSafe(session, as.secureCookies)
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {

--- a/internal/auth/oauth2.go
+++ b/internal/auth/oauth2.go
@@ -432,7 +432,7 @@ func (as *AuthenticationService) VerifyClientCredentials(ctx context.Context, cl
 // Note browsers require cookies with the same-site policy as 'none' to additionally have the secure flag set.
 func sessionCrossOriginSafe(session *sessions.Session, secure bool) *sessions.Session {
 	session.Options.Secure = secure                  // Ensures only sent with HTTPS
-	session.Options.HttpOnly = false                 // Allow Javascript to read it
+	session.Options.HttpOnly = true                  // Don't allow Javascript to modify cookie
 	session.Options.SameSite = http.SameSiteNoneMode // Allow cross-origin requests via Javascript
 	return session
 }

--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -50,6 +50,7 @@ func setupTestAuthSvc(ctx context.Context, c *qt.C, expiry time.Duration) (*auth
 		SessionStore:        sessionStore,
 		SessionCookieMaxAge: 60,
 		JWTSessionKey:       "secret-key",
+		SecureCookies:       false,
 	})
 	c.Assert(err, qt.IsNil)
 	cleanup := func() {
@@ -295,7 +296,7 @@ func TestCreateBrowserSession(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
 	c.Assert(err, qt.IsNil)
 
-	err = authSvc.CreateBrowserSession(ctx, rec, req, false, "jimm-test@canonical.com")
+	err = authSvc.CreateBrowserSession(ctx, rec, req, "jimm-test@canonical.com")
 	c.Assert(err, qt.IsNil)
 
 	cookies := rec.Header().Get("Set-Cookie")

--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -509,6 +509,6 @@ func TestAuthenticateBrowserSessionHandlesMissingOrExpiredRefreshTokens(t *testi
 	c.Assert(
 		setCookieCookies,
 		qt.Equals,
-		"jimm-browser-session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0",
+		"jimm-browser-session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; HttpOnly; SameSite=None",
 	)
 }

--- a/internal/jimmhttp/auth_handler.go
+++ b/internal/jimmhttp/auth_handler.go
@@ -34,7 +34,6 @@ type OAuthHandler struct {
 	Router                    *chi.Mux
 	authenticator             BrowserOAuthAuthenticator
 	dashboardFinalRedirectURL string
-	secureCookies             bool
 }
 
 // OAuthHandlerParams holds the parameters to configure the OAuthHandler.
@@ -45,10 +44,6 @@ type OAuthHandlerParams struct {
 	// DashboardFinalRedirectURL is the final redirection URL to send users to
 	// upon completing the authorisation code flow.
 	DashboardFinalRedirectURL string
-
-	// SessionCookies determines if HTTPS must be enabled in order for JIMM
-	// to set cookies when creating browser based sessions.
-	SecureCookies bool
 }
 
 // BrowserOAuthAuthenticator handles authorisation code authentication within JIMM
@@ -63,7 +58,6 @@ type BrowserOAuthAuthenticator interface {
 		ctx context.Context,
 		w http.ResponseWriter,
 		r *http.Request,
-		secureCookies bool,
 		email string,
 	) error
 	Logout(ctx context.Context, w http.ResponseWriter, req *http.Request) error
@@ -83,7 +77,6 @@ func NewOAuthHandler(p OAuthHandlerParams) (*OAuthHandler, error) {
 		Router:                    chi.NewRouter(),
 		authenticator:             p.Authenticator,
 		dashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
-		secureCookies:             p.SecureCookies,
 	}, nil
 }
 
@@ -173,7 +166,6 @@ func (oah *OAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		ctx,
 		w,
 		r,
-		oah.secureCookies,
 		email,
 	); err != nil {
 		writeError(ctx, w, http.StatusInternalServerError, err, "failed to setup session")

--- a/internal/jimmtest/auth.go
+++ b/internal/jimmtest/auth.go
@@ -239,6 +239,7 @@ func SetupTestDashboardCallbackHandler(browserURL string, db *db.Database, sessi
 		SessionStore:        sessionStore,
 		SessionCookieMaxAge: 60,
 		JWTSessionKey:       "test-secret",
+		SecureCookies:       false,
 	})
 	if err != nil {
 		return nil, err
@@ -247,7 +248,6 @@ func SetupTestDashboardCallbackHandler(browserURL string, db *db.Database, sessi
 	h, err := jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
 		Authenticator:             authSvc,
 		DashboardFinalRedirectURL: browserURL,
-		SecureCookies:             false,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/jujuapi/admin_test.go
+++ b/internal/jujuapi/admin_test.go
@@ -62,6 +62,7 @@ func (s *adminSuite) SetUpTest(c *gc.C) {
 		SessionStore:        sessionStore,
 		SessionCookieMaxAge: 60,
 		JWTSessionKey:       "test-secret",
+		SecureCookies:       false,
 	})
 	c.Assert(err, gc.Equals, nil)
 	s.JIMM.OAuthAuthenticator = authSvc


### PR DESCRIPTION
## Description

This PR does a few things around CORS to fix issues raised by the Juju dashboard.
1. Added CORS middleware to return valid CORS headers - I've opted to use the https://github.com/rs/cors module which was already a dependency in our go.sum because it is pulled in by a Juju dependency.
2. Fixed bug with cookies differing when calling login and whoami endpoints. The options set on a cookie when calling /login were wiped when calling /whoami because the options are not saved to the database. So we set them before we return a cookie to the user.
3. Changed the cookie's "sameSite" policy from **lax** to **none** to allow the Juju dashboard to send the cookie in cross-origin requests.

There are some things worth mentioning here:
1. Setting the cors allowed origin option to the wildcard "*" to accept all origins is not valid when also setting the `Access-Control-Allow-Credentials` header to true. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#examples_of_access_control_scenarios).
>If a request includes a credential (most commonly a Cookie header) and the response includes an Access-Control-Allow-Origin: * header (that is, with the wildcard), the browser will block access to the response, and report a CORS error in the devtools console.

2. A "sameSite" policy of **none** is necessary because **strict** and **lax** do not permit sending a cookies cross-origin via AJAX. See [here](https://stackoverflow.com/questions/59990864/what-is-the-difference-between-samesite-lax-and-samesite-strict) for more info.

Fixes [CSS-10514](https://warthogs.atlassian.net/browse/CSS-10514)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
I tested the changes with a react app and made a request from the app, running at `localhost:3006` to JIMM's /auth/whoami endpoint. After configuring CORS there was a 403 error because the browser did not send JIMM's session cookie in the request until the cookie's sameSite policy was changed to **none**.

[CSS-10514]: https://warthogs.atlassian.net/browse/CSS-10514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ