### PR TITLE
Juju 7074/identities filter

### DIFF
--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -121,7 +121,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 }
 
 // ListIdentities returns a paginated list of identities defined by limit and offset.
-// match is used to fuzzy find based on entries' name using the LIKE operator (ex. LIKE %<match>%).
+// match is used to fuzzy find based on entries' name or uuid using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match string) (_ []dbmodel.Identity, err error) {
 	const op = errors.Op("db.ListIdentities")
 	if err := d.ready(); err != nil {

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -121,7 +121,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 }
 
 // ListIdentities returns a paginated list of identities defined by limit and offset.
-// match is used to fuzzy find based on entries' name or uuid using the LIKE operator (ex. LIKE %<match>%).
+// match is used to fuzzy find based on entries' name using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match string) (_ []dbmodel.Identity, err error) {
 	const op = errors.Op("db.ListIdentities")
 	if err := d.ready(); err != nil {

--- a/internal/jimm/identity.go
+++ b/internal/jimm/identity.go
@@ -30,14 +30,14 @@ func (j *JIMM) FetchIdentity(ctx context.Context, id string) (*openfga.User, err
 }
 
 // ListIdentities lists a page of users in our database and parse them into openfga entities.
-// `match` will filter the list for fuzzy find on identity name.
+// `match` will filter the list for fuzzy find on identity name or uuid.
 func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 	const op = errors.Op("jimm.ListIdentities")
 
 	if !user.JimmAdmin {
 		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
-	identities, err := j.Database.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), "")
+	identities, err := j.Database.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), match)
 	var users []openfga.User
 
 	for _, id := range identities {

--- a/internal/jimm/identity.go
+++ b/internal/jimm/identity.go
@@ -30,23 +30,23 @@ func (j *JIMM) FetchIdentity(ctx context.Context, id string) (*openfga.User, err
 }
 
 // ListIdentities lists a page of users in our database and parse them into openfga entities.
-func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]openfga.User, error) {
+// `match` will filter the list for fuzzy find on identity name.
+func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 	const op = errors.Op("jimm.ListIdentities")
 
 	if !user.JimmAdmin {
 		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
+	identities, err := j.Database.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), "")
+	var users []openfga.User
 
-	var identities []openfga.User
-	err := j.Database.ForEachIdentity(ctx, filter.Limit(), filter.Offset(), func(ge *dbmodel.Identity) error {
-		u := openfga.NewUser(ge, j.OpenFGAClient)
-		identities = append(identities, *u)
-		return nil
-	})
+	for _, id := range identities {
+		users = append(users, *openfga.NewUser(&id, j.OpenFGAClient))
+	}
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	return identities, nil
+	return users, nil
 }
 
 // CountIdentities returns the count of all the identities in our database.

--- a/internal/jimm/identity.go
+++ b/internal/jimm/identity.go
@@ -30,7 +30,7 @@ func (j *JIMM) FetchIdentity(ctx context.Context, id string) (*openfga.User, err
 }
 
 // ListIdentities lists a page of users in our database and parse them into openfga entities.
-// `match` will filter the list for fuzzy find on identity name or uuid.
+// `match` will filter the list for fuzzy find on identity name.
 func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 	const op = errors.Op("jimm.ListIdentities")
 

