### PR TITLE
refactor(internal/jimm/jimm.go): introduces a jimm constructor

### DIFF
--- a/cmd/jimmctl/cmd/relation_test.go
+++ b/cmd/jimmctl/cmd/relation_test.go
@@ -339,7 +339,7 @@ func initializeEnvironment(c *gc.C, ctx context.Context, db *db.Database, u dbmo
 }
 
 func (s *relationSuite) TestListRelations(c *gc.C) {
-	env := initializeEnvironment(c, context.Background(), &s.JIMM.Database, *s.AdminUser)
+	env := initializeEnvironment(c, context.Background(), s.JIMM.Database, *s.AdminUser)
 	bClient := s.SetupCLIAccess(c, "alice") // alice is superuser
 
 	relations := []apiparams.RelationshipTuple{{
@@ -420,7 +420,7 @@ func (s *relationSuite) TestListRelations(c *gc.C) {
 }
 
 func (s *relationSuite) TestListRelationsWithError(c *gc.C) {
-	env := initializeEnvironment(c, context.Background(), &s.JIMM.Database, *s.AdminUser)
+	env := initializeEnvironment(c, context.Background(), s.JIMM.Database, *s.AdminUser)
 	// alice is superuser
 	bClient := s.SetupCLIAccess(c, "alice")
 

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -38,10 +38,10 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// newTestJimmParams returns a set of JIMM params with sensible defaults
+// newTestServiceParameters returns a set of JIMM params with sensible defaults
 // for tests. A test can override any parameter that it needs.
-// Note that newTestJimmParams will create an empty test database.
-func newTestJimmParams(t jimmtest.Tester) jimmsvc.Params {
+// Note that newTestServiceParameters will create an empty test database.
+func newTestServiceParameters(t jimmtest.Tester) jimmsvc.Params {
 	return jimmsvc.Params{
 		DSN:            jimmtest.CreateEmptyDatabase(t),
 		ControllerUUID: "6acf4fd8-32d6-49ea-b4eb-dcb9d1590c11",
@@ -62,12 +62,14 @@ func newTestJimmParams(t jimmtest.Tester) jimmsvc.Params {
 func TestDefaultService(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 	p.InsecureSecretStorage = true
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 	rr := httptest.NewRecorder()
@@ -82,24 +84,28 @@ func TestDefaultService(t *testing.T) {
 func TestServiceDoesNotStartWithoutCredentialStore(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
-	_, err = jimmsvc.NewService(context.Background(), p)
+	_, err = jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.ErrorMatches, "jimm cannot start without a credential store")
 }
 
 func TestAuthenticator(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.InsecureSecretStorage = true
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 
@@ -149,13 +155,14 @@ const testVaultEnv = `clouds:
 
 func TestVault(t *testing.T) {
 	c := qt.New(t)
+
 	ctx := context.Background()
 
 	ofgaClient, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
 	vaultClient, _, roleID, roleSecretID, _ := jimmtest.VaultClient(c)
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.VaultAddress = "http://localhost:8200"
 	p.VaultPath = "/jimm-kv/"
 	p.VaultRoleID = roleID
@@ -213,25 +220,28 @@ func TestVault(t *testing.T) {
 func TestPostgresSecretStore(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.InsecureSecretStorage = true
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 }
 
 func TestOpenFGA(t *testing.T) {
 	c := qt.New(t)
+
 	ctx := context.Background()
 
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.InsecureSecretStorage = true
 	p.ControllerAdmins = []string{"alice", "eve"}
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
@@ -276,13 +286,15 @@ func TestOpenFGA(t *testing.T) {
 func TestPublicKey(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 	p.InsecureSecretStorage = true
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 
@@ -300,14 +312,16 @@ func TestPublicKey(t *testing.T) {
 func TestRebacAdminApi(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.InsecureSecretStorage = true
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 
@@ -326,14 +340,14 @@ func TestRebacAdminApi(t *testing.T) {
 func TestThirdPartyCaveatDischarge(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	offer := dbmodel.ApplicationOffer{
 		UUID: "7e4e7ffb-5116-4544-a400-f584d08c410e",
 		Name: "test-application-offer",
 	}
 	user, err := dbmodel.NewIdentity("alice@canonical.com")
 	c.Assert(err, qt.IsNil)
-
-	ctx := context.Background()
 
 	tests := []struct {
 		about          string
@@ -382,10 +396,10 @@ func TestThirdPartyCaveatDischarge(t *testing.T) {
 			ofgaClient, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 			c.Assert(err, qt.IsNil)
 
-			p := newTestJimmParams(c)
+			p := newTestServiceParameters(c)
 			p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 			p.InsecureSecretStorage = true
-			svc, err := jimmsvc.NewService(context.Background(), p)
+			svc, err := jimmsvc.NewService(ctx, p)
 			c.Assert(err, qt.IsNil)
 			defer svc.Cleanup()
 
@@ -447,14 +461,16 @@ func TestThirdPartyCaveatDischarge(t *testing.T) {
 func TestDisableOAuthEndpointsWhenDashboardRedirectURLNotSet(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.DashboardFinalRedirectURL = ""
 	p.InsecureSecretStorage = true
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 
@@ -470,15 +486,17 @@ func TestDisableOAuthEndpointsWhenDashboardRedirectURLNotSet(t *testing.T) {
 func TestEnableOAuthEndpointsWhenDashboardRedirectURLSet(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.DashboardFinalRedirectURL = "some-redirect-url"
 	p.InsecureSecretStorage = true
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 
@@ -519,13 +537,15 @@ func TestCleanup(t *testing.T) {
 func TestCleanupDoesNotPanic_SessionStoreRelatedCleanups(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 	p.InsecureSecretStorage = true
 
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 
 	// Make sure `cleanups` is not empty.
@@ -537,15 +557,17 @@ func TestCleanupDoesNotPanic_SessionStoreRelatedCleanups(t *testing.T) {
 func TestCORS(t *testing.T) {
 	c := qt.New(t)
 
+	ctx := context.Background()
+
 	_, _, cofgaParams, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
-	p := newTestJimmParams(c)
+	p := newTestServiceParameters(c)
 	p.OpenFGAParams = cofgaParamsToJIMMOpenFGAParams(*cofgaParams)
 	allowedOrigin := "http://my-referrer.com"
 	p.CorsAllowedOrigins = []string{allowedOrigin}
 	p.InsecureSecretStorage = true
 
-	svc, err := jimmsvc.NewService(context.Background(), p)
+	svc, err := jimmsvc.NewService(ctx, p)
 	c.Assert(err, qt.IsNil)
 	defer svc.Cleanup()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
       POSTGRES_PASSWORD: jimm
     # Since it's mainly used for testing purposes, it's okay to set fsync=off for
     # improved performance.
-    command: -c fsync=off -c full_page_writes=off
+    command: -c fsync=off -c full_page_writes=off -c max_connections=200
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U jimm" ]
       interval: 5s

--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -244,7 +244,7 @@ controllers:
     region: test-region
     priority: 1
 `)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	cr, err := s.Database.FindRegion(ctx, "testp", "test-region")
 	c.Assert(err, qt.IsNil)
@@ -363,7 +363,7 @@ controllers:
     region: test-region-2
     priority: 1
 `)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	cl := dbmodel.Cloud{
 		Name: "test-cloud-1",

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -278,7 +278,7 @@ func (s *dbSuite) TestForEachCloudCredential(c *qt.C) {
 	env := jimmtest.ParseEnvironment(c, forEachCloudCredentialEnv)
 	err := s.Database.Migrate(ctx, false)
 	c.Assert(err, qt.IsNil)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	for _, test := range forEachCloudCredentialTests {
 		c.Run(test.name, func(c *qt.C) {

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -138,7 +138,7 @@ func (s *dbSuite) TestForEachController(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachControllerEnv)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	testError := errors.E("test error")
 	err = s.Database.ForEachController(ctx, func(controller *dbmodel.Controller) error {
@@ -321,9 +321,9 @@ func (s *dbSuite) TestForEachControllerModel(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachControllerModelEnv)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
-	ctl := env.Controller("test").DBObject(c, *s.Database)
+	ctl := env.Controller("test").DBObject(c, s.Database)
 	testError := errors.E("test error")
 	err = s.Database.ForEachControllerModel(ctx, &ctl, func(_ *dbmodel.Model) error {
 		return testError

--- a/internal/db/identitymodeldefaults_test.go
+++ b/internal/db/identitymodeldefaults_test.go
@@ -5,7 +5,6 @@ package db_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -21,7 +20,6 @@ func TestSetIdentityModelDefaults(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
 	type testConfig struct {
 		identity         *dbmodel.Identity
@@ -135,17 +133,11 @@ func TestSetIdentityModelDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := &jimm.JIMM{
-				Database: db.Database{
-					DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-				},
-			}
-			err := j.Database.Migrate(ctx, true)
-			c.Assert(err, qt.Equals, nil)
+			j := jimmtest.NewJIMM(c, nil)
 
 			testConfig := test.setup(c, j)
 
-			err = j.SetIdentityModelDefaults(ctx, testConfig.identity, testConfig.defaults)
+			err := j.SetIdentityModelDefaults(ctx, testConfig.identity, testConfig.defaults)
 			if testConfig.expectedError == "" {
 				c.Assert(err, qt.Equals, nil)
 				dbDefaults := dbmodel.IdentityModelDefaults{

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -533,7 +533,7 @@ func (s *dbSuite) TestForEachModel(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testForEachModelEnv)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	testError := errors.E("test error")
 	err = s.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
@@ -619,7 +619,7 @@ func (s *dbSuite) TestGetModelsByUUID(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testGetModelsByUUIDEnv)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 
 	modelUUIDs := []string{
 		"00000002-0000-0000-0000-000000000001",
@@ -782,9 +782,9 @@ func (s *dbSuite) TestCountModelsByController(c *qt.C) {
 	c.Assert(err, qt.Equals, nil)
 
 	env := jimmtest.ParseEnvironment(c, testCountModelsByControllerEnv)
-	env.PopulateDB(c, *s.Database)
+	env.PopulateDB(c, s.Database)
 	c.Assert(len(env.Controllers), qt.Equals, 1)
-	count, err := s.Database.CountModelsByController(context.Background(), env.Controllers[0].DBObject(c, *s.Database))
+	count, err := s.Database.CountModelsByController(context.Background(), env.Controllers[0].DBObject(c, s.Database))
 	c.Assert(err, qt.IsNil)
 	c.Assert(count, qt.Equals, 3)
 }

--- a/internal/jimm/access.go
+++ b/internal/jimm/access.go
@@ -707,7 +707,7 @@ func (j *JIMM) parseAndValidateTag(ctx context.Context, key string) (*ofganames.
 		return tag, nil
 	}
 	tagString := key
-	tag, err := resolveTag(j.UUID, &j.Database, tagString)
+	tag, err := resolveTag(j.UUID, j.Database, tagString)
 	if err != nil {
 		zapctx.Debug(ctx, "failed to resolve tuple object", zap.Error(err))
 		return nil, errors.E(op, errors.CodeFailedToResolveTupleResource, err)

--- a/internal/jimm/access_test.go
+++ b/internal/jimm/access_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/canonical/ofga"
 	petname "github.com/dustinkirkland/golang-petname"
@@ -14,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
@@ -111,21 +109,10 @@ func (t *testJWTService) NewJWT(ctx context.Context, params jimmjwx.JWTParams) (
 func TestAuditLogAccess(t *testing.T) {
 	c := qt.New(t)
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
 	ctx := context.Background()
 
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
 	i, err := dbmodel.NewIdentity("alice")
 	c.Assert(err, qt.IsNil)
 	adminUser := openfga.NewUser(i, j.OpenFGAClient)
@@ -428,20 +415,7 @@ func TestParseAndValidateTag(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	user, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 
@@ -479,16 +453,7 @@ func TestResolveTags(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-	}
-
-	err := j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	identity, group, controller, model, offer, cloud, _, role := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 
@@ -556,7 +521,7 @@ func TestResolveTags(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			jujuTag, err := jimm.ResolveTag(j.UUID, &j.Database, tC.input)
+			jujuTag, err := jimm.ResolveTag(j.UUID, j.Database, tC.input)
 			c.Assert(err, qt.IsNil)
 			c.Assert(jujuTag, qt.DeepEquals, tC.expected)
 		})
@@ -567,16 +532,7 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-	}
-
-	err := j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	_, _, controller, model, offer, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 
@@ -627,7 +583,7 @@ func TestResolveTupleObjectHandlesErrors(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			_, err := jimm.ResolveTag(j.UUID, &j.Database, tc.input)
+			_, err := jimm.ResolveTag(j.UUID, j.Database, tc.input)
 			c.Assert(err, qt.ErrorMatches, tc.want)
 		})
 	}
@@ -637,16 +593,7 @@ func TestToJAASTag(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-	}
-
-	err := j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	user, group, controller, model, applicationOffer, cloud, _, role := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 
@@ -699,16 +646,7 @@ func TestToJAASTagNoUUIDResolution(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-	}
-
-	err := j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	user, group, controller, model, applicationOffer, cloud, _, role := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 	serviceAccountId := petname.Generate(2, "-") + "@serviceaccount"
@@ -760,23 +698,10 @@ func TestOpenFGACleanup(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	// run cleanup on an empty authorizaton store
-	err = j.OpenFGACleanup(ctx)
+	err := j.OpenFGACleanup(ctx)
 	c.Assert(err, qt.IsNil)
 
 	type createTagFunction func(int) *ofga.Entity
@@ -838,7 +763,7 @@ func TestOpenFGACleanup(t *testing.T) {
 				Relation: ofga.Relation(test.relation),
 				Target:   targetTag,
 			}
-			err = ofgaClient.AddRelation(ctx, tuple)
+			err = j.OpenFGAClient.AddRelation(ctx, tuple)
 			c.Assert(err, qt.IsNil)
 
 			orphanedTuples = append(orphanedTuples, tuple)
@@ -850,7 +775,7 @@ func TestOpenFGACleanup(t *testing.T) {
 
 	for _, tuple := range orphanedTuples {
 		c.Logf("checking relation for %+v", tuple)
-		ok, err := ofgaClient.CheckRelation(ctx, tuple, false)
+		ok, err := j.OpenFGAClient.CheckRelation(ctx, tuple, false)
 		c.Assert(err, qt.IsNil)
 		c.Assert(ok, qt.IsFalse)
 	}

--- a/internal/jimm/admin_test.go
+++ b/internal/jimm/admin_test.go
@@ -13,18 +13,16 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/oauth2"
 
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
 func TestLoginDevice(t *testing.T) {
 	c := qt.New(t)
-	mockAuthenticator := jimmtest.NewMockOAuthAuthenticator(c, nil)
-	jimm := jimm.JIMM{
-		OAuthAuthenticator: &mockAuthenticator,
-	}
-	resp, err := jimm.LoginDevice(context.Background())
+
+	j := jimmtest.NewJIMM(c, nil)
+
+	resp, err := j.LoginDevice(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(*resp, qt.CmpEquals(cmpopts.IgnoreTypes(time.Time{})), oauth2.DeviceAuthResponse{
 		DeviceCode:              "test-device-code",
@@ -38,12 +36,15 @@ func TestLoginDevice(t *testing.T) {
 func TestGetDeviceSessionToken(t *testing.T) {
 	c := qt.New(t)
 	pollingChan := make(chan string, 1)
+
 	mockAuthenticator := jimmtest.NewMockOAuthAuthenticator(c, pollingChan)
-	jimm := jimm.JIMM{
+
+	j := jimmtest.NewJIMM(c, &jimm.Parameters{
 		OAuthAuthenticator: &mockAuthenticator,
-	}
+	})
+
 	pollingChan <- "user-foo"
-	token, err := jimm.GetDeviceSessionToken(context.Background(), nil)
+	token, err := j.GetDeviceSessionToken(context.Background(), nil)
 	c.Assert(err, qt.IsNil)
 	c.Assert(token, qt.Not(qt.Equals), "")
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
@@ -55,46 +56,26 @@ func TestGetDeviceSessionToken(t *testing.T) {
 
 func TestLoginClientCredentials(t *testing.T) {
 	c := qt.New(t)
-	mockAuthenticator := jimmtest.NewMockOAuthAuthenticator(c, nil)
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name(), t.Name())
-	c.Assert(err, qt.IsNil)
-	jimm := jimm.JIMM{
-		UUID: "foo",
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OAuthAuthenticator: &mockAuthenticator,
-		OpenFGAClient:      client,
-	}
+
+	j := jimmtest.NewJIMM(c, nil)
+
 	ctx := context.Background()
-	err = jimm.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
 	invalidClientID := "123@123@"
-	_, err = jimm.LoginClientCredentials(ctx, invalidClientID, "foo-secret")
+	_, err := j.LoginClientCredentials(ctx, invalidClientID, "foo-secret")
 	c.Assert(err, qt.ErrorMatches, "invalid client ID")
 
 	validClientID := "my-svc-acc"
-	user, err := jimm.LoginClientCredentials(ctx, validClientID, "foo-secret")
+	user, err := j.LoginClientCredentials(ctx, validClientID, "foo-secret")
 	c.Assert(err, qt.IsNil)
 	c.Assert(user.Name, qt.Equals, "my-svc-acc@serviceaccount")
 }
 
 func TestLoginWithSessionToken(t *testing.T) {
 	c := qt.New(t)
-	mockAuthenticator := jimmtest.NewMockOAuthAuthenticator(c, nil)
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name(), t.Name())
-	c.Assert(err, qt.IsNil)
-	jimm := jimm.JIMM{
-		UUID: "foo",
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OAuthAuthenticator: &mockAuthenticator,
-		OpenFGAClient:      client,
-	}
+
+	j := jimmtest.NewJIMM(c, nil)
+
 	ctx := context.Background()
-	err = jimm.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
 
 	token, err := jwt.NewBuilder().
 		Subject("alice@canonical.com").
@@ -104,35 +85,24 @@ func TestLoginWithSessionToken(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	b64Token := base64.StdEncoding.EncodeToString(serialisedToken)
 
-	_, err = jimm.LoginWithSessionToken(ctx, "invalid-token")
+	_, err = j.LoginWithSessionToken(ctx, "invalid-token")
 	c.Assert(err, qt.ErrorMatches, "failed to decode token")
 
-	user, err := jimm.LoginWithSessionToken(ctx, b64Token)
+	user, err := j.LoginWithSessionToken(ctx, b64Token)
 	c.Assert(err, qt.IsNil)
 	c.Assert(user.Name, qt.Equals, "alice@canonical.com")
 }
 
 func TestLoginWithSessionCookie(t *testing.T) {
 	c := qt.New(t)
-	mockAuthenticator := jimmtest.NewMockOAuthAuthenticator(c, nil)
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name(), t.Name())
-	c.Assert(err, qt.IsNil)
-	jimm := jimm.JIMM{
-		UUID: "foo",
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OAuthAuthenticator: &mockAuthenticator,
-		OpenFGAClient:      client,
-	}
 	ctx := context.Background()
-	err = jimm.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
 
-	_, err = jimm.LoginWithSessionCookie(ctx, "")
+	j := jimmtest.NewJIMM(c, nil)
+
+	_, err := j.LoginWithSessionCookie(ctx, "")
 	c.Assert(err, qt.ErrorMatches, "missing cookie identity")
 
-	user, err := jimm.LoginWithSessionCookie(ctx, "alice@canonical.com")
+	user, err := j.LoginWithSessionCookie(ctx, "alice@canonical.com")
 	c.Assert(err, qt.IsNil)
 	c.Assert(user.Name, qt.Equals, "alice@canonical.com")
 }

--- a/internal/jimm/audit_log.go
+++ b/internal/jimm/audit_log.go
@@ -130,7 +130,7 @@ func (o recorder) HandleReply(r rpc.Request, header *rpc.Header, body interface{
 // on a defined retention period. The retention period is in DAYS.
 type auditLogCleanupService struct {
 	auditLogRetentionPeriodInDays int
-	db                            db.Database
+	db                            *db.Database
 }
 
 // pollTimeOfDay holds the time hour, minutes and seconds to poll at.
@@ -146,7 +146,7 @@ var pollDuration = pollTimeOfDay{
 
 // NewAuditLogCleanupService returns a service capable of cleaning up audit logs
 // on a defined retention period. The retention period is in DAYS.
-func NewAuditLogCleanupService(db db.Database, auditLogRetentionPeriodInDays int) *auditLogCleanupService {
+func NewAuditLogCleanupService(db *db.Database, auditLogRetentionPeriodInDays int) *auditLogCleanupService {
 	return &auditLogCleanupService{
 		auditLogRetentionPeriodInDays: auditLogRetentionPeriodInDays,
 		db:                            db,

--- a/internal/jimm/audit_log_test.go
+++ b/internal/jimm/audit_log_test.go
@@ -22,7 +22,7 @@ func TestAuditLogCleanupServicePurgesLogs(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC().Round(time.Millisecond)
 
-	db := db.Database{
+	db := &db.Database{
 		DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
 	}
 

--- a/internal/jimm/cloud.go
+++ b/internal/jimm/cloud.go
@@ -160,7 +160,7 @@ func (j *JIMM) AddCloudToController(ctx context.Context, user *openfga.User, con
 		return errors.E(op, err)
 	}
 
-	if err := validateCloudRegion(ctx, &j.Database, user, cloud, controllerName); err != nil {
+	if err := validateCloudRegion(ctx, j.Database, user, cloud, controllerName); err != nil {
 		return errors.E(op, err)
 	}
 

--- a/internal/jimm/clouddefaults_test.go
+++ b/internal/jimm/clouddefaults_test.go
@@ -5,7 +5,6 @@ package jimm_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -23,7 +22,6 @@ func TestSetCloudDefaults(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
 	type testConfig struct {
 		user             *dbmodel.Identity
@@ -232,17 +230,11 @@ func TestSetCloudDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := &jimm.JIMM{
-				Database: db.Database{
-					DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-				},
-			}
-			err := j.Database.Migrate(ctx, true)
-			c.Assert(err, qt.Equals, nil)
+			j := jimmtest.NewJIMM(c, nil)
 
 			testConfig := test.setup(c, j)
 
-			err = j.SetModelDefaults(ctx, testConfig.user, testConfig.cloud, testConfig.region, testConfig.defaults)
+			err := j.SetModelDefaults(ctx, testConfig.user, testConfig.cloud, testConfig.region, testConfig.defaults)
 			if testConfig.expectedError == "" {
 				c.Assert(err, qt.Equals, nil)
 				dbDefaults := dbmodel.CloudDefaults{
@@ -266,7 +258,6 @@ func TestUnsetCloudDefaults(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
 	type testConfig struct {
 		user             *dbmodel.Identity
@@ -425,17 +416,11 @@ func TestUnsetCloudDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := &jimm.JIMM{
-				Database: db.Database{
-					DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-				},
-			}
-			err := j.Database.Migrate(ctx, true)
-			c.Assert(err, qt.Equals, nil)
+			j := jimmtest.NewJIMM(c, nil)
 
 			testConfig := test.setup(c, j)
 
-			err = j.UnsetModelDefaults(ctx, testConfig.user, testConfig.cloud, testConfig.region, testConfig.keys)
+			err := j.UnsetModelDefaults(ctx, testConfig.user, testConfig.cloud, testConfig.region, testConfig.keys)
 			if testConfig.expectedError == "" {
 				c.Assert(err, qt.Equals, nil)
 				dbDefaults := dbmodel.CloudDefaults{
@@ -459,15 +444,8 @@ func TestModelDefaultsForCloud(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
-	j := &jimm.JIMM{
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-	}
-	err := j.Database.Migrate(ctx, true)
-	c.Assert(err, qt.Equals, nil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	user, err := dbmodel.NewIdentity("bob@canonical.com")
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/export_test.go
+++ b/internal/jimm/export_test.go
@@ -28,7 +28,7 @@ func WatchController(w *Watcher, ctx context.Context, ctl *dbmodel.Controller) e
 	return w.watchController(ctx, ctl)
 }
 
-func NewWatcherWithControllerUnavailableChan(db db.Database, dialer Dialer, pubsub Publisher, testChannel chan error) *Watcher {
+func NewWatcherWithControllerUnavailableChan(db *db.Database, dialer Dialer, pubsub Publisher, testChannel chan error) *Watcher {
 	return &Watcher{
 		Pubsub:                    pubsub,
 		Database:                  db,
@@ -37,7 +37,7 @@ func NewWatcherWithControllerUnavailableChan(db db.Database, dialer Dialer, pubs
 	}
 }
 
-func NewWatcherWithDeltaProcessedChannel(db db.Database, dialer Dialer, pubsub Publisher, testChannel chan bool) *Watcher {
+func NewWatcherWithDeltaProcessedChannel(db *db.Database, dialer Dialer, pubsub Publisher, testChannel chan bool) *Watcher {
 	return &Watcher{
 		Pubsub:             pubsub,
 		Database:           db,

--- a/internal/jimm/group/group_test.go
+++ b/internal/jimm/group/group_test.go
@@ -112,7 +112,7 @@ func (s *groupManagerSuite) TestRemoveGroup(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	_, group, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, *s.db)
+	_, group, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 
 	err := s.manager.RemoveGroup(ctx, s.adminUser, group.Name)
 	c.Assert(err, qt.IsNil)
@@ -125,7 +125,7 @@ func (s *groupManagerSuite) TestRemoveGroupRemovesTuples(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	user, group, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, *s.db)
+	user, group, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 
 	_, err := s.db.AddGroup(ctx, "test-group2")
 	c.Assert(err, qt.IsNil)
@@ -191,7 +191,7 @@ func (s *groupManagerSuite) TestRenameGroup(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	user, group, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, *s.db)
+	user, group, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 
 	tuples := []openfga.Tuple{
 		{
@@ -265,7 +265,7 @@ func (s *groupManagerSuite) TestListGroups(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	user, group, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, *s.db)
+	user, group, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 
 	u := openfga.NewUser(&user, s.ofgaClient)
 	u.JimmAdmin = true

--- a/internal/jimm/identity_test.go
+++ b/internal/jimm/identity_test.go
@@ -5,15 +5,11 @@ package jimm_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
@@ -22,20 +18,7 @@ func TestFetchIdentity(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	user, _, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 	u, err := j.FetchIdentity(ctx, user.Name)
@@ -50,22 +33,9 @@ func TestListIdentities(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
-
-	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, j.OpenFGAClient)
 	u.JimmAdmin = true
 
 	pag := pagination.NewOffsetFilter(10, 0)
@@ -135,22 +105,9 @@ func TestCountIdentities(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
-
-	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, j.OpenFGAClient)
 	u.JimmAdmin = true
 
 	userNames := []string{

--- a/internal/jimm/identitymodeldefaults_test.go
+++ b/internal/jimm/identitymodeldefaults_test.go
@@ -5,7 +5,6 @@ package jimm_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -21,7 +20,6 @@ func TestSetIdentityModelDefaults(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
 	type testConfig struct {
 		identity         *dbmodel.Identity
@@ -119,17 +117,11 @@ func TestSetIdentityModelDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := &jimm.JIMM{
-				Database: db.Database{
-					DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-				},
-			}
-			err := j.Database.Migrate(ctx, true)
-			c.Assert(err, qt.Equals, nil)
+			j := jimmtest.NewJIMM(c, nil)
 
 			testConfig := test.setup(c, j)
 
-			err = j.SetIdentityModelDefaults(ctx, testConfig.identity, testConfig.defaults)
+			err := j.SetIdentityModelDefaults(ctx, testConfig.identity, testConfig.defaults)
 			if testConfig.expectedError == "" {
 				c.Assert(err, qt.Equals, nil)
 				dbDefaults := dbmodel.IdentityModelDefaults{
@@ -149,7 +141,6 @@ func TestIdentityModelDefaults(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	now := time.Now()
 
 	type testConfig struct {
 		identity         *dbmodel.Identity
@@ -206,13 +197,7 @@ func TestIdentityModelDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := &jimm.JIMM{
-				Database: db.Database{
-					DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-				},
-			}
-			err := j.Database.Migrate(ctx, true)
-			c.Assert(err, qt.Equals, nil)
+			j := jimmtest.NewJIMM(c, nil)
 
 			testConfig := test.setup(c, j)
 

--- a/internal/jimm/model_status_parser_test.go
+++ b/internal/jimm/model_status_parser_test.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/uuid"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
@@ -326,15 +324,7 @@ func TestQueryModelsJq(t *testing.T) {
 	ctx := context.Background()
 
 	// Test setup
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: client,
+	j := jimmtest.NewJIMM(c, &jimm.Parameters{
 		Dialer: jimmtest.ModelDialerMap{
 			"10000000-0000-0000-0000-000000000000": &jimmtest.Dialer{
 				API: &jimmtest.API{
@@ -429,10 +419,7 @@ func TestQueryModelsJq(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	})
 
 	env := jimmtest.ParseEnvironment(c, crossModelQueryEnv)
 	env.PopulateDB(c, j.Database)

--- a/internal/jimm/relation_test.go
+++ b/internal/jimm/relation_test.go
@@ -5,15 +5,11 @@ package jimm_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
@@ -25,28 +21,14 @@ func TestListRelationshipTuples(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
-
-	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, j.OpenFGAClient)
 	u.JimmAdmin = true
 
 	user, _, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
-	c.Assert(err, qt.IsNil)
 
-	err = j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
+	err := j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
 		{
 			Object:       user.Tag().String(),
 			Relation:     names.ReaderRelation.String(),
@@ -174,28 +156,14 @@ func TestListObjectRelations(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
-
-	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, j.OpenFGAClient)
 	u.JimmAdmin = true
 
 	user, group, controller, model, _, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
-	c.Assert(err, qt.IsNil)
 
-	err = j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
+	err := j.AddRelation(ctx, u, []apiparams.RelationshipTuple{
 		{
 			Object:       user.Tag().String(),
 			Relation:     names.ReaderRelation.String(),

--- a/internal/jimm/resource_test.go
+++ b/internal/jimm/resource_test.go
@@ -4,15 +4,11 @@ package jimm_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
@@ -20,25 +16,14 @@ import (
 func TestGetResources(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
 
-	now := time.Now().UTC().Round(time.Millisecond)
-	j := &jimm.JIMM{
-		UUID: uuid.NewString(),
-		Database: db.Database{
-			DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
-		},
-		OpenFGAClient: ofgaClient,
-	}
+	j := jimmtest.NewJIMM(c, nil)
 
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
 	_, _, controller, model, applicationOffer, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, j.Database)
 
 	ids := []string{applicationOffer.UUID, cloud.Name, controller.UUID, model.UUID.String}
 
-	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, ofgaClient)
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, j.OpenFGAClient)
 	u.JimmAdmin = true
 
 	testCases := []struct {

--- a/internal/jimm/user_test.go
+++ b/internal/jimm/user_test.go
@@ -21,20 +21,8 @@ func TestGetUser(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
-	}
 
-	j := &jimm.JIMM{
-		UUID:          "test",
-		Database:      *db,
-		OpenFGAClient: client,
-	}
-
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
+	j := jimmtest.NewJIMM(c, nil)
 
 	ofgaUser, err := j.GetUser(ctx, "bob@canonical.com.com")
 	c.Assert(err, qt.IsNil)
@@ -68,23 +56,17 @@ func TestUpdateUserLastLogin(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
-	client, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
+
 	now := time.Now().Truncate(time.Millisecond)
 	db := &db.Database{
 		DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
 	}
 
-	j := &jimm.JIMM{
-		UUID:          "test",
-		Database:      *db,
-		OpenFGAClient: client,
-	}
+	j := jimmtest.NewJIMM(c, &jimm.Parameters{
+		Database: db,
+	})
 
-	err = j.Database.Migrate(ctx, false)
-	c.Assert(err, qt.IsNil)
-
-	err = j.UpdateUserLastLogin(ctx, "bob@canonical.com.com")
+	err := j.UpdateUserLastLogin(ctx, "bob@canonical.com.com")
 	c.Assert(err, qt.IsNil)
 	user := dbmodel.Identity{Name: "bob@canonical.com.com"}
 	err = j.Database.GetIdentity(ctx, &user)

--- a/internal/jimm/watcher.go
+++ b/internal/jimm/watcher.go
@@ -28,7 +28,7 @@ type Publisher interface {
 // A Watcher watches juju controllers for changes to all models.
 type Watcher struct {
 	// Database is the database used by the Watcher.
-	Database db.Database
+	Database *db.Database
 
 	// Dialer is the API dialer JIMM uses to contact juju controllers. if
 	// this is not configured all connection attempts will fail.

--- a/internal/jimm/watcher_test.go
+++ b/internal/jimm/watcher_test.go
@@ -86,9 +86,9 @@ models:
 
 var watcherTests = []struct {
 	name    string
-	initDB  func(*qt.C, db.Database)
+	initDB  func(*qt.C, *db.Database)
 	deltas  [][]jujuparams.Delta
-	checkDB func(*qt.C, db.Database)
+	checkDB func(*qt.C, *db.Database)
 }{{
 	name: "AddMachine",
 	deltas: [][]jujuparams.Delta{
@@ -104,7 +104,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -140,7 +140,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -176,7 +176,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -202,7 +202,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -233,7 +233,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -265,7 +265,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -292,7 +292,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -328,7 +328,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -376,7 +376,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -400,7 +400,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -424,7 +424,7 @@ var watcherTests = []struct {
 		}},
 		nil,
 	},
-	checkDB: func(c *qt.C, db db.Database) {
+	checkDB: func(c *qt.C, db *db.Database) {
 		ctx := context.Background()
 
 		model := dbmodel.Model{
@@ -481,7 +481,7 @@ func TestWatcher(t *testing.T) {
 			deltaProcessedChannel := make(chan bool, len(test.deltas))
 
 			w := jimm.NewWatcherWithDeltaProcessedChannel(
-				db.Database{
+				&db.Database{
 					DB: jimmtest.PostgresDB(c, nil),
 				},
 				&jimmtest.Dialer{
@@ -645,7 +645,7 @@ func TestModelSummaryWatcher(t *testing.T) {
 
 			w := &jimm.Watcher{
 				Pubsub: publisher,
-				Database: db.Database{
+				Database: &db.Database{
 					DB: jimmtest.PostgresDB(c, nil),
 				},
 				Dialer: &jimmtest.Dialer{
@@ -728,7 +728,7 @@ func TestWatcherSetsControllerUnavailable(t *testing.T) {
 
 	controllerUnavailableChannel := make(chan error, 1)
 	w := jimm.NewWatcherWithControllerUnavailableChan(
-		db.Database{
+		&db.Database{
 			DB: jimmtest.PostgresDB(c, nil),
 		},
 		&jimmtest.Dialer{
@@ -774,7 +774,7 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 	defer cancel()
 
 	w := jimm.Watcher{
-		Database: db.Database{
+		Database: &db.Database{
 			DB: jimmtest.PostgresDB(c, nil),
 		},
 		Dialer: &jimmtest.Dialer{
@@ -846,7 +846,7 @@ func TestWatcherRemoveDyingModelsOnStartup(t *testing.T) {
 
 	w := &jimm.Watcher{
 		Pubsub: &testPublisher{},
-		Database: db.Database{
+		Database: &db.Database{
 			DB: jimmtest.PostgresDB(c, nil),
 		},
 		Dialer: &jimmtest.Dialer{
@@ -935,7 +935,7 @@ func TestWatcherIgnoreDeltasForModelsFromIncorrectController(t *testing.T) {
 	nextC := make(chan []jujuparams.Delta)
 	w := &jimm.Watcher{
 		Pubsub: &testPublisher{},
-		Database: db.Database{
+		Database: &db.Database{
 			DB: jimmtest.PostgresDB(c, nil),
 		},
 		Dialer: jimmtest.DialerMap{

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -37,7 +37,7 @@ func (s *groupsService) ListGroups(ctx context.Context, params *resources.GetGro
 	if err != nil {
 		return nil, err
 	}
-	count, err := s.jimm.GetGroupManager().CountGroups(ctx, user)
+	count, err := s.jimm.GroupManager().CountGroups(ctx, user)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (s *groupsService) ListGroups(ctx context.Context, params *resources.GetGro
 	if params.Filter != nil && *params.Filter != "" {
 		match = *params.Filter
 	}
-	groups, err := s.jimm.GetGroupManager().ListGroups(ctx, user, pagination, match)
+	groups, err := s.jimm.GroupManager().ListGroups(ctx, user, pagination, match)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (s *groupsService) CreateGroup(ctx context.Context, group *resources.Group)
 	if err != nil {
 		return nil, err
 	}
-	groupInfo, err := s.jimm.GetGroupManager().AddGroup(ctx, user, group.Name)
+	groupInfo, err := s.jimm.GroupManager().AddGroup(ctx, user, group.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *groupsService) GetGroup(ctx context.Context, groupId string) (*resource
 	if err != nil {
 		return nil, err
 	}
-	group, err := s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, groupId)
+	group, err := s.jimm.GroupManager().GetGroupByUUID(ctx, user, groupId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("failed to find group")
@@ -105,14 +105,14 @@ func (s *groupsService) UpdateGroup(ctx context.Context, group *resources.Group)
 	if group.Id == nil {
 		return nil, v1.NewValidationError("missing group ID")
 	}
-	existingGroup, err := s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, *group.Id)
+	existingGroup, err := s.jimm.GroupManager().GetGroupByUUID(ctx, user, *group.Id)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("failed to find group")
 		}
 		return nil, err
 	}
-	err = s.jimm.GetGroupManager().RenameGroup(ctx, user, existingGroup.Name, group.Name)
+	err = s.jimm.GroupManager().RenameGroup(ctx, user, existingGroup.Name, group.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -128,14 +128,14 @@ func (s *groupsService) DeleteGroup(ctx context.Context, groupId string) (bool, 
 	if err != nil {
 		return false, err
 	}
-	existingGroup, err := s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, groupId)
+	existingGroup, err := s.jimm.GroupManager().GetGroupByUUID(ctx, user, groupId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return false, nil
 		}
 		return false, err
 	}
-	err = s.jimm.GetGroupManager().RemoveGroup(ctx, user, existingGroup.Name)
+	err = s.jimm.GroupManager().RemoveGroup(ctx, user, existingGroup.Name)
 	if err != nil {
 		return false, err
 	}
@@ -153,7 +153,7 @@ func (s *groupsService) GetGroupIdentities(ctx context.Context, groupId string, 
 	}
 	filter := utils.CreateTokenPaginationFilter(params.Size, params.NextToken, params.NextPageToken)
 	groupTag := jimmnames.NewGroupTag(groupId)
-	_, err = s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, groupId)
+	_, err = s.jimm.GroupManager().GetGroupByUUID(ctx, user, groupId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("group not found")
@@ -248,7 +248,7 @@ func (s *groupsService) GetGroupRoles(ctx context.Context, groupId string, param
 
 	filter := utils.CreateTokenPaginationFilter(params.Size, params.NextToken, params.NextPageToken)
 	groupTag := jimmnames.NewGroupTag(groupId)
-	_, err = s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, groupId)
+	_, err = s.jimm.GroupManager().GetGroupByUUID(ctx, user, groupId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("group not found")
@@ -269,7 +269,7 @@ func (s *groupsService) GetGroupRoles(ctx context.Context, groupId string, param
 	data := make([]resources.Role, 0, len(roles))
 	for _, role := range roles {
 		roleUUID := role.Target.ID
-		roleEntry, err := s.jimm.GetRoleManager().GetRoleByUUID(ctx, user, roleUUID)
+		roleEntry, err := s.jimm.RoleManager().GetRoleByUUID(ctx, user, roleUUID)
 		if err != nil {
 			// If a role does not exist in the database but a linger tuple exists, drop the role from the results.
 			if errors.ErrorCode(err) == errors.CodeNotFound {

--- a/internal/jimmhttp/rebac_admin/groups_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_integration_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&rebacAdminSuite{})
 func (s rebacAdminSuite) TestListGroupsWithFilterIntegration(c *gc.C) {
 	ctx := context.Background()
 	for i := range 10 {
-		_, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, fmt.Sprintf("test-group-filter-%d", i))
+		_, err := s.JIMM.GroupManager().AddGroup(ctx, s.AdminUser, fmt.Sprintf("test-group-filter-%d", i))
 		c.Assert(err, gc.IsNil)
 	}
 
@@ -63,7 +63,7 @@ func (s rebacAdminSuite) TestListGroupsWithFilterIntegration(c *gc.C) {
 
 func (s rebacAdminSuite) TestGetGroupIdentitiesIntegration(c *gc.C) {
 	ctx := context.Background()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
+	group, err := s.JIMM.GroupManager().AddGroup(ctx, s.AdminUser, "test-group")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Relation: ofganames.MemberRelation,
@@ -111,7 +111,7 @@ func (s rebacAdminSuite) TestGetGroupIdentitiesIntegration(c *gc.C) {
 
 func (s rebacAdminSuite) TestPatchGroupIdentitiesIntegration(c *gc.C) {
 	ctx := context.Background()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
+	group, err := s.JIMM.GroupManager().AddGroup(ctx, s.AdminUser, "test-group")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Relation: ofganames.MemberRelation,
@@ -214,7 +214,7 @@ func (s rebacAdminSuite) TestPatchGroupRolesIntegration(c *gc.C) {
 
 func (s rebacAdminSuite) TestGetGroupEntitlementsIntegration(c *gc.C) {
 	ctx := context.Background()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
+	group, err := s.JIMM.GroupManager().AddGroup(ctx, s.AdminUser, "test-group")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),
@@ -320,7 +320,7 @@ func (s rebacAdminSuite) TestPatchGroupEntitlementsIntegration(c *gc.C) {
 	oldModels := []string{env.Models[0].UUID, env.Models[1].UUID}
 	newModels := []string{env.Models[2].UUID, env.Models[3].UUID}
 
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
+	group, err := s.JIMM.GroupManager().AddGroup(ctx, s.AdminUser, "test-group")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -34,7 +34,7 @@ func TestCreateGroup(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 	}
@@ -67,7 +67,7 @@ func TestUpdateGroup(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 	}
@@ -102,7 +102,7 @@ func TestListGroups(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 	}
@@ -142,7 +142,7 @@ func TestDeleteGroup(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 	}
@@ -174,7 +174,7 @@ func TestGetGroupIdentities(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 		RelationService: mocks.RelationService{
@@ -279,10 +279,10 @@ func TestGetGroupRoles(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetRoleManager_: func() jimm.RoleManager {
+		RoleManager_: func() jimm.RoleManager {
 			return roleManager
 		},
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 		RelationService: mocks.RelationService{

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -120,7 +120,7 @@ func (s *identitiesService) GetIdentityRoles(ctx context.Context, identityId str
 
 	roles := make([]resources.Role, 0, len(tuples))
 	for _, t := range tuples {
-		dbRole, err := s.jimm.GetRoleManager().GetRoleByUUID(ctx, user, t.Target.ID)
+		dbRole, err := s.jimm.RoleManager().GetRoleByUUID(ctx, user, t.Target.ID)
 		if err != nil {
 			// Handle the case where the role was removed from the DB but a lingering OpenFGA tuple still exists.
 			// Don't return an error as that would prevent a user from viewing their groups, instead drop the role from the result.
@@ -216,7 +216,7 @@ func (s *identitiesService) GetIdentityGroups(ctx context.Context, identityId st
 
 	groups := make([]resources.Group, 0, len(tuples))
 	for _, t := range tuples {
-		dbGroup, err := s.jimm.GetGroupManager().GetGroupByUUID(ctx, user, t.Target.ID)
+		dbGroup, err := s.jimm.GroupManager().GetGroupByUUID(ctx, user, t.Target.ID)
 		if err != nil {
 			// Handle the case where the group was removed from the DB but a lingering OpenFGA tuple still exists.
 			// Don't return an error as that would prevent a user from viewing their groups, instead drop the group from the result.

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -169,7 +169,7 @@ func TestGetIdentityGroups(t *testing.T) {
 				return []openfga.Tuple{testTuple}, "continuation-token", listTuplesErr
 			},
 		},
-		GetGroupManager_: func() jimm.GroupManager {
+		GroupManager_: func() jimm.GroupManager {
 			return &groupManager
 		},
 	}
@@ -269,7 +269,7 @@ func TestGetIdentityRoles(t *testing.T) {
 				return []openfga.Tuple{testTuple}, "continuation-token", listTuplesErr
 			},
 		},
-		GetRoleManager_: func() jimm.RoleManager {
+		RoleManager_: func() jimm.RoleManager {
 			return roleManager
 		},
 	}

--- a/internal/jimmhttp/rebac_admin/roles.go
+++ b/internal/jimmhttp/rebac_admin/roles.go
@@ -35,7 +35,7 @@ func (s *rolesService) ListRoles(ctx context.Context, params *resources.GetRoles
 	if err != nil {
 		return nil, err
 	}
-	count, err := s.jimm.GetRoleManager().CountRoles(ctx, user)
+	count, err := s.jimm.RoleManager().CountRoles(ctx, user)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (s *rolesService) ListRoles(ctx context.Context, params *resources.GetRoles
 	if params.Filter != nil && *params.Filter != "" {
 		match = *params.Filter
 	}
-	roles, err := s.jimm.GetRoleManager().ListRoles(ctx, user, pagination, match)
+	roles, err := s.jimm.RoleManager().ListRoles(ctx, user, pagination, match)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *rolesService) CreateRole(ctx context.Context, role *resources.Role) (*r
 	if err != nil {
 		return nil, err
 	}
-	roleInfo, err := s.jimm.GetRoleManager().AddRole(ctx, user, role.Name)
+	roleInfo, err := s.jimm.RoleManager().AddRole(ctx, user, role.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *rolesService) GetRole(ctx context.Context, roleId string) (*resources.R
 	if err != nil {
 		return nil, err
 	}
-	role, err := s.jimm.GetRoleManager().GetRoleByUUID(ctx, user, roleId)
+	role, err := s.jimm.RoleManager().GetRoleByUUID(ctx, user, roleId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("failed to find role")
@@ -103,14 +103,14 @@ func (s *rolesService) UpdateRole(ctx context.Context, role *resources.Role) (*r
 	if role.Id == nil {
 		return nil, v1.NewValidationError("missing role ID")
 	}
-	existingRole, err := s.jimm.GetRoleManager().GetRoleByUUID(ctx, user, *role.Id)
+	existingRole, err := s.jimm.RoleManager().GetRoleByUUID(ctx, user, *role.Id)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, v1.NewNotFoundError("failed to find role")
 		}
 		return nil, err
 	}
-	err = s.jimm.GetRoleManager().RenameRole(ctx, user, existingRole.Name, role.Name)
+	err = s.jimm.RoleManager().RenameRole(ctx, user, existingRole.Name, role.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -126,14 +126,14 @@ func (s *rolesService) DeleteRole(ctx context.Context, roleId string) (bool, err
 	if err != nil {
 		return false, err
 	}
-	existingRole, err := s.jimm.GetRoleManager().GetRoleByUUID(ctx, user, roleId)
+	existingRole, err := s.jimm.RoleManager().GetRoleByUUID(ctx, user, roleId)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return false, nil
 		}
 		return false, err
 	}
-	err = s.jimm.GetRoleManager().RemoveRole(ctx, user, existingRole.Name)
+	err = s.jimm.RoleManager().RemoveRole(ctx, user, existingRole.Name)
 	if err != nil {
 		return false, err
 	}

--- a/internal/jimmhttp/rebac_admin/roles_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/roles_integration_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&roleSuite{})
 func (s roleSuite) TestListRolesWithFilterIntegration(c *gc.C) {
 	ctx := context.Background()
 	for i := range 10 {
-		_, err := s.JIMM.RoleManager.AddRole(ctx, s.AdminUser, fmt.Sprintf("test-role-filter-%d", i))
+		_, err := s.JIMM.RoleManager().AddRole(ctx, s.AdminUser, fmt.Sprintf("test-role-filter-%d", i))
 		c.Assert(err, gc.IsNil)
 	}
 
@@ -63,7 +63,7 @@ func (s roleSuite) TestListRolesWithFilterIntegration(c *gc.C) {
 
 func (s roleSuite) TestGetRoleEntitlementsIntegration(c *gc.C) {
 	ctx := context.Background()
-	role, err := s.JIMM.RoleManager.AddRole(ctx, s.AdminUser, "test-role")
+	role, err := s.JIMM.RoleManager().AddRole(ctx, s.AdminUser, "test-role")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewRoleTag(role.UUID), ofganames.AssigneeRelation),
@@ -169,7 +169,7 @@ func (s roleSuite) TestPatchRoleEntitlementsIntegration(c *gc.C) {
 	oldModels := []string{env.Models[0].UUID, env.Models[1].UUID}
 	newModels := []string{env.Models[2].UUID, env.Models[3].UUID}
 
-	role, err := s.JIMM.RoleManager.AddRole(ctx, s.AdminUser, "test-role")
+	role, err := s.JIMM.RoleManager().AddRole(ctx, s.AdminUser, "test-role")
 	c.Assert(err, gc.IsNil)
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewRoleTag(role.UUID), ofganames.AssigneeRelation),

--- a/internal/jimmhttp/rebac_admin/roles_test.go
+++ b/internal/jimmhttp/rebac_admin/roles_test.go
@@ -32,7 +32,7 @@ func TestCreateRole(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetRoleManager_: func() jimm.RoleManager {
+		RoleManager_: func() jimm.RoleManager {
 			return roleManager
 		},
 	}
@@ -65,7 +65,7 @@ func TestUpdateRole(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetRoleManager_: func() jimm.RoleManager {
+		RoleManager_: func() jimm.RoleManager {
 			return roleManager
 		},
 	}
@@ -100,7 +100,7 @@ func TestListRoles(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetRoleManager_: func() jimm.RoleManager {
+		RoleManager_: func() jimm.RoleManager {
 			return roleManager
 		},
 	}
@@ -128,7 +128,7 @@ func TestListRoles(t *testing.T) {
 func TestDeleteRole(t *testing.T) {
 	c := qt.New(t)
 	var deleteErr error
-	RoleManager := mocks.RoleManager{
+	roleManager := mocks.RoleManager{
 		GetRoleByUUID_: func(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.RoleEntry, error) {
 			return &dbmodel.RoleEntry{UUID: uuid, Name: "test-role"}, nil
 		},
@@ -140,8 +140,8 @@ func TestDeleteRole(t *testing.T) {
 		},
 	}
 	jimm := jimmtest.JIMM{
-		GetRoleManager_: func() jimm.RoleManager {
-			return RoleManager
+		RoleManager_: func() jimm.RoleManager {
+			return roleManager
 		},
 	}
 	user := openfga.User{}

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -33,7 +33,7 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 		return resp, errors.E(op, errors.CodeBadRequest, "invalid group name")
 	}
 
-	groupEntry, err := r.jimm.GetGroupManager().AddGroup(ctx, r.user, req.Name)
+	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
 	if err != nil {
 		zapctx.Error(ctx, "failed to add group", zaputil.Error(err))
 		return resp, errors.E(op, err)
@@ -58,9 +58,9 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 	case req.UUID != "" && req.Name != "":
 		return apiparams.Group{}, errors.E(op, errors.CodeBadRequest, "only one of UUID or Name should be provided")
 	case req.UUID != "":
-		groupEntry, err = r.jimm.GetGroupManager().GetGroupByUUID(ctx, r.user, req.UUID)
+		groupEntry, err = r.jimm.GroupManager().GetGroupByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
-		groupEntry, err = r.jimm.GetGroupManager().GetGroupByName(ctx, r.user, req.Name)
+		groupEntry, err = r.jimm.GroupManager().GetGroupByName(ctx, r.user, req.Name)
 	default:
 		return apiparams.Group{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
 	}
@@ -85,7 +85,7 @@ func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGr
 		return errors.E(op, errors.CodeBadRequest, "invalid group name")
 	}
 
-	if err := r.jimm.GetGroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {
+	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {
 		zapctx.Error(ctx, "failed to rename group", zaputil.Error(err))
 		return errors.E(op, err)
 	}
@@ -96,7 +96,7 @@ func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGr
 func (r *controllerRoot) RemoveGroup(ctx context.Context, req apiparams.RemoveGroupRequest) error {
 	const op = errors.Op("jujuapi.RemoveGroup")
 
-	if err := r.jimm.GetGroupManager().RemoveGroup(ctx, r.user, req.Name); err != nil {
+	if err := r.jimm.GroupManager().RemoveGroup(ctx, r.user, req.Name); err != nil {
 		zapctx.Error(ctx, "failed to remove group", zaputil.Error(err))
 		return errors.E(op, err)
 	}
@@ -108,7 +108,7 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 	const op = errors.Op("jujuapi.ListGroups")
 
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
-	groups, err := r.jimm.GetGroupManager().ListGroups(ctx, r.user, pagination, "")
+	groups, err := r.jimm.GroupManager().ListGroups(ctx, r.user, pagination, "")
 	if err != nil {
 		return apiparams.ListGroupResponse{}, errors.E(op, err)
 	}

--- a/internal/jujuapi/admin_test.go
+++ b/internal/jujuapi/admin_test.go
@@ -58,7 +58,7 @@ func (s *adminSuite) SetUpTest(c *gc.C) {
 		ClientSecret:        "SwjDofnbDzJDm9iyfUhEp67FfUFMY8L4",
 		Scopes:              []string{oidc.ScopeOpenID, "profile", "email"},
 		SessionTokenExpiry:  time.Hour,
-		Store:               &s.JIMM.Database,
+		Store:               s.JIMM.Database,
 		SessionStore:        sessionStore,
 		SessionCookieMaxAge: 60,
 		JWTSessionKey:       "test-secret",
@@ -124,7 +124,7 @@ func testBrowserLogin(c *gc.C, s *adminSuite, username, password, expectedEmail,
 	defer sessionStore.Close()
 
 	cookie, err := jimmtest.RunBrowserLogin(
-		&s.JIMM.Database,
+		s.JIMM.Database,
 		sessionStore,
 		username,
 		password,

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -50,8 +50,8 @@ type JIMM interface {
 	GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
 	GetCredentialStore() credentials.CredentialStore
-	GetRoleManager() jimm.RoleManager
-	GetGroupManager() jimm.GroupManager
+	RoleManager() jimm.RoleManager
+	GroupManager() jimm.GroupManager
 	GetJimmControllerAccess(ctx context.Context, user *openfga.User, tag names.UserTag) (string, error)
 	// FetchIdentity finds the user in jimm or returns a not-found error
 	FetchIdentity(ctx context.Context, username string) (*openfga.User, error)

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -25,7 +25,7 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 		return resp, errors.E(op, errors.CodeBadRequest, "invalid role name")
 	}
 
-	roleEntry, err := r.jimm.GetRoleManager().AddRole(ctx, r.user, req.Name)
+	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
 	if err != nil {
 		zapctx.Error(ctx, "failed to add role", zaputil.Error(err))
 		return resp, errors.E(op, err)
@@ -52,9 +52,9 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 	case req.Name != "" && !jimmnames.IsValidRoleName(req.Name):
 		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "invalid role name")
 	case req.UUID != "":
-		roleEntry, err = r.jimm.GetRoleManager().GetRoleByUUID(ctx, r.user, req.UUID)
+		roleEntry, err = r.jimm.RoleManager().GetRoleByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
-		roleEntry, err = r.jimm.GetRoleManager().GetRoleByName(ctx, r.user, req.Name)
+		roleEntry, err = r.jimm.RoleManager().GetRoleByName(ctx, r.user, req.Name)
 	default:
 		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
 	}
@@ -79,7 +79,7 @@ func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRol
 		return errors.E(op, errors.CodeBadRequest, "invalid role name")
 	}
 
-	if err := r.jimm.GetRoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
+	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
 		zapctx.Error(ctx, "failed to rename role", zaputil.Error(err))
 		return errors.E(op, err)
 	}
@@ -94,7 +94,7 @@ func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRol
 		return errors.E(op, errors.CodeBadRequest, "invalid role name")
 	}
 
-	if err := r.jimm.GetRoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {
+	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {
 		zapctx.Error(ctx, "failed to remove role", zaputil.Error(err))
 		return errors.E(op, err)
 	}
@@ -106,7 +106,7 @@ func (r *controllerRoot) ListRoles(ctx context.Context, req apiparams.ListRolesR
 	const op = errors.Op("jujuapi.ListRoles")
 
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
-	roles, err := r.jimm.GetRoleManager().ListRoles(ctx, r.user, pagination, "")
+	roles, err := r.jimm.RoleManager().ListRoles(ctx, r.user, pagination, "")
 	if err != nil {
 		return apiparams.ListRoleResponse{}, errors.E(op, err)
 	}

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -172,7 +172,7 @@ func modelInfoFromPath(path string) (uuid string, finalPath string, err error) {
 // We act as a proxier, handling auth on requests before forwarding the
 // requests to the appropriate Juju controller.
 func (s apiProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
-	jwtGenerator := jimm.NewJWTGenerator(&s.jimm.Database, s.jimm, s.jimm.JWTService)
+	jwtGenerator := jimm.NewJWTGenerator(s.jimm.Database, s.jimm, s.jimm.JWTService)
 	connectionFunc := controllerConnectionFunc(s, &jwtGenerator)
 	zapctx.Debug(ctx, "Starting proxier")
 	auditLogger := s.jimm.AddAuditLogEntry

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -103,7 +103,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	var res jujuparams.LoginResult
 	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
 		client.Close()
-		return nil, errors.E(op, errors.CodeConnectionFailed, "authentication failed", err)
+		return nil, errors.E(op, errors.CodeConnectionFailed, err)
 	}
 
 	ct, err := names.ParseControllerTag(res.ControllerTag)

--- a/internal/testutils/cmdtest/jimmsuite.go
+++ b/internal/testutils/cmdtest/jimmsuite.go
@@ -99,6 +99,7 @@ func (s *JimmCmdSuite) SetUpTest(c *gc.C) {
 
 	srv, err := service.NewService(ctx, s.Params)
 	c.Assert(err, gc.Equals, nil)
+
 	s.Service = srv
 	s.JIMM = srv.JIMM()
 	s.HTTP.Config = &http.Server{Handler: srv, ReadHeaderTimeout: time.Second * 5}

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -132,7 +132,7 @@ func (e *Environment) User(name string) *User {
 }
 
 // addUserRelations adds permissions the user should have.
-func (u User) addUserRelations(c *qt.C, jimmTag names.ControllerTag, db db.Database, client *openfga.OFGAClient) {
+func (u User) addUserRelations(c *qt.C, jimmTag names.ControllerTag, db *db.Database, client *openfga.OFGAClient) {
 	if u.ControllerAccess == "superuser" {
 		dbUser := u.DBObject(c, db)
 		u := openfga.NewUser(&dbUser, client)
@@ -142,7 +142,7 @@ func (u User) addUserRelations(c *qt.C, jimmTag names.ControllerTag, db db.Datab
 }
 
 // addCloudRelations adds permissions the cloud should have and adds permissions for users to the cloud.
-func (cl Cloud) addCloudRelations(c *qt.C, db db.Database, client *openfga.OFGAClient) {
+func (cl Cloud) addCloudRelations(c *qt.C, db *db.Database, client *openfga.OFGAClient) {
 	for _, u := range cl.Users {
 		dbUser := cl.env.User(u.User).DBObject(c, db)
 		var relation openfga.Relation
@@ -163,7 +163,7 @@ func (cl Cloud) addCloudRelations(c *qt.C, db db.Database, client *openfga.OFGAC
 }
 
 // addModelRelations adds permissions the model should have and adds permissions for users to the model.
-func (m Model) addModelRelations(c *qt.C, db db.Database, client *openfga.OFGAClient) {
+func (m Model) addModelRelations(c *qt.C, db *db.Database, client *openfga.OFGAClient) {
 	owner := openfga.NewUser(&m.dbo.Owner, client)
 	err := owner.SetModelAccess(context.Background(), m.dbo.ResourceTag(), ofganames.AdministratorRelation)
 	c.Assert(err, qt.IsNil)
@@ -207,7 +207,7 @@ func (ctl Controller) addControllerRelations(c *qt.C, client *openfga.OFGAClient
 	c.Assert(err, qt.IsNil)
 }
 
-func (e *Environment) addJIMMRelations(c *qt.C, jimmTag names.ControllerTag, db db.Database, client *openfga.OFGAClient) {
+func (e *Environment) addJIMMRelations(c *qt.C, jimmTag names.ControllerTag, db *db.Database, client *openfga.OFGAClient) {
 	for _, user := range e.Users {
 		user.addUserRelations(c, jimmTag, db, client)
 	}
@@ -226,13 +226,13 @@ func (e *Environment) addJIMMRelations(c *qt.C, jimmTag names.ControllerTag, db 
 	}
 }
 
-func (e *Environment) PopulateDBAndPermissions(c *qt.C, jimmTag names.ControllerTag, db db.Database, client *openfga.OFGAClient) {
+func (e *Environment) PopulateDBAndPermissions(c *qt.C, jimmTag names.ControllerTag, db *db.Database, client *openfga.OFGAClient) {
 	e.PopulateDB(c, db)
 	c.Assert(client, qt.IsNotNil)
 	e.addJIMMRelations(c, jimmTag, db, client)
 }
 
-func (e *Environment) PopulateDB(c Tester, db db.Database) {
+func (e *Environment) PopulateDB(c Tester, db *db.Database) {
 	for i := range e.Users {
 		e.Users[i].env = e
 		e.Users[i].DBObject(c, db)
@@ -279,7 +279,7 @@ type ApplicationOffer struct {
 	dbo dbmodel.ApplicationOffer
 }
 
-func (cd *ApplicationOffer) DBObject(c Tester, db db.Database) dbmodel.ApplicationOffer {
+func (cd *ApplicationOffer) DBObject(c Tester, db *db.Database) dbmodel.ApplicationOffer {
 	if cd.dbo.ID != 0 {
 		return cd.dbo
 	}
@@ -307,7 +307,7 @@ type UserDefaults struct {
 	dbo dbmodel.IdentityModelDefaults
 }
 
-func (cd *UserDefaults) DBObject(c Tester, db db.Database) dbmodel.IdentityModelDefaults {
+func (cd *UserDefaults) DBObject(c Tester, db *db.Database) dbmodel.IdentityModelDefaults {
 	if cd.dbo.ID != 0 {
 		return cd.dbo
 	}
@@ -334,7 +334,7 @@ type CloudDefaults struct {
 	dbo dbmodel.CloudDefaults
 }
 
-func (cd *CloudDefaults) DBObject(c Tester, db db.Database) dbmodel.CloudDefaults {
+func (cd *CloudDefaults) DBObject(c Tester, db *db.Database) dbmodel.CloudDefaults {
 	if cd.dbo.ID != 0 {
 		return cd.dbo
 	}
@@ -372,7 +372,7 @@ type CloudRegion struct {
 
 // DBObject returns a database object for the specified cloud, suitable
 // for adding to the database.
-func (cl *Cloud) DBObject(c Tester, db db.Database) dbmodel.Cloud {
+func (cl *Cloud) DBObject(c Tester, db *db.Database) dbmodel.Cloud {
 	if cl.dbo.ID != 0 {
 		return cl.dbo
 	}
@@ -407,7 +407,7 @@ type CloudCredential struct {
 	dbo dbmodel.CloudCredential
 }
 
-func (cc *CloudCredential) DBObject(c Tester, db db.Database) dbmodel.CloudCredential {
+func (cc *CloudCredential) DBObject(c Tester, db *db.Database) dbmodel.CloudCredential {
 	if cc.dbo.ID != 0 {
 		return cc.dbo
 	}
@@ -443,7 +443,7 @@ type Controller struct {
 	dbo dbmodel.Controller
 }
 
-func (ctl *Controller) DBObject(c Tester, db db.Database) dbmodel.Controller {
+func (ctl *Controller) DBObject(c Tester, db *db.Database) dbmodel.Controller {
 	if ctl.dbo.ID != 0 {
 		return ctl.dbo
 	}
@@ -505,7 +505,7 @@ type Model struct {
 	dbo dbmodel.Model
 }
 
-func (m *Model) DBObject(c Tester, db db.Database) dbmodel.Model {
+func (m *Model) DBObject(c Tester, db *db.Database) dbmodel.Model {
 	if m.dbo.ID != 0 {
 		return m.dbo
 	}
@@ -556,7 +556,7 @@ type User struct {
 	dbo dbmodel.Identity
 }
 
-func (u *User) DBObject(c Tester, db db.Database) dbmodel.Identity {
+func (u *User) DBObject(c Tester, db *db.Database) dbmodel.Identity {
 	if u.dbo.ID != 0 {
 		return u.dbo
 	}

--- a/internal/testutils/jimmtest/fixture.go
+++ b/internal/testutils/jimmtest/fixture.go
@@ -31,7 +31,7 @@ import (
 //
 // TODO(ale8k): Make this an implicit thing on the JIMM suite per test & refactor the current state.
 // and make the suite argument an interface of the required calls we use here.
-func CreateTestControllerEnvironment(ctx context.Context, c *qt.C, db db.Database) (
+func CreateTestControllerEnvironment(ctx context.Context, c *qt.C, db *db.Database) (
 	dbmodel.Identity,
 	dbmodel.GroupEntry,
 	dbmodel.Controller,

--- a/internal/testutils/jimmtest/jimm.go
+++ b/internal/testutils/jimmtest/jimm.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Canonical.
+
+package jimmtest
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/jimm"
+	"github.com/canonical/jimm/v3/internal/jimmjwx"
+	"github.com/canonical/jimm/v3/internal/pubsub"
+)
+
+var now = (time.Time{}).UTC().Round(time.Millisecond)
+
+type Option func(j *jimm.JIMM)
+
+var (
+	UnsetCredentialStore Option = func(j *jimm.JIMM) {
+		j.CredentialStore = nil
+	}
+)
+
+func NewJIMM(t Tester, additionalParameters *jimm.Parameters, options ...Option) *jimm.JIMM {
+
+	auth := NewMockOAuthAuthenticator(t, nil)
+
+	p := jimm.Parameters{
+		UUID:               uuid.NewString(),
+		Dialer:             &Dialer{},
+		Pubsub:             &pubsub.Hub{},
+		JWKService:         &jimmjwx.JWKSService{},
+		JWTService:         &jimmjwx.JWTService{},
+		OAuthAuthenticator: &auth,
+	}
+
+	if additionalParameters != nil {
+		if additionalParameters.UUID != "" {
+			p.UUID = additionalParameters.UUID
+		}
+		if additionalParameters.Dialer != nil {
+			p.Dialer = additionalParameters.Dialer
+		}
+		if additionalParameters.Database != nil {
+			p.Database = additionalParameters.Database
+		}
+		if additionalParameters.CredentialStore != nil {
+			p.CredentialStore = additionalParameters.CredentialStore
+		}
+		if additionalParameters.Pubsub != nil {
+			p.Pubsub = additionalParameters.Pubsub
+		}
+		if len(additionalParameters.ReservedCloudNames) > 0 {
+			p.ReservedCloudNames = append(p.ReservedCloudNames, additionalParameters.ReservedCloudNames...)
+		}
+		if additionalParameters.OpenFGAClient != nil {
+			p.OpenFGAClient = additionalParameters.OpenFGAClient
+		}
+		if additionalParameters.JWKService != nil {
+			p.JWKService = additionalParameters.JWKService
+		}
+		if additionalParameters.JWTService != nil {
+			p.JWTService = additionalParameters.JWTService
+		}
+		if additionalParameters.OAuthAuthenticator != nil {
+			p.OAuthAuthenticator = additionalParameters.OAuthAuthenticator
+		}
+	}
+
+	if p.Database == nil {
+		p.Database = &db.Database{
+			DB: PostgresDB(t, func() time.Time { return now }),
+		}
+	}
+	if p.CredentialStore == nil {
+		p.CredentialStore = p.Database
+	}
+	if p.OpenFGAClient == nil {
+		ofgaClient, _, _, err := SetupTestOFGAClient(t.Name())
+		if err != nil {
+			t.Fatalf("setting up openfga client: %v", err)
+		}
+		p.OpenFGAClient = ofgaClient
+	}
+
+	j, err := jimm.New(p)
+	if err != nil {
+		t.Fatalf("instantiating jimm: %v", err)
+	}
+
+	for _, option := range options {
+		option(j)
+	}
+
+	return j
+}


### PR DESCRIPTION
## Description

Introduces a constructor for jimm in internal/jimm. With the lightest touch possible atm.

drive-by fix: the db.Database type holds a `migrated` (uint32) field. however we were passing the database around by value and every time we copied it, whoever tried to use it would get a `CodeUpgradeInProgress` error. In this PR we pass a pointer to the database around, hopefully avoiding further migration voes.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->