### PR TITLE
fix rock release

### DIFF
--- a/rocks/jimm.yaml
+++ b/rocks/jimm.yaml
@@ -44,4 +44,4 @@ parts:
             mkdir -p $CRAFT_PART_INSTALL/root/openfga/
             # Note that we can't use go run directly (https://github.com/canonical/rockcraft/issues/755)
             go install github.com/openfga/cli/cmd/fga@latest
-            /root/go/bin/fga model transform --file ./openfga/authorisation_model.fga --output-format json > $CRAFT_PART_INSTALL/root/openfga/authorisation_model.json
+            $GOBIN/fga model transform --file ./openfga/authorisation_model.fga --output-format json > $CRAFT_PART_INSTALL/root/openfga/authorisation_model.json


### PR DESCRIPTION
## Description

Rock release is broken because `fga` binary cannot be found.
https://github.com/canonical/jimm/actions/runs/12122372895/job/33795406016

This is a fix for it.

Fixes _JIRA/GitHub issue number_

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->