### PR TITLE
Move to jaas tag tests

### DIFF
--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -448,7 +448,7 @@ func TestParseAndValidateTag(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, _, _, model, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, _, _, model, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	jimmTag := "model-" + user.Name + "/" + model.Name + "#administrator"
 
@@ -495,7 +495,7 @@ func TestResolveTags(t *testing.T) {
 	err := j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	identity, group, controller, model, offer, cloud, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	identity, group, controller, model, offer, cloud, _, role := createTestControllerEnvironment(ctx, c, j.Database)
 
 	testCases := []struct {
 		desc     string
@@ -517,6 +517,14 @@ func TestResolveTags(t *testing.T) {
 		desc:     "map group UUID with relation",
 		input:    "group-" + group.UUID + "#member",
 		expected: ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),
+	}, {
+		desc:     "map role UUID",
+		input:    "role-" + role.UUID,
+		expected: ofganames.ConvertTag(jimmnames.NewRoleTag(role.UUID)),
+	}, {
+		desc:     "map role UUID with relation",
+		input:    "role-" + role.UUID + "#assignee",
+		expected: ofganames.ConvertTagWithRelation(jimmnames.NewRoleTag(role.UUID), ofganames.AssigneeRelation),
 	}, {
 		desc:     "map jimm controller",
 		input:    "controller-" + "jimm",
@@ -575,7 +583,7 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 	err := j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	_, _, controller, model, offer, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	_, _, controller, model, offer, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	type test struct {
 		input string
@@ -638,6 +646,7 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 //   - application offer
 //   - cloud
 //   - cloud credential
+//   - role
 //
 // Into the test database, returning the dbmodels to be utilised for values within tests.
 //
@@ -654,7 +663,8 @@ func createTestControllerEnvironment(ctx context.Context, c *qt.C, db db.Databas
 	dbmodel.Model,
 	dbmodel.ApplicationOffer,
 	dbmodel.Cloud,
-	dbmodel.CloudCredential) {
+	dbmodel.CloudCredential,
+	dbmodel.RoleEntry) {
 
 	_, err := db.AddGroup(ctx, "test-group")
 	c.Assert(err, qt.IsNil)
@@ -735,7 +745,10 @@ func createTestControllerEnvironment(ctx context.Context, c *qt.C, db db.Databas
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(offer.UUID), qt.Equals, 36)
 
-	return *u, group, controller, model, offer, cloud, cred
+	role, err := db.AddRole(ctx, petname.Generate(2, "-"))
+	c.Assert(err, qt.IsNil)
+
+	return *u, group, controller, model, offer, cloud, cred, *role
 }
 
 func TestAddGroup(t *testing.T) {
@@ -867,7 +880,7 @@ func TestRemoveGroup(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, group, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, _, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 	u := openfga.NewUser(&user, ofgaClient)
 	u.JimmAdmin = true
 
@@ -897,7 +910,7 @@ func TestRemoveGroupRemovesTuples(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, group, controller, model, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, controller, model, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	_, err = j.Database.AddGroup(ctx, "test-group2")
 	c.Assert(err, qt.IsNil)
@@ -981,7 +994,7 @@ func TestRenameGroup(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, group, controller, model, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, controller, model, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	u := openfga.NewUser(&user, ofgaClient)
 	u.JimmAdmin = true
@@ -1073,7 +1086,7 @@ func TestListGroups(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, group, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, _, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	u := openfga.NewUser(&user, ofgaClient)
 	u.JimmAdmin = true

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -638,6 +638,129 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 	}
 }
 
+func TestToJAASTag(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Round(time.Millisecond)
+	j := &jimm.JIMM{
+		UUID: uuid.NewString(),
+		Database: db.Database{
+			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
+		},
+	}
+
+	err := j.Database.Migrate(ctx, false)
+	c.Assert(err, qt.IsNil)
+
+	user, group, controller, model, applicationOffer, cloud, _, role := createTestControllerEnvironment(ctx, c, j.Database)
+
+	serviceAccountId := petname.Generate(2, "-") + "@serviceaccount"
+
+	tests := []struct {
+		tag             *ofganames.Tag
+		expectedJAASTag string
+		expectedError   string
+	}{{
+		tag:             ofganames.ConvertTag(user.ResourceTag()),
+		expectedJAASTag: "user-" + user.Name,
+	}, {
+		tag:             ofganames.ConvertTag(jimmnames.NewServiceAccountTag(serviceAccountId)),
+		expectedJAASTag: "serviceaccount-" + serviceAccountId,
+	}, {
+		tag:             ofganames.ConvertTag(group.ResourceTag()),
+		expectedJAASTag: "group-" + group.Name,
+	}, {
+		tag:             ofganames.ConvertTag(controller.ResourceTag()),
+		expectedJAASTag: "controller-" + controller.Name,
+	}, {
+		tag:             ofganames.ConvertTag(model.ResourceTag()),
+		expectedJAASTag: "model-" + user.Name + "/" + model.Name,
+	}, {
+		tag:             ofganames.ConvertTag(applicationOffer.ResourceTag()),
+		expectedJAASTag: "applicationoffer-" + applicationOffer.URL,
+	}, {
+		tag:           &ofganames.Tag{},
+		expectedError: "unexpected tag kind: ",
+	}, {
+		tag:             ofganames.ConvertTag(cloud.ResourceTag()),
+		expectedJAASTag: "cloud-" + cloud.Name,
+	}, {
+		tag:             ofganames.ConvertTag(role.ResourceTag()),
+		expectedJAASTag: "role-" + role.Name,
+	}}
+	for _, test := range tests {
+		t, err := j.ToJAASTag(ctx, test.tag, true)
+		if test.expectedError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, qt.IsNil)
+			c.Assert(t, qt.Equals, test.expectedJAASTag)
+		}
+	}
+}
+
+func TestToJAASTagNoUUIDResolution(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Round(time.Millisecond)
+	j := &jimm.JIMM{
+		UUID: uuid.NewString(),
+		Database: db.Database{
+			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
+		},
+	}
+
+	err := j.Database.Migrate(ctx, false)
+	c.Assert(err, qt.IsNil)
+
+	user, group, controller, model, applicationOffer, cloud, _, role := createTestControllerEnvironment(ctx, c, j.Database)
+	serviceAccountId := petname.Generate(2, "-") + "@serviceaccount"
+
+	tests := []struct {
+		tag             *ofganames.Tag
+		expectedJAASTag string
+		expectedError   string
+	}{{
+		tag:             ofganames.ConvertTag(user.ResourceTag()),
+		expectedJAASTag: "user-" + user.Name,
+	}, {
+		tag:             ofganames.ConvertTag(jimmnames.NewServiceAccountTag(serviceAccountId)),
+		expectedJAASTag: "serviceaccount-" + serviceAccountId,
+	}, {
+		tag:             ofganames.ConvertTag(group.ResourceTag()),
+		expectedJAASTag: "group-" + group.UUID,
+	}, {
+		tag:             ofganames.ConvertTag(controller.ResourceTag()),
+		expectedJAASTag: "controller-" + controller.UUID,
+	}, {
+		tag:             ofganames.ConvertTag(model.ResourceTag()),
+		expectedJAASTag: "model-" + model.UUID.String,
+	}, {
+		tag:             ofganames.ConvertTag(applicationOffer.ResourceTag()),
+		expectedJAASTag: "applicationoffer-" + applicationOffer.UUID,
+	}, {
+		tag:             ofganames.ConvertTag(cloud.ResourceTag()),
+		expectedJAASTag: "cloud-" + cloud.Name,
+	}, {
+		tag:             ofganames.ConvertTag(role.ResourceTag()),
+		expectedJAASTag: "role-" + role.UUID,
+	}, {
+		tag:             &ofganames.Tag{},
+		expectedJAASTag: "-",
+	}}
+	for _, test := range tests {
+		t, err := j.ToJAASTag(ctx, test.tag, false)
+		if test.expectedError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, qt.IsNil)
+			c.Assert(t, qt.Equals, test.expectedJAASTag)
+		}
+	}
+}
+
 // createTestControllerEnvironment is a utility function creating the necessary components of adding a:
 //   - user
 //   - user group

--- a/internal/jimm/identity_test.go
+++ b/internal/jimm/identity_test.go
@@ -37,7 +37,7 @@ func TestFetchIdentity(t *testing.T) {
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
 
-	user, _, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, _, _, _, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 	u, err := j.FetchIdentity(ctx, user.Name)
 	c.Assert(err, qt.IsNil)
 	c.Assert(u.Name, qt.Equals, user.Name)

--- a/internal/jimm/relation_test.go
+++ b/internal/jimm/relation_test.go
@@ -43,7 +43,7 @@ func TestListRelationshipTuples(t *testing.T) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
 	u.JimmAdmin = true
 
-	user, _, controller, model, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, _, controller, model, _, _, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 	c.Assert(err, qt.IsNil)
 
 	err = j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
@@ -192,7 +192,7 @@ func TestListObjectRelations(t *testing.T) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
 	u.JimmAdmin = true
 
-	user, group, controller, model, _, cloud, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	user, group, controller, model, _, cloud, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 	c.Assert(err, qt.IsNil)
 
 	err = j.AddRelation(ctx, u, []apiparams.RelationshipTuple{

--- a/internal/jimm/resource_test.go
+++ b/internal/jimm/resource_test.go
@@ -34,7 +34,7 @@ func TestGetResources(t *testing.T) {
 
 	err = j.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	_, _, controller, model, applicationOffer, cloud, _ := createTestControllerEnvironment(ctx, c, j.Database)
+	_, _, controller, model, applicationOffer, cloud, _, _ := createTestControllerEnvironment(ctx, c, j.Database)
 
 	ids := []string{applicationOffer.UUID, cloud.Name, controller.UUID, model.UUID.String}
 

--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -7,10 +7,7 @@ import (
 
 	jujuparams "github.com/juju/juju/rpc/params"
 
-	"github.com/canonical/jimm/v3/internal/db"
-	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/openfga"
-	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
 var (
@@ -37,13 +34,6 @@ func ModelAccessWatcherMatch(w *modelAccessWatcher, model string) bool {
 
 func RunModelAccessWatcher(w *modelAccessWatcher) {
 	go w.loop()
-}
-
-func ToJAASTag(db db.Database, tag *ofganames.Tag, resolveUUIDs bool) (string, error) {
-	jimm := &jimm.JIMM{
-		Database: db,
-	}
-	return jimm.ToJAASTag(context.Background(), tag, resolveUUIDs)
 }
 
 func NewControllerRoot(j JIMM, p Params) *controllerRoot {

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -43,7 +43,7 @@ var (
 
 // allRelations contains a slice of all valid relations.
 // NB: Add any new relations from the above to this slice.
-var allRelations = []cofga.Relation{MemberRelation, AdministratorRelation, ControllerRelation, ModelRelation, ConsumerRelation, ReaderRelation, WriterRelation, CanAddModelRelation, AuditLogViewerRelation, NoRelation}
+var allRelations = []cofga.Relation{MemberRelation, AdministratorRelation, ControllerRelation, ModelRelation, ConsumerRelation, ReaderRelation, WriterRelation, CanAddModelRelation, AuditLogViewerRelation, AssigneeRelation, NoRelation}
 
 // EveryoneUser is the username representing all users and is treated uniquely when used in OpenFGA tuples.
 const EveryoneUser = "everyone@external"
@@ -171,6 +171,8 @@ func ParseRelation(relationString string) (cofga.Relation, error) {
 		return CanAddModelRelation, nil
 	case AuditLogViewerRelation.String():
 		return AuditLogViewerRelation, nil
+	case AssigneeRelation.String():
+		return AssigneeRelation, nil
 	default:
 		return cofga.Relation(""), errors.E(op, fmt.Sprintf("unknown relation %s", relationString))
 


### PR DESCRIPTION
## Description

The `ToJAASTag` method was moved from the jujuapi to the jimm in https://github.com/canonical/jimm/pull/1122 but its test was not moved. This PR moves the test.
Additionally we add tests for roles.

Builds on #1466.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests