### PR TITLE
Use go version from go.mod in golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
 
       - name: Run Golangci-lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
## Description

The go version used by the golangci-lint workflow differs from the one used by our project and other workflows. This PR makes it use the go version from `go.mod`