### PR TITLE
run setup python action for ubuntu 24.04 runners

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -15,6 +15,10 @@ inputs:
       PAT Token that has package:read access to canonical/JIMM
       The PAT token can be left empty when building the development version of JIMM.
     required: true
+  python-version:
+    description: Python version to install in the setup-python action.
+    default: "3.12"
+    required: false
 
 outputs:
   url:
@@ -84,6 +88,12 @@ runs:
       env:
         SKIP_BOOTSTRAP: true
         CLOUDINIT_FILE: "cloudinit.temp.yaml"
+
+    # See: https://github.com/charmed-kubernetes/actions-operator/issues/82
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
 
     - name: Setup Juju Controller
       uses: charmed-kubernetes/actions-operator@main


### PR DESCRIPTION
## Description

This PR fixes an issue in our setup-jimm action that was introduced with Ubuntu 24.04 runners.

C/p from https://github.com/charmed-kubernetes/actions-operator/issues/82
>Github recently released their ubuntu-24.04 series runners. Using those results in an error because actions-operator tries to install tox globally with pip, rather than in a virtual environment.

This affects the setup-jimm action when we call `charmed-kubernetes/actions-operator` to start a Juju controller. Run the setup-python action to fix this.
