### PR TITLE
Lightweight application offers.

### DIFF
--- a/cmd/jimmctl/cmd/relation_test.go
+++ b/cmd/jimmctl/cmd/relation_test.go
@@ -324,14 +324,12 @@ func initializeEnvironment(c *gc.C, ctx context.Context, db *db.Database, u dbmo
 	env.models = []dbmodel.Model{model}
 
 	offer := dbmodel.ApplicationOffer{
-		ID:              1,
-		UUID:            "436b2264-d8f8-4e24-b16f-dd43c4116528",
-		URL:             env.controllers[0].Name + ":" + env.models[0].OwnerIdentityName + "/" + env.models[0].Name + ".testoffer1",
-		Name:            "testoffer1",
-		ModelID:         model.ID,
-		Model:           model,
-		ApplicationName: "test-app",
-		CharmURL:        "cs:test-app:17",
+		ID:      1,
+		UUID:    "436b2264-d8f8-4e24-b16f-dd43c4116528",
+		URL:     env.controllers[0].Name + ":" + env.models[0].OwnerIdentityName + "/" + env.models[0].Name + ".testoffer1",
+		Name:    "testoffer1",
+		ModelID: model.ID,
+		Model:   model,
 	}
 	err = db.AddApplicationOffer(ctx, &offer)
 	c.Assert(err, gc.IsNil)

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -5,8 +5,6 @@ package db
 import (
 	"context"
 
-	"gorm.io/gorm"
-
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
@@ -33,46 +31,6 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	return nil
 }
 
-// UpdateApplicationOffer updates the application offer information.
-func (d *Database) UpdateApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
-	const op = errors.Op("db.UpdateApplicationOffer")
-
-	if err := d.ready(); err != nil {
-		return errors.E(op, err)
-	}
-
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
-	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
-
-	db := d.DB.WithContext(ctx)
-	err = db.Transaction(func(tx *gorm.DB) error {
-		tx.Omit("Connections", "Endpoints", "Spaces").Save(offer)
-		err = tx.Model(offer).Association("Connections").Replace(offer.Connections)
-		if err != nil {
-			return err
-		}
-		err = tx.Model(offer).Association("Endpoints").Replace(offer.Endpoints)
-		if err != nil {
-			return err
-		}
-		err = tx.Model(offer).Association("Spaces").Replace(offer.Spaces)
-		if err != nil {
-			return err
-		}
-		return tx.Error
-	})
-	if err != nil {
-		return errors.E(op, dbError(err))
-	}
-
-	if err := d.GetApplicationOffer(ctx, offer); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetApplicationOffer returns application offer information based on the
 // offer UUID or URL.
 func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
@@ -95,10 +53,8 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	default:
 		return errors.E(op, "missing offer UUID or URL")
 	}
-	db = db.Preload("Connections")
-	db = db.Preload("Endpoints")
+
 	db = db.Preload("Model").Preload("Model.Controller")
-	db = db.Preload("Spaces")
 	if err := db.First(&offer).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
@@ -130,71 +86,12 @@ func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.Ap
 	return nil
 }
 
