### PR TITLE
Juju 7058/fix pagination for entitlement

### DIFF
--- a/internal/common/pagination/pagination.go
+++ b/internal/common/pagination/pagination.go
@@ -84,7 +84,7 @@ type OpenFGAPagination struct {
 
 // NewOpenFGAFilter creates a filter for token pagination.
 func NewOpenFGAFilter(limit int, token string) OpenFGAPagination {
-	if limit < 0 {
+	if limit <= 0 {
 		limit = defaultOpenFGAPageSize
 	}
 	if limit > maxOpenFGAPageSize {

--- a/internal/jimm/relation.go
+++ b/internal/jimm/relation.go
@@ -110,29 +110,58 @@ func (j *JIMM) ListObjectRelations(ctx context.Context, user *openfga.User, obje
 	if !user.JimmAdmin {
 		return nil, e, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
-	continuationToken, kind, err := pagination.DecodeEntitlementToken(entitlementToken)
+	responseTuples, nextToken, err := j.getObjectRelationsPage(ctx, object, pageSize, entitlementToken)
 	if err != nil {
-		return nil, e, err
+		return nil, e, errors.E(op, err)
 	}
+	// Verify next page contain some entries. Otherwise return empty nextToken
+	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
+		responseTuples, _, err := j.getObjectRelationsPage(ctx, object, 1, nextToken)
+		if err != nil {
+			return nil, e, errors.E(op, "error getting next page to verify it cointains something", err)
+		}
+		if len(responseTuples) == 0 {
+			nextToken = pagination.EntitlementToken{}
+		}
+	}
+	return responseTuples, nextToken, nil
+}
+
+func (j *JIMM) getObjectRelationsPage(ctx context.Context, object string, pageSize int32, entitlementToken pagination.EntitlementToken) ([]openfga.Tuple, pagination.EntitlementToken, error) {
+	var err error
+	var e pagination.EntitlementToken
 	tuple := &openfga.Tuple{}
 	tuple.Object, err = j.parseAndValidateTag(ctx, object)
 	if err != nil {
 		return nil, e, err
 	}
-	tuple.Target, err = j.parseAndValidateTag(ctx, kind.String())
-	if err != nil {
-		return nil, e, err
+	var responseTuples []openfga.Tuple
+	nextToken := entitlementToken
+	for {
+		nextContinuationToken, kind, err := pagination.DecodeEntitlementToken(nextToken)
+		if err != nil {
+			return nil, e, err
+		}
+		tuple.Target, err = j.parseAndValidateTag(ctx, kind.String())
+		if err != nil {
+			return nil, e, err
+		}
+		t, nextContinuationToken, err := j.OpenFGAClient.ReadRelatedObjects(ctx, *tuple, pageSize, nextContinuationToken)
+		if err != nil {
+			return nil, e, err
+		}
+		responseTuples = append(responseTuples, t...)
+		pageSize -= int32(len(t))
+		nextToken, err = pagination.NextEntitlementToken(kind, nextContinuationToken)
+		if err != nil {
+			return nil, e, err
+		}
+		// either we have a page full or we don't have more entries
+		if pageSize <= 0 || nextToken.String() == "" {
+			break
+		}
 	}
-
-	responseTuples, nextContinuationToken, err := j.OpenFGAClient.ReadRelatedObjects(ctx, *tuple, pageSize, continuationToken)
-	if err != nil {
-		return nil, e, errors.E(op, err)
-	}
-	nextEntitlementToken, err := pagination.NextEntitlementToken(kind, nextContinuationToken)
-	if err != nil {
-		return nil, e, err
-	}
-	return responseTuples, nextEntitlementToken, nil
+	return responseTuples, nextToken, nil
 }
 
 // parseTuples translate the api request struct containing tuples to a slice of openfga tuple keys.

--- a/internal/jimm/relation.go
+++ b/internal/jimm/relation.go
@@ -114,7 +114,7 @@ func (j *JIMM) ListObjectRelations(ctx context.Context, user *openfga.User, obje
 	if err != nil {
 		return nil, e, errors.E(op, err)
 	}
-	// Verify next page contain some entries. Otherwise return empty nextToken
+	// berify next page contains some entries. Otherwise return empty nextToken.
 	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
 		responseTuples, _, err := j.getObjectRelationsPage(ctx, object, 1, nextToken)
 		if err != nil {
@@ -137,6 +137,7 @@ func (j *JIMM) getObjectRelationsPage(ctx context.Context, object string, pageSi
 	}
 	var responseTuples []openfga.Tuple
 	nextToken := entitlementToken
+	// loop around entity kinds, each with a different continuation token.
 	for {
 		nextContinuationToken, kind, err := pagination.DecodeEntitlementToken(nextToken)
 		if err != nil {
@@ -151,12 +152,13 @@ func (j *JIMM) getObjectRelationsPage(ctx context.Context, object string, pageSi
 			return nil, e, err
 		}
 		responseTuples = append(responseTuples, t...)
+		// nolint:gosec
 		pageSize -= int32(len(t))
 		nextToken, err = pagination.NextEntitlementToken(kind, nextContinuationToken)
 		if err != nil {
 			return nil, e, err
 		}
-		// either we have a page full or we don't have more entries
+		// break on a full page or no other entries.
 		if pageSize <= 0 || nextToken.String() == "" {
 			break
 		}

--- a/internal/jimm/relation.go
+++ b/internal/jimm/relation.go
@@ -114,7 +114,7 @@ func (j *JIMM) ListObjectRelations(ctx context.Context, user *openfga.User, obje
 	if err != nil {
 		return nil, e, errors.E(op, err)
 	}
-	// berify next page contains some entries. Otherwise return empty nextToken.
+	// verify next page contains some entries. Otherwise return empty nextToken.
 	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
 		responseTuples, _, err := j.getObjectRelationsPage(ctx, object, 1, nextToken)
 		if err != nil {

--- a/internal/jimm/relation_test.go
+++ b/internal/jimm/relation_test.go
@@ -240,28 +240,28 @@ func TestListObjectRelations(t *testing.T) {
 	}
 
 	testCases := []struct {
-		description    string
-		object         string
-		initialToken   pagination.EntitlementToken
-		pageSize       int32
-		expectNumPages int
-		expectedError  string
-		expectedLength int
-		expectedTuples []ExpectedTuple
+		description          string
+		object               string
+		initialToken         pagination.EntitlementToken
+		pageSize             int32
+		expectNumPages       int
+		expectedError        string
+		expectedTuplesLength int
+		expectedTuples       []ExpectedTuple
 	}{
 		{
-			description:    "test listing all relations in single page",
-			object:         user.Tag().String(),
-			pageSize:       10,
-			expectNumPages: 1,
-			expectedLength: 7,
+			description:          "test listing all relations in single page",
+			object:               user.Tag().String(),
+			pageSize:             10,
+			expectNumPages:       1,
+			expectedTuplesLength: 7,
 		},
 		{
-			description:    "test listing all relations in multiple pages",
-			object:         user.Tag().String(),
-			pageSize:       2,
-			expectNumPages: 4,
-			expectedLength: 7,
+			description:          "test listing all relations in multiple pages",
+			object:               user.Tag().String(),
+			pageSize:             2,
+			expectNumPages:       4,
+			expectedTuplesLength: 7,
 		},
 		{
 			description:   "invalid initial token",
@@ -295,7 +295,7 @@ func TestListObjectRelations(t *testing.T) {
 				token = nextToken
 			}
 			c.Assert(numPages, qt.Equals, t.expectNumPages)
-			c.Assert(tuples, qt.HasLen, t.expectedLength)
+			c.Assert(tuples, qt.HasLen, t.expectedTuplesLength)
 			for i, expectedTuple := range t.expectedTuples {
 				c.Assert(tuples[i].Relation.String(), qt.Equals, expectedTuple.expectedRelation)
 				c.Assert(tuples[i].Target.ID, qt.Equals, expectedTuple.expectedTargetId)

--- a/internal/jimm/relation_test.go
+++ b/internal/jimm/relation_test.go
@@ -192,7 +192,7 @@ func TestListObjectRelations(t *testing.T) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
 	u.JimmAdmin = true
 
-	user, _, controller, model, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, controller, model, _, cloud, _ := createTestControllerEnvironment(ctx, c, j.Database)
 	c.Assert(err, qt.IsNil)
 
 	err = j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
@@ -211,7 +211,28 @@ func TestListObjectRelations(t *testing.T) {
 			Relation:     names.AuditLogViewerRelation.String(),
 			TargetObject: controller.ResourceTag().String(),
 		},
+		{
+			Object:       user.Tag().String(),
+			Relation:     names.AdministratorRelation.String(),
+			TargetObject: controller.ResourceTag().String(),
+		},
+		{
+			Object:       user.Tag().String(),
+			Relation:     names.AdministratorRelation.String(),
+			TargetObject: cloud.ResourceTag().String(),
+		},
+		{
+			Object:       user.Tag().String(),
+			Relation:     names.CanAddModelRelation.String(),
+			TargetObject: cloud.ResourceTag().String(),
+		},
+		{
+			Object:       user.Tag().String(),
+			Relation:     names.MemberRelation.String(),
+			TargetObject: group.ResourceTag().String(),
+		},
 	})
+
 	c.Assert(err, qt.IsNil)
 	type ExpectedTuple struct {
 		expectedRelation string
@@ -233,14 +254,14 @@ func TestListObjectRelations(t *testing.T) {
 			object:         user.Tag().String(),
 			pageSize:       10,
 			expectNumPages: 1,
-			expectedLength: 3,
+			expectedLength: 7,
 		},
 		{
 			description:    "test listing all relations in multiple pages",
 			object:         user.Tag().String(),
-			pageSize:       1,
-			expectNumPages: 3,
-			expectedLength: 3,
+			pageSize:       2,
+			expectNumPages: 4,
+			expectedLength: 7,
 		},
 		{
 			description:   "invalid initial token",

--- a/internal/jimm/relation_test.go
+++ b/internal/jimm/relation_test.go
@@ -222,17 +222,29 @@ func TestListObjectRelations(t *testing.T) {
 		description    string
 		object         string
 		initialToken   pagination.EntitlementToken
+		pageSize       int32
+		expectNumPages int
 		expectedError  string
 		expectedLength int
 		expectedTuples []ExpectedTuple
 	}{
 		{
-			description:    "test listing all relations",
+			description:    "test listing all relations in single page",
 			object:         user.Tag().String(),
+			pageSize:       10,
+			expectNumPages: 1,
+			expectedLength: 3,
+		},
+		{
+			description:    "test listing all relations in multiple pages",
+			object:         user.Tag().String(),
+			pageSize:       1,
+			expectNumPages: 3,
 			expectedLength: 3,
 		},
 		{
 			description:   "invalid initial token",
+			object:        user.Tag().String(),
 			initialToken:  pagination.NewEntitlementToken("bar"),
 			expectedError: "failed to decode pagination token.*",
 		},
@@ -247,18 +259,21 @@ func TestListObjectRelations(t *testing.T) {
 		c.Run(t.description, func(c *qt.C) {
 			token := t.initialToken
 			tuples := []openfga.Tuple{}
+			numPages := 0
 			for {
-				res, nextToken, err := j.ListObjectRelations(ctx, u, t.object, 10, token)
+				res, nextToken, err := j.ListObjectRelations(ctx, u, t.object, t.pageSize, token)
 				if t.expectedError != "" {
 					c.Assert(err, qt.ErrorMatches, t.expectedError)
 					break
 				}
 				tuples = append(tuples, res...)
+				numPages += 1
 				if nextToken.String() == "" {
 					break
 				}
 				token = nextToken
 			}
+			c.Assert(numPages, qt.Equals, t.expectNumPages)
 			c.Assert(tuples, qt.HasLen, t.expectedLength)
 			for i, expectedTuple := range t.expectedTuples {
 				c.Assert(tuples[i].Relation.String(), qt.Equals, expectedTuple.expectedRelation)

--- a/internal/jimmhttp/rebac_admin/groups_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_integration_test.go
@@ -177,18 +177,10 @@ func (s rebacAdminSuite) TestGetGroupEntitlementsIntegration(c *gc.C) {
 	emptyPageToken := ""
 	req := resources.GetGroupsItemEntitlementsParams{NextPageToken: &emptyPageToken}
 	var entitlements []resources.EntityEntitlement
-	for {
-		res, err := s.groupSvc.GetGroupEntitlements(ctx, group.UUID, &req)
-		c.Assert(err, gc.IsNil)
-		c.Assert(res, gc.Not(gc.IsNil))
-		entitlements = append(entitlements, res.Data...)
-		if res.Next.PageToken == nil {
-			break
-		}
-		c.Assert(*res.Meta.PageToken, gc.Equals, *req.NextPageToken)
-		c.Assert(*res.Next.PageToken, gc.Not(gc.Equals), "")
-		req.NextPageToken = res.Next.PageToken
-	}
+	res, err := s.groupSvc.GetGroupEntitlements(ctx, group.UUID, &req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.Not(gc.IsNil))
+	entitlements = append(entitlements, res.Data...)
 	c.Assert(entitlements, gc.HasLen, 6)
 	modelEntitlementCount := 0
 	controllerEntitlementCount := 0

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -221,18 +221,10 @@ func (s *identitiesSuite) TestIdentityEntitlements(c *gc.C) {
 	emptyPageToken := ""
 	req := resources.GetIdentitiesItemEntitlementsParams{NextPageToken: &emptyPageToken}
 	var entitlements []resources.EntityEntitlement
-	for {
-		res, err := identitySvc.GetIdentityEntitlements(ctx, user.Id(), &req)
-		c.Assert(err, gc.IsNil)
-		c.Assert(res, gc.Not(gc.IsNil))
-		entitlements = append(entitlements, res.Data...)
-		if res.Next.PageToken == nil || *res.Next.PageToken == "" {
-			break
-		}
-		c.Assert(*res.Meta.PageToken, gc.Equals, *req.NextPageToken)
-		c.Assert(*res.Next.PageToken, gc.Not(gc.Equals), "")
-		req.NextPageToken = res.Next.PageToken
-	}
+	res, err := identitySvc.GetIdentityEntitlements(ctx, user.Id(), &req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res, gc.Not(gc.IsNil))
+	entitlements = append(entitlements, res.Data...)
 	c.Assert(entitlements, gc.HasLen, 7)
 	modelEntitlementCount := 0
 	controllerEntitlementCount := 0


### PR DESCRIPTION
## Description

In this PR we change the way we return pages of entries from OpenFGA.
Before, we returned a page containing only one entity kind, which caused confusion to users because if they asked for a `pageSize` 10 and we returned a `pageSize` 5 with a continuation token, they would assume there weren't more entries.

Now we try to fill the page of `pageSize` entries, independently of entity kind.

> the second-page fetch of `pageSize` is to ensure that if we return a continuation token, there are at least one more entry in openfga.
 

Address #1419 

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->