### PR TITLE
use resource tag instead of dbmodel

### DIFF
--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -130,9 +130,9 @@ func (s *identitiesSuite) TestGetIdentityGroupsWithDeletedDbGroup(c *gc.C) {
 		Relation: ofganames.MemberRelation,
 	}
 	group1Access := baseTuple
-	group1Access.Target = ofganames.ConvertTag(group1)
+	group1Access.Target = ofganames.ConvertTag(group1.ResourceTag())
 	group2Access := baseTuple
-	group2Access.Target = ofganames.ConvertTag(group2)
+	group2Access.Target = ofganames.ConvertTag(group2.ResourceTag())
 
 	err := s.JIMM.OpenFGAClient.AddRelation(ctx, group1Access, group2Access)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
## Description

Fix a broken test, after enabling the merge queue it seems I managed to land two PRs where PR#1 had a change that PR#2 didn't incorporate. This is normally handled by the "require PR to have latest changes" setting in Github, but with the introduction of the merge queue some behaviour may have changed.