### PR TITLE
add exception for cors checks

### DIFF
--- a/internal/middleware/websocketcors.go
+++ b/internal/middleware/websocketcors.go
@@ -36,7 +36,10 @@ func (c *WebsocketCors) Handler(h http.Handler) http.Handler {
 		// include cookies. For now we enforce CORS protection on all requests
 		// because the only client that is expected to connect cross-origin
 		// is the Juju dashboard which uses cookies for auth.
-		originPresent := r.Header.Get("Origin") != ""
+		//
+		// Ignoring "http://localhost/" to support CLI clients that send this header.
+		// https://github.com/juju/juju/pull/18419
+		originPresent := r.Header.Get("Origin") != "" && r.Header.Get("Origin") != "http://localhost/"
 		if originPresent && !c.cors.OriginAllowed(r) {
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/internal/middleware/websocketcors_test.go
+++ b/internal/middleware/websocketcors_test.go
@@ -57,6 +57,13 @@ func TestWebsocketCors(t *testing.T) {
 			method:         http.MethodConnect,
 			expectedStatus: http.StatusBadRequest,
 		},
+		{
+			name:           "exception origin is allowed",
+			method:         http.MethodGet,
+			allowedOrigins: []string{"jaas.com"},
+			origin:         "http://localhost/",
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

The Juju CLI sends a value in the "Origin" header, hardcoded to "http://localhost/" only when connecting to streaming endpoints (like the /log when consuming debug-logs). This caused the `juju debug-log` to break when used against JIMM after CORS protection on the websocket was added. It's unclear why the Juju CLI was hardcoding this value but a [PR here](https://github.com/juju/juju/pull/18419) is up to remove it.

For now we ignore this specific value to support existing CLI clients.

This would be caught by an end-to-end test which I considered adding in this PR but I think is best left for a separate piece of work where we add Juju's bash test suite to JIMM.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
- `make qa-lxd`
- `juju debug-log`