### PR TITLE
track response time for http endpoints

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -273,7 +273,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	s := new(Service)
 	s.mux = chi.NewRouter()
 
-	s.mux.Use(middleware.MeasureResponseTime)
+	s.mux.Use(middleware.MeasureHTTPResponseTime)
 
 	// Setup all dependency services
 

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -273,6 +273,8 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	s := new(Service)
 	s.mux = chi.NewRouter()
 
+	s.mux.Use(middleware.MeasureResponseTime)
+
 	// Setup all dependency services
 
 	if p.ControllerUUID == "" {

--- a/internal/middleware/responsetime.go
+++ b/internal/middleware/responsetime.go
@@ -4,21 +4,40 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
+
+// statusRecorder to record the status code from the ResponseWriter
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rec *statusRecorder) WriteHeader(statusCode int) {
+	rec.statusCode = statusCode
+	rec.ResponseWriter.WriteHeader(statusCode)
+}
 
 // MeasureResponseTime tracks response time of requests.
 func MeasureResponseTime(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check the upgrade header because we only track http endpoints
-		if r.Header.Get("Upgrade") != "websocket" {
-			start := time.Now()
-			defer func() {
-				servermon.ResponseTimeHistogram.WithLabelValues(r.URL.Path, r.Method).Observe(time.Since(start).Seconds())
-			}()
+		if r.Header.Get("Upgrade") == "websocket" {
+			next.ServeHTTP(w, r)
+			return
 		}
-		next.ServeHTTP(w, r)
+		rec := statusRecorder{w, 200}
+		start := time.Now()
+		defer func() {
+			route := chi.RouteContext(r.Context()).RoutePattern()
+			statusCode := strconv.Itoa(rec.statusCode)
+			servermon.ResponseTimeHistogram.WithLabelValues(route, r.Method, statusCode).Observe(time.Since(start).Seconds())
+		}()
+		next.ServeHTTP(&rec, r)
 	})
 }

--- a/internal/middleware/responsetime.go
+++ b/internal/middleware/responsetime.go
@@ -23,8 +23,9 @@ func (rec *statusRecorder) WriteHeader(statusCode int) {
 	rec.ResponseWriter.WriteHeader(statusCode)
 }
 
-// MeasureResponseTime tracks response time of requests.
-func MeasureResponseTime(next http.Handler) http.Handler {
+// MeasureHTTPResponseTime tracks response time of HTTP requests.
+// We don't track websocket requests.
+func MeasureHTTPResponseTime(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check the upgrade header because we only track http endpoints
 		if r.Header.Get("Upgrade") == "websocket" {

--- a/internal/middleware/responsetime.go
+++ b/internal/middleware/responsetime.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Canonical.
+
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// MeasureResponseTime tracks response time of requests.
+func MeasureResponseTime(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		duration := time.Since(start)
+		route := r.URL.Path
+		servermon.ResponseTimeHistogram.WithLabelValues(route, r.Method).Observe(duration.Seconds())
+	})
+}

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -136,7 +136,7 @@ var (
 		Name:      "http",
 		Help:      "request_duration_seconds",
 		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
-	}, []string{"route", "method"})
+	}, []string{"route", "method", "status_code"})
 )
 
 // DurationObserver returns a function that, when run with `defer` will

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -131,6 +131,12 @@ var (
 		Name:      "controller",
 		Help:      "The number of controllers managed by JIMM.",
 	})
+	ResponseTimeHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "jimm",
+		Name:      "http",
+		Help:      "request_duration_seconds",
+		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+	}, []string{"route", "method"})
 )
 
 // DurationObserver returns a function that, when run with `defer` will

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -133,8 +133,9 @@ var (
 	})
 	ResponseTimeHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "jimm",
-		Name:      "http",
-		Help:      "request_duration_seconds",
+		Subsystem: "http",
+		Name:      "request_duration_seconds",
+		Help:      "The duration of handling an HTTP request in seconds.",
 		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	}, []string{"route", "method", "status_code"})
 )


### PR DESCRIPTION
## Description

Add middleware to track response time for HTTP requests.
This can help us understand our performance bottlenecks and improve our observability.

> with some work we can use the juju calls' metrics to calculate jimm's overhead

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->