### PR TITLE
Change goheader template to avoid bug

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,11 +69,8 @@ linters-settings:
   gocognit:
     min-complexity: 30
   goheader:
-    values:
-      regexp:
-        year: (\d{4})
     template: |-
-      Copyright {{year}} Canonical.
+      Copyright {{MOD-YEAR}} Canonical.
   importas:
     no-unaliased: false
     no-extra-aliases: false


### PR DESCRIPTION
## Description

This PR updates the goheader template with the same changes we have for Livepatch repos. As discovered by Kian, regexes cause buggy behaviour in the goheader linter which under certain conditions puts them in place as literals.
We use the built-in `MOD-YEAR` value instead which causes more updates of headers but works correctly.