### PR TITLE
return model summaries with new model owner

### DIFF
--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -701,13 +701,7 @@ func (j *JIMM) ModelInfo(ctx context.Context, user *openfga.User, mt names.Model
 		return nil, errors.E(op, err)
 	}
 
-	modelAccess, err := j.GetUserModelAccess(ctx, user, mt)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	if modelAccess == "" {
-		// If the user doesn't have any access on the model return an
-		// unauthorized error
+	if ok, err := user.IsModelReader(ctx, mt); !ok || err != nil {
 		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
@@ -724,6 +718,19 @@ func (j *JIMM) ModelInfo(ctx context.Context, user *openfga.User, mt names.Model
 		return nil, errors.E(op, err)
 	}
 
+	return j.mergeModelInfo(ctx, user, mi, m)
+}
+
+// mergeModelInfo replaces fields on the juju model info object with
+// information from JIMM where JIMM specific information should be used.
+func (j *JIMM) mergeModelInfo(ctx context.Context, user *openfga.User, modelInfo *jujuparams.ModelInfo, jimmModel dbmodel.Model) (*jujuparams.ModelInfo, error) {
+	const op = errors.Op("jimm.mergeModelInfo")
+
+	jimmSummary := jimmModel.ToJujuModelSummary()
+	modelInfo.CloudCredentialTag = jimmSummary.CloudCredentialTag
+	modelInfo.ControllerUUID = jimmSummary.ControllerUUID
+	modelInfo.OwnerTag = jimmSummary.OwnerTag
+
 	userAccess := make(map[string]string)
 
 	for _, relation := range []openfga.Relation{
@@ -733,7 +740,7 @@ func (j *JIMM) ModelInfo(ctx context.Context, user *openfga.User, mt names.Model
 		ofganames.WriterRelation,
 		ofganames.ReaderRelation,
 	} {
-		usersWithSpecifiedRelation, err := openfga.ListUsersWithAccess(ctx, j.OpenFGAClient, mt, relation)
+		usersWithSpecifiedRelation, err := openfga.ListUsersWithAccess(ctx, j.OpenFGAClient, jimmModel.ResourceTag(), relation)
 		if err != nil {
 			return nil, errors.E(op, err)
 		}
@@ -745,6 +752,11 @@ func (j *JIMM) ModelInfo(ctx context.Context, user *openfga.User, mt names.Model
 				userAccess[u.Name] = ToModelAccessString(relation)
 			}
 		}
+	}
+
+	modelAccess, err := j.GetUserModelAccess(ctx, user, jimmModel.ResourceTag())
+	if err != nil {
+		return nil, errors.E(op, err)
 	}
 
 	users := make([]jujuparams.ModelUserInfo, 0, len(userAccess))
@@ -762,15 +774,15 @@ func (j *JIMM) ModelInfo(ctx context.Context, user *openfga.User, mt names.Model
 			})
 		}
 	}
-	mi.Users = users
+	modelInfo.Users = users
 
 	if modelAccess != "admin" && modelAccess != "write" {
 		// Users need "write" level access (or above) to see machine
 		// information.
-		mi.Machines = nil
+		modelInfo.Machines = nil
 	}
 
-	return mi, nil
+	return modelInfo, nil
 }
 
 // ModelStatus returns a jujuparams.ModelStatus for the given model. If

--- a/internal/jimmtest/api.go
+++ b/internal/jimmtest/api.go
@@ -55,9 +55,12 @@ func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelT
 		return nil, d.Err
 	}
 	atomic.AddInt64(&d.open, 1)
-	ctl.UUID = d.UUID
 	if ctl.UUID == "" {
-		ctl.UUID = DefaultControllerUUID
+		if d.UUID == "" {
+			ctl.UUID = DefaultControllerUUID
+		} else {
+			ctl.UUID = d.UUID
+		}
 	}
 	ctl.AgentVersion = d.AgentVersion
 	if ctl.AgentVersion == "" {


### PR DESCRIPTION
## Description

This PR intends to fix an inconsistency in JIMM between the `ModelInfo` and `ModelSummaries` methods. The latter takes each JIMM dbmodel.Model object that a user has access to and converts into into a model summary.
The former makes an API call to the Juju controller and returns the modelInfo object to the user after replacing some JIMM specific fields like `userAccess`.

One issue is that the modelOwner field was not being replaced in the `modelInfo` call. But this value is unique when using JIMM. In a similar vein, the modelOwner may be different in JIMM versus the Juju controller, particularly when importing a model.

Full list of changes:
- refactor ModelInfo slightly to use a separate function where we merge the juju model info with JIMM specific data
- refactor the test for ModelInfo to reduce duplication
- tweak the test dialer to have less surprising behavior

Partially fixes [CSS-10592](https://warthogs.atlassian.net/browse/CSS-10592)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[CSS-10592]: https://warthogs.atlassian.net/browse/CSS-10592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