### PR TITLE
JUJU-7073: add filter on group name/id for listGroups

### DIFF
--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -83,7 +83,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 }
 
 // ListGroups returns a paginated list of groups defined by limit and offset.
-// match is used to fuzzy find based on entries' name using the LIKE operator (ex. LIKE %<match>%).
+// match is used to fuzzy find based on entries' name or uuid using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
 	const op = errors.Op("db.ListGroups")
 	if err := d.ready(); err != nil {
@@ -96,7 +96,7 @@ func (d *Database) ListGroups(ctx context.Context, limit, offset int, match stri
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
-		db = db.Where("name LIKE ?", "%"+match+"%")
+		db = db.Where("name LIKE ? OR uuid LIKE ?", "%"+match+"%", "%"+match+"%")
 	}
 	db = db.Order("name asc")
 	db = db.Limit(limit)

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -85,7 +85,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 // ForEachGroup iterates through every group calling the given function
 // for each one. If the given function returns an error the iteration
 // will stop immediately and the error will be returned unmodified.
-// `match` will filter with the LIKE operator on id or name.
+// `match` will filter with the LIKE operator on uuid or name.
 func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, match string, f func(*dbmodel.GroupEntry) error) (err error) {
 	const op = errors.Op("db.ForEachGroup")
 	if err := d.ready(); err != nil {

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -82,14 +82,13 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 	return nil
 }
 
-// ForEachGroup iterates through every group calling the given function
-// for each one. If the given function returns an error the iteration
-// will stop immediately and the error will be returned unmodified.
+// ListGroups returns a paginated list of groups defined by limit and offset.
+// match is used to filter entries based on name.
 // `match` will filter with the LIKE operator on uuid or name.
-func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, match string, f func(*dbmodel.GroupEntry) error) (err error) {
+func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
 	const op = errors.Op("db.ForEachGroup")
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return nil, errors.E(op, err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -98,30 +97,16 @@ func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, match st
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
-		match = "%" + match + "%"
-		db = db.Where("uuid LIKE ? OR name LIKE ?", match, match)
+		db = db.Where("name LIKE ?", "%"+match+"%")
 	}
 	db = db.Order("name asc")
 	db = db.Limit(limit)
 	db = db.Offset(offset)
-	rows, err := db.Model(&dbmodel.GroupEntry{}).Rows()
-	if err != nil {
-		return errors.E(op, err)
+	var groups []dbmodel.GroupEntry
+	if err := db.Find(&groups).Error; err != nil {
+		return nil, errors.E(op, dbError(err))
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var group dbmodel.GroupEntry
-		if err := db.ScanRows(rows, &group); err != nil {
-			return errors.E(op, err)
-		}
-		if err := f(&group); err != nil {
-			return err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return errors.E(op, dbError(err))
-	}
-	return nil
+	return groups, nil
 }
 
 // UpdateGroup updates the group identified by its ID.

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -83,9 +83,9 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 }
 
 // ListGroups returns a paginated list of groups defined by limit and offset.
-// match is used to filter entries based on name.
+// match is used to fuzzy find based on entries' name using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
-	const op = errors.Op("db.ForEachGroup")
+	const op = errors.Op("db.ListGroups")
 	if err := d.ready(); err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -98,6 +98,7 @@ func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, match st
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
+		match = "%" + match + "%"
 		db = db.Where("uuid LIKE ? OR name LIKE ?", match, match)
 	}
 	db = db.Order("name asc")

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -84,7 +84,6 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 
 // ListGroups returns a paginated list of groups defined by limit and offset.
 // match is used to filter entries based on name.