-// ApplicationOfferFilter can be used to find application offers that match certain criteria.
-type ApplicationOfferFilter func(*gorm.DB) *gorm.DB
+// FindApplicationOffersByModel returns all application offers in a model specified by model name and owner.
+func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, modelOwner string) (_ []dbmodel.ApplicationOffer, err error) {
+	const op = errors.Op("db.FindApplicationOfferByModel")
 
-// ApplicationOfferFilterByName filters application offers by the offer name.
-func ApplicationOfferFilterByName(name string) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("offers.name LIKE ?", "%"+name+"%")
-	}
-}
-
-// ApplicationOfferFilterByDescription filters application offers by application description.
-func ApplicationOfferFilterByDescription(substring string) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("offers.application_description LIKE ?", "%"+substring+"%")
-	}
-}
-
-// ApplicationOfferFilterByModel filters application offers by model name and owner.
-func ApplicationOfferFilterByModel(modelName, modelOwner string) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		tx := db.Joins("JOIN models ON models.id = offers.model_id").
-			Where("models.name = ?", modelName).
-			Where("models.owner_identity_name = ?", modelOwner)
-		return tx
-	}
-}
-
-// ApplicationOfferFilterByApplication filters application offers by application name.
-func ApplicationOfferFilterByApplication(applicationName string) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("offers.application_name = ?", applicationName)
-	}
-}
-
-// ApplicationOfferFilterByUUID filters application offers by UUID.
-func ApplicationOfferFilterByUUID(uuids []string) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		db = db.Where("offers.uuid IN ?", uuids)
-		return db
-	}
-}
-
-// ApplicationOfferFilterByEndpoint filters application offer accessible by the user.
-func ApplicationOfferFilterByEndpoint(endpoint dbmodel.ApplicationOfferRemoteEndpoint) ApplicationOfferFilter {
-	return func(db *gorm.DB) *gorm.DB {
-		db = db.Joins("JOIN application_offer_remote_endpoints AS endpoints ON endpoints.application_offer_id = offers.id")
-		if endpoint.Interface != "" {
-			db = db.Where("endpoints.interface = ?", endpoint.Interface)
-		}
-		if endpoint.Name != "" {
-			db = db.Where("endpoints.name = ?", endpoint.Name)
-		}
-		if endpoint.Role != "" {
-			db = db.Where("endpoints.role = ?", endpoint.Role)
-		}
-		return db
-	}
-}
-
-// FindApplicationOffers returns application offers matching criteria specified by the filters.
-func (d *Database) FindApplicationOffers(ctx context.Context, filters ...ApplicationOfferFilter) (_ []dbmodel.ApplicationOffer, err error) {
-	const op = errors.Op("db.FindApplicationOffer")
-
-	if len(filters) == 0 {
-		return nil, errors.E(op, errors.CodeBadRequest, "no filters specified")
+	if modelName == "" || modelOwner == "" {
+		return nil, errors.E(op, errors.CodeBadRequest, "model name or owner not specified")
 	}
 	if err := d.ready(); err != nil {
 		return nil, errors.E(op, err)
@@ -207,12 +104,12 @@ func (d *Database) FindApplicationOffers(ctx context.Context, filters ...Applica
 	db := d.DB.WithContext(ctx)
 	db = db.Table("application_offers AS offers")
 
-	for _, filter := range filters {
-		db = filter(db)
-	}
+	db = db.Joins("JOIN models ON models.id = offers.model_id").
+		Where("models.name = ?", modelName).
+		Where("models.owner_identity_name = ?", modelOwner)
 
 	var offers []dbmodel.ApplicationOffer
-	result := db.Find(&offers)
+	result := db.Preload("Model").Find(&offers)
 	if result.Error != nil {
 		return nil, errors.E(op, dbError(result.Error))
 	}

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -212,7 +212,7 @@ func preloadModel(prefix string, db *gorm.DB) *gorm.DB {
 	// loading a model, as we just use the credential to deploy
 	// applications.
 	db = db.Preload(prefix + "CloudCredential")
-	db = db.Preload(prefix + "Offers").Preload(prefix + "Offers.Connections").Preload(prefix + "Offers.Endpoints")
+	db = db.Preload(prefix + "Offers")
 
 	return db
 }

--- a/internal/dbmodel/applicationoffer.go
+++ b/internal/dbmodel/applicationoffer.go
@@ -5,10 +5,7 @@ package dbmodel
 import (
 	"time"
 
-	"github.com/juju/charm/v12"
-	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"gorm.io/gorm"
 )
 
 // An ApplicationOffer is an offer for an application.
@@ -21,11 +18,6 @@ type ApplicationOffer struct {
 	ModelID uint
 	Model   Model
 
-	// Application is the application that this offer is for.
-	ApplicationName string
-
-	ApplicationDescription string
-
 	// Name is the name of the offer.
 	Name string
 
@@ -34,21 +26,6 @@ type ApplicationOffer struct {
 
 	// Application offer URL.
 	URL string `gorm:"unique;not null"`
-
-	// Endpoints contains remote endpoints for the application offer.
-	Endpoints []ApplicationOfferRemoteEndpoint
-
-	// Spaces contains spaces in remote models for the application offer.
-	Spaces []ApplicationOfferRemoteSpace
-
-	// Bindings contains bindings for the application offer.
-	Bindings StringMap
-
-	// Connections contains details about connections to the application offer.
-	Connections []ApplicationOfferConnection
-
-	// CharmURL is the URL of the charm deployed to the application.
-	CharmURL string `gorm:"column:charm_url"`
 }
 
 // Tag returns a names.Tag for the application-offer.
@@ -67,147 +44,4 @@ func (o ApplicationOffer) ResourceTag() names.ApplicationOfferTag {
 // SetTag sets the application-offer's UUID from the given tag.
 func (o *ApplicationOffer) SetTag(t names.ApplicationOfferTag) {
 	o.UUID = t.Id()
-}
-
-// FromJujuApplicationOfferAdminDetails maps the Juju ApplicationOfferDetails struct type to a JIMM type
-// such that it can be persisted.
-func (o *ApplicationOffer) FromJujuApplicationOfferAdminDetailsV5(offerDetails jujuparams.ApplicationOfferAdminDetailsV5) {
-	o.ApplicationName = offerDetails.ApplicationName
-	o.ApplicationDescription = offerDetails.ApplicationDescription
-	o.Name = offerDetails.OfferName
-	o.UUID = offerDetails.OfferUUID
-	o.URL = offerDetails.OfferURL
-	o.CharmURL = offerDetails.CharmURL
-	o.Endpoints = mapJujuRemoteEndpointsToJIMMRemoteEndpoints(offerDetails.Endpoints)
-	o.Connections = mapJujuConnectionsToJIMMConnections(offerDetails.Connections)
-}
-
-// ToJujuApplicationOfferDetails maps the JIMM ApplicationOfferDetails struct type to a jujuparams type
-// such that it can be sent over the wire.
-func (o *ApplicationOffer) ToJujuApplicationOfferDetailsV5() jujuparams.ApplicationOfferAdminDetailsV5 {
-	v5Details := jujuparams.ApplicationOfferDetailsV5{
-		SourceModelTag:         o.Model.Tag().String(),
-		OfferUUID:              o.UUID,
-		OfferURL:               o.URL,
-		OfferName:              o.Name,
-		ApplicationDescription: o.ApplicationDescription,
-		Endpoints:              mapJIMMRemoteEndpointsToJujuRemoteEndpoints(o.Endpoints),
-	}
-
-	v5AdminDetails := jujuparams.ApplicationOfferAdminDetailsV5{
-		ApplicationOfferDetailsV5: v5Details,
-		ApplicationName:           o.ApplicationName,
-		CharmURL:                  o.CharmURL,
-		Connections:               mapJIMMConnectionsToJujuConnections(o.Connections),
-	}
-
-	return v5AdminDetails
-}
-
-// ApplicationOfferRemoteEndpoint represents a remote application endpoint.
-type ApplicationOfferRemoteEndpoint struct {
-	gorm.Model
-
-	// ApplicationOffer is the application-offer associated with this endpoint.
-	ApplicationOfferID uint
-	ApplicationOffer   ApplicationOffer
-
-	Name      string
-	Role      string
-	Interface string
-	Limit     int
-}
-
-// ApplicationOfferRemoteSpace represents a space in some remote model.
-type ApplicationOfferRemoteSpace struct {
-	gorm.Model
-
-	// ApplicationOffer is the application-offer associated with this space.
-	ApplicationOfferID uint
-	ApplicationOffer   ApplicationOffer `gorm:"constraint:OnDelete:CASCADE"`
-
-	CloudType          string
-	Name               string
-	ProviderID         string
-	ProviderAttributes Map
-}
-
-// ApplicationOfferConnection holds details about a connection to an offer.
-type ApplicationOfferConnection struct {
-	gorm.Model
-
-	// ApplicationOffer is the application-offer associated with this connection.
-	ApplicationOfferID uint
-	ApplicationOffer   ApplicationOffer `gorm:"constraint:OnDelete:CASCADE"`
-
-	SourceModelTag string
-	RelationID     int
-	IdentityName   string
-	Endpoint       string
-	IngressSubnets Strings
-}
-
-// mapJIMMRemoteEndpointsToJujuRemoteEndpoints maps the types between JIMM's
-// remote endpoints type (with gorm embedded for persistence) to a jujuparams
-// remote endpoint, such that it can be sent over the wire and contains the correct
-// json tags.
-func mapJIMMRemoteEndpointsToJujuRemoteEndpoints(endpoints []ApplicationOfferRemoteEndpoint) []jujuparams.RemoteEndpoint {
-	mappedEndpoints := make([]jujuparams.RemoteEndpoint, len(endpoints))
-	for i, endpoint := range endpoints {
-		mappedEndpoints[i] = jujuparams.RemoteEndpoint{
-			Name:      endpoint.Name,
-			Role:      charm.RelationRole(endpoint.Role),
-			Interface: endpoint.Interface,
-			Limit:     endpoint.Limit,
-		}
-	}
-	return mappedEndpoints
-}
-
-// mapJujuRemoteEndpointsToJIMMRemoteEndpoints - See above for details, this does the opposite.
-func mapJujuRemoteEndpointsToJIMMRemoteEndpoints(endpoints []jujuparams.RemoteEndpoint) []ApplicationOfferRemoteEndpoint {
-	mappedEndpoints := make([]ApplicationOfferRemoteEndpoint, len(endpoints))
-	for i, endpoint := range endpoints {
-		mappedEndpoints[i] = ApplicationOfferRemoteEndpoint{
-			Name:      endpoint.Name,
-			Role:      string(endpoint.Role),
-			Interface: endpoint.Interface,
-			Limit:     endpoint.Limit,
-		}
-	}
-	return mappedEndpoints
-}
-
-// mapJIMMConnectionsToJujuConnections maps the types between JIMM's
-// offer connection type (with gorm embedded for persistence) to a jujuparams
-// offer connection, such that it can be sent over the wire and contains the correct
-// json tags.
-func mapJIMMConnectionsToJujuConnections(connections []ApplicationOfferConnection) []jujuparams.OfferConnection {
-	mappedConnections := make([]jujuparams.OfferConnection, len(connections))
-	for i, connection := range connections {
-		mappedConnections[i] = jujuparams.OfferConnection{
-			SourceModelTag: connection.SourceModelTag,
-			RelationId:     connection.RelationID,
-			Username:       connection.IdentityName,
-			Endpoint:       connection.Endpoint,
-			IngressSubnets: connection.IngressSubnets,
-			// TODO(ale8k): Status is missing, do we need it??
-		}
-	}
-	return mappedConnections
-}
-
-// mapJujuConnectionsToJIMMConnections - See above for details, this does the opposite.
-func mapJujuConnectionsToJIMMConnections(connections []jujuparams.OfferConnection) []ApplicationOfferConnection {
-	mappedConnections := make([]ApplicationOfferConnection, len(connections))
-	for i, connection := range connections {
-		mappedConnections[i] = ApplicationOfferConnection{
-			SourceModelTag: connection.SourceModelTag,
-			RelationID:     connection.RelationId,
-			IdentityName:   connection.Username,
-			Endpoint:       connection.Endpoint,
-			IngressSubnets: connection.IngressSubnets,
-		}
-	}
-	return mappedConnections
 }

--- a/internal/dbmodel/applicationoffer_test.go
+++ b/internal/dbmodel/applicationoffer_test.go
@@ -51,14 +51,13 @@ func TestApplicationOfferUniqueConstraint(t *testing.T) {
 	c.Assert(db.Create(&m).Error, qt.IsNil)
 
 	ao := dbmodel.ApplicationOffer{
-		Name:  "offer1",
+		Name:  "offer",
 		UUID:  "00000003-0000-0000-0000-0000-000000000001",
 		URL:   "foo",
 		Model: m,
 	}
 	c.Assert(db.Create(&ao).Error, qt.IsNil)
 	ao.ID = 0
-	ao.Name = "offer2"
 	ao.UUID = "00000003-0000-0000-0000-0000-000000000002"
 	c.Assert(db.Create(&ao).Error, qt.ErrorMatches, `ERROR: duplicate key value violates unique constraint "application_offers_url_key" .*`)
 }

--- a/internal/dbmodel/sql/postgres/1_14.sql
+++ b/internal/dbmodel/sql/postgres/1_14.sql
@@ -1,0 +1,19 @@
+-- 1_13.sql is a migration simplifies application offers
+DROP INDEX IF EXISTS idx_application_offer_connections_deleted_at;
+DROP INDEX IF EXISTS idx_application_offer_remote_endpoints_deleted_at;
+DROP INDEX IF EXISTS idx_application_offer_remote_spaces_deleted_at;
+DROP INDEX IF EXISTS idx_user_application_offer_access_deleted_at;
+DROP TABLE IF EXISTS application_offer_connections;
+DROP TABLE IF EXISTS application_offer_remote_endpoints;
+DROP TABLE IF EXISTS application_offer_remote_spaces;
+DROP TABLE IF EXISTS user_application_offer_access;
+ALTER TABLE application_offers ALTER COLUMN application_name DROP NOT NULL;
+ALTER TABLE application_offers ALTER COLUMN application_description DROP NOT NULL;
+ALTER TABLE application_offers ALTER COLUMN charm_url DROP NOT NULL;
+ALTER TABLE application_offers DROP COLUMN IF EXISTS application_name;
+ALTER TABLE application_offers DROP COLUMN IF EXISTS application_description;
+ALTER TABLE application_offers DROP COLUMN IF EXISTS bindings;
+ALTER TABLE application_offers DROP COLUMN IF EXISTS charm_url;
+
+UPDATE versions SET major=1, minor=14 WHERE component='jimmdb';
+

--- a/internal/dbmodel/version.go
+++ b/internal/dbmodel/version.go
@@ -20,7 +20,7 @@ const (
 	// Minor is the minor version of the model described in the dbmodel
 	// package. It should be incremented for any change made to the
 	// database model from database model in a released JIMM.
-	Minor = 13
+	Minor = 14
 )
 
 type Version struct {

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -610,7 +610,7 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 		},
 		// Resolves bad applicationoffers where it cannot be found on the specified controller/model combo
 		{
-			input: "applicationoffer-" + controller.Name + ":alex/" + model.Name + "." + offer.Name + "fluff",
+			input: "applicationoffer-" + controller.Name + ":alex/" + model.Name + "." + offer.UUID + "fluff",
 			want:  "application offer not found",
 		},
 		{
@@ -726,11 +726,10 @@ func createTestControllerEnvironment(ctx context.Context, c *qt.C, db db.Databas
 	c.Assert(err, qt.IsNil)
 
 	offer := dbmodel.ApplicationOffer{
-		UUID:            id.String(),
-		Name:            offerName,
-		ModelID:         model.ID,
-		ApplicationName: petname.Generate(2, "-"),
-		URL:             offerURL.String(),
+		UUID:    id.String(),
+		Name:    offerName,
+		ModelID: model.ID,
+		URL:     offerURL.String(),
 	}
 	err = db.AddApplicationOffer(context.Background(), &offer)
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/applicationoffer_test.go
+++ b/internal/jimm/applicationoffer_test.go
@@ -146,14 +146,12 @@ var initializeEnvironment = func(c *qt.C, ctx context.Context, db *db.Database, 
 	c.Assert(err, qt.IsNil)
 
 	offer := dbmodel.ApplicationOffer{
-		ID:              1,
-		UUID:            "00000000-0000-0000-0000-0000-0000000000011",
-		URL:             "test-offer-url",
-		Name:            "test-offer",
-		ModelID:         model.ID,
-		Model:           model,
-		ApplicationName: "test-app",
-		CharmURL:        "cs:test-app:17",
+		ID:      1,
+		UUID:    "00000000-0000-0000-0000-0000-0000000000011",
+		URL:     "test-offer-url",
+		Name:    "test-offer",
+		ModelID: model.ID,
+		Model:   model,
 	}
 	err = db.AddApplicationOffer(ctx, &offer)
 	c.Assert(err, qt.IsNil)
@@ -620,13 +618,11 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	offer := dbmodel.ApplicationOffer{
-		ID:              1,
-		UUID:            uuid.NewString(),
-		URL:             "test-offer-url",
-		ModelID:         model.ID,
-		Model:           model,
-		ApplicationName: "test-app",
-		CharmURL:        "cs:test-app:17",
+		ID:      1,
+		UUID:    uuid.NewString(),
+		URL:     "test-offer-url",
+		ModelID: model.ID,
+		Model:   model,
 	}
 	err = db.AddApplicationOffer(ctx, &offer)
 	c.Assert(err, qt.IsNil)
@@ -660,11 +656,10 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 			API: &jimmtest.API{
 				GetApplicationOfferConsumeDetails_: func(ctx context.Context, user names.UserTag, details *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
 					details.Offer = &jujuparams.ApplicationOfferDetailsV5{
-						SourceModelTag:         names.NewModelTag(model.UUID.String).String(),
-						OfferUUID:              offer.UUID,
-						OfferURL:               offer.URL,
-						OfferName:              offer.Name,
-						ApplicationDescription: offer.ApplicationDescription,
+						SourceModelTag: names.NewModelTag(model.UUID.String).String(),
+						OfferUUID:      offer.UUID,
+						OfferURL:       offer.URL,
+						OfferName:      offer.Name,
 						Endpoints: []jujuparams.RemoteEndpoint{{
 							Name:      "test-endpoint",
 							Role:      "requirer",
@@ -714,11 +709,10 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 			},
 			Macaroon: &macaroon.Macaroon{},
 			Offer: &jujuparams.ApplicationOfferDetailsV5{
-				SourceModelTag:         names.NewModelTag(model.UUID.String).String(),
-				OfferUUID:              offer.UUID,
-				OfferURL:               offer.URL,
-				OfferName:              offer.Name,
-				ApplicationDescription: offer.ApplicationDescription,
+				SourceModelTag: names.NewModelTag(model.UUID.String).String(),
+				OfferUUID:      offer.UUID,
+				OfferURL:       offer.URL,
+				OfferName:      offer.Name,
 				Endpoints: []jujuparams.RemoteEndpoint{{
 					Name:      "test-endpoint",
 					Role:      "requirer",
@@ -756,11 +750,10 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 			},
 			Macaroon: &macaroon.Macaroon{},
 			Offer: &jujuparams.ApplicationOfferDetailsV5{
-				SourceModelTag:         names.NewModelTag(model.UUID.String).String(),
-				OfferUUID:              offer.UUID,
-				OfferURL:               offer.URL,
-				OfferName:              offer.Name,
-				ApplicationDescription: offer.ApplicationDescription,
+				SourceModelTag: names.NewModelTag(model.UUID.String).String(),
+				OfferUUID:      offer.UUID,
+				OfferURL:       offer.URL,
+				OfferName:      offer.Name,
 				Endpoints: []jujuparams.RemoteEndpoint{{
 					Name:      "test-endpoint",
 					Role:      "requirer",
@@ -840,7 +833,7 @@ func TestGetApplicationOffer(t *testing.T) {
 					}}
 					details.ApplicationOfferDetailsV5 = jujuparams.ApplicationOfferDetailsV5{
 						SourceModelTag:         names.NewModelTag("00000000-0000-0000-0000-0000-0000000000003").String(),
-						OfferUUID:              "00000000-0000-0000-0000-0000-0000000000011",
+						OfferUUID:              "00000000-0000-0000-0000-0000-0000000000004",
 						OfferURL:               "test-offer-url",
 						ApplicationDescription: "changed offer description",
 						Endpoints: []jujuparams.RemoteEndpoint{{
@@ -927,28 +920,11 @@ func TestGetApplicationOffer(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	offer := dbmodel.ApplicationOffer{
-		ID:                     1,
-		ModelID:                1,
-		ApplicationName:        "test-app",
-		CharmURL:               "cs:test-app:17",
-		ApplicationDescription: "a test app offering",
-		Name:                   "test-application-offer",
-		UUID:                   "00000000-0000-0000-0000-0000-0000000000004",
-		URL:                    "test-offer-url",
-		Endpoints: []dbmodel.ApplicationOfferRemoteEndpoint{{
-			ApplicationOfferID: 1,
-			Name:               "test-endpoint",
-			Role:               "requirer",
-			Interface:          "unknown",
-			Limit:              1,
-		}},
-		Connections: []dbmodel.ApplicationOfferConnection{{
-			ApplicationOfferID: 1,
-			SourceModelTag:     "test-model-src",
-			RelationID:         1,
-			IdentityName:       "unknown",
-			Endpoint:           "test-endpoint",
-		}},
+		ID:      1,
+		ModelID: 1,
+		Name:    "test-application-offer",
+		UUID:    "00000000-0000-0000-0000-0000-0000000000004",
+		URL:     "test-offer-url",
 	}
 	err = j.Database.AddApplicationOffer(ctx, &offer)
 	c.Assert(err, qt.IsNil)
@@ -974,7 +950,7 @@ func TestGetApplicationOffer(t *testing.T) {
 		expectedOfferDetails: jujuparams.ApplicationOfferAdminDetailsV5{
 			ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
 				SourceModelTag:         names.NewModelTag(model.UUID.String).String(),
-				OfferUUID:              "00000000-0000-0000-0000-0000-0000000000011",
+				OfferUUID:              "00000000-0000-0000-0000-0000-0000000000004",
 				OfferURL:               "test-offer-url",
 				ApplicationDescription: "changed offer description",
 				Endpoints: []jujuparams.RemoteEndpoint{{
@@ -1007,7 +983,7 @@ func TestGetApplicationOffer(t *testing.T) {
 		expectedOfferDetails: jujuparams.ApplicationOfferAdminDetailsV5{
 			ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
 				SourceModelTag:         names.NewModelTag(model.UUID.String).String(),
-				OfferUUID:              "00000000-0000-0000-0000-0000-0000000000011",
+				OfferUUID:              "00000000-0000-0000-0000-0000-0000000000004",
 				OfferURL:               "test-offer-url",
 				ApplicationDescription: "changed offer description",
 				Endpoints: []jujuparams.RemoteEndpoint{{
@@ -1168,27 +1144,10 @@ func TestOffer(t *testing.T) {
 			}
 
 			offer := dbmodel.ApplicationOffer{
-				ID:                     1,
-				ModelID:                1,
-				ApplicationName:        "test-app",
-				CharmURL:               "cs:test-app:17",
-				ApplicationDescription: "a test app offering",
-				UUID:                   "00000000-0000-0000-0000-0000-0000000000004",
-				URL:                    "test-offer-url",
-				Endpoints: []dbmodel.ApplicationOfferRemoteEndpoint{{
-					ApplicationOfferID: 1,
-					Name:               "test-endpoint",
-					Role:               "requirer",
-					Interface:          "unknown",
-					Limit:              1,
-				}},
-				Connections: []dbmodel.ApplicationOfferConnection{{
-					ApplicationOfferID: 1,
-					SourceModelTag:     "test-model-src",
-					RelationID:         1,
-					IdentityName:       "unknown",
-					Endpoint:           "test-endpoint",
-				}},
+				ID:      1,
+				ModelID: 1,
+				UUID:    "00000000-0000-0000-0000-0000-0000000000004",
+				URL:     "test-offer-url",
 			}
 
 			return *u, offerParams, offer, nil
@@ -1790,27 +1749,10 @@ func TestOfferAssertOpenFGARelationsExist(t *testing.T) {
 		}
 
 		offer := dbmodel.ApplicationOffer{
-			ID:                     1,
-			ModelID:                model.ID,
-			ApplicationName:        "test-app",
-			CharmURL:               "cs:test-app:17",
-			ApplicationDescription: "a test app offering",
-			UUID:                   "00000000-0000-0000-0000-0000-0000000000004",
-			URL:                    "test-offer-url",
-			Endpoints: []dbmodel.ApplicationOfferRemoteEndpoint{{
-				ApplicationOfferID: 1,
-				Name:               "test-endpoint",
-				Role:               "requirer",
-				Interface:          "unknown",
-				Limit:              1,
-			}},
-			Connections: []dbmodel.ApplicationOfferConnection{{
-				ApplicationOfferID: 1,
-				SourceModelTag:     "test-model-src",
-				RelationID:         1,
-				IdentityName:       "unknown",
-				Endpoint:           "test-endpoint",
-			}},
+			ID:      1,
+			ModelID: model.ID,
+			UUID:    "00000000-0000-0000-0000-0000-0000000000004",
+			URL:     "test-offer-url",
 		}
 
 		return *u, offerParams, offer, nil
@@ -2095,169 +2037,25 @@ func TestDestroyOffer(t *testing.T) {
 	}
 }
 
-func TestUpdateOffer(t *testing.T) {
-	c := qt.New(t)
-
-	ctx := context.Background()
-	now := time.Now().UTC().Round(time.Millisecond)
-
-	tests := []struct {
-		about         string
-		parameterFunc func(*environment) (string, bool)
-		expectedError string
-		expectedOffer dbmodel.ApplicationOffer
-	}{{
-		about: "update works",
-		parameterFunc: func(env *environment) (string, bool) {
-			return env.applicationOffers[0].UUID, false
-		},
-		expectedOffer: dbmodel.ApplicationOffer{
-			ID:                     1,
-			UUID:                   "00000000-0000-0000-0000-0000-0000000000011",
-			URL:                    "test-offer-url",
-			ModelID:                1,
-			ApplicationName:        "test-app",
-			CharmURL:               "cs:test-app:17",
-			ApplicationDescription: "changed offer description",
-			Connections: []dbmodel.ApplicationOfferConnection{{
-				ApplicationOfferID: 1,
-				SourceModelTag:     "test-model-src",
-				RelationID:         1,
-				IdentityName:       "unknown",
-				Endpoint:           "test-endpoint",
-			}},
-			Endpoints: []dbmodel.ApplicationOfferRemoteEndpoint{{
-				ApplicationOfferID: 1,
-				Name:               "test-endpoint",
-				Role:               "requirer",
-				Interface:          "unknown",
-				Limit:              1,
-			}},
-		},
-	}, {
-		about: "offer removed",
-		parameterFunc: func(env *environment) (string, bool) {
-			return env.applicationOffers[0].UUID, true
-		},
-	}, {
-		about: "offer not found",
-		parameterFunc: func(env *environment) (string, bool) {
-			return "no-such-uuid", false
-		},
-		expectedError: "application offer not found",
-	}}
-
-	for _, test := range tests {
-		c.Run(test.about, func(c *qt.C) {
-
-			db := db.Database{
-				DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-			}
-			err := db.Migrate(ctx, false)
-			c.Assert(err, qt.IsNil)
-
-			client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name(), test.about)
-			c.Assert(err, qt.IsNil)
-
-			jimmUUID := uuid.NewString()
-
-			environment := initializeEnvironment(c, ctx, &db, client, jimmUUID)
-			offerUUID, removed := test.parameterFunc(environment)
-
-			j := &jimm.JIMM{
-				UUID:          jimmUUID,
-				OpenFGAClient: client,
-				Database:      db,
-				Dialer: &jimmtest.Dialer{
-					API: &jimmtest.API{
-						GetApplicationOffer_: func(_ context.Context, details *jujuparams.ApplicationOfferAdminDetailsV5) error {
-							details.ApplicationName = "test-app"
-							details.CharmURL = "cs:test-app:17"
-							details.Connections = []jujuparams.OfferConnection{{
-								SourceModelTag: "test-model-src",
-								RelationId:     1,
-								Username:       "unknown",
-								Endpoint:       "test-endpoint",
-							}}
-							details.ApplicationOfferDetailsV5 = jujuparams.ApplicationOfferDetailsV5{
-								OfferUUID:              "00000000-0000-0000-0000-0000-0000000000011",
-								OfferURL:               "test-offer-url",
-								ApplicationDescription: "changed offer description",
-								Endpoints: []jujuparams.RemoteEndpoint{{
-									Name:      "test-endpoint",
-									Role:      charm.RoleRequirer,
-									Interface: "unknown",
-									Limit:     1,
-								}},
-								Users: []jujuparams.OfferUserDetails{{
-									UserName:    "alice",
-									DisplayName: "alice, sister of eve",
-									Access:      string(jujuparams.OfferAdminAccess),
-								}},
-							}
-							return nil
-						},
-					},
-				},
-			}
-
-			err = j.UpdateApplicationOffer(ctx, &environment.controllers[0], offerUUID, removed)
-			if test.expectedError == "" {
-				c.Assert(err, qt.IsNil)
-
-				offer := dbmodel.ApplicationOffer{
-					UUID: offerUUID,
-				}
-				err = db.GetApplicationOffer(ctx, &offer)
-				if removed {
-					c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
-				} else {
-					c.Assert(err, qt.IsNil)
-					c.Assert(
-						offer,
-						qt.CmpEquals(
-							cmpopts.EquateEmpty(),
-							cmpopts.IgnoreTypes(time.Time{}),
-							cmpopts.IgnoreTypes(gorm.Model{}),
-							cmpopts.IgnoreTypes(dbmodel.Model{}),
-						),
-						test.expectedOffer,
-					)
-				}
-			} else {
-				c.Assert(err, qt.ErrorMatches, test.expectedError)
-			}
-		})
-	}
-}
-
 func TestFindApplicationOffers(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
 	now := time.Now().UTC().Round(time.Millisecond)
 
-	expectedOffer := dbmodel.ApplicationOffer{
-		ID:      1,
-		UUID:    "00000000-0000-0000-0000-0000-0000000000011",
-		URL:     "test-offer-url",
-		Name:    "test-offer",
-		ModelID: 1,
-		Model: dbmodel.Model{
-			UUID: sql.NullString{
-				String: "00000000-0000-0000-0000-0000-0000000000003",
-				Valid:  true,
-			},
+	expectedOffer := jujuparams.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+			OfferUUID: "00000000-0000-0000-0000-0000-0000000000011",
+			OfferURL:  "test-offer-url",
+			OfferName: "test-offer",
 		},
-		ApplicationName: "test-app",
-		CharmURL:        "cs:test-app:17",
 	}
 
 	tests := []struct {
 		about         string
 		parameterFunc func(*environment) (dbmodel.Identity, string, []jujuparams.OfferFilter)
 		expectedError string
-		expectedOffer *dbmodel.ApplicationOffer
+		expectedOffer *jujuparams.ApplicationOfferAdminDetailsV5
 	}{{
 		about: "find an offer as an offer consumer",
 		parameterFunc: func(env *environment) (dbmodel.Identity, string, []jujuparams.OfferFilter) {
@@ -2327,7 +2125,14 @@ func TestFindApplicationOffers(t *testing.T) {
 				UUID:     jimmUUID,
 				Database: db,
 				Dialer: &jimmtest.Dialer{
-					API: &jimmtest.API{},
+					API: &jimmtest.API{
+						FindApplicationOffers_: func(ctx context.Context, of []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+							if test.expectedOffer != nil {
+								return []jujuparams.ApplicationOfferAdminDetailsV5{*test.expectedOffer}, nil
+							}
+							return nil, nil
+						},
+					},
 				},
 				OpenFGAClient: client,
 			}
@@ -2336,7 +2141,7 @@ func TestFindApplicationOffers(t *testing.T) {
 			if test.expectedError == "" {
 				c.Assert(err, qt.IsNil)
 				if test.expectedOffer != nil {
-					details := test.expectedOffer.ToJujuApplicationOfferDetailsV5()
+					details := test.expectedOffer
 					if accessLevel != string(jujuparams.OfferAdminAccess) {
 						details.Users = []jujuparams.OfferUserDetails{{
 							UserName: user.Name,
@@ -2380,7 +2185,7 @@ func TestFindApplicationOffers(t *testing.T) {
 							cmpopts.IgnoreTypes(gorm.Model{}),
 							cmpopts.IgnoreTypes(dbmodel.Model{}),
 						),
-						[]jujuparams.ApplicationOfferAdminDetailsV5{details},
+						[]jujuparams.ApplicationOfferAdminDetailsV5{*details},
 					)
 				} else {
 					c.Assert(offers, qt.HasLen, 0)
@@ -2501,94 +2306,113 @@ func TestListApplicationOffers(t *testing.T) {
 		Database:      db,
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
-				GetApplicationOffer_: func(ctx context.Context, aoadv *jujuparams.ApplicationOfferAdminDetailsV5) error {
-					switch aoadv.OfferURL {
-					case "test-offer-url":
-						*aoadv = jujuparams.ApplicationOfferAdminDetailsV5{
-							ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-								SourceModelTag:         "00000011-0000-0000-0000-000000000001",
-								OfferUUID:              "00000012-0000-0000-0000-000000000001",
-								OfferURL:               "test-offer-url",
-								OfferName:              "offer-1",
-								ApplicationDescription: "app description 1",
-								Endpoints: []jujuparams.RemoteEndpoint{{
-									Name:      "test-endpoint",
-									Role:      "requirer",
-									Interface: "unknown",
-									Limit:     1,
+				ListApplicationOffers_: func(_ context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+					offers := []jujuparams.ApplicationOfferAdminDetailsV5{}
+					for _, filter := range filters {
+						switch filter.ModelName {
+						case "model-1":
+							offers = append(offers, []jujuparams.ApplicationOfferAdminDetailsV5{{
+								ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+									SourceModelTag:         "00000011-0000-0000-0000-000000000001",
+									OfferUUID:              "00000012-0000-0000-0000-000000000001",
+									OfferURL:               "test-offer-url",
+									OfferName:              "offer-1",
+									ApplicationDescription: "app description 1",
+									Endpoints: []jujuparams.RemoteEndpoint{{
+										Name:      "test-endpoint",
+										Role:      "requirer",
+										Interface: "unknown",
+										Limit:     1,
+									}},
+									Users: []jujuparams.OfferUserDetails{{
+										UserName: "alice@canonical.com",
+										Access:   "admin",
+									}, {
+										UserName: "eve@canonical.com",
+										Access:   "read",
+									}, {
+										UserName: "bob@canonical.com",
+										Access:   "consume",
+									}},
+								},
+								ApplicationName: "application-1",
+								CharmURL:        "charm-1",
+								Connections: []jujuparams.OfferConnection{{
+									SourceModelTag: "00000011-0000-0000-0000-000000000001",
+									RelationId:     1,
+									Username:       "charlie@canonical.com",
+									Endpoint:       "an-endpoint",
 								}},
-							},
-							ApplicationName: "application-1",
-							CharmURL:        "charm-1",
-							Connections: []jujuparams.OfferConnection{{
-								SourceModelTag: "00000011-0000-0000-0000-000000000001",
-								RelationId:     1,
-								Username:       "charlie@canonical.com",
-								Endpoint:       "an-endpoint",
-							}},
+							}, {
+								ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+									SourceModelTag:         "00000011-0000-0000-0000-000000000002",
+									OfferUUID:              "00000012-0000-0000-0000-000000000002",
+									OfferURL:               "test-offer-url-2",
+									OfferName:              "offer-2",
+									ApplicationDescription: "app description 2",
+									Endpoints: []jujuparams.RemoteEndpoint{{
+										Name:      "test-endpoint",
+										Role:      "requirer",
+										Interface: "unknown",
+										Limit:     1,
+									}},
+									Users: []jujuparams.OfferUserDetails{{
+										UserName: "alice@canonical.com",
+										Access:   "admin",
+									}, {
+										UserName: "eve@canonical.com",
+										Access:   "read",
+									}, {
+										UserName: "bob@canonical.com",
+										Access:   "consume",
+									}},
+								},
+								ApplicationName: "application-2",
+								CharmURL:        "charm-2",
+								Connections: []jujuparams.OfferConnection{{
+									SourceModelTag: "00000011-0000-0000-0000-000000000002",
+									RelationId:     2,
+									Username:       "charlie@canonical.com",
+									Endpoint:       "an-endpoint",
+								}},
+							}}...)
+						case "model-2":
+							offers = append(offers, []jujuparams.ApplicationOfferAdminDetailsV5{{
+								ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+									SourceModelTag:         "00000011-0000-0000-0000-000000000003",
+									OfferUUID:              "00000012-0000-0000-0000-000000000003",
+									OfferURL:               "test-offer-url-3",
+									OfferName:              "offer-3",
+									ApplicationDescription: "app description 3",
+									Endpoints: []jujuparams.RemoteEndpoint{{
+										Name:      "test-endpoint",
+										Role:      "requirer",
+										Interface: "unknown",
+										Limit:     1,
+									}},
+									Users: []jujuparams.OfferUserDetails{{
+										UserName: "alice@canonical.com",
+										Access:   "admin",
+									}, {
+										UserName: "eve@canonical.com",
+										Access:   "read",
+									}, {
+										UserName: "bob@canonical.com",
+										Access:   "consume",
+									}},
+								},
+								ApplicationName: "application-3",
+								CharmURL:        "charm-3",
+								Connections: []jujuparams.OfferConnection{{
+									SourceModelTag: "00000011-0000-0000-0000-000000000003",
+									RelationId:     3,
+									Username:       "charlie@canonical.com",
+									Endpoint:       "an-endpoint",
+								}},
+							}}...)
 						}
-					case "test-offer-url-2":
-						*aoadv = jujuparams.ApplicationOfferAdminDetailsV5{
-							ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-								SourceModelTag:         "00000011-0000-0000-0000-000000000002",
-								OfferUUID:              "00000012-0000-0000-0000-000000000002",
-								OfferURL:               "test-offer-url-2",
-								OfferName:              "offer-2",
-								ApplicationDescription: "app description 2",
-								Endpoints: []jujuparams.RemoteEndpoint{{
-									Name:      "test-endpoint",
-									Role:      "requirer",
-									Interface: "unknown",
-									Limit:     1,
-								}},
-							},
-							ApplicationName: "application-2",
-							CharmURL:        "charm-2",
-							Connections: []jujuparams.OfferConnection{{
-								SourceModelTag: "00000011-0000-0000-0000-000000000002",
-								RelationId:     2,
-								Username:       "charlie@canonical.com",
-								Endpoint:       "an-endpoint",
-							}},
-						}
-					case "test-offer-url-3":
-						*aoadv = jujuparams.ApplicationOfferAdminDetailsV5{
-							ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-								SourceModelTag:         "00000011-0000-0000-0000-000000000003",
-								OfferUUID:              "00000012-0000-0000-0000-000000000003",
-								OfferURL:               "test-offer-url-3",
-								OfferName:              "offer-3",
-								ApplicationDescription: "app description 3",
-								Endpoints: []jujuparams.RemoteEndpoint{{
-									Name:      "test-endpoint",
-									Role:      "requirer",
-									Interface: "unknown",
-									Limit:     1,
-								}},
-								Users: []jujuparams.OfferUserDetails{{
-									UserName: "alice@canonical.com",
-									Access:   "admin",
-								}, {
-									UserName: "eve@canonical.com",
-									Access:   "read",
-								}, {
-									UserName: "bob@canonical.com",
-									Access:   "consume",
-								}},
-							},
-							ApplicationName: "application-3",
-							CharmURL:        "charm-3",
-							Connections: []jujuparams.OfferConnection{{
-								SourceModelTag: "00000011-0000-0000-0000-000000000003",
-								RelationId:     3,
-								Username:       "charlie@canonical.com",
-								Endpoint:       "an-endpoint",
-							}},
-						}
-					default:
-						return errors.E("unknown offer UUID")
 					}
-					return nil
+					return offers, nil
 				},
 			},
 		},
@@ -2638,9 +2462,6 @@ func TestListApplicationOffers(t *testing.T) {
 	_, err = j.ListApplicationOffers(ctx, openfga.NewUser(&u, client))
 	c.Assert(err, qt.ErrorMatches, `at least one filter must be specified`)
 
-	_, err = j.ListApplicationOffers(ctx, openfga.NewUser(&u, client), jujuparams.OfferFilter{})
-	c.Assert(err, qt.ErrorMatches, `application offer filter must specify a model name`)
-
 	filters := []jujuparams.OfferFilter{{
 		OwnerName: "bob@canonical.com",
 		ModelName: "model-1",
@@ -2657,38 +2478,6 @@ func TestListApplicationOffers(t *testing.T) {
 		})
 	}
 	c.Check(offers, qt.DeepEquals, []jujuparams.ApplicationOfferAdminDetailsV5{{
-		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-			SourceModelTag:         "00000011-0000-0000-0000-000000000003",
-			OfferUUID:              "00000012-0000-0000-0000-000000000003",
-			OfferURL:               "test-offer-url-3",
-			OfferName:              "offer-3",
-			ApplicationDescription: "app description 3",
-			Endpoints: []jujuparams.RemoteEndpoint{{
-				Name:      "test-endpoint",
-				Role:      "requirer",
-				Interface: "unknown",
-				Limit:     1,
-			}},
-			Users: []jujuparams.OfferUserDetails{{
-				UserName: "alice@canonical.com",
-				Access:   "admin",
-			}, {
-				UserName: "bob@canonical.com",
-				Access:   "consume",
-			}, {
-				UserName: "eve@canonical.com",
-				Access:   "read",
-			}},
-		},
-		ApplicationName: "application-3",
-		CharmURL:        "charm-3",
-		Connections: []jujuparams.OfferConnection{{
-			SourceModelTag: "00000011-0000-0000-0000-000000000003",
-			RelationId:     3,
-			Username:       "charlie@canonical.com",
-			Endpoint:       "an-endpoint",
-		}},
-	}, {
 		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
 			SourceModelTag:         "00000011-0000-0000-0000-000000000001",
 			OfferUUID:              "00000012-0000-0000-0000-000000000001",
@@ -2749,6 +2538,38 @@ func TestListApplicationOffers(t *testing.T) {
 		Connections: []jujuparams.OfferConnection{{
 			SourceModelTag: "00000011-0000-0000-0000-000000000002",
 			RelationId:     2,
+			Username:       "charlie@canonical.com",
+			Endpoint:       "an-endpoint",
+		}},
+	}, {
+		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+			SourceModelTag:         "00000011-0000-0000-0000-000000000003",
+			OfferUUID:              "00000012-0000-0000-0000-000000000003",
+			OfferURL:               "test-offer-url-3",
+			OfferName:              "offer-3",
+			ApplicationDescription: "app description 3",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "test-endpoint",
+				Role:      "requirer",
+				Interface: "unknown",
+				Limit:     1,
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName: "alice@canonical.com",
+				Access:   "admin",
+			}, {
+				UserName: "bob@canonical.com",
+				Access:   "consume",
+			}, {
+				UserName: "eve@canonical.com",
+				Access:   "read",
+			}},
+		},
+		ApplicationName: "application-3",
+		CharmURL:        "charm-3",
+		Connections: []jujuparams.OfferConnection{{
+			SourceModelTag: "00000011-0000-0000-0000-000000000003",
+			RelationId:     3,
 			Username:       "charlie@canonical.com",
 			Endpoint:       "an-endpoint",
 		}},

--- a/internal/jimm/cloud.go
+++ b/internal/jimm/cloud.go
@@ -224,14 +224,6 @@ func (j *JIMM) AddHostedCloud(ctx context.Context, user *openfga.User, tag names
 		return errors.E(op, err)
 	}
 
-	allowedAddModel, err := user.IsAllowedAddModel(ctx, region.Cloud.ResourceTag())
-	if err != nil {
-		return errors.E(op, err)
-	}
-	if !allowedAddModel {
-		return errors.E(op, errors.CodeUnauthorized, fmt.Sprintf("missing add-model access on %q", cloud.HostCloudRegion))
-	}
-
 	if region.Cloud.HostCloudRegion != "" {
 		// Do not support creating a new cloud on an already hosted
 		// cloud.

--- a/internal/jimm/cloud_test.go
+++ b/internal/jimm/cloud_test.go
@@ -518,20 +518,6 @@ var addHostedCloudTests = []struct {
 	expectError:     `invalid cloud/region format "ec2"`,
 	expectErrorCode: errors.CodeBadRequest,
 }, {
-	name:      "UserHasNoCloudAccess",
-	username:  "bob@canonical.com",
-	cloudName: "new-cloud",
-	cloud: jujuparams.Cloud{
-		Type:             "kubernetes",
-		HostCloudRegion:  "test-provider2/test-region",
-		AuthTypes:        []string{"empty", "userpass"},
-		Endpoint:         "https://example.com",
-		IdentityEndpoint: "https://example.com/identity",
-		StorageEndpoint:  "https://example.com/storage",
-	},
-	expectError:     `missing add-model access on "test-provider2/test-region"`,
-	expectErrorCode: errors.CodeUnauthorized,
-}, {
 	name:      "HostCloudIsHosted",
 	username:  "alice@canonical.com",
 	cloudName: "new-cloud",

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -570,9 +570,12 @@ func (m *modelImporter) save(ctx context.Context) error {
 			return err
 		}
 		for _, offer := range m.offersToAdd {
-			var dbOffer dbmodel.ApplicationOffer
-			dbOffer.FromJujuApplicationOfferAdminDetailsV5(offer)
-			dbOffer.ModelID = m.model.ID
+			dbOffer := dbmodel.ApplicationOffer{
+				UUID:    offer.OfferUUID,
+				Name:    offer.OfferName,
+				URL:     offer.OfferURL,
+				ModelID: m.model.ID,
+			}
 			if err := m.jimm.Database.AddApplicationOffer(ctx, &dbOffer); err != nil {
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 					return fmt.Errorf("offer with URL %s already exists", offer.OfferURL)

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -964,39 +964,31 @@ func TestImportModel(t *testing.T) {
 				Level: "essential",
 				Owner: "alice@canonical.com",
 			},
-			Offers: []dbmodel.ApplicationOffer{
-				{
-					ApplicationName: "app1",
-					URL:             "url1",
-					UUID:            "00000001-0000-0000-0000-000000000001",
-					Name:            "offer1",
-				},
-				{
-					ApplicationName: "app2",
-					URL:             "url2",
-					UUID:            "00000001-0000-0000-0000-000000000002",
-					Name:            "offer2",
-				},
-			},
+			Offers: []dbmodel.ApplicationOffer{{
+				URL:  "url1",
+				UUID: "00000001-0000-0000-0000-000000000001",
+				Name: "offer1",
+			}, {
+				URL:  "url2",
+				UUID: "00000001-0000-0000-0000-000000000002",
+				Name: "offer2",
+			}},
 		},
-		offers: []jujuparams.ApplicationOfferAdminDetailsV5{
-			{
-				ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-					OfferUUID: "00000001-0000-0000-0000-000000000001",
-					OfferName: "offer1",
-					OfferURL:  "url1",
-				},
-				ApplicationName: "app1",
+		offers: []jujuparams.ApplicationOfferAdminDetailsV5{{
+			ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+				OfferUUID: "00000001-0000-0000-0000-000000000001",
+				OfferName: "offer1",
+				OfferURL:  "url1",
 			},
-			{
-				ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
-					OfferUUID: "00000001-0000-0000-0000-000000000002",
-					OfferName: "offer2",
-					OfferURL:  "url2",
-				},
-				ApplicationName: "app2",
+			ApplicationName: "app1",
+		}, {
+			ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+				OfferUUID: "00000001-0000-0000-0000-000000000002",
+				OfferName: "offer2",
+				OfferURL:  "url2",
 			},
-		},
+			ApplicationName: "app2",
+		}},
 	}}
 
 	for _, test := range tests {

--- a/internal/jimm/export_test.go
+++ b/internal/jimm/export_test.go
@@ -46,8 +46,8 @@ func NewWatcherWithDeltaProcessedChannel(db db.Database, dialer Dialer, pubsub P
 	}
 }
 
-func (j *JIMM) ListApplicationOfferUsers(ctx context.Context, offer names.ApplicationOfferTag, user *dbmodel.Identity, accessLevel string) ([]jujuparams.OfferUserDetails, error) {
-	return j.listApplicationOfferUsers(ctx, offer, user, accessLevel)
+func (j *JIMM) ListApplicationOfferUsers(ctx context.Context, offer names.ApplicationOfferTag, user *dbmodel.Identity, adminAccess bool) ([]jujuparams.OfferUserDetails, error) {
+	return j.listApplicationOfferUsers(ctx, offer, user, adminAccess)
 }
 
 func (j *JIMM) ParseAndValidateTag(ctx context.Context, key string) (*ofganames.Tag, error) {

--- a/internal/jimm/watcher_test.go
+++ b/internal/jimm/watcher_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/life"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -191,49 +190,6 @@ var watcherTests = []struct {
 
 		c.Check(model.Machines, qt.Equals, int64(0))
 		c.Check(model.Cores, qt.Equals, int64(0))
-	},
-}, {
-	name: "UpdateApplication",
-	initDB: func(c *qt.C, db db.Database) {
-		ctx := context.Background()
-
-		var m dbmodel.Model
-		m.SetTag(names.NewModelTag("00000002-0000-0000-0000-000000000001"))
-		err := db.GetModel(ctx, &m)
-		c.Assert(err, qt.IsNil)
-
-		err = db.AddApplicationOffer(ctx, &dbmodel.ApplicationOffer{
-			ModelID:         m.ID,
-			UUID:            "00000010-0000-0000-0000-000000000001",
-			Name:            "offer-1",
-			ApplicationName: "app-1",
-		})
-		c.Assert(err, qt.IsNil)
-	},
-	deltas: [][]jujuparams.Delta{
-		{{
-			Entity: &jujuparams.ApplicationInfo{
-				ModelUUID:       "00000002-0000-0000-0000-000000000001",
-				Name:            "app-1",
-				Exposed:         true,
-				CharmURL:        "cs:app-1",
-				Life:            life.Value(state.Alive.String()),
-				MinUnits:        1,
-				WorkloadVersion: "2",
-			},
-		}},
-		nil,
-	},
-	checkDB: func(c *qt.C, db db.Database) {
-		ctx := context.Background()
-
-		var m dbmodel.Model
-		m.SetTag(names.NewModelTag("00000002-0000-0000-0000-000000000001"))
-		err := db.GetModel(ctx, &m)
-		c.Assert(err, qt.IsNil)
-
-		c.Assert(m.Offers, qt.HasLen, 1)
-		c.Assert(m.Offers[0].CharmURL, qt.Equals, "cs:app-1")
 	},
 }, {
 	name: "AddUnit",

--- a/internal/jujuapi/access_control_test.go
+++ b/internal/jujuapi/access_control_test.go
@@ -1632,11 +1632,10 @@ func createTestControllerEnvironment(ctx context.Context, c *gc.C, s *accessCont
 	c.Assert(err, gc.IsNil)
 
 	offer := dbmodel.ApplicationOffer{
-		UUID:            id.String(),
-		Name:            offerName,
-		ModelID:         model.ID,
-		ApplicationName: petname.Generate(2, "-"),
-		URL:             offerURL.String(),
+		UUID:    id.String(),
+		Name:    offerName,
+		ModelID: model.ID,
+		URL:     offerURL.String(),
 	}
 	err = db.AddApplicationOffer(context.Background(), &offer)
 	c.Assert(err, gc.IsNil)

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -80,7 +80,6 @@ type JIMM interface {
 	RevokeModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error
 	RevokeOfferAccess(ctx context.Context, user *openfga.User, offerURL string, ut names.UserTag, access jujuparams.OfferAccessPermission) (err error)
 	ToJAASTag(ctx context.Context, tag *ofganames.Tag, resolveUUIDs bool) (string, error)
-	UpdateApplicationOffer(ctx context.Context, controller *dbmodel.Controller, offerUUID string, removed bool) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args jimm.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
 	UserLogin(ctx context.Context, identityName string) (*openfga.User, error)

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -269,20 +269,11 @@ func (e *Environment) PopulateDB(c Tester, db db.Database) {
 
 // ApplicationOffer represents Juju application offers.
 type ApplicationOffer struct {
-	ModelName              string `json:"model-name"`
-	ModelOwner             string `json:"model-owner"`
-	ApplicationName        string `json:"application-name"`
-	ApplicationDescription string `json:"application-description"`
-	Name                   string `json:"name"`
-	UUID                   string `json:"uuid"`
-	URL                    string `json:"url"`
-	// The fields below cannot currently be set by the yaml declaration
-	// but they don't need to be populated at the moment.
-	// Endpoints []ApplicationOfferRemoteEndpoint
-	// Spaces []ApplicationOfferRemoteSpace
-	// Bindings StringMap
-	// Connections []ApplicationOfferConnection
-	CharmURL string `json:"charm-url"`
+	ModelName  string `json:"model-name"`
+	ModelOwner string `json:"model-owner"`
+	Name       string `json:"name"`
+	UUID       string `json:"uuid"`
+	URL        string `json:"url"`
 
 	env *Environment
 	dbo dbmodel.ApplicationOffer
@@ -294,12 +285,10 @@ func (cd *ApplicationOffer) DBObject(c Tester, db db.Database) dbmodel.Applicati
 	}
 
 	cd.dbo.Model = cd.env.Model(cd.ModelOwner, cd.ModelName).DBObject(c, db)
-	cd.dbo.ApplicationName = cd.ApplicationName
-	cd.dbo.ApplicationDescription = cd.ApplicationDescription
+
 	cd.dbo.Name = cd.Name
 	cd.dbo.UUID = cd.UUID
 	cd.dbo.URL = cd.URL
-	cd.dbo.CharmURL = cd.CharmURL
 
 	err := db.AddApplicationOffer(context.Background(), &cd.dbo)
 	if err != nil {

--- a/local/seed_db/main.go
+++ b/local/seed_db/main.go
@@ -121,11 +121,10 @@ func main() {
 	offerName := petname.Generate(2, "-")
 	offerURL, _ := crossmodel.ParseOfferURL(controller.Name + ":" + u.Name + "/" + model.Name + "." + offerName)
 	offer := dbmodel.ApplicationOffer{
-		UUID:            id.String(),
-		Name:            offerName,
-		ModelID:         model.ID,
-		ApplicationName: petname.Generate(2, "-"),
-		URL:             offerURL.String(),
+		UUID:    id.String(),
+		Name:    offerName,
+		ModelID: model.ID,
+		URL:     offerURL.String(),
 	}
 	if err = db.AddApplicationOffer(context.Background(), &offer); err != nil {
 		fmt.Println("failed to add application offer to db ", err)


### PR DESCRIPTION
## Description

    Removes data from ApplicationOffer type that JIMM does not need to store. Instead the source of
    truth for application offers becomes the offering juju controller. Controllers are now queries when
    we need details on application offers.
    
    It also allowed me to remove the update method for application offers and simplify the
    AllWatcher so that we don't have to process deltas for offers.
    
    A drive-by fix: we no longer require the user to have add-model permission to add a k8s cloud.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->