### PR TITLE
fix sdk release

### DIFF
--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -32,11 +32,6 @@ jobs:
         ref: ${{ github.event.inputs.sdk-version }}
         path: ./sdk
 
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: ./project/go.mod
-
     - name: Update SDK
       working-directory: ./sdk
       env:
@@ -45,7 +40,7 @@ jobs:
         SDK_VERSION: ${{ github.event.inputs.sdk-version }}
       run: |
         # Remove all in case some files are removed
-        shopt -s nullglob
+        shopt -s nullglob extglob
         rm -rf .[!.git]* !(go.mod|go.sum)
         cp -r $PROJECT/pkg/.[^.]* $PROJECT/pkg/* .
 


### PR DESCRIPTION
## Description

This workflow https://github.com/canonical/jimm/actions/runs/12049367128 is broken.
After some googling I think it's because the shell don't allow for pattern matching with `(` unless you set the option.

See https://unix.stackexchange.com/questions/504590/what-is-the-meaning-of-the-following-shell-option-shopt-s-nullglob-extglob

> fly-by remove go checkout because i don't see any go commands.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->