-// `match` will filter with the LIKE operator on uuid or name.
 func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
 	const op = errors.Op("db.ForEachGroup")
 	if err := d.ready(); err != nil {

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -85,7 +85,8 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 // ForEachGroup iterates through every group calling the given function
 // for each one. If the given function returns an error the iteration
 // will stop immediately and the error will be returned unmodified.
-func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, f func(*dbmodel.GroupEntry) error) (err error) {
+// `match` will filter with the LIKE operator on id or name.
+func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, match string, f func(*dbmodel.GroupEntry) error) (err error) {
 	const op = errors.Op("db.ForEachGroup")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -96,6 +97,9 @@ func (d *Database) ForEachGroup(ctx context.Context, limit, offset int, f func(*
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	db := d.DB.WithContext(ctx)
+	if match != "" {
+		db = db.Where("uuid LIKE ? OR name LIKE ?", match, match)
+	}
 	db = db.Order("name asc")
 	db = db.Limit(limit)
 	db = db.Offset(offset)

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -195,7 +195,7 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 	}
 	firstGroups := []*dbmodel.GroupEntry{}
 	ctx := context.Background()
-	err = s.Database.ForEachGroup(ctx, 5, 0, func(ge *dbmodel.GroupEntry) error {
+	err = s.Database.ForEachGroup(ctx, 5, 0, "", func(ge *dbmodel.GroupEntry) error {
 		firstGroups = append(firstGroups, ge)
 		return nil
 	})
@@ -204,7 +204,7 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 		c.Assert(firstGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i))
 	}
 	secondGroups := []*dbmodel.GroupEntry{}
-	err = s.Database.ForEachGroup(ctx, 5, 5, func(ge *dbmodel.GroupEntry) error {
+	err = s.Database.ForEachGroup(ctx, 5, 5, "", func(ge *dbmodel.GroupEntry) error {
 		secondGroups = append(secondGroups, ge)
 		return nil
 	})
@@ -212,4 +212,24 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 	for i := 0; i < 5; i++ {
 		c.Assert(secondGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i+5))
 	}
+
+	matchedGroups := []*dbmodel.GroupEntry{}
+	err = s.Database.ForEachGroup(ctx, 5, 0, "%group-1%", func(ge *dbmodel.GroupEntry) error {
+		matchedGroups = append(matchedGroups, ge)
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(matchedGroups, qt.HasLen, 1)
+	c.Assert(matchedGroups[0].Name, qt.Equals, "test-group-1")
+
+	matchedGroups = []*dbmodel.GroupEntry{}
+	testGroup, err := s.Database.AddGroup(context.Background(), "test-group-matched")
+	c.Assert(err, qt.IsNil)
+	err = s.Database.ForEachGroup(ctx, 5, 0, "%"+testGroup.UUID+"%", func(ge *dbmodel.GroupEntry) error {
+		matchedGroups = append(matchedGroups, ge)
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(matchedGroups, qt.HasLen, 1)
+	c.Assert(matchedGroups[0].Name, qt.Equals, testGroup.Name)
 }

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -193,43 +193,32 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 		_, err := s.Database.AddGroup(context.Background(), fmt.Sprintf("test-group-%d", i))
 		c.Assert(err, qt.IsNil)
 	}
-	firstGroups := []*dbmodel.GroupEntry{}
 	ctx := context.Background()
-	err = s.Database.ForEachGroup(ctx, 5, 0, "", func(ge *dbmodel.GroupEntry) error {
-		firstGroups = append(firstGroups, ge)
-		return nil
-	})
+	firstGroups, err := s.Database.ListGroups(ctx, 5, 0, "")
 	c.Assert(err, qt.IsNil)
 	for i := 0; i < 5; i++ {
 		c.Assert(firstGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i))
 	}
-	secondGroups := []*dbmodel.GroupEntry{}
-	err = s.Database.ForEachGroup(ctx, 5, 5, "", func(ge *dbmodel.GroupEntry) error {
-		secondGroups = append(secondGroups, ge)
-		return nil
-	})
+	secondGroups, err := s.Database.ListGroups(ctx, 5, 5, "")
 	c.Assert(err, qt.IsNil)
 	for i := 0; i < 5; i++ {
 		c.Assert(secondGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i+5))
 	}
 
-	matchedGroups := []*dbmodel.GroupEntry{}
-	err = s.Database.ForEachGroup(ctx, 5, 0, "group-1", func(ge *dbmodel.GroupEntry) error {
-		matchedGroups = append(matchedGroups, ge)
-		return nil
-	})
+	matchedGroups, err := s.Database.ListGroups(ctx, 5, 0, "group-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(matchedGroups, qt.HasLen, 1)
 	c.Assert(matchedGroups[0].Name, qt.Equals, "test-group-1")
 
-	matchedGroups = []*dbmodel.GroupEntry{}
-	testGroup, err := s.Database.AddGroup(context.Background(), "test-group-matched")
+	matchedGroups, err = s.Database.ListGroups(ctx, 5, 0, "%not-existing%")
 	c.Assert(err, qt.IsNil)
-	err = s.Database.ForEachGroup(ctx, 5, 0, testGroup.UUID, func(ge *dbmodel.GroupEntry) error {
-		matchedGroups = append(matchedGroups, ge)
-		return nil
-	})
+	c.Assert(matchedGroups, qt.HasLen, 0)
+
+	tg, err := s.Database.AddGroup(context.Background(), "\\%test-group")
+	c.Assert(err, qt.IsNil)
+
+	matchedGroups, err = s.Database.ListGroups(ctx, 5, 0, "\\%t")
 	c.Assert(err, qt.IsNil)
 	c.Assert(matchedGroups, qt.HasLen, 1)
-	c.Assert(matchedGroups[0].Name, qt.Equals, testGroup.Name)
+	c.Assert(matchedGroups[0].UUID, qt.Equals, tg.UUID)
 }

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -214,7 +214,7 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 	}
 
 	matchedGroups := []*dbmodel.GroupEntry{}
-	err = s.Database.ForEachGroup(ctx, 5, 0, "%group-1%", func(ge *dbmodel.GroupEntry) error {
+	err = s.Database.ForEachGroup(ctx, 5, 0, "group-1", func(ge *dbmodel.GroupEntry) error {
 		matchedGroups = append(matchedGroups, ge)
 		return nil
 	})
@@ -225,7 +225,7 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 	matchedGroups = []*dbmodel.GroupEntry{}
 	testGroup, err := s.Database.AddGroup(context.Background(), "test-group-matched")
 	c.Assert(err, qt.IsNil)
-	err = s.Database.ForEachGroup(ctx, 5, 0, "%"+testGroup.UUID+"%", func(ge *dbmodel.GroupEntry) error {
+	err = s.Database.ForEachGroup(ctx, 5, 0, testGroup.UUID, func(ge *dbmodel.GroupEntry) error {
 		matchedGroups = append(matchedGroups, ge)
 		return nil
 	})

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -221,4 +221,9 @@ func (s *dbSuite) TestForEachGroup(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(matchedGroups, qt.HasLen, 1)
 	c.Assert(matchedGroups[0].UUID, qt.Equals, tg.UUID)
+
+	matchedGroups, err = s.Database.ListGroups(ctx, 5, 0, tg.UUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(matchedGroups, qt.HasLen, 1)
+	c.Assert(matchedGroups[0].UUID, qt.Equals, tg.UUID)
 }

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -798,11 +798,7 @@ func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagina
 		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
-	var groups []dbmodel.GroupEntry
-	err := j.Database.ForEachGroup(ctx, filter.Limit(), filter.Offset(), match, func(ge *dbmodel.GroupEntry) error {
-		groups = append(groups, *ge)
-		return nil
-	})
+	groups, err := j.Database.ListGroups(ctx, filter.Limit(), filter.Offset(), match)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -790,7 +790,7 @@ func (j *JIMM) RemoveGroup(ctx context.Context, user *openfga.User, name string)
 }
 
 // ListGroups returns a list of groups known to JIMM.
-// `match` will filter the list for name or uuid matching it.
+// `match` will filter the list fuzzy matching group's names.
 func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	const op = errors.Op("jimm.ListGroups")
 

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -791,14 +791,14 @@ func (j *JIMM) RemoveGroup(ctx context.Context, user *openfga.User, name string)
 
 // ListGroups returns a list of groups known to JIMM.
 // `match` will filter the list for name or uuid matching it.
-func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
+func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	const op = errors.Op("jimm.ListGroups")
 
 	if !user.JimmAdmin {
 		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
-	groups, err := j.Database.ListGroups(ctx, filter.Limit(), filter.Offset(), match)
+	groups, err := j.Database.ListGroups(ctx, pagination.Limit(), pagination.Offset(), match)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -790,7 +790,7 @@ func (j *JIMM) RemoveGroup(ctx context.Context, user *openfga.User, name string)
 }
 
 // ListGroups returns a list of groups known to JIMM.
-// `match` will filter the list fuzzy matching group's names.
+// `match` will filter the list fuzzy matching group's name or uuid.
 func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	const op = errors.Op("jimm.ListGroups")
 

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -790,7 +790,7 @@ func (j *JIMM) RemoveGroup(ctx context.Context, user *openfga.User, name string)
 }
 
 // ListGroups returns a list of groups known to JIMM.
-func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]dbmodel.GroupEntry, error) {
+func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	const op = errors.Op("jimm.ListGroups")
 
 	if !user.JimmAdmin {
@@ -798,7 +798,7 @@ func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagina
 	}
 
 	var groups []dbmodel.GroupEntry
-	err := j.Database.ForEachGroup(ctx, filter.Limit(), filter.Offset(), func(ge *dbmodel.GroupEntry) error {
+	err := j.Database.ForEachGroup(ctx, filter.Limit(), filter.Offset(), match, func(ge *dbmodel.GroupEntry) error {
 		groups = append(groups, *ge)
 		return nil
 	})

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -790,6 +790,7 @@ func (j *JIMM) RemoveGroup(ctx context.Context, user *openfga.User, name string)
 }
 
 // ListGroups returns a list of groups known to JIMM.
+// `match` will filter the list for name or uuid matching it.
 func (j *JIMM) ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	const op = errors.Op("jimm.ListGroups")
 

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -1080,7 +1080,7 @@ func TestListGroups(t *testing.T) {
 	u.JimmAdmin = true
 
 	filter := pagination.NewOffsetFilter(10, 0)
-	groups, err := j.ListGroups(ctx, u, filter)
+	groups, err := j.ListGroups(ctx, u, filter, "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(groups, qt.DeepEquals, []dbmodel.GroupEntry{group})
 
@@ -1095,7 +1095,7 @@ func TestListGroups(t *testing.T) {
 		_, err := j.AddGroup(ctx, u, name)
 		c.Assert(err, qt.IsNil)
 	}
-	groups, err = j.ListGroups(ctx, u, filter)
+	groups, err = j.ListGroups(ctx, u, filter, "")
 	c.Assert(err, qt.IsNil)
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Name < groups[j].Name

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -1079,8 +1079,8 @@ func TestListGroups(t *testing.T) {
 	u := openfga.NewUser(&user, ofgaClient)
 	u.JimmAdmin = true
 
-	filter := pagination.NewOffsetFilter(10, 0)
-	groups, err := j.ListGroups(ctx, u, filter, "")
+	pagination := pagination.NewOffsetFilter(10, 0)
+	groups, err := j.ListGroups(ctx, u, pagination, "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(groups, qt.DeepEquals, []dbmodel.GroupEntry{group})
 
@@ -1095,7 +1095,7 @@ func TestListGroups(t *testing.T) {
 		_, err := j.AddGroup(ctx, u, name)
 		c.Assert(err, qt.IsNil)
 	}
-	groups, err = j.ListGroups(ctx, u, filter, "")
+	groups, err = j.ListGroups(ctx, u, pagination, "")
 	c.Assert(err, qt.IsNil)
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Name < groups[j].Name

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -43,7 +43,7 @@ func (s *groupsService) ListGroups(ctx context.Context, params *resources.GetGro
 	page, nextPage, pagination := pagination.CreatePagination(params.Size, params.Page, count)
 	match := ""
 	if params.Filter != nil && *params.Filter != "" {
-		match = "%" + *params.Filter + "%" // fuzzy search on the filter received
+		match = *params.Filter
 	}
 	groups, err := s.jimm.ListGroups(ctx, user, pagination, match)
 	if err != nil {

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -41,7 +41,11 @@ func (s *groupsService) ListGroups(ctx context.Context, params *resources.GetGro
 		return nil, err
 	}
 	page, nextPage, pagination := pagination.CreatePagination(params.Size, params.Page, count)
-	groups, err := s.jimm.ListGroups(ctx, user, pagination)
+	match := ""
+	if params.Filter != nil && *params.Filter != "" {
+		match = "%" + *params.Filter + "%" // fuzzy search on the filter received
+	}
+	groups, err := s.jimm.ListGroups(ctx, user, pagination, match)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -86,7 +86,7 @@ func TestListGroups(t *testing.T) {
 	}
 	jimm := jimmtest.JIMM{
 		GroupService: mocks.GroupService{
-			ListGroups_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]dbmodel.GroupEntry, error) {
+			ListGroups_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 				return returnedGroups, listErr
 			},
 			CountGroups_: func(ctx context.Context, user *openfga.User) (int, error) {

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -86,7 +86,7 @@ func TestListGroups(t *testing.T) {
 	}
 	jimm := jimmtest.JIMM{
 		GroupService: mocks.GroupService{
-			ListGroups_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
+			ListGroups_: func(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 				return returnedGroups, listErr
 			},
 			CountGroups_: func(ctx context.Context, user *openfga.User) (int, error) {

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -30,7 +30,7 @@ type GroupService interface {
 	CountGroups(ctx context.Context, user *openfga.User) (int, error)
 	GetGroupByUUID(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error)
 	GetGroupByName(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error)
-	ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
+	ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
 	RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error
 	RemoveGroup(ctx context.Context, user *openfga.User, name string) error
 }
@@ -118,8 +118,8 @@ func (r *controllerRoot) RemoveGroup(ctx context.Context, req apiparams.RemoveGr
 func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroupsRequest) (apiparams.ListGroupResponse, error) {
 	const op = errors.Op("jujuapi.ListGroups")
 
-	filter := pagination.NewOffsetFilter(req.Limit, req.Offset)
-	groups, err := r.jimm.ListGroups(ctx, r.user, filter, "")
+	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
+	groups, err := r.jimm.ListGroups(ctx, r.user, pagination, "")
 	if err != nil {
 		return apiparams.ListGroupResponse{}, errors.E(op, err)
 	}

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -30,7 +30,7 @@ type GroupService interface {
 	CountGroups(ctx context.Context, user *openfga.User) (int, error)
 	GetGroupByUUID(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error)
 	GetGroupByName(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error)
-	ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]dbmodel.GroupEntry, error)
+	ListGroups(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
 	RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error
 	RemoveGroup(ctx context.Context, user *openfga.User, name string) error
 }
@@ -119,7 +119,7 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 	const op = errors.Op("jujuapi.ListGroups")
 
 	filter := pagination.NewOffsetFilter(req.Limit, req.Offset)
-	groups, err := r.jimm.ListGroups(ctx, r.user, filter)
+	groups, err := r.jimm.ListGroups(ctx, r.user, filter, "")
 	if err != nil {
 		return apiparams.ListGroupResponse{}, errors.E(op, err)
 	}

--- a/internal/testutils/jimmtest/mocks/jimm_group_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_group_mock.go
@@ -22,7 +22,7 @@ type GroupService struct {
 	CountGroups_    func(ctx context.Context, user *openfga.User) (int, error)
 	GetGroupByUUID_ func(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error)
 	GetGroupByName_ func(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error)
-	ListGroups_     func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
+	ListGroups_     func(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
 	RenameGroup_    func(ctx context.Context, user *openfga.User, oldName, newName string) error
 	RemoveGroup_    func(ctx context.Context, user *openfga.User, name string) error
 }
@@ -55,11 +55,11 @@ func (j *GroupService) GetGroupByName(ctx context.Context, user *openfga.User, n
 	return j.GetGroupByName_(ctx, user, name)
 }
 
-func (j *GroupService) ListGroups(ctx context.Context, user *openfga.User, filters pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
+func (j *GroupService) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	if j.ListGroups_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ListGroups_(ctx, user, filters, match)
+	return j.ListGroups_(ctx, user, pagination, match)
 }
 
 func (j *GroupService) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {

--- a/internal/testutils/jimmtest/mocks/jimm_group_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_group_mock.go
@@ -22,7 +22,7 @@ type GroupService struct {
 	CountGroups_    func(ctx context.Context, user *openfga.User) (int, error)
 	GetGroupByUUID_ func(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error)
 	GetGroupByName_ func(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error)
-	ListGroups_     func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]dbmodel.GroupEntry, error)
+	ListGroups_     func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error)
 	RenameGroup_    func(ctx context.Context, user *openfga.User, oldName, newName string) error
 	RemoveGroup_    func(ctx context.Context, user *openfga.User, name string) error
 }
@@ -55,11 +55,11 @@ func (j *GroupService) GetGroupByName(ctx context.Context, user *openfga.User, n
 	return j.GetGroupByName_(ctx, user, name)
 }
 
-func (j *GroupService) ListGroups(ctx context.Context, user *openfga.User, filters pagination.LimitOffsetPagination) ([]dbmodel.GroupEntry, error) {
+func (j *GroupService) ListGroups(ctx context.Context, user *openfga.User, filters pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	if j.ListGroups_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ListGroups_(ctx, user, filters)
+	return j.ListGroups_(ctx, user, filters, match)
 }
 
 func (j *GroupService) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {


### PR DESCRIPTION
## Description

This pr adds filtering for rebac `listGroups` on group name/id.

Address #1421 


## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->