### PR TITLE
fixes a flaky test that expected ordering

### DIFF
--- a/internal/jimmhttp/rebac_admin/groups_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_integration_test.go
@@ -57,7 +57,7 @@ func (s rebacAdminSuite) TestGetGroupIdentitiesIntegration(c *gc.C) {
 	c.Assert(*res.Meta.PageToken, gc.Equals, "")
 	c.Assert(*res.Next.PageToken, gc.Not(gc.Equals), "")
 	c.Assert(res.Data, gc.HasLen, 5)
-	c.Assert(res.Data[0].Email, gc.Equals, "foo0@canonical.com")
+	c.Assert(res.Data[0].Email, gc.Matches, `foo\d@canonical\.com`)
 
 	// Request next page
 	params.NextPageToken = res.Next.PageToken
@@ -68,7 +68,7 @@ func (s rebacAdminSuite) TestGetGroupIdentitiesIntegration(c *gc.C) {
 	c.Assert(*res.Meta.PageToken, gc.Equals, *params.NextPageToken)
 	c.Assert(res.Next.PageToken, gc.IsNil)
 	c.Assert(res.Data, gc.HasLen, 5)
-	c.Assert(res.Data[0].Email, gc.Equals, "foo5@canonical.com")
+	c.Assert(res.Data[0].Email, gc.Matches, `foo\d@canonical\.com`)
 
 	// Request all items, no next page.
 	allItems := &resources.GetGroupsItemIdentitiesParams{}


### PR DESCRIPTION
## Description

OpenFGA does not provide any ordering guarantees on the results provided. Refactor a test that expected ordering in the rebac-admin handlers.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests