### PR TITLE
fix parse cloud-tag error and add test for adding cloud relations

### DIFF
--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -611,7 +611,7 @@ func (t *tagResolver) cloudTag(ctx context.Context, db *db.Database) (*ofga.Enti
 
 	err := db.GetCloud(ctx, &cloud)
 	if err != nil {
-		return nil, errors.E("application offer not found")
+		return nil, errors.E("cloud not found")
 	}
 
 	return ofganames.ConvertTagWithRelation(cloud.ResourceTag(), t.relation), nil


### PR DESCRIPTION
## Description

This PR fixes the error returned when parsing a cloud tag was incorrect. Additionally, I've added a test verifying that the rebac-admin-ui can properly grant access to a cloud.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests