### PR TITLE
Return the group name when listing a user's groups.

### DIFF
--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -129,7 +129,7 @@ func (s *identitiesService) GetIdentityGroups(ctx context.Context, identityId st
 		dbGroup, err := s.jimm.GetGroupByUUID(ctx, user, t.Target.ID)
 		if err != nil {
 			// Handle the case where the group was removed from the DB but a lingering OpenFGA tuple still exists.
-			// Don't return an error as that would prevent a user from viewing their groups, instead show the group as "removed".
+			// Don't return an error as that would prevent a user from viewing their groups, instead drop the group from the result.
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				continue
 			}

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -124,18 +124,21 @@ func (s *identitiesService) GetIdentityGroups(ctx context.Context, identityId st
 		return nil, err
 	}
 
-	groups := make([]resources.Group, len(tuples))
-	for i, t := range tuples {
+	groups := make([]resources.Group, 0, len(tuples))
+	for _, t := range tuples {
 		dbGroup, err := s.jimm.GetGroupByUUID(ctx, user, t.Target.ID)
 		if err != nil {
 			// Handle the case where the group was removed from the DB but a lingering OpenFGA tuple still exists.
 			// Don't return an error as that would prevent a user from viewing their groups, instead show the group as "removed".
-			dbGroup.Name = "(removed)"
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				continue
+			}
+			return nil, err
 		}
-		groups[i] = resources.Group{
+		groups = append(groups, resources.Group{
 			Id:   &t.Target.ID,
 			Name: dbGroup.Name,
-		}
+		})
 	}
 
 	originalToken := filter.Token()

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -120,17 +120,24 @@ func (s *identitiesService) GetIdentityGroups(ctx context.Context, identityId st
 		Relation:     ofganames.MemberRelation.String(),
 		TargetObject: openfga.GroupType.String(),
 	}, int32(filter.Limit()), filter.Token()) // #nosec G115 accept integer conversion
-
 	if err != nil {
 		return nil, err
 	}
+
 	groups := make([]resources.Group, len(tuples))
 	for i, t := range tuples {
+		dbGroup, err := s.jimm.GetGroupByUUID(ctx, user, t.Target.ID)
+		if err != nil {
+			// Handle the case where the group was removed from the DB but a lingering OpenFGA tuple still exists.
+			// Don't return an error as that would prevent a user from viewing their groups, instead show the group as "removed".
+			dbGroup.Name = "(removed)"
+		}
 		groups[i] = resources.Group{
 			Id:   &t.Target.ID,
-			Name: t.Target.ID,
+			Name: dbGroup.Name,
 		}
 	}
