### PR TITLE
chore: simplify jwx tests

### DIFF
--- a/internal/jimmjwx/jwt_test.go
+++ b/internal/jimmjwx/jwt_test.go
@@ -3,7 +3,6 @@ package jimmjwx_test
 
 import (
 	"context"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -22,16 +21,15 @@ func TestRegisterJWKSCacheRegistersTheCacheSuccessfully(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	_, srv, store := setupService(ctx, c)
+	store := setupCredentialStore(ctx, c)
 
 	// Setup JWKSService
 	jwksService := jimmjwx.NewJWKSService(store)
 	// Start rotator
 	startAndTestRotator(c, ctx, store, jwksService)
 	// Setup JWTService
-	u, _ := url.Parse(srv.URL)
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   u.Host,
+		Host:   "host",
 		Store:  store,
 		Expiry: time.Minute,
 	})
@@ -54,16 +52,15 @@ func TestNewJWTIsParsableByExponent(t *testing.T) {
 		os.Clearenv()
 	})
 
-	_, srv, store := setupService(ctx, c)
+	store := setupCredentialStore(ctx, c)
 
 	// Setup JWKSService
 	jwksService := jimmjwx.NewJWKSService(store)
 	// Start rotator
 	startAndTestRotator(c, ctx, store, jwksService)
 	// Setup JWTService
-	u, _ := url.Parse(srv.URL)
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   u.Host,
+		Host:   "host",
 		Store:  store,
 		Expiry: time.Minute,
 	})
@@ -99,7 +96,7 @@ func TestNewJWTIsParsableByExponent(t *testing.T) {
 		"controller": "superuser",
 		"model":      "administrator",
 	})
-	c.Assert(token.Issuer(), qt.Equals, u.Host)
+	c.Assert(token.Issuer(), qt.Equals, "host")
 }
 
 func TestNewJWTExpires(t *testing.T) {
@@ -115,16 +112,15 @@ func TestNewJWTExpires(t *testing.T) {
 		os.Clearenv()
 	})
 
-	_, srv, store := setupService(ctx, c)
+	store := setupCredentialStore(ctx, c)
 
 	// Setup JWKSService
 	jwksService := jimmjwx.NewJWKSService(store)
 	// Start rotator
 	startAndTestRotator(c, ctx, store, jwksService)
 	// Setup JWTService
-	u, _ := url.Parse(srv.URL)
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   u.Host,
+		Host:   "host",
 		Store:  store,
 		Expiry: time.Nanosecond,
 	})


### PR DESCRIPTION
## Description

In #1148 I refactored the JWKS cache, previously the cache worked by making an HTTP to call to jimm from jimm which is why this test creates a server. That was changed to remove the circular dependency but the tests weren't updated, this finally does that.

This PR builds on #1456. View the 2nd commit to see only the changes here.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests