### PR TITLE
fix: flaky test in TestProxySocketsAdminFacade

### DIFF
--- a/internal/rpc/apiproxy_test.go
+++ b/internal/rpc/apiproxy_test.go
@@ -70,8 +70,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		expectedClientResponse    *message
 		expectedControllerMessage *message
 		oauthAuthenticatorError   error
-		expectProxyError          bool
-		proxyErrorMessage         string
+		expectedProxyError        string
 	}{{
 		about: "login device call - client gets response with both user code and verification uri",
 		messageToSend: message{
@@ -233,19 +232,21 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		},
 		oauthAuthenticatorError: errors.E(errors.CodeUnauthorized),
 	}, {
-		about:            "connection to controller fails",
-		expectProxyError: true,
+		about: "connection to controller fails",
 		expectedClientResponse: &message{
 			Error: "controller connection error",
 		},
-		proxyErrorMessage: "failed to connect to controller: controller connection error",
+		expectedProxyError: "failed to connect to controller: controller connection error",
 	}}
 
 	for _, test := range tests {
 		t.Run(test.about, func(t *testing.T) {
+			proxyError := test.expectedProxyError != ""
+
 			ctx := context.Background()
 			ctx, cancelFunc := context.WithCancel(ctx)
 			defer cancelFunc()
+
 			clientWebsocket := newMockWebsocketConnection(10)
 			controllerWebsocket := newMockWebsocketConnection(10)
 			loginSvc := &mockLoginService{
@@ -259,7 +260,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 				ConnClient: clientWebsocket,
 				TokenGen:   &mockTokenGenerator{},
 				ConnectController: func(ctx context.Context) (rpc.WebsocketConnectionWithMetadata, error) {
-					if test.expectProxyError {
+					if proxyError {
 						return rpc.WebsocketConnectionWithMetadata{}, goerr.New("controller connection error")
 					}
 					return rpc.WebsocketConnectionWithMetadata{
@@ -277,8 +278,8 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				err = rpc.ProxySockets(ctx, helpers)
-				if test.expectProxyError {
-					c.Assert(err, qt.ErrorMatches, test.proxyErrorMessage)
+				if proxyError {
+					c.Assert(err, qt.ErrorMatches, test.expectedProxyError)
 				} else {
 					c.Assert(err, qt.ErrorMatches, "Context cancelled")
 				}
@@ -302,7 +303,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 					c.Fatal("timed out waiting for response")
 				}
 			}
-			if !test.expectProxyError {
+			if !proxyError {
 				cancelFunc()
 			}
 			wg.Wait()

--- a/internal/rpc/apiproxy_test.go
+++ b/internal/rpc/apiproxy_test.go
@@ -70,7 +70,8 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		expectedClientResponse    *message
 		expectedControllerMessage *message
 		oauthAuthenticatorError   error
-		expectConnectTofail       bool
+		expectProxyError          bool
+		proxyErrorMessage         string
 	}{{
 		about: "login device call - client gets response with both user code and verification uri",
 		messageToSend: message{
@@ -232,11 +233,12 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		},
 		oauthAuthenticatorError: errors.E(errors.CodeUnauthorized),
 	}, {
-		about:               "connection to controller fails",
-		expectConnectTofail: true,
+		about:            "connection to controller fails",
+		expectProxyError: true,
 		expectedClientResponse: &message{
 			Error: "controller connection error",
 		},
+		proxyErrorMessage: "failed to connect to controller: controller connection error",
 	}}
 
 	for _, test := range tests {
@@ -257,7 +259,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 				ConnClient: clientWebsocket,
 				TokenGen:   &mockTokenGenerator{},
 				ConnectController: func(ctx context.Context) (rpc.WebsocketConnectionWithMetadata, error) {
-					if test.expectConnectTofail {
+					if test.expectProxyError {
 						return rpc.WebsocketConnectionWithMetadata{}, goerr.New("controller connection error")
 					}
 					return rpc.WebsocketConnectionWithMetadata{
@@ -275,8 +277,8 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				err = rpc.ProxySockets(ctx, helpers)
-				if test.expectConnectTofail {
-					c.Assert(err, qt.ErrorMatches, "failed to connect to controller: controller connection error")
+				if test.expectProxyError {
+					c.Assert(err, qt.ErrorMatches, test.proxyErrorMessage)
 				} else {
 					c.Assert(err, qt.ErrorMatches, "Context cancelled")
 				}
@@ -300,7 +302,9 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 					c.Fatal("timed out waiting for response")
 				}
 			}
-			cancelFunc()
+			if !test.expectProxyError {
+				cancelFunc()
+			}
 			wg.Wait()
 			t.Logf("completed test %s", t.Name())
 		})


### PR DESCRIPTION
## Description

This PR fixes a flaky test case in `TestProxySocketsAdminFacade`.

The test was incorrectly cancelling the context. When the proxySockets function encounters an error like a failure to connect to a Juju controller it returns with an error. Otherwise it returns a nil error when the context is cancelled. Here we were expecting the former for one of the tests cases but sometimes encountering the latter in a race condition.

The test failed often when running `go test -timeout 30s -run ^TestProxySocketsAdminFacade$ github.com/canonical/jimm/v3/internal/rpc -count=1000`, after the fix I didn't encounter any failures even after increasing count to 10 000.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests