### PR TITLE
Ignore auth for `/swagger.json` endpoint

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -408,7 +408,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	s.mux.Mount("/metrics", promhttp.Handler())
 
-	s.mux.Mount("/rebac", middleware.AuthenticateRebac(rebacBackend.Handler(""), &s.jimm))
+	s.mux.Mount("/rebac", middleware.AuthenticateRebac("/rebac", rebacBackend.Handler(""), &s.jimm))
 
 	mountHandler(
 		"/debug",

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -294,7 +294,10 @@ func TestRebacAdminApi(t *testing.T) {
 	response, err := srv.Client().Get(srv.URL + "/rebac/v1/swagger.json")
 	c.Assert(err, qt.IsNil)
 	defer response.Body.Close()
-	c.Assert(response.StatusCode, qt.Equals, 401)
+
+	// The `/swagger.json` endpoint doesn't require authentication, so the returned
+	// status code should be 200.
+	c.Assert(response.StatusCode, qt.Equals, 200)
 }
 
 func TestThirdPartyCaveatDischarge(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 require (
 	github.com/antonlindstrom/pgstore v0.0.0-20220421113606-e3a6e3fed12a
 	github.com/canonical/ofga v0.10.0
-	github.com/canonical/rebac-admin-ui-handlers v0.1.1
+	github.com/canonical/rebac-admin-ui-handlers v0.1.2
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/canonical/rebac-admin-ui-handlers v0.1.0 h1:Bef1N/RgQine8hHX4ZMksQz/1
 github.com/canonical/rebac-admin-ui-handlers v0.1.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/canonical/rebac-admin-ui-handlers v0.1.1 h1:rjsb45diShhwD/uUFpai6gmhFUzT+jTdsnEWcOvcKx4=
 github.com/canonical/rebac-admin-ui-handlers v0.1.1/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
+github.com/canonical/rebac-admin-ui-handlers v0.1.2 h1:tQU/NWQVD9IEgy3ct8JWZXpLK/dedWjKcy9E8W4glpo=
+github.com/canonical/rebac-admin-ui-handlers v0.1.2/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -4,6 +4,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 
 	rebac_handlers "github.com/canonical/rebac-admin-ui-handlers/v1"
 	"github.com/juju/zaputil/zapctx"
@@ -27,11 +28,13 @@ func AuthenticateViaCookie(next http.Handler, jimm jujuapi.JIMM) http.Handler {
 	})
 }
 
-// AuthenticateRebac is a layer on top of AuthenticateViaCookie
-// It places the OpenFGA user for the session identity inside the request's context
-// and verifies that the user is a JIMM admin.
-func AuthenticateRebac(next http.Handler, jimm jujuapi.JIMM) http.Handler {
-	return AuthenticateViaCookie(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// AuthenticateRebac is a layer on top of AuthenticateViaCookie. It places the
+// OpenFGA user for the session identity inside the request's context and
+// verifies that the user is a JIMM admin. Note that the method needs the base
+// URL to decide if the request does not require authentication; this is to
+// safeguard against conflicting/similar endpoint names in the future.
+func AuthenticateRebac(baseURL string, next http.Handler, jimm jujuapi.JIMM) http.Handler {
+	cookieAuthenticator := AuthenticateViaCookie(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
 		identity := auth.SessionIdentityFromContext(ctx)
@@ -56,4 +59,13 @@ func AuthenticateRebac(next http.Handler, jimm jujuapi.JIMM) http.Handler {
 		ctx = rebac_handlers.ContextWithIdentity(ctx, user)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}), jimm)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		relativePath, _ := strings.CutPrefix(r.URL.Path, baseURL)
+		if relativePath == "/v1/swagger.json" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		cookieAuthenticator.ServeHTTP(w, r)
+	})
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -28,6 +28,11 @@ func AuthenticateViaCookie(next http.Handler, jimm jujuapi.JIMM) http.Handler {
 	})
 }
 
+// Set of ReBAC Admin API endpoints that do not require authentication.
+var unauthenticatedEndpoints = map[string]any{
+	"/v1/swagger.json": nil,
+}
+
 // AuthenticateRebac is a layer on top of AuthenticateViaCookie. It places the
 // OpenFGA user for the session identity inside the request's context and
 // verifies that the user is a JIMM admin. Note that the method needs the base
@@ -62,7 +67,7 @@ func AuthenticateRebac(baseURL string, next http.Handler, jimm jujuapi.JIMM) htt
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		relativePath, _ := strings.CutPrefix(r.URL.Path, baseURL)
-		if relativePath == "/v1/swagger.json" {
+		if _, found := unauthenticatedEndpoints[relativePath]; found {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -29,8 +29,8 @@ func AuthenticateViaCookie(next http.Handler, jimm jujuapi.JIMM) http.Handler {
 }
 
 // Set of ReBAC Admin API endpoints that do not require authentication.
-var unauthenticatedEndpoints = map[string]any{
-	"/v1/swagger.json": nil,
+var unauthenticatedEndpoints = map[string]struct{}{
+	"/v1/swagger.json": {},
 }
 
 // AuthenticateRebac is a layer on top of AuthenticateViaCookie. It places the


### PR DESCRIPTION
## Description

This PR disables authentication on `/swagger.json` in the ReBAC Admin API.

Fixes CSS-10918

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
