### PR TITLE
change use of group parameter for PatchIdentityGroups

### DIFF
--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
 type identitiesService struct {
@@ -158,10 +159,13 @@ func (s *identitiesService) PatchIdentityGroups(ctx context.Context, identityId 
 	additions := make([]apiparams.RelationshipTuple, 0)
 	deletions := make([]apiparams.RelationshipTuple, 0)
 	for _, p := range groupPatches {
+		if !jimmnames.IsValidGroupId(p.Group) {
+			return false, v1.NewValidationError(fmt.Sprintf("ID %s is not a valid group ID", p.Group))
+		}
 		t := apiparams.RelationshipTuple{
 			Object:       objUser.ResourceTag().String(),
 			Relation:     ofganames.MemberRelation.String(),
-			TargetObject: p.Group,
+			TargetObject: jimmnames.NewGroupTag(p.Group).String(),
 		}
 		if p.Op == "add" {
 			additions = append(additions, t)

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -11,6 +11,7 @@ import (
 	rebac_handlers "github.com/canonical/rebac-admin-ui-handlers/v1"
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/common/utils"
@@ -210,9 +211,11 @@ func TestPatchIdentityGroups(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".* not found")
 
 	username := "bob@canonical.com"
+	group1ID := uuid.New()
+	group2ID := uuid.New()
 	operations := []resources.IdentityGroupsPatchItem{
-		{Group: "test-group1", Op: resources.IdentityGroupsPatchItemOpAdd},
-		{Group: "test-group2", Op: resources.IdentityGroupsPatchItemOpRemove},
+		{Group: group1ID.String(), Op: resources.IdentityGroupsPatchItemOpAdd},
+		{Group: group2ID.String(), Op: resources.IdentityGroupsPatchItemOpRemove},
 	}
 	res, err := idSvc.PatchIdentityGroups(ctx, username, operations)
 	c.Assert(err, qt.IsNil)
@@ -221,4 +224,10 @@ func TestPatchIdentityGroups(t *testing.T) {
 	patchTuplesErr = errors.New("foo")
 	_, err = idSvc.PatchIdentityGroups(ctx, username, operations)
 	c.Assert(err, qt.ErrorMatches, ".*foo")
+
+	invalidGroupName := []resources.IdentityGroupsPatchItem{
+		{Group: "test-group1", Op: resources.IdentityGroupsPatchItemOpAdd},
+	}
+	_, err = idSvc.PatchIdentityGroups(ctx, "bob@canonical.com", invalidGroupName)
+	c.Assert(err, qt.ErrorMatches, "Bad Request: ID test-group1 is not a valid group ID")
 }

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -29,7 +29,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/pubsub"
-	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
 // ControllerUUID is the UUID of the JIMM controller used in tests.
@@ -267,11 +266,11 @@ func (s *JIMMSuite) AddModel(c *gc.C, owner names.UserTag, name string, cloud na
 	return names.NewModelTag(mi.UUID)
 }
 
-func (s *JIMMSuite) AddGroup(c *gc.C, groupName string) jimmnames.GroupTag {
+func (s *JIMMSuite) AddGroup(c *gc.C, groupName string) dbmodel.GroupEntry {
 	ctx := context.Background()
 	group, err := s.JIMM.AddGroup(ctx, s.AdminUser, groupName)
 	c.Assert(err, gc.Equals, nil)
-	return group.ResourceTag()
+	return *group
 }
 
 // EnableDeviceFlow allows a test to use the device flow.


### PR DESCRIPTION
## Description

The group parameter passed to the PatchIdentityGroups method is a group ID not a group tag (i.e. not `group-ID` and instead just `ID`). This PR fixes that misinterpretation and fixes the issue that a user's groups couldn't be updated.

Fixes #1420
Fixes [JUJU-7056](https://warthogs.atlassian.net/browse/JUJU-7056)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

[JUJU-7056]: https://warthogs.atlassian.net/browse/JUJU-7056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