### PR TITLE
fix flaky test by checking error properly

### DIFF
--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -518,12 +518,12 @@ func handleWS(f func(*websocket.Conn) error) http.Handler {
 		defer c.Close()
 		err = f(c)
 		var cm []byte
+		closeError, isCloseError := err.(*websocket.CloseError)
 		switch {
 		case err == nil:
 			cm = websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
-		case websocket.IsCloseError(err):
-			ce := err.(*websocket.CloseError)
-			cm = websocket.FormatCloseMessage(ce.Code, ce.Text)
+		case isCloseError:
+			cm = websocket.FormatCloseMessage(closeError.Code, closeError.Text)
 		default:
 			cm = websocket.FormatCloseMessage(websocket.CloseInternalServerErr, err.Error())
 		}


### PR DESCRIPTION
## Description

We had a flaky test that in some cases where the test runner was under pressure failed.
ex. 
- https://github.com/canonical/jimm/actions/runs/11509775185/job/32040489299
- https://github.com/canonical/jimm/actions/runs/11570348073/job/32205943025

The reason is that:
we were using `websocket.IsCloseError(err)` wrong and we were returning `internal error` for `close errors`.
Here is the godoc:
```go
// IsCloseError returns boolean indicating whether the error is a *CloseError
// with one of the specified codes.
func IsCloseError(err error, codes ...int) bool
```

## QA steps
To reproduce the bug locally just run the same test many times
![image](https://github.com/user-attachments/assets/f86d752b-4aff-44ce-b487-9d6e65fb2166)

After the fix:
![image](https://github.com/user-attachments/assets/7eabfdf5-a48a-4154-a92b-530a5a44ef82)


Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->