### PR TITLE
Update channel used for setting up LXD to LTS channel

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -89,7 +89,7 @@ runs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: "lxd"
-        channel: "5.19/stable"
+        channel: "5.21/stable"
         juju-channel: ${{ inputs.juju-channel }}
         bootstrap-options: "--config ${{ github.action_path }}/../../../cloudinit.temp.yaml --config login-token-refresh-url=https://jimm.localhost/.well-known/jwks.json"
 


### PR DESCRIPTION
## Description

LXD 5.21 is the [LTS channel](https://ubuntu.com/blog/lxd_5-21-0_lts) and 5.19 seems to be having issues on the Snapstore. This PR ensures we use LXD 5.21 in the action for integration testing JIMM.