### PR TITLE
import offers during model import

### DIFF
--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -103,7 +103,7 @@ func (m *Model) SetTag(t names.ModelTag) {
 	m.UUID.Valid = true
 }
 
-// FromModelUpdate updates the model from the given ModelUpdate.
+// SwitchOwner updates the model owner.
 func (m *Model) SwitchOwner(u *Identity) {
 	m.OwnerIdentityName = u.Name
 	m.Owner = *u

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -103,8 +103,8 @@ func (m *Model) SetTag(t names.ModelTag) {
 	m.UUID.Valid = true
 }
 
-// SwitchOwner updates the model owner.
-func (m *Model) SwitchOwner(u *Identity) {
+// SetOwner updates the model owner.
+func (m *Model) SetOwner(u *Identity) {
 	m.OwnerIdentityName = u.Name
 	m.Owner = *u
 }

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -398,6 +398,7 @@ type modelImporter struct {
 	model         dbmodel.Model
 	modelInfo     jujuparams.ModelInfo
 	originalOwner names.UserTag
+	offersToAdd   []jujuparams.ApplicationOfferAdminDetailsV5
 }
 
 func newModelImporter(jimm *JIMM) modelImporter {
@@ -429,6 +430,16 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName strin
 	m.originalOwner, err = names.ParseUserTag(m.modelInfo.OwnerTag)
 	if err != nil {
 		return errors.E(fmt.Sprintf("invalid username %s from original model owner", m.modelInfo.OwnerTag))
+	}
+
+	m.offersToAdd, err = api.ListApplicationOffers(ctx, []jujuparams.OfferFilter{
+		{
+			OwnerName: m.originalOwner.Id(),
+			ModelName: m.modelInfo.Name,
+		},
+	})
+	if err != nil {
+		return err
 	}
 
 	// fill in data from model info
@@ -476,6 +487,13 @@ func (m *modelImporter) addPermissions(ctx context.Context) error {
 
 	if err := m.jimm.addModelPermissions(ctx, ofgaUser, m.model.ResourceTag(), controllerTag); err != nil {
 		return err
+	}
+
+	for _, offer := range m.offersToAdd {
+		err := m.jimm.OpenFGAClient.AddModelApplicationOffer(ctx, m.model.ResourceTag(), names.NewApplicationOfferTag(offer.OfferUUID))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -540,6 +558,17 @@ func (m *modelImporter) save(ctx context.Context) error {
 				return fmt.Errorf("model (%s) already exists", m.model.Name)
 			}
 			return err
+		}
+		for _, offer := range m.offersToAdd {
+			var dbOffer dbmodel.ApplicationOffer
+			dbOffer.FromJujuApplicationOfferAdminDetailsV5(offer)
+			dbOffer.ModelID = m.model.ID
+			if err := m.jimm.Database.AddApplicationOffer(ctx, &dbOffer); err != nil {
+				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+					return fmt.Errorf("offer with URL %s already exists", offer.OfferURL)
+				}
+				return err
+			}
 		}
 		return nil
 	})

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -487,6 +487,8 @@ func (m *modelImporter) setModelOwner(ctx context.Context) error {
 	return nil
 }
 
+// addPermissions grants the model owner with admin access to the model
+// and, in turn, admin access to any offers within the model.
 func (m *modelImporter) addPermissions(ctx context.Context) error {
 	// Note that only the new owner is given access. All previous users that had access according to Juju
 	// are discarded as access must now be governed by JIMM and OpenFGA.

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -394,17 +394,28 @@ func (j *JIMM) GetUserControllerAccess(ctx context.Context, user *openfga.User, 
 }
 
 type modelImporter struct {
-	jimm          *JIMM
-	model         dbmodel.Model
-	modelInfo     jujuparams.ModelInfo
+	jimm      *JIMM
+	model     dbmodel.Model
+	modelInfo jujuparams.ModelInfo
+	// newOwner may be nil if the user wants to keep the original owner.
+	newOwner      *names.UserTag
 	originalOwner names.UserTag
 	offersToAdd   []jujuparams.ApplicationOfferAdminDetailsV5
 }
 
-func newModelImporter(jimm *JIMM) modelImporter {
-	return modelImporter{
+func newModelImporter(jimm *JIMM, newOwner string) (modelImporter, error) {
+	modelImporter := modelImporter{
 		jimm: jimm,
 	}
+	if newOwner == "" {
+		return modelImporter, nil
+	}
+	if !names.IsValidUser(newOwner) {
+		return modelImporter, errors.E(errors.CodeBadRequest, "invalid new username for new model owner")
+	}
+	newOwnerTag := names.NewUserTag(newOwner)
+	modelImporter.newOwner = &newOwnerTag
+	return modelImporter, nil
 }
 
 func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName string, modelTag names.ModelTag) error {
@@ -453,13 +464,10 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName strin
 	return nil
 }
 
-func (m *modelImporter) setModelOwner(ctx context.Context, newOwner string) error {
+func (m *modelImporter) setModelOwner(ctx context.Context) error {
 	var ownerTag names.UserTag
-	if newOwner != "" {
-		if !names.IsValidUser(newOwner) {
-			return errors.E(errors.CodeBadRequest, "invalid new username for new model owner")
-		}
-		ownerTag = names.NewUserTag(newOwner)
+	if m.newOwner != nil {
+		ownerTag = *m.newOwner
 	} else {
 		ownerTag = m.originalOwner
 	}
@@ -474,7 +482,7 @@ func (m *modelImporter) setModelOwner(ctx context.Context, newOwner string) erro
 	if err != nil {
 		return errors.E(err)
 	}
-	m.model.SwitchOwner(&owner)
+	m.model.SetOwner(&owner)
 
 	return nil
 }
@@ -574,7 +582,8 @@ func (m *modelImporter) save(ctx context.Context) error {
 	})
 }
 
-// ImportModel imports model with the specified UUID from the controller.
+// ImportModel imports a model and existing offers into JIMM.  A new owner  must be set to
+// represent the external user who will own this model (if the original owner is a local user).
 func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
 	const op = errors.Op("jimm.ImportModel")
 
@@ -582,12 +591,16 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 		return err
 	}
 
-	importer := newModelImporter(j)
+	importer, err := newModelImporter(j, newOwner)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
 	if err := importer.fetchModelInfo(ctx, controllerName, modelTag); err != nil {
 		return errors.E(op, err)
 	}
 
-	if err := importer.setModelOwner(ctx, newOwner); err != nil {
+	if err := importer.setModelOwner(ctx); err != nil {
 		return errors.E(op, err)
 	}
 

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -393,6 +393,158 @@ func (j *JIMM) GetUserControllerAccess(ctx context.Context, user *openfga.User, 
 	return ToControllerAccessString(accessLevel), nil
 }
 
+type modelImporter struct {
+	jimm          *JIMM
+	model         dbmodel.Model
+	modelInfo     jujuparams.ModelInfo
+	originalOwner names.UserTag
+}
+
+func newModelImporter(jimm *JIMM) modelImporter {
+	return modelImporter{
+		jimm: jimm,
+	}
+}
+
+func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName string, modelTag names.ModelTag) error {
+	controller, err := m.jimm.getControllerByName(ctx, controllerName)
+	if err != nil {
+		return err
+	}
+
+	api, err := m.jimm.dialController(ctx, controller)
+	if err != nil {
+		return errors.E("failed to dial the controller", err)
+	}
+	defer api.Close()
+
+	m.modelInfo = jujuparams.ModelInfo{
+		UUID: modelTag.Id(),
+	}
+	err = api.ModelInfo(ctx, &m.modelInfo)
+	if err != nil {
+		return err
+	}
+
+	m.originalOwner, err = names.ParseUserTag(m.modelInfo.OwnerTag)
+	if err != nil {
+		return errors.E(fmt.Sprintf("invalid username %s from original model owner", m.modelInfo.OwnerTag))
+	}
+
+	// fill in data from model info
+	err = m.model.FromJujuModelInfo(m.modelInfo)
+	if err != nil {
+		return err
+	}
+	m.model.ControllerID = controller.ID
+	m.model.Controller = *controller
+
+	return nil
+}
+
+func (m *modelImporter) setModelOwner(ctx context.Context, newOwner string) error {
+	var ownerTag names.UserTag
+	if newOwner != "" {
+		if !names.IsValidUser(newOwner) {
+			return errors.E(errors.CodeBadRequest, "invalid new username for new model owner")
+		}
+		ownerTag = names.NewUserTag(newOwner)
+	} else {
+		ownerTag = m.originalOwner
+	}
+
+	if ownerTag.IsLocal() {
+		return errors.E("cannot import model from local user, try --owner to switch the model owner")
+	}
+	owner := dbmodel.Identity{}
+	owner.SetTag(ownerTag)
+
+	err := m.jimm.Database.GetIdentity(ctx, &owner)
+	if err != nil {
+		return errors.E(err)
+	}
+	m.model.SwitchOwner(&owner)
+
+	return nil
+}
+
+func (m *modelImporter) addPermissions(ctx context.Context) error {
+	// Note that only the new owner is given access. All previous users that had access according to Juju
+	// are discarded as access must now be governed by JIMM and OpenFGA.
+	ofgaUser := openfga.NewUser(&m.model.Owner, m.jimm.OpenFGAClient)
+	controllerTag := m.model.Controller.ResourceTag()
+
+	if err := m.jimm.addModelPermissions(ctx, ofgaUser, m.model.ResourceTag(), controllerTag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *modelImporter) setCloudCredential(ctx context.Context) error {
+	// fetch cloud credential used by the model
+	cloudTag, err := names.ParseCloudTag(m.modelInfo.CloudTag)
+	if err != nil {
+		return err
+	}
+
+	// Note that the model already has a cloud credential configured which it will use when deploying new
+	// applications. JIMM needs some cloud credential reference to be able to import the model so use any
+	// credential against the cloud the model is deployed against. Even using the correct cloud for the
+	// credential is not strictly necessary, but will help prevent the user thinking they can create new
+	// models on the incoming cloud.
+	allCredentials, err := m.jimm.Database.GetIdentityCloudCredentials(ctx, &m.model.Owner, cloudTag.Id())
+	if err != nil {
+		return err
+	}
+	if len(allCredentials) == 0 {
+		return errors.E(errors.CodeNotFound, fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, cloudTag.Id()))
+	}
+	cloudCredential := allCredentials[0]
+
+	m.model.CloudCredentialID = cloudCredential.ID
+	m.model.CloudCredential = cloudCredential
+
+	return nil
+}
+
+func (m *modelImporter) setModelCloud(ctx context.Context) error {
+	// fetch the cloud used by the model
+	cloudTag, err := names.ParseCloudTag(m.modelInfo.CloudTag)
+	if err != nil {
+		return err
+	}
+	cloud := dbmodel.Cloud{Name: cloudTag.Id()}
+	err = m.jimm.Database.GetCloud(ctx, &cloud)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get cloud", zap.String("cloud", cloud.Name))
+		return err
+	}
+
+	cr := cloud.Region(m.modelInfo.CloudRegion)
+	if cr.Name != m.modelInfo.CloudRegion {
+		return errors.E("cloud region not found")
+	}
+
+	m.model.CloudRegionID = cr.ID
+	m.model.CloudRegion = cr
+
+	return nil
+}
+
+func (m *modelImporter) save(ctx context.Context) error {
+	return m.jimm.Database.Transaction(func(d *db.Database) error {
+		err := m.jimm.Database.AddModel(ctx, &m.model)
+		if err != nil {
+			if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+				return fmt.Errorf("model (%s) already exists", m.model.Name)
+			}
+			return err
+		}
+		return nil
+	})
+}
+
 // ImportModel imports model with the specified UUID from the controller.
 func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
 	const op = errors.Op("jimm.ImportModel")