+
 	originalToken := filter.Token()
 	return &resources.PaginatedResponse[resources.Group]{
 		Data: groups,

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -103,7 +103,8 @@ func (s *identitiesSuite) TestIdentityGetGroups(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		token = *groups.Next.PageToken
 		for j := 0; j < len(groups.Data); j++ {
-			c.Assert(groups.Data[j].Name, gc.Equals, groupTags[i+j].Id())
+			c.Assert(groups.Data[j].Name, gc.Equals, fmt.Sprintf("group-test%d", i+j))
+			c.Assert(groupTags[j].Id(), gc.Matches, `\w*-\w*-\w*-\w*-\w*`)
 		}
 		if *groups.Next.PageToken == "" {
 			break

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -113,11 +113,10 @@ func (s *identitiesSuite) TestIdentityGetGroups(c *gc.C) {
 	}
 }
 
-// TestIdentityGetGroupsWithMissingDbGroup tests the behaviour
+// TestGetIdentityGroupsWithDeletedDbGroup tests the behaviour
 // of GetIdentityGroups when a tuple lingers in OpenFGA but the group
 // has been removed from the database.
-func (s *identitiesSuite) TestIdentityGetGroupsWithMissingDbGroup(c *gc.C) {
-	// initialization
+func (s *identitiesSuite) TestGetIdentityGroupsWithDeletedDbGroup(c *gc.C) {
 	ctx := context.Background()
 	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
 	identitySvc := rebac_admin.NewidentitiesService(s.JIMM)

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
 
+	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
@@ -110,6 +111,46 @@ func (s *identitiesSuite) TestIdentityGetGroups(c *gc.C) {
 			break
 		}
 	}
+}
+
+// TestIdentityGetGroupsWithMissingDbGroup tests the behaviour
+// of GetIdentityGroups when a tuple lingers in OpenFGA but the group
+// has been removed from the database.
+func (s *identitiesSuite) TestIdentityGetGroupsWithMissingDbGroup(c *gc.C) {
+	// initialization
+	ctx := context.Background()
+	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
+	identitySvc := rebac_admin.NewidentitiesService(s.JIMM)
+	username := s.AdminUser.Name
+
+	group1 := s.AddGroup(c, "group1")
+	group2 := s.AddGroup(c, "group2")
+
+	baseTuple := openfga.Tuple{
+		Object:   ofganames.ConvertTag(s.AdminUser.ResourceTag()),
+		Relation: ofganames.MemberRelation,
+	}
+	group1Access := baseTuple
+	group1Access.Target = ofganames.ConvertTag(group1)
+	group2Access := baseTuple
+	group2Access.Target = ofganames.ConvertTag(group2)
+
+	err := s.JIMM.OpenFGAClient.AddRelation(ctx, group1Access, group2Access)
+	c.Assert(err, gc.IsNil)
+
+	groups, err := identitySvc.GetIdentityGroups(ctx, username, &resources.GetIdentitiesItemGroupsParams{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(groups.Data, gc.HasLen, 2)
+
+	groupToDelete := dbmodel.GroupEntry{Name: "group2"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupToDelete)
+	c.Assert(err, gc.IsNil)
+	err = s.JIMM.Database.RemoveGroup(ctx, &groupToDelete)
+	c.Assert(err, gc.IsNil)
+
+	groups, err = identitySvc.GetIdentityGroups(ctx, username, &resources.GetIdentitiesItemGroupsParams{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(groups.Data, gc.HasLen, 1)
 }
 
 // TestIdentityEntitlements tests the listing of entitlements for a specific identityId.

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -147,7 +147,7 @@ func TestGetIdentityGroups(t *testing.T) {
 	testTuple := openfga.Tuple{
 		Object:   &ofga.Entity{Kind: "user", ID: "foo"},
 		Relation: ofga.Relation("member"),
-		Target:   &ofga.Entity{Kind: "group", ID: "my-group"},
+		Target:   &ofga.Entity{Kind: "group", ID: "my-group-id"},
 	}
 	jimm := jimmtest.JIMM{
 		FetchIdentity_: func(ctx context.Context, username string) (*openfga.User, error) {
@@ -159,6 +159,11 @@ func TestGetIdentityGroups(t *testing.T) {
 		RelationService: mocks.RelationService{
 			ListRelationshipTuples_: func(ctx context.Context, user *openfga.User, tuple params.RelationshipTuple, pageSize int32, continuationToken string) ([]openfga.Tuple, string, error) {
 				return []openfga.Tuple{testTuple}, "continuation-token", listTuplesErr
+			},
+		},
+		GroupService: mocks.GroupService{
+			GetGroupByUUID_: func(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error) {
+				return &dbmodel.GroupEntry{Name: "fake-group-name"}, nil
 			},
 		},
 	}
@@ -175,6 +180,8 @@ func TestGetIdentityGroups(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(res, qt.IsNotNil)
 	c.Assert(res.Data, qt.HasLen, 1)
+	c.Assert(*res.Data[0].Id, qt.Equals, "my-group-id")
+	c.Assert(res.Data[0].Name, qt.Equals, "fake-group-name")
 	c.Assert(*res.Next.PageToken, qt.Equals, "continuation-token")
 
 	listTuplesErr = errors.New("foo")


### PR DESCRIPTION
## Description

This PR fixes the response from the rebac admin's "GetIdentityGroups" endpoint. Currently we return a group name in place of the group ID. One issue we face is that the group name may no longer exist in the DB but an OpenFGA may still exist. To handle this case I considered:
- Returning an error
- Dropping the offending result
- Returning the group with a name of "removed"

~~I've opted for option 3. The first would prevent the user from viewing their groups and the second would hide the issue.~~
Changed to option 2 to drop the result since it is not useful to the user.

Fixes #1418.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests