### PR TITLE
fix panic when connection to controller fails

### DIFF
--- a/internal/rpc/apiproxy.go
+++ b/internal/rpc/apiproxy.go
@@ -401,6 +401,7 @@ func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
 		connWithMetadata, err := p.createControllerConn(ctx)
 		if err != nil {
 			createConnErr = errors.E(op, err)
+			return
 		}
 
 		p.msgs.controllerUUID = connWithMetadata.ControllerUUID


### PR DESCRIPTION
## Description
This pr fixes a bug that causes Jimm to panic when it is issued `juju status` on a not-existing model.

> I think this bug is even bigger because Jimm will crash on a failing controller's connection generally.

## How to reproduce the bug
- set a qa environment with make `qa-microk8s`
- remove from the database the model (ex. `make dev-env-cleanup` and `make dev-env` again)
- `juju status`

Jimm will panic. It can't find the model in the database, so it is not able to create the connection. Therefore, it will later try to read Json from a nil connection.

This fix returns the error and adds a test for it.

## Before the fix
![image](https://github.com/user-attachments/assets/dc7e8473-578d-41a5-919d-91529c96f34f)
and juju status hangs

## After the fix
![image](https://github.com/user-attachments/assets/eb824781-9252-4534-9ecb-c6c14669a4e7)
juju status will return `ERROR model not found (not found)`

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->