--- a/internal/jimm/identity_test.go
+++ b/internal/jimm/identity_test.go
@@ -89,6 +89,7 @@ func TestListIdentities(t *testing.T) {
 		desc       string
 		limit      int
 		offset     int
+		match      string
 		identities []string
 	}{
 		{
@@ -109,11 +110,18 @@ func TestListIdentities(t *testing.T) {
 			offset:     6,
 			identities: []string{},
 		},
+		{
+			desc:       "test with match",
+			limit:      5,
+			offset:     0,
+			identities: []string{userNames[0]},
+			match:      userNames[0][:5],
+		},
 	}
 	for _, t := range testCases {
 		c.Run(t.desc, func(c *qt.C) {
 			pag = pagination.NewOffsetFilter(t.limit, t.offset)
-			identities, err := j.ListIdentities(ctx, u, pag, "")
+			identities, err := j.ListIdentities(ctx, u, pag, t.match)
 			c.Assert(err, qt.IsNil)
 			c.Assert(identities, qt.HasLen, len(t.identities))
 			for i := range len(t.identities) {

--- a/internal/jimm/identity_test.go
+++ b/internal/jimm/identity_test.go
@@ -68,8 +68,8 @@ func TestListIdentities(t *testing.T) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
 	u.JimmAdmin = true
 
-	filter := pagination.NewOffsetFilter(10, 0)
-	users, err := j.ListIdentities(ctx, u, filter)
+	pag := pagination.NewOffsetFilter(10, 0)
+	users, err := j.ListIdentities(ctx, u, pag, "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(users), qt.Equals, 0)
 
@@ -112,8 +112,8 @@ func TestListIdentities(t *testing.T) {
 	}
 	for _, t := range testCases {
 		c.Run(t.desc, func(c *qt.C) {
-			filter = pagination.NewOffsetFilter(t.limit, t.offset)
-			identities, err := j.ListIdentities(ctx, u, filter)
+			pag = pagination.NewOffsetFilter(t.limit, t.offset)
+			identities, err := j.ListIdentities(ctx, u, pag, "")
 			c.Assert(err, qt.IsNil)
 			c.Assert(identities, qt.HasLen, len(t.identities))
 			for i := range len(t.identities) {

--- a/internal/jimm/identity_test.go
+++ b/internal/jimm/identity_test.go
@@ -115,7 +115,7 @@ func TestListIdentities(t *testing.T) {
 			limit:      5,
 			offset:     0,
 			identities: []string{userNames[0]},
-			match:      userNames[0][:5],
+			match:      "bob1",
 		},
 	}
 	for _, t := range testCases {

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -44,8 +44,11 @@ func (s *identitiesService) ListIdentities(ctx context.Context, params *resource
 		return nil, err
 	}
 	page, nextPage, pagination := pagination.CreatePagination(params.Size, params.Page, count)
-
-	users, err := s.jimm.ListIdentities(ctx, user, pagination)
+	match := ""
+	if params.Filter != nil && *params.Filter != "" {
+		match = *params.Filter
+	}
+	users, err := s.jimm.ListIdentities(ctx, user, pagination, match)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -54,7 +54,6 @@ func (s *identitiesSuite) TestIdentitiesList(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(res, gc.Not(gc.IsNil))
 	c.Assert(len(res.Data), gc.Equals, pageSize)
-
 }
 
 func (s *identitiesSuite) TestIdentityPatchGroups(c *gc.C) {

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -25,10 +25,41 @@ type identitiesSuite struct {
 
 var _ = gc.Suite(&identitiesSuite{})
 
+func (s *identitiesSuite) TestIdentitiesList(c *gc.C) {
+	ctx := context.Background()
+	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
+	identitySvc := rebac_admin.NewidentitiesService(s.JIMM)
+	for i := range 5 {
+		user := names.NewUserTag(fmt.Sprintf("test-user-match-%d@canonical.com", i))
+		s.AddUser(c, user.Id())
+	}
+	pageSize := 5
+	page := 0
+	params := &resources.GetIdentitiesParams{Size: &pageSize, Page: &page}
+	res, err := identitySvc.ListIdentities(ctx, params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.Not(gc.IsNil))
+	c.Assert(res.Meta.Size, gc.Equals, 5)
+
+	match := "test-user-match-1"
+	params.Filter = &match
+	res, err = identitySvc.ListIdentities(ctx, params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.Not(gc.IsNil))
+	c.Assert(len(res.Data), gc.Equals, 1)
+
+	match = "test-user"
+	params.Filter = &match
+	res, err = identitySvc.ListIdentities(ctx, params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.Not(gc.IsNil))
+	c.Assert(len(res.Data), gc.Equals, pageSize)
+
+}
+
 func (s *identitiesSuite) TestIdentityPatchGroups(c *gc.C) {
 	// initialization
 	ctx := context.Background()
-	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
 	identitySvc := rebac_admin.NewidentitiesService(s.JIMM)
 	groupName := "group-test1"
 	username := s.AdminUser.Name

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -60,6 +60,7 @@ func (s *identitiesSuite) TestIdentitiesList(c *gc.C) {
 func (s *identitiesSuite) TestIdentityPatchGroups(c *gc.C) {
 	// initialization
 	ctx := context.Background()
+	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
 	identitySvc := rebac_admin.NewidentitiesService(s.JIMM)
 	groupName := "group-test1"
 	username := s.AdminUser.Name

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -60,9 +60,9 @@ func TestListIdentities(t *testing.T) {
 	}
 	c := qt.New(t)
 	jimm := jimmtest.JIMM{
-		ListIdentities_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
-			start := filter.Offset()
-			end := start + filter.Limit()
+		ListIdentities_: func(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
+			start := pagination.Offset()
+			end := start + pagination.Limit()
 			if end > len(testUsers) {
 				end = len(testUsers)
 			}

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -60,7 +60,7 @@ func TestListIdentities(t *testing.T) {
 	}
 	c := qt.New(t)
 	jimm := jimmtest.JIMM{
-		ListIdentities_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]openfga.User, error) {
+		ListIdentities_: func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 			start := filter.Offset()
 			end := start + filter.Limit()
 			if end > len(testUsers) {

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -65,7 +65,7 @@ type JIMM interface {
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)
 	ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
-	ListIdentities(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]openfga.User, error)
+	ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error)
 	ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error)
 	Offer(ctx context.Context, user *openfga.User, offer jimm.AddApplicationOfferParams) error
 	PubSubHub() *pubsub.Hub

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -56,7 +56,7 @@ type JIMM struct {
 	GetJimmControllerAccess_           func(ctx context.Context, user *openfga.User, tag names.UserTag) (string, error)
 	FetchIdentity_                     func(ctx context.Context, username string) (*openfga.User, error)
 	CountIdentities_                   func(ctx context.Context, user *openfga.User) (int, error)
-	ListIdentities_                    func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]openfga.User, error)
+	ListIdentities_                    func(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error)
 	GetUserCloudAccess_                func(ctx context.Context, user *openfga.User, cloud names.CloudTag) (string, error)
 	GetUserControllerAccess_           func(ctx context.Context, user *openfga.User, controller names.ControllerTag) (string, error)
 	GetUserModelAccess_                func(ctx context.Context, user *openfga.User, model names.ModelTag) (string, error)

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -56,7 +56,7 @@ type JIMM struct {
 	GetJimmControllerAccess_           func(ctx context.Context, user *openfga.User, tag names.UserTag) (string, error)
 	FetchIdentity_                     func(ctx context.Context, username string) (*openfga.User, error)
 	CountIdentities_                   func(ctx context.Context, user *openfga.User) (int, error)
-	ListIdentities_                    func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]openfga.User, error)
+	ListIdentities_                    func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, match string) ([]openfga.User, error)
 	GetUserCloudAccess_                func(ctx context.Context, user *openfga.User, cloud names.CloudTag) (string, error)
 	GetUserControllerAccess_           func(ctx context.Context, user *openfga.User, controller names.ControllerTag) (string, error)
 	GetUserModelAccess_                func(ctx context.Context, user *openfga.User, model names.ModelTag) (string, error)
@@ -227,11 +227,11 @@ func (j *JIMM) CountIdentities(ctx context.Context, user *openfga.User) (int, er
 	}
 	return j.CountIdentities_(ctx, user)
 }
-func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination) ([]openfga.User, error) {
+func (j *JIMM) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 	if j.ListIdentities_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ListIdentities_(ctx, user, filter)
+	return j.ListIdentities_(ctx, user, pagination, match)
 }
 func (j *JIMM) GetUserCloudAccess(ctx context.Context, user *openfga.User, cloud names.CloudTag) (string, error) {
 	if j.GetUserCloudAccess_ == nil {


### PR DESCRIPTION
## Description

This pr adds filtering for rebac `listIdentities` on group name/id.

Address #1421 

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->