### PR TITLE
Fix websocket dial to ipv6

### DIFF
--- a/internal/rpc/dial _test.go
+++ b/internal/rpc/dial _test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Canonical.
+package rpc_test
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/core/network"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/rpc"
+)
+
+func TestDialIPv4(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	fakeController := newServer(echo)
+	defer fakeController.Close()
+	controller := dbmodel.Controller{}
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: fakeController.Certificate().Raw,
+	})
+	controller.CACertificate = string(pemData)
+	hp, err := network.ParseMachineHostPort(fakeController.Listener.Addr().String())
+	c.Assert(err, qt.Equals, nil)
+	controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
+		Address: jujuparams.Address{
+			Value: hp.Value,
+			Type:  "ipv4",
+		},
+		Port: hp.Port(),
+	}})
+	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{})
+	c.Assert(err, qt.Equals, nil)
+}
+
+func TestDialIPv6(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	fakeController := newIPv6Server(echo)
+	defer fakeController.Close()
+	controller := dbmodel.Controller{}
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: fakeController.Certificate().Raw,
+	})
+	controller.CACertificate = string(pemData)
+	hp, err := network.ParseMachineHostPort(fakeController.Listener.Addr().String())
+	c.Assert(err, qt.Equals, nil)
+	controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
+		Address: jujuparams.Address{
+			Value: hp.Value,
+			Type:  "ipv6",
+		},
+		Port: hp.Port(),
+	}})
+	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{})
+	c.Assert(err, qt.Equals, nil)
+}

--- a/internal/rpc/dial _test.go
+++ b/internal/rpc/dial _test.go
@@ -1,4 +1,5 @@
 // Copyright 2024 Canonical.
+
 package rpc_test
 
 import (

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -45,7 +45,7 @@ func (d Dialer) DialWebsocket(ctx context.Context, url string, headers http.Head
 	dialer := websocket.Dialer{
 		TLSClientConfig: d.TLSConfig,
 	}
-	conn, resp, err := dialer.DialContext(context.Background(), url, headers)
+	conn, resp, err := dialer.DialContext(ctx, url, headers)
 	if err != nil {
 		zapctx.Error(ctx, "BasicDial failed", zap.Error(err))
 		return nil, errors.E(op, err)

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -89,7 +89,13 @@ func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag,
 	for _, hps := range ctl.Addresses {
 		for _, hp := range hps {
 			if maybeReachable(hp.Scope) {
-				urls = append(urls, websocketURL(fmt.Sprintf("%s:%d", hp.Value, hp.Port), modelTag, finalPath))
+				var ip string
+				if hp.Type == string(network.IPv6Address) {
+					ip = fmt.Sprintf("[%s]:%d", hp.Value, hp.Port)
+				} else {
+					ip = fmt.Sprintf("%s:%d", hp.Value, hp.Port)
+				}
+				urls = append(urls, websocketURL(ip, modelTag, finalPath))
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This pr fixes our websocket dial to ipv6.
The issue is that `url.URL` doesn't escape properly ipv6. 
See this golang issue: https://github.com/golang/go/issues/47763

Add some tests for both ipv4 and ipv6 dialing. Fly-by, pass down right context to dial to cancel it appropriately.

> [!NOTE] 
> httptest pkg doesn't have an handy `StartIPv6Sever`, so I've created one.

> [!WARNING] 
> dial via ipv6 inside of our docker-compose doesn't work because we don't have an ipv6 configured network.

Fixes: #1449 

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->