### PR TITLE
use consistent permissions when adding/import models

### DIFF
--- a/cmd/jimmctl/cmd/importmodel_test.go
+++ b/cmd/jimmctl/cmd/importmodel_test.go
@@ -66,6 +66,8 @@ func (s *importModelSuite) TestImportModelFromLocalUser(c *gc.C) {
 	model.SetTag(mt)
 	err := s.JIMM.Database.GetModel(context.Background(), &model)
 	c.Assert(err, gc.Equals, nil)
+	err = s.JIMM.OpenFGAClient.RemoveControllerModel(context.Background(), model.Controller.ResourceTag(), model.ResourceTag())
+	c.Assert(err, gc.Equals, nil)
 	err = s.JIMM.Database.DeleteModel(context.Background(), &model)
 	c.Assert(err, gc.Equals, nil)
 

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -455,14 +455,10 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 	// Note that only the new owner is given access. All previous users that had access according to Juju
 	// are discarded as access must now be governed by JIMM and OpenFGA.
 	ofgaUser := openfga.NewUser(&ownerUser, j.OpenFGAClient)
-	if err := ofgaUser.SetModelAccess(ctx, modelTag, ofganames.AdministratorRelation); err != nil {
-		zapctx.Error(
-			ctx,
-			"failed to set model admin",
-			zap.String("owner", ownerUser.Name),
-			zap.String("model", modelTag.String()),
-			zap.Error(err),
-		)
+	controllerTag := model.Controller.ResourceTag()
+
+	if err := j.addModelPermissions(ctx, ofgaUser, modelTag, controllerTag); err != nil {
+		return errors.E(op, err)
 	}
 
 	// TODO(CSS-5458): Remove the below section on cloud credentials once we no longer persist the relation between

--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -665,7 +665,10 @@ func (j *JIMM) AddModel(ctx context.Context, user *openfga.User, args *ModelCrea
 	modelTag := names.NewModelTag(mi.UUID)
 	controllerTag := builder.controller.ResourceTag()
 
-	return mi, j.addModelPermissions(ctx, ownerUser, modelTag, controllerTag)
+	if err := j.addModelPermissions(ctx, ownerUser, modelTag, controllerTag); err != nil {
+		return nil, errors.E(op, err)
+	}
+	return mi, nil
 }
 
 // addModelPermissions grants a user access to a model and sets the relation between the controller and model.
@@ -674,7 +677,7 @@ func (j *JIMM) addModelPermissions(ctx context.Context, owner *openfga.User, mt 
 	if err := j.OpenFGAClient.AddControllerModel(ctx, ct, mt); err != nil {
 		zapctx.Error(
 			ctx,
-			"failed to add controller-model relation",
+			"failed to add controller->model relation",
 			zap.String("controller", ct.Id()),
 			zap.String("model", mt.Id()),
 		)
@@ -683,7 +686,7 @@ func (j *JIMM) addModelPermissions(ctx context.Context, owner *openfga.User, mt 
 	if err := owner.SetModelAccess(ctx, mt, ofganames.AdministratorRelation); err != nil {
 		zapctx.Error(
 			ctx,
-			"failed to add administrator relation",
+			"failed to add user->model administrator relation",
 			zap.String("user", owner.Tag().Id()),
 			zap.String("model", mt.Id()),
 		)

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -596,7 +596,9 @@ func (s *jimmSuite) TestImportModel(c *gc.C) {
 	conn := s.open(c, nil, "bob")
 	defer conn.Close()
 
-	err := s.JIMM.Database.DeleteModel(context.Background(), s.Model2)
+	err := s.JIMM.OpenFGAClient.RemoveControllerModel(context.Background(), s.Model2.Controller.ResourceTag(), s.Model2.ResourceTag())
+	c.Assert(err, gc.Equals, nil)
+	err = s.JIMM.Database.DeleteModel(context.Background(), s.Model2)
 	c.Assert(err, gc.Equals, nil)
 
 	req := apiparams.ImportModelRequest{

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -238,7 +238,7 @@ func (o *OFGAClient) AddControllerModel(ctx context.Context, controller names.Co
 	return nil
 }
 
-// AddControllerModel removes a relation between a controller and a model.
+// RemoveControllerModel removes a relation between a controller and a model.
 func (o *OFGAClient) RemoveControllerModel(ctx context.Context, controller names.ControllerTag, model names.ModelTag) error {
 	if err := o.RemoveRelation(
 		ctx,

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -238,6 +238,21 @@ func (o *OFGAClient) AddControllerModel(ctx context.Context, controller names.Co
 	return nil
 }
 
+// AddControllerModel removes a relation between a controller and a model.
+func (o *OFGAClient) RemoveControllerModel(ctx context.Context, controller names.ControllerTag, model names.ModelTag) error {
+	if err := o.RemoveRelation(
+		ctx,
+		Tuple{
+			Object:   ofganames.ConvertTag(controller),
+			Relation: ofganames.ControllerRelation,
+			Target:   ofganames.ConvertTag(model),
+		},
+	); err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
 // RemoveModel removes a model.
 func (o *OFGAClient) RemoveModel(ctx context.Context, model names.ModelTag) error {
 	if err := o.removeTuples(

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -197,6 +197,35 @@ func (s *openFGATestSuite) TestAddControllerModel(c *gc.C) {
 	c.Assert(allowed, gc.Equals, true)
 }
 
+func (s *openFGATestSuite) TestRemoveControllerModel(c *gc.C) {
+	modelUUID, err := uuid.NewRandom()
+	c.Assert(err, gc.IsNil)
+	controllerUUID, err := uuid.NewRandom()
+	c.Assert(err, gc.IsNil)
+
+	controller := names.NewControllerTag(controllerUUID.String())
+	model := names.NewModelTag(modelUUID.String())
+
+	err = s.ofgaClient.AddControllerModel(context.Background(), controller, model)
+	c.Assert(err, gc.IsNil)
+
+	tuple := openfga.Tuple{
+		Object:   ofganames.ConvertTag(controller),
+		Relation: "controller",
+		Target:   ofganames.ConvertTag(model),
+	}
+	allowed, err := s.ofgaClient.CheckRelation(context.Background(), tuple, false)
+	c.Assert(err, gc.IsNil)
+	c.Assert(allowed, gc.Equals, true)
+
+	err = s.ofgaClient.RemoveControllerModel(context.Background(), controller, model)
+	c.Assert(err, gc.IsNil)
+
+	allowed, err = s.ofgaClient.CheckRelation(context.Background(), tuple, false)
+	c.Assert(err, gc.IsNil)
+	c.Assert(allowed, gc.Equals, false)
+}
+
 func (s *openFGATestSuite) TestRemoveModel(c *gc.C) {
 	modelUUID, err := uuid.NewRandom()
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
## Description

This PR fixes an inconsistency when creating vs importing models.

When a model is created we grant the user access to the model and set the backing controller as an admin of the model.
The latter step was missing when importing the model. 

This PR encapsulates the logic of adding permissions for a new model into a function that can be called from both places.

Partially fixes [CSS-10592](https://warthogs.atlassian.net/browse/CSS-10592)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[CSS-10592]: https://warthogs.atlassian.net/browse/CSS-10592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