### PR TITLE
remove filtering entitlements for receiver type

### DIFF
--- a/internal/jimmhttp/rebac_admin/entitlements.go
+++ b/internal/jimmhttp/rebac_admin/entitlements.go
@@ -89,8 +89,7 @@ func (s *entitlementsService) ListEntitlements(ctx context.Context, params *reso
 
 	for _, entitlement := range entitlementsList {
 		if strings.Contains(entitlement.Entitlement, match) ||
-			strings.Contains(entitlement.EntityType, match) ||
-			strings.Contains(entitlement.ReceiverType, match) {
+			strings.Contains(entitlement.EntityType, match) {
 			entitlementsFilteredList = append(entitlementsFilteredList, entitlement)
 		}
 	}

--- a/internal/jimmhttp/rebac_admin/entitlements_test.go
+++ b/internal/jimmhttp/rebac_admin/entitlements_test.go
@@ -38,5 +38,5 @@ func TestEntitlements(t *testing.T) {
 	params.Filter = &match
 	entitlements, err = entitlementSvc.ListEntitlements(ctx, params)
 	c.Assert(err, qt.IsNil)
-	c.Assert(entitlements, qt.HasLen, 12)
+	c.Assert(entitlements, qt.HasLen, 0)
 }


### PR DESCRIPTION
## Description

After a chat with Lukas, the entitlements are filtered by Entity and Entity Type, not ReceiverType

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->