### PR TITLE
Remove juju debug-log from test logs when a test fails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     ],
     "go.lintOnSave": "workspace",
     "go.testEnvVars": {
-        "JIMM_TEST_LOG_SQL": "false"
+        "JIMM_TEST_LOG_SQL": "false",
+        "TEST_LOGGING_CONFIG": "ERROR" // this is the logging level for juju connsuite logs
     }
 }

--- a/internal/logger/gocheck_logger.go
+++ b/internal/logger/gocheck_logger.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Canonical.
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	gc "gopkg.in/check.v1"
+)
+
+func NewGoCheckLogger(c *gc.C) *zap.Logger {
+	output := gocheckZapWriter{c}
+
+	devConfig := zap.NewDevelopmentEncoderConfig()
+	devConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	devConfig.EncodeTime = shortTimeEncoder
+
+	return zap.New(
+		zapcore.NewCore(
+			zapcore.NewConsoleEncoder(devConfig),
+			output,
+			zap.DebugLevel,
+		),
+	)
+}
+
+type gocheckZapWriter struct {
+	c *gc.C
+}
+
+func (w gocheckZapWriter) Write(buf []byte) (int, error) {
+	w.c.Logf(string(buf))
+	return len(buf), nil
+}
+
+func (w gocheckZapWriter) Sync() error {
+	return nil
+}

--- a/internal/logger/gocheck_logger.go
+++ b/internal/logger/gocheck_logger.go
@@ -1,4 +1,5 @@
 // Copyright 2024 Canonical.
+
 package logger
 
 import (
@@ -7,6 +8,8 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+// NewGoCheckLogger create a logger to be used by the gocheck test library.
+// The logs are shown only when the test fails.
 func NewGoCheckLogger(c *gc.C) *zap.Logger {
 	output := gocheckZapWriter{c}
 

--- a/internal/testutils/jimmtest/logging.go
+++ b/internal/testutils/jimmtest/logging.go
@@ -2,15 +2,10 @@
 package jimmtest
 
 import (
-	"os"
-	"strings"
-
-	"github.com/juju/loggo"
-	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/logger"
 )
 
 // LoggingSuite is a replacement for github.com/juju/testing.LoggingSuite
@@ -34,49 +29,6 @@ func (s *LoggingSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *LoggingSuite) setUp(c *gc.C) {
-	output := gocheckZapWriter{c}
-	logger := zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
-			LevelKey:    "level",
-			MessageKey:  "msg",
-			EncodeLevel: zapcore.CapitalLevelEncoder,
-			EncodeTime:  zapcore.ISO8601TimeEncoder,
-		}),
-		output,
-		zap.DebugLevel,
-	))
-
-	zapctx.Default = logger
-
-	loggo.ResetLogging()
-	// Don't use the default writer for the test logging, which
-	// means we can still get logging output from tests that
-	// replace the default writer.
-	err := loggo.RegisterWriter(loggo.DefaultWriterName, discardWriter{})
-	c.Assert(err, gc.IsNil)
-	err = loggo.RegisterWriter("loggingsuite", zaputil.NewLoggoWriter(logger))
-	c.Assert(err, gc.IsNil)
-	level := "DEBUG"
-	if envLevel := os.Getenv("TEST_LOGGING_CONFIG"); envLevel != "" {
-		level = envLevel
-	}
-	err = loggo.ConfigureLoggers(level)
-	c.Assert(err, gc.Equals, nil)
-}
-
-type discardWriter struct{}
-
-func (discardWriter) Write(entry loggo.Entry) {
-}
-
-type gocheckZapWriter struct {
-	c *gc.C
-}
-
-func (w gocheckZapWriter) Write(buf []byte) (int, error) {
-	return len(buf), w.c.Output(1, strings.TrimSuffix(string(buf), "\n"))
-}
-
-func (w gocheckZapWriter) Sync() error {
-	return nil
+	goCheckLogger := logger.NewGoCheckLogger(c)
+	zapctx.Default = goCheckLogger
 }

