### PR TITLE
Update copyright header in linter with year regexp

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,8 +69,11 @@ linters-settings:
   gocognit:
     min-complexity: 30
   goheader:
+    values:
+      regexp:
+        year: (\d{4})
     template: |-
-      Copyright 2024 Canonical.
+      Copyright {{year}} Canonical.
   importas:
     no-unaliased: false
     no-extra-aliases: false


### PR DESCRIPTION
## Description

This PR updates the header template in golangci.yaml to allow any year in file headers not only the current one which was hard-coded. It is not legally required to update the year and only causes unnecessary changes to the files.