@@ -401,125 +553,42 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 		return err
 	}
 
-	controller, err := j.getControllerByName(ctx, controllerName)
-	if err != nil {
+	importer := newModelImporter(j)
+	if err := importer.fetchModelInfo(ctx, controllerName, modelTag); err != nil {
 		return errors.E(op, err)
 	}
 
-	api, err := j.dialController(ctx, controller)
-	if err != nil {
-		return errors.E(op, "failed to dial the controller", err)
-	}
-	defer api.Close()
-
-	modelInfo := jujuparams.ModelInfo{
-		UUID: modelTag.Id(),
-	}
-	err = api.ModelInfo(ctx, &modelInfo)
-	if err != nil {
+	if err := importer.setModelOwner(ctx, newOwner); err != nil {
 		return errors.E(op, err)
 	}
-	model := dbmodel.Model{}
-	// fill in data from model info
-	err = model.FromJujuModelInfo(modelInfo)
-	if err != nil {
-		return errors.E(op, err)
-	}
-	model.ControllerID = controller.ID
-	model.Controller = *controller
 
-	var ownerTag names.UserTag
-	if newOwner != "" {
-		// Switch the model to be owned by the specified user.
-		if !names.IsValidUser(newOwner) {
-			return errors.E(op, errors.CodeBadRequest, "invalid new username for new model owner")
-		}
-		ownerTag = names.NewUserTag(newOwner)
-	} else {
-		// Use the model owner user
-		ownerTag, err = names.ParseUserTag(modelInfo.OwnerTag)
-		if err != nil {
-			return errors.E(op, fmt.Sprintf("invalid username %s from original model owner", modelInfo.OwnerTag))
-		}
-	}
-	if ownerTag.IsLocal() {
-		return errors.E(op, "cannot import model from local user, try --owner to switch the model owner")
-	}
-	ownerUser := dbmodel.Identity{}
-	ownerUser.SetTag(ownerTag)
-	err = j.Database.GetIdentity(ctx, &ownerUser)
-	if err != nil {
-		return errors.E(op, err)
-	}
-	model.SwitchOwner(&ownerUser)
-
-	// Note that only the new owner is given access. All previous users that had access according to Juju
-	// are discarded as access must now be governed by JIMM and OpenFGA.
-	ofgaUser := openfga.NewUser(&ownerUser, j.OpenFGAClient)
-	controllerTag := model.Controller.ResourceTag()
-
-	if err := j.addModelPermissions(ctx, ofgaUser, modelTag, controllerTag); err != nil {
+	if err := importer.addPermissions(ctx); err != nil {
 		return errors.E(op, err)
 	}
 
 	// TODO(CSS-5458): Remove the below section on cloud credentials once we no longer persist the relation between
-	// cloud credentials and models
-
-	// fetch cloud credential used by the model
-	cloudTag, err := names.ParseCloudTag(modelInfo.CloudTag)
-	if err != nil {
-		return errors.E(op, err)
-	}
-	// Note that the model already has a cloud credential configured which it will use when deploying new
-	// applications. JIMM needs some cloud credential reference to be able to import the model so use any
-	// credential against the cloud the model is deployed against. Even using the correct cloud for the
-	// credential is not strictly necessary, but will help prevent the user thinking they can create new
-	// models on the incoming cloud.
-	allCredentials, err := j.Database.GetIdentityCloudCredentials(ctx, &ownerUser, cloudTag.Id())
-	if err != nil {
-		return errors.E(op, err)
-	}
-	if len(allCredentials) == 0 {
-		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", ownerUser.Name, cloudTag.Id()))
-	}
-	cloudCredential := allCredentials[0]
-
-	model.CloudCredentialID = cloudCredential.ID
-	model.CloudCredential = cloudCredential
-
-	// fetch the cloud used by the model
-	cloud := dbmodel.Cloud{
-		Name: cloudCredential.CloudName,
-	}
-	err = j.Database.GetCloud(ctx, &cloud)
-	if err != nil {
-		zapctx.Error(ctx, "failed to get cloud", zap.String("cloud", cloud.Name))
+	// cloud credentials and models.
+	// Update: We need to investigate this further, if a user updates their cloud-credential it will update the credential
+	// on this model.
+	if err := importer.setCloudCredential(ctx); err != nil {
 		return errors.E(op, err)
 	}
 
-	cr := cloud.Region(modelInfo.CloudRegion)
-	if cr.Name != modelInfo.CloudRegion {
-		return errors.E(op, "cloud region not found")
-	}
-
-	model.CloudRegionID = cr.ID
-	model.CloudRegion = cr
-
-	err = j.Database.AddModel(ctx, &model)
-	if err != nil {
-		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(op, err, "model already exists")
-		}
+	if err := importer.setModelCloud(ctx); err != nil {
 		return errors.E(op, err)
 	}
 
-	return j.handleModelDeltas(ctx, controller, modelTag, model)
+	if err := importer.save(ctx); err != nil {
+		return errors.E(op, err)
+	}
+
+	return importer.handleModelDeltas(ctx)
 }
 
-func (j *JIMM) handleModelDeltas(ctx context.Context, controller *dbmodel.Controller, modelTag names.ModelTag, model dbmodel.Model) error {
+func (m *modelImporter) handleModelDeltas(ctx context.Context) error {
 	const op = errors.Op("jimm.getModelDeltas")
 
-	modelAPI, err := j.dialModel(ctx, controller, modelTag)
+	modelAPI, err := m.jimm.dialModel(ctx, &m.model.Controller, m.model.ResourceTag())
 	if err != nil {
 		return errors.E(op, err)
 	}
@@ -541,9 +610,9 @@ func (j *JIMM) handleModelDeltas(ctx context.Context, controller *dbmodel.Contro
 	}
 
 	modelIDf := func(uuid string) *modelState {
-		if uuid == model.UUID.String {
+		if uuid == m.model.UUID.String {
 			return &modelState{
-				id:       model.ID,
+				id:       m.model.ID,
 				machines: make(map[string]int64),
 				units:    make(map[string]bool),
 			}
@@ -552,7 +621,7 @@ func (j *JIMM) handleModelDeltas(ctx context.Context, controller *dbmodel.Contro
 	}
 
 	w := &Watcher{
-		Database: j.Database,
+		Database: m.jimm.Database,
 	}
 	for _, d := range deltas {
 		if err := w.handleDelta(ctx, modelIDf, d); err != nil {

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -495,6 +495,7 @@ func TestImportModel(t *testing.T) {
 		expectedModel  dbmodel.Model
 		expectedError  string
 		deltas         []jujuparams.Delta
+		offers         []jujuparams.ApplicationOfferAdminDetailsV5
 	}{{
 		about:          "model imported",
 		user:           "alice@canonical.com",
@@ -889,6 +890,113 @@ func TestImportModel(t *testing.T) {
 			return nil
 		},
 		expectedError: `model (.*) already exists`,
+	}, {
+		about:          "import model with offers",
+		user:           "alice@canonical.com",
+		controllerName: "test-controller",
+		newOwner:       "",
+		modelUUID:      "00000002-0000-0000-0000-000000000001",
+		jimmAdmin:      true,
+		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
+			info.Name = "test-model"
+			info.Type = "test-type"
+			info.UUID = "00000002-0000-0000-0000-000000000001"
+			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
+			info.DefaultSeries = "test-series"
+			info.CloudTag = names.NewCloudTag("test-cloud").String()
+			info.CloudRegion = "test-region"
+			info.CloudCredentialTag = names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential").String()
+			info.CloudCredentialValidity = &trueValue
+			info.OwnerTag = names.NewUserTag("alice@canonical.com").String()
+			info.Life = life.Alive
+			info.Status = jujuparams.EntityStatus{
+				Status: status.Status("ok"),
+				Info:   "test-info",
+				Since:  &now,
+			}
+			info.SLA = &jujuparams.ModelSLAInfo{
+				Level: "essential",
+				Owner: "alice@canonical.com",
+			}
+			info.AgentVersion = newVersion("2.1.0")
+			return nil
+		},
+		expectedModel: dbmodel.Model{
+			Name: "test-model",
+			UUID: sql.NullString{
+				String: "00000002-0000-0000-0000-000000000001",
+				Valid:  true,
+			},
+			Owner: dbmodel.Identity{
+				Name:        "alice@canonical.com",
+				DisplayName: "Alice",
+			},
+			Controller: dbmodel.Controller{
+				Name:         "test-controller",
+				UUID:         "00000001-0000-0000-0000-000000000001",
+				CloudName:    "test-cloud",
+				CloudRegion:  "test-region-1",
+				AgentVersion: "3.2.1",
+			},
+			CloudRegion: dbmodel.CloudRegion{
+				Cloud: dbmodel.Cloud{
+					Name: "test-cloud",
+					Type: "test",
+				},
+				Name: "test-region",
+			},
+			CloudCredential: dbmodel.CloudCredential{
+				Name: "test-credential",
+			},
+			Type:          "test-type",
+			DefaultSeries: "test-series",
+			Life:          state.Alive.String(),
+			Status: dbmodel.Status{
+				Status: "ok",
+				Info:   "test-info",
+				Since: sql.NullTime{
+					Valid: true,
+					Time:  now,
+				},
+				Version: "2.1.0",
+			},
+			SLA: dbmodel.SLA{
+				Level: "essential",
+				Owner: "alice@canonical.com",
+			},
+			Offers: []dbmodel.ApplicationOffer{
+				{
+					ApplicationName: "app1",
+					URL:             "url1",
+					UUID:            "00000001-0000-0000-0000-000000000001",
+					Name:            "offer1",
+				},
+				{
+					ApplicationName: "app2",
+					URL:             "url2",
+					UUID:            "00000001-0000-0000-0000-000000000002",
+					Name:            "offer2",
+				},
+			},
+		},
+		offers: []jujuparams.ApplicationOfferAdminDetailsV5{
+			{
+				ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+					OfferUUID: "00000001-0000-0000-0000-000000000001",
+					OfferName: "offer1",
+					OfferURL:  "url1",
+				},
+				ApplicationName: "app1",
+			},
+			{
+				ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+					OfferUUID: "00000001-0000-0000-0000-000000000002",
+					OfferName: "offer2",
+					OfferURL:  "url2",
+				},
+				ApplicationName: "app2",
+			},
+		},
 	}}
 
 	for _, test := range tests {
@@ -909,6 +1017,9 @@ func TestImportModel(t *testing.T) {
 				},
 				WatchAll_: func(context.Context) (string, error) {
 					return test.about, nil
+				},
+				ListApplicationOffers_: func(ctx context.Context, of []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+					return test.offers, nil
 				},
 			}
 
@@ -956,6 +1067,17 @@ func TestImportModel(t *testing.T) {
 				ok, err := client.CheckRelation(ctx, controllerPermissionCheck, false)
 				c.Assert(err, qt.IsNil)
 				c.Assert(ok, qt.IsTrue)
+
+				for _, offer := range test.expectedModel.Offers {
+					offerPermissionCheck := ofga.Tuple{
+						Object:   ofganames.ConvertTag(names.NewUserTag(test.user)),
+						Relation: ofganames.AdministratorRelation,
+						Target:   ofganames.ConvertTag(names.NewApplicationOfferTag(offer.UUID)),
+					}
+					ok, err := client.CheckRelation(ctx, offerPermissionCheck, false)
+					c.Assert(err, qt.IsNil)
+					c.Assert(ok, qt.IsTrue)
+				}
 			} else {
 				c.Assert(err, qt.ErrorMatches, test.expectedError)
 			}

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -888,7 +888,7 @@ func TestImportModel(t *testing.T) {
 			info.OwnerTag = names.NewUserTag("alice@canonical.com").String()
 			return nil
 		},
-		expectedError: `model already exists`,
+		expectedError: `model (.*) already exists`,
 	}}
 
 	for _, test := range tests {

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -135,7 +135,7 @@ func (s *identitiesSuite) TestIdentityGetGroups(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		token = *groups.Next.PageToken
 		for j := 0; j < len(groups.Data); j++ {
-			c.Assert(groups.Data[j].Name, gc.Equals, fmt.Sprintf("group-test%d", i+j))
+			c.Assert(groups.Data[j].Name, gc.Matches, `group-test\d+`)
 			c.Assert(groupTags[j].Id(), gc.Matches, `\w*-\w*-\w*-\w*-\w*`)
 		}
 		if *groups.Next.PageToken == "" {

--- a/internal/testutils/jimmtest/cmp.go
+++ b/internal/testutils/jimmtest/cmp.go
@@ -47,6 +47,7 @@ var DBObjectEquals = qt.CmpEquals(
 	cmpopts.IgnoreFields(dbmodel.CloudRegionControllerPriority{}, "CloudRegionID", "ControllerID"),
 	cmpopts.IgnoreFields(dbmodel.Controller{}, "ID", "UpdatedAt", "CreatedAt"),
 	cmpopts.IgnoreFields(dbmodel.Model{}, "ID", "CreatedAt", "UpdatedAt", "OwnerIdentityName", "ControllerID", "CloudRegionID", "CloudCredentialID"),
+	cmpopts.IgnoreFields(dbmodel.ApplicationOffer{}, "ID", "CreatedAt", "UpdatedAt", "ModelID"),
 )
 
 // CmpEquals uses cmp.Diff (see http://godoc.org/github.com/google/go-cmp/cmp#Diff)


### PR DESCRIPTION
## Description

This PR does two things:
1. Refactors the ImportModel method. I started getting linting errors on cognitive complexity when trying to add functionality so I took the time to refactor the method.
2. Adds functionality to the ImportModel method to import a model's application-offers.

**Please Note:** The first commit contains only the first change and the second commit contains the second change.

One issue that remains is how to handle offer URLs that already exist. This will be tackled in a separate PR.

Partially fixes [JUJU-7011](https://warthogs.atlassian.net/browse/JUJU-7011)

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-7011]: https://warthogs.atlassian.net/browse/JUJU-7011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