--- a/internal/testutils/jimmtest/logging.go
+++ b/internal/testutils/jimmtest/logging.go
@@ -2,11 +2,23 @@
 package jimmtest
 
 import (
+	"fmt"
+
+	"github.com/juju/loggo"
 	"github.com/juju/zaputil/zapctx"
 	gc "gopkg.in/check.v1"
 
 	"github.com/canonical/jimm/v3/internal/logger"
 )
+
+func init() {
+	go func() {
+		fmt.Println("RESETTING")
+		for {
+			loggo.ResetLogging()
+		}
+	}()
+}
 
 // LoggingSuite is a replacement for github.com/juju/testing.LoggingSuite
 // zap logging but also replaces the global loggo logger.

--- a/internal/testutils/jimmtest/logging.go
+++ b/internal/testutils/jimmtest/logging.go
@@ -2,7 +2,7 @@
 package jimmtest
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/juju/loggo"
 	"github.com/juju/zaputil/zapctx"
@@ -12,10 +12,16 @@ import (
 )
 
 func init() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	done := make(chan bool)
 	go func() {
-		fmt.Println("RESETTING")
 		for {
-			loggo.ResetLogging()
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				loggo.ResetLogging()
+			}
 		}
 	}()
 }
@@ -43,4 +49,5 @@ func (s *LoggingSuite) TearDownTest(c *gc.C) {
 func (s *LoggingSuite) setUp(c *gc.C) {
 	goCheckLogger := logger.NewGoCheckLogger(c)
 	zapctx.Default = goCheckLogger
+	loggo.ResetLogging()
 }

--- a/internal/testutils/jimmtest/logging.go
+++ b/internal/testutils/jimmtest/logging.go
@@ -11,6 +11,8 @@ import (
 	"github.com/canonical/jimm/v3/internal/logger"
 )
 
+// init is a workaround to reset the logger coming from the loggo library.
+// This is to prevent juju debug logs from cluttering our tests output.
 func init() {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	done := make(chan bool)

--- a/internal/testutils/jimmtest/logging.go
+++ b/internal/testutils/jimmtest/logging.go
@@ -2,31 +2,11 @@
 package jimmtest
 
 import (
-	"time"
-
-	"github.com/juju/loggo"
 	"github.com/juju/zaputil/zapctx"
 	gc "gopkg.in/check.v1"
 
 	"github.com/canonical/jimm/v3/internal/logger"
 )
-
-// init is a workaround to reset the logger coming from the loggo library.
-// This is to prevent juju debug logs from cluttering our tests output.
-func init() {
-	ticker := time.NewTicker(100 * time.Millisecond)
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				loggo.ResetLogging()
-			}
-		}
-	}()
-}
 
 // LoggingSuite is a replacement for github.com/juju/testing.LoggingSuite
 // zap logging but also replaces the global loggo logger.
@@ -51,5 +31,4 @@ func (s *LoggingSuite) TearDownTest(c *gc.C) {
 func (s *LoggingSuite) setUp(c *gc.C) {
 	goCheckLogger := logger.NewGoCheckLogger(c)
 	zapctx.Default = goCheckLogger
-	loggo.ResetLogging()
 }


### PR DESCRIPTION
## Description



The problem we face is that our tests are cluttered with many juju logs.
Ex when test fail:
![Screenshot from 2024-10-24 17-11-28](https://github.com/user-attachments/assets/ba44af92-d6f3-4e89-bbb6-1ce2315be5e3)
The reason is that `corejujutesting.JujuConnSuite` is logging a lot of stuff it is doing in `setupSuite`.

The solution is to set the env variable in the test config to increase the connsuite log level to error.

Ex when test fail now:
![Screenshot from 2024-10-24 17-10-34](https://github.com/user-attachments/assets/247b2654-2000-4928-9df4-dec01b19fb73)


Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->