### PR TITLE
move wellknown handler

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -42,7 +42,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/pubsub"
 	"github.com/canonical/jimm/v3/internal/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/vault"
-	"github.com/canonical/jimm/v3/internal/wellknownapi"
 )
 
 const (
@@ -416,7 +415,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	)
 	mountHandler(
 		"/.well-known",
-		wellknownapi.NewWellKnownHandler(s.jimm.CredentialStore),
+		jimmhttp.NewWellKnownHandler(s.jimm.CredentialStore),
 	)
 
 	if p.DashboardFinalRedirectURL == "" {

--- a/internal/jimmhttp/debug_handler_test.go
+++ b/internal/jimmhttp/debug_handler_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/canonical/jimm/v3/version"
 )
 
-func setupHandlerAndRecorder(c *qt.C, startTime jimmhttp.StatusCheck, path string) *httptest.ResponseRecorder {
+func setupDebugHandlerAndRecorder(c *qt.C, startTime jimmhttp.StatusCheck, path string) *httptest.ResponseRecorder {
 	r := (&jimmhttp.DebugHandler{
 		Router: chi.NewRouter(),
 		StatusChecks: map[string]jimmhttp.StatusCheck{
@@ -37,7 +37,7 @@ func setupHandlerAndRecorder(c *qt.C, startTime jimmhttp.StatusCheck, path strin
 func TestDebugInfo(t *testing.T) {
 	c := qt.New(t)
 
-	rr := setupHandlerAndRecorder(c, jimmhttp.ServerStartTime, "/info")
+	rr := setupDebugHandlerAndRecorder(c, jimmhttp.ServerStartTime, "/info")
 
 	resp := rr.Result()
 	defer resp.Body.Close()
@@ -53,7 +53,7 @@ func TestDebugStatus(t *testing.T) {
 	startTime, err := jimmhttp.ServerStartTime.Check(ctx)
 	c.Assert(err, qt.IsNil)
 
-	rr := setupHandlerAndRecorder(c, jimmhttp.ServerStartTime, "/status")
+	rr := setupDebugHandlerAndRecorder(c, jimmhttp.ServerStartTime, "/status")
 
 	resp := rr.Result()
 	defer resp.Body.Close()
@@ -74,7 +74,7 @@ func TestDebugStatus(t *testing.T) {
 func TestDebugStatusStatusError(t *testing.T) {
 	c := qt.New(t)
 
-	rr := setupHandlerAndRecorder(c, jimmhttp.MakeStatusCheck("Test", func(context.Context) (interface{}, error) {
+	rr := setupDebugHandlerAndRecorder(c, jimmhttp.MakeStatusCheck("Test", func(context.Context) (interface{}, error) {
 		return nil, errors.E("test error")
 	}), "/status")
 

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -1,5 +1,5 @@
 // Copyright 2024 Canonical.
-package wellknownapi
+package jimmhttp
 
 import (
 	"fmt"

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -1,5 +1,5 @@
 // Copyright 2024 Canonical.
-package wellknownapi_test
+package jimmhttp_test
 
 import (
 	"context"
@@ -15,9 +15,9 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/vault"
-	"github.com/canonical/jimm/v3/internal/wellknownapi"
 )
 
 func newStore(t testing.TB) *vault.VaultStore {
@@ -52,8 +52,8 @@ func getJWKS(c *qt.C) jwk.Set {
 	return set
 }
 
-func setupHandlerAndRecorder(c *qt.C, path string, store *vault.VaultStore) *httptest.ResponseRecorder {
-	handler := wellknownapi.NewWellKnownHandler(store).Routes()
+func setupWellknownHandlerAndRecorder(c *qt.C, path string, store *vault.VaultStore) *httptest.ResponseRecorder {
+	handler := jimmhttp.NewWellKnownHandler(store).Routes()
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", path, nil)
 	c.Assert(err, qt.IsNil)
@@ -70,7 +70,7 @@ func TestWellknownAPIJWKSJSONHandles404(t *testing.T) {
 	err := store.CleanupJWKS(ctx)
 	c.Assert(err, qt.IsNil)
 
-	rr := setupHandlerAndRecorder(c, "/jwks.json", store)
+	rr := setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
 
 	resp := rr.Result()
 	defer resp.Body.Close()
@@ -99,7 +99,7 @@ func TestWellknownAPIJWKSJSONHandles500(t *testing.T) {
 	err = store.PutJWKS(ctx, jwks)
 	c.Assert(err, qt.IsNil)
 
-	rr := setupHandlerAndRecorder(c, "/jwks.json", store)
+	rr := setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
 
 	resp := rr.Result()
 	defer resp.Body.Close()
@@ -135,7 +135,7 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	err = store.PutJWKSExpiry(ctx, expiry)
 	c.Assert(err, qt.IsNil)
 
-	rr := setupHandlerAndRecorder(c, "/jwks.json", store)
+	rr := setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
 
 	resp := rr.Result()
 	defer resp.Body.Close()

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
-	"github.com/canonical/jimm/v3/internal/wellknownapi"
 )
 
 type websocketSuite struct {
@@ -62,7 +61,7 @@ func (s *websocketSuite) SetUpTest(c *gc.C) {
 		jimmhttp.NewHTTPProxyHandler(s.JIMM),
 	)
 	mux.Handle("/model/*", http.StripPrefix("/model", jujuapi.ModelHandler(ctx, s.JIMM, s.Params)))
-	jwks := wellknownapi.NewWellKnownHandler(s.JIMM.CredentialStore)
+	jwks := jimmhttp.NewWellKnownHandler(s.JIMM.CredentialStore)
 	mux.HandleFunc("/.well-known/jwks.json", jwks.JWKS)
 
 	s.APIHandler = mux

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -29,7 +29,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/pubsub"
-	"github.com/canonical/jimm/v3/internal/wellknownapi"
 	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
@@ -120,7 +119,7 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 
 	mountHandler(
 		"/.well-known",
-		wellknownapi.NewWellKnownHandler(s.JIMM.CredentialStore),
+		jimmhttp.NewWellKnownHandler(s.JIMM.CredentialStore),
 	)
 	macaroonDischarger := s.setupMacaroonDischarger(c)
 	localDischargePath := "/macaroons"


### PR DESCRIPTION
## Description

Moves the wellknown handler into jimmhttp (with the rest of our handlers).

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->