### PR TITLE
chore: update jimmctl command info

### DIFF
--- a/cmd/jimmctl/cmd/addcloudtocontroller.go
+++ b/cmd/jimmctl/cmd/addcloudtocontroller.go
@@ -25,18 +25,18 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	addCloudToControllerCommandDoc = `
-	add-cloud-to-controller command adds the specified cloud to a specific 
-	controller on jimm.
+The add-cloud-to-controller command adds the specified cloud to a specific 
+controller on jimm.
 
-	One can specify a cloud definition via a yaml file passed with the --cloud 
-	flag. If the flag is missing, the command will assume the cloud definition
-	is already known and will error otherwise.
-
-	Example:
-		jimmctl add-cloud-to-controller <controller_name> <cloud_name>
-		jimmctl add-cloud-to-controller <controller_name> <cloud_name> --cloud=<cloud_file_path> 
+One can specify a cloud definition via a yaml file passed with the --cloud 
+flag. If the flag is missing, the command will assume the cloud definition
+is already known and will error otherwise.
+`
+	addCloudToControllerExample = `
+    jimmctl add-cloud-to-controller mycontroller mycloud
+    jimmctl add-cloud-to-controller mycontroller mycloud --cloud=./cloud-definition.yaml
 `
 )
 
@@ -78,9 +78,11 @@ type addCloudToControllerCommand struct {
 // Info implements Command.Info.
 func (c *addCloudToControllerCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add-cloud-to-controller",
-		Purpose: "Add cloud to specific controller in jimm",
-		Doc:     addCloudToControllerCommandDoc,
+		Name:     "add-cloud-to-controller",
+		Args:     "<controller_name> <cloud_name>",
+		Purpose:  "Add cloud to specific controller in jimm",
+		Doc:      addCloudToControllerCommandDoc,
+		Examples: addCloudToControllerExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/addcontroller.go
+++ b/cmd/jimmctl/cmd/addcontroller.go
@@ -21,11 +21,11 @@ var (
 	stdinMarkers = []string{"-"}
 
 	addControllerCommandDoc = `
-	add-controller command adds a controller to jimm.
-
-	Example:
-		jimmctl add-controller <filename> 
-		jimmctl add-controller <filename> --format json
+The add-controller command adds a controller to jimm.
+`
+	addControllerCommandExample = `
+    jimmctl add-controller ./controller-info 
+    jimmctl add-controller ./controller-info.yaml --format json
 `
 )
 
@@ -50,9 +50,11 @@ type addControllerCommand struct {
 
 func (c *addControllerCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add-controller",
-		Purpose: "Add controller to jimm",
-		Doc:     addControllerCommandDoc,
+		Name:     "add-controller",
+		Purpose:  "Add controller to jimm",
+		Args:     "<filepath>",
+		Doc:      addControllerCommandDoc,
+		Examples: addControllerCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/auth.go
+++ b/cmd/jimmctl/cmd/auth.go
@@ -6,15 +6,16 @@ import (
 	jujucmd "github.com/juju/cmd/v3"
 )
 
-var authDoc = `
-auth enables users to manage authorisation model used by JIMM.
+const authDoc = `
+The auth command enables users to manage authorisation model used by JIMM.
 `
 
 func NewAuthCommand() *jujucmd.SuperCommand {
 	cmd := jujucmd.NewSuperCommand(jujucmd.SuperCommandParams{
-		Name:    "auth",
-		Doc:     authDoc,
-		Purpose: "Authorisation model management.",
+		Name:        "auth",
+		UsagePrefix: "jimmctl",
+		Doc:         authDoc,
+		Purpose:     "Authorisation model management.",
 	})
 	cmd.Register(NewGroupCommand())
 	cmd.Register(NewRelationCommand())

--- a/cmd/jimmctl/cmd/auth.go
+++ b/cmd/jimmctl/cmd/auth.go
@@ -7,7 +7,7 @@ import (
 )
 
 const authDoc = `
-The auth command enables users to manage authorisation model used by JIMM.
+The auth command enables user access management.
 `
 
 func NewAuthCommand() *jujucmd.SuperCommand {

--- a/cmd/jimmctl/cmd/controllerinfo.go
+++ b/cmd/jimmctl/cmd/controllerinfo.go
@@ -16,22 +16,20 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	controllerInfoCommandDoc = `
-	controller-info command writes controller information contained
-	in the juju client store to a yaml file.
+The controller-info command writes controller information contained
+in the juju client store to a yaml file.
 
-	If a public address is specified, the output controller information
-	will contain the public address provided and omit a CA cert, this assumes
-	that the server is secured with a public certificate.
-	
-	Use the --local flag if the server is not configured with a public cert.
+If a public address is specified, the output controller information
+will contain the public address provided and omit a CA cert, this assumes
+that the server is secured with a public certificate.
 
-	See examples below for usage.
-
-	Examples:
-		jimmctl controller-info <name> <filename> <public address> 
-		jimmctl controller-info <name> <filename> --local
+Use the --local flag if the server is not configured with a public address.
+`
+	controllerInfoCommandExample = `
+    jimmctl controller-info mycontroller ./destination/file.yaml mycontroller.example.com 
+    jimmctl controller-info mycontroller ./destination/file.yaml --local
 `
 )
 
@@ -60,9 +58,11 @@ type controllerInfoCommand struct {
 
 func (c *controllerInfoCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "controller-info",
-		Purpose: "Stores controller info to a yaml file",
-		Doc:     controllerInfoCommandDoc,
+		Name:     "controller-info",
+		Args:     "<name> <filepath> [<public address>]",
+		Purpose:  "Stores controller info to a yaml file",
+		Doc:      controllerInfoCommandDoc,
+		Examples: controllerInfoCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/controllerinfo.go
+++ b/cmd/jimmctl/cmd/controllerinfo.go
@@ -70,7 +70,7 @@ func (c *controllerInfoCommand) Info() *cmd.Info {
 func (c *controllerInfoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
 	f.BoolVar(&c.local, "local", false, "If local flag is specified, then the local API address and CA cert of the controller will be used.")
-	f.StringVar(&c.tlsHostname, "tls-hostname", "", "Specify the hostname for TLS verfiication.")
+	f.StringVar(&c.tlsHostname, "tls-hostname", "", "Specify the hostname for TLS verification.")
 }
 
 // Init implements the cmd.Command interface.

--- a/cmd/jimmctl/cmd/crossmodelquery.go
+++ b/cmd/jimmctl/cmd/crossmodelquery.go
@@ -15,20 +15,20 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	// stdinMarkers contains file names that are taken to be stdin.
 	crossModelQueryDoc = `
-query-models command queries all models available to the current user
+The query-models command queries all models available to the current user
 performing the query against each model status individually, returning
 the collated query responses for each model.
 
-The query will run against the exact output of "juju status --format json",
+The query runs against the output of "juju status --format json",
 as such you can format your query against an output like this.
 
-The queries will expect a JQ query string.
-
-Example:
-	jimmctl query-models '.applications | with_entries(select(.key=="nginx-ingress-integrator"))'
+The queries expect a JQ query string.
+`
+	crossModelQueryExample = `
+    jimmctl query-models '.applications | with_entries(select(.key=="nginx-ingress-integrator"))'
 `
 )
 
@@ -80,9 +80,11 @@ func (c *crossModelQueryCommand) SetFlags(f *gnuflag.FlagSet) {
 // Info implements modelcmd.Command.
 func (c *crossModelQueryCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "query-models",
-		Purpose: "Query model statuses",
-		Doc:     crossModelQueryDoc,
+		Name:     "query-models",
+		Args:     "<query>",
+		Purpose:  "Query model statuses",
+		Doc:      crossModelQueryDoc,
+		Examples: crossModelQueryExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/grantauditlogaccess.go
+++ b/cmd/jimmctl/cmd/grantauditlogaccess.go
@@ -16,12 +16,15 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var grantAuditLogAccessDoc = `
-	grant-audit-log-access grants user access to audit logs.
-
-	Example:
-		jimmctl grant-audit-log-access <username> 
+const (
+	grantAuditLogAccessDoc = `
+Grants a user access to read audit logs.
 `
+
+	grantAuditLogAccessExamples = `
+    jimmctl grant-audit-log-access <username> 
+`
+)
 
 // NewGrantAuditLogAccessCommand returns a command used to grant
 // users access to audit logs.
@@ -45,9 +48,11 @@ type grantAuditLogAccessCommand struct {
 
 func (c *grantAuditLogAccessCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "grant-audit-log-access",
-		Purpose: "Grants access to audit logs.",
-		Doc:     grantAuditLogAccessDoc,
+		Name:     "grant-audit-log-access",
+		Args:     "<username>",
+		Purpose:  "Grants access to audit logs.",
+		Doc:      grantAuditLogAccessDoc,
+		Examples: grantAuditLogAccessExamples,
 	})
 }
 

--- a/cmd/jimmctl/cmd/group.go
+++ b/cmd/jimmctl/cmd/group.go
@@ -20,47 +20,46 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	groupDoc = `
-group command enables group management for jimm
+The group command enables group management for jimm
 `
 
 	addGroupDoc = `
-add command adds group to jimm.
-
-Example:
-	jimmctl auth group add <name> 
+The add command adds group to jimm.
+`
+	addGroupExample = `
+    jimmctl auth group add mygroup
 `
 	renameGroupDoc = `
-rename command renames a group in jimm.
-
-Example:
-	jimmctl auth group rename <name> <new name>
+The rename command renames a group in jimm.
+`
+	renameGroupExample = `
+    jimmctl auth group rename mygroup newgroup
 `
 	removeGroupDoc = `
-rename command removes a group in jimm.
+The remove command removes a group in jimm.
+`
 
-Usage:
--y	Remove group without promping for confirmation
-
-Example:
-	jimmctl auth group remove <name>
+	removeGroupExample = `
+    jimmctl auth group remove mygroup
 `
 
 	listGroupsDoc = `
-list command lists all groups in jimm.
-
-Example:
-	jimmctl auth group list
+The list command lists all groups in jimm.
+`
+	listGroupsExample = `
+    jimmctl auth group list
 `
 )
 
 // NewGroupCommand returns a command for group management.
 func NewGroupCommand() *jujucmdv3.SuperCommand {
 	cmd := jujucmd.NewSuperCommand(jujucmdv3.SuperCommandParams{
-		Name:    "group",
-		Doc:     groupDoc,
-		Purpose: "Group management.",
+		Name:        "group",
+		UsagePrefix: "auth",
+		Doc:         groupDoc,
+		Purpose:     "Group management.",
 	})
 	cmd.Register(newAddGroupCommand())
 	cmd.Register(newRenameGroupCommand())
@@ -93,9 +92,11 @@ type addGroupCommand struct {
 // Info implements the cmd.Command interface.
 func (c *addGroupCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add",
-		Purpose: "Add group to jimm.",
-		Doc:     addGroupDoc,
+		Name:     "add",
+		Args:     "<name>",
+		Purpose:  "Add group to jimm.",
+		Doc:      addGroupDoc,
+		Examples: addGroupExample,
 	})
 }
 
@@ -170,9 +171,11 @@ type renameGroupCommand struct {
 // Info implements the cmd.Command interface.
 func (c *renameGroupCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "rename",
-		Purpose: "Rename a group.",
-		Doc:     renameGroupDoc,
+		Name:     "rename",
+		Args:     "<name> <new name>",
+		Purpose:  "Rename a group.",
+		Doc:      renameGroupDoc,
+		Examples: renameGroupExample,
 	})
 }
 
@@ -238,9 +241,11 @@ type removeGroupCommand struct {
 // Info implements the cmd.Command interface.
 func (c *removeGroupCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove",
-		Purpose: "Remove a group.",
-		Doc:     removeGroupDoc,
+		Name:     "remove",
+		Args:     "<name>",
+		Purpose:  "Remove a group.",
+		Doc:      removeGroupDoc,
+		Examples: removeGroupExample,
 	})
 }
 
@@ -331,9 +336,10 @@ type listGroupsCommand struct {
 // Info implements the cmd.Command interface.
 func (c *listGroupsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "list",
-		Purpose: "List all groups.",
-		Doc:     listGroupsDoc,
+		Name:     "list",
+		Purpose:  "List all groups.",
+		Doc:      listGroupsDoc,
+		Examples: listGroupsExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/importcloudcredentials.go
+++ b/cmd/jimmctl/cmd/importcloudcredentials.go
@@ -17,24 +17,27 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
-//nolint:gosec // Thinks a credential is exposed.
-const importCloudCredentialsDoc = `
-	import-cloud-credentials imports a set of cloud credentials
-	loaded from a file containing a series of JSON objects. The JSON
-	objects specifying the credentials should be of the form:
+const (
+	//nolint:gosec // Thinks a credential is exposed.
+	importCloudCredentialsDoc = `
+The import-cloud-credentials imports a set of cloud credentials
+loaded from a file containing a series of JSON objects. The JSON
+objects specifying the credentials should be of the form:
 
-	{
-		"_id": <cloud-credential-id>,
-		"type": <credential-type>,
-		"attributes": {
-			<key1>: <value1>,
-			...
-		}
+{
+	"_id": <cloud-credential-id>,
+	"type": <credential-type>,
+	"attributes": {
+		<key1>: <value1>,
+		...
 	}
-
-	Example:
-		jimmctl import-cloud-credentials creds.json
+}
 `
+	//nolint:gosec // Thinks a credential is exposed.
+	importCloudCredentialsExample = `
+    jimmctl import-cloud-credentials ./path/creds.json
+`
+)
 
 // NewImportCloudCredentialsCommand returns a command to import cloud
 // credentials.
@@ -58,10 +61,11 @@ type importCloudCredentialsCommand struct {
 // Info implements cmd.Command interface.
 func (c *importCloudCredentialsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "import-cloud-credentials",
-		Args:    "<credentials file>",
-		Purpose: "Import cloud credentials to jimm",
-		Doc:     importCloudCredentialsDoc,
+		Name:     "import-cloud-credentials",
+		Args:     "<filepath>",
+		Purpose:  "Import cloud credentials to jimm",
+		Doc:      importCloudCredentialsDoc,
+		Examples: importCloudCredentialsExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/importmodel.go
+++ b/cmd/jimmctl/cmd/importmodel.go
@@ -16,20 +16,21 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-const importModelCommandDoc = `
-	import-model imports a model running on a controller to jimm.
+const (
+	importModelCommandDoc = `
+The import-model imports a model running on a controller to jimm.
 
-	When importing, it is necessary for JIMM to contain a set of cloud credentials
-	that represent a user's access to the incoming model's cloud. 
+When importing, it is necessary for JIMM to contain a set of cloud credentials
+that represent a user's access to the incoming model's cloud. 
 
-	The --owner command is necessary when importing a model created by a 
-	local user and it will switch the model owner to the desired external user.
-	E.g. --owner my-user@canonical.com
-
-	Example:
-		jimmctl import-model <controller name> <model-uuid>
-		jimmctl import-model <controller name> <model-uuid> --owner <username>
+The --owner command is necessary when importing a model created by a 
+local user and it will switch the model owner to the desired external user.
 `
+	importModelCommandExample = `
+    jimmctl import-model mycontroller ac30d6ae-0bed-4398-bba7-75d49e39f189
+    jimmctl import-model mycontroller ac30d6ae-0bed-4398-bba7-75d49e39f189 --owner user@canonical.com
+`
+)
 
 // NewImportModelCommand returns a command to import a model.
 func NewImportModelCommand() cmd.Command {
@@ -52,15 +53,17 @@ type importModelCommand struct {
 // Info implements the cmd.Command interface.
 func (c *importModelCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "import-model",
-		Args:    "<controller name> <model uuid>",
-		Purpose: "Import a model to jimm",
-		Doc:     importModelCommandDoc,
+		Name:     "import-model",
+		Args:     "<controller name> <model uuid>",
+		Purpose:  "Import a model to jimm",
+		Doc:      importModelCommandDoc,
+		Examples: importModelCommandExample,
 	})
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *importModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
 	f.StringVar(&c.req.Owner, "owner", "", "switch the model owner to the desired user")
 }
 

--- a/cmd/jimmctl/cmd/listauditevents.go
+++ b/cmd/jimmctl/cmd/listauditevents.go
@@ -20,13 +20,16 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var listAuditEventsCommandDoc = `
-	list-audit-events command displays matching audit events.
-
-	Example:
-		jimmctl list-audit-events --after <time> --before <time> --user-tag <user-tag> --limit <limit>
-		jimmctl audit-events --after <time> --format yaml
+const (
+	listAuditEventsCommandDoc = `
+The list-audit-events command displays matching audit events.
 `
+	listAuditEventsCommandExample = `
+    jimmctl list-audit-events --after 2020-01-01T15:00:00 --before 2020-01-01T15:00:00 --user-tag user@canonical.com --limit 50
+	jimmctl list-audit-events --method CreateModel
+    jimmctl audit-events --after 2020-01-01T15:00:00 --format yaml
+`
+)
 
 // NewListAuditEventsCommand returns a command to list audit events matching
 // specified criteria.
@@ -51,10 +54,11 @@ type listAuditEventsCommand struct {
 
 func (c *listAuditEventsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "list-audit-events",
-		Purpose: "Displays audit events",
-		Doc:     listAuditEventsCommandDoc,
-		Aliases: []string{"audit-events"},
+		Name:     "list-audit-events",
+		Purpose:  "Displays audit events",
+		Doc:      listAuditEventsCommandDoc,
+		Examples: listAuditEventsCommandExample,
+		Aliases:  []string{"audit-events"},
 	})
 }
 
@@ -66,8 +70,8 @@ func (c *listAuditEventsCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json":    cmd.FormatJson,
 		"tabular": formatTabular,
 	})
-	f.StringVar(&c.args.After, "after", "", "display events that happened after specified time")
-	f.StringVar(&c.args.Before, "before", "", "display events that happened before specified time")
+	f.StringVar(&c.args.After, "after", "", "display events that happened after a specified time, formatted as RFC3339")
+	f.StringVar(&c.args.Before, "before", "", "display events that happened before specified time, formatted as RFC3339")
 	f.StringVar(&c.args.UserTag, "user-tag", "", "display events performed by authenticated user")
 	f.StringVar(&c.args.Method, "method", "", "display events for a specific method call")
 	f.StringVar(&c.args.Model, "model", "", "display events for a specific model (model name is controller/model)")

--- a/cmd/jimmctl/cmd/listcontrollers.go
+++ b/cmd/jimmctl/cmd/listcontrollers.go
@@ -14,14 +14,16 @@ import (
 	"github.com/canonical/jimm/v3/pkg/api"
 )
 
-var listControllersComandDoc = `
-	list-controllers command displays controller information
-	for all controllers known to JIMM.
-
-	Example:
-		jimmctl controllers 
-		jimmctl controllers --format json --output ~/tmp/controllers.json
+const (
+	listControllersCommandDoc = `
+The list-controllers command displays controller information
+for all controllers known to JIMM.
 `
+	listControllersCommandExample = `
+    jimmctl controllers 
+    jimmctl controllers --format json
+`
+)
 
 // NewListControllersCommand returns a command to list controller information.
 func NewListControllersCommand() cmd.Command {
@@ -44,10 +46,11 @@ type listControllersCommand struct {
 
 func (c *listControllersCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "controllers",
-		Purpose: "Lists all controllers known to JIMM.",
-		Doc:     listControllersComandDoc,
-		Aliases: []string{"list-controllers"},
+		Name:     "controllers",
+		Purpose:  "Lists all controllers known to JIMM.",
+		Doc:      listControllersCommandDoc,
+		Examples: listControllersCommandExample,
+		Aliases:  []string{"list-controllers"},
 	})
 }
 

--- a/cmd/jimmctl/cmd/migratemodel.go
+++ b/cmd/jimmctl/cmd/migratemodel.go
@@ -18,17 +18,19 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var migrateModelCommandDoc = `
-	The migrate command migrates a model(s) to a new controller. Specify
-	a model-uuid to migrate and the destination controller name.
+const (
+	migrateModelCommandDoc = `
+The migrate command migrates a model(s) to a new controller. Specify
+a model-uuid to migrate and the destination controller name.
 
-	Note that multiple models can be targeted for migration by supplying
-	multiple model uuids.
-
-	Example:
-		jimmctl migrate <controller-name> <model-uuid> 
-		jimmctl migrate <controller-name> <model-uuid> <model-uuid> <model-uuid>
+Note that multiple models can be targeted for migration by supplying
+multiple model uuids.
 `
+	migrateModelCommandExample = `
+    jimmctl migrate mycontroller 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    jimmctl migrate mycontroller 2cb433a6-04eb-4ec4-9567-90426d20a004 fd469983-27c2-423b-bebf-84f616fb036b ...
+`
+)
 
 // NewMigrateModelCommand returns a command to migrate models.
 func NewMigrateModelCommand() cmd.Command {
@@ -52,9 +54,11 @@ type migrateModelCommand struct {
 
 func (c *migrateModelCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "migrate",
-		Purpose: "Migrate models to the target controller",
-		Doc:     migrateModelCommandDoc,
+		Name:     "migrate",
+		Args:     "<controller name> <model uuid> [<model uuid>...]",
+		Purpose:  "Migrate models to the target controller",
+		Doc:      migrateModelCommandDoc,
+		Examples: migrateModelCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/modelstatus.go
+++ b/cmd/jimmctl/cmd/modelstatus.go
@@ -16,13 +16,15 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var modelStatusCommandDoc = `
-	model-status command displays full model status.
-
-	Example:
-		jimmctl model-status <model uuid> 
-		jimmctl model-status <model uuid> --format yaml
+const (
+	modelStatusCommandDoc = `
+The model-status command displays full model status.
 `
+	modelStatusCommandExample = `
+    jimmctl model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    jimmctl model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 --format yaml
+`
+)
 
 // NewModelStatusCommand returns a command to display full model status.
 func NewModelStatusCommand() cmd.Command {
@@ -46,9 +48,11 @@ type modelStatusCommand struct {
 
 func (c *modelStatusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "model-status",
-		Purpose: "Displays full model status",
-		Doc:     modelStatusCommandDoc,
+		Name:     "model-status",
+		Args:     "<model uuid>",
+		Purpose:  "Displays full model status",
+		Doc:      modelStatusCommandDoc,
+		Examples: modelStatusCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/purge_logs.go
+++ b/cmd/jimmctl/cmd/purge_logs.go
@@ -16,14 +16,18 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-const purgeLogsDoc = `
-	purge-audit-logs purges logs from the database before the given date.
+const (
+	purgeLogsDoc = `
+The purge-audit-logs purges logs from the database before the given date.
 
-	Examples:
-		jimmctl purge-audit-logs 2021-02-03
-		jimmctl purge-audit-logs 2021-02-03T00
-		jimmctl purge-audit-logs 2021-02-03T15:04:05Z	
+The provided date must be formatted as an ISO8601 date string.
 `
+	purgeLogsExample = `
+    jimmctl purge-audit-logs 2021-02-03
+    jimmctl purge-audit-logs 2021-02-03T00
+    jimmctl purge-audit-logs 2021-02-03T15:04:05Z	
+`
+)
 
 // NewPurgeLogsCommand returns a command to purge logs.
 func NewPurgeLogsCommand() cmd.Command {
@@ -46,10 +50,11 @@ type purgeLogsCommand struct {
 // Info implements Command.Info. It returns the command information.
 func (c *purgeLogsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "purge-audit-logs",
-		Args:    "<ISO8601 date>",
-		Purpose: "purges audit logs from the database before the given date",
-		Doc:     purgeLogsDoc,
+		Name:     "purge-audit-logs",
+		Args:     "<date>",
+		Purpose:  "purge audit logs from the database before the given date",
+		Doc:      purgeLogsDoc,
+		Examples: purgeLogsExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/relation.go
+++ b/cmd/jimmctl/cmd/relation.go
@@ -30,7 +30,7 @@ const (
 	defaultPageSize     = 50
 )
 
-var (
+const (
 	relationDoc = `
 relation command enables relation management for jimm
 `
@@ -90,65 +90,59 @@ This will grant/revoke the relation to all users within TeamA:
 `
 
 	addRelationDoc = `
-add command adds relation to jimm.
+The add command adds relation to jimm.
+` + genericConstraintsDoc
 
-Example:
-	jimmctl auth relation add <object> <relation> <target_object>
-	jimmctl auth relation add -f <filename>
-` + genericConstraintsDoc +
-		`
-Examples:
-jimmctl auth relation add user-Alice member group-MyGroup
-jimmctl auth relation add group-MyTeam#member loginer controller-MyController
+	addRelationExample = `
+    jimmctl auth relation add user-alice@canonical.com member group-mygroup
+    jimmctl auth relation add group-MyTeam#member admin model-mymodel
+	jimmctl auth relation add -f /path/to/file.yaml
 `
 
 	removeRelationDoc = `
-remove command removes a relation from jimm.
+The remove command removes a relation from jimm.
+` + genericConstraintsDoc
 
-Example:
-	jimmctl auth relation remove <object> <relation> <target_object>
-	jimmctl auth relation remove -f <filename>
-	` + genericConstraintsDoc +
-		`
-Examples:
-jimmctl auth relation remove user-Alice member group-MyGroup
-jimmctl auth relation remove group-MyTeam#member loginer controller-MyController`
+	removeRelationExample = `
+    jimmctl auth relation remove user-alice@canonical.com member group-mygroup
+    jimmctl auth relation remove group-MyTeam#member admin model-mymodel
+	jimmctl auth relation remove -f /path/to/file.yaml
+`
 
 	checkRelationDoc = `
 Verifies the access between resources.
-
-Example:
-jimmctl auth relation check user-alice@canonical.com administrator controller-aws-controller-1
-
-Example:
-	jimmctl auth relation check <object> <relation> <target_object>
-	jimmctl auth relation check -f <filename>
-	`
+`
+	checkRelationExample = `
+    jimmctl auth relation check user-alice@canonical.com administrator controller-aws-controller-1
+`
 
 	listRelationsDoc = `
-list relations known to jimm. Using the "target", "relation"
-and "object" flags, only those relations matching the filter
-will be returned.
-Examples:
-	jimmctl auth relation list
-	returns the list of all relations
+List relations known to jimm. Using the "target", "relation" and "object" flags, 
+only those relations matching the filter will be returned.
+`
 
-	jimmctl auth relation list --target <target_object>
-	returns the list of relations, where target object
-	matches the specified one
+	listRelationsExample = `
+List all relations
 
-	jimmctl auth relation list --target <target_object>  --relation <relation>
-	returns the list of relations, where target object
-	and relation match the specified ones
+    jimmctl auth relation list
+	
+List relations where the target object match
+
+    jimmctl auth relation list --target model-mymodel
+
+List relations where the target object and relation match
+
+	jimmctl auth relation list --target model-mymodel  --relation admin
 `
 )
 
 // NewRelationCommand returns a command for relation management.
 func NewRelationCommand() *cmd.SuperCommand {
 	cmd := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
-		Name:    "relation",
-		Doc:     relationDoc,
-		Purpose: "Relation management.",
+		Name:        "relation",
+		UsagePrefix: "auth",
+		Doc:         relationDoc,
+		Purpose:     "Relation management.",
 	})
 	cmd.Register(newAddRelationCommand())
 	cmd.Register(newRemoveRelationCommand())
@@ -185,9 +179,11 @@ type addRelationCommand struct {
 // Info implements the cmd.Command interface.
 func (c *addRelationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add",
-		Purpose: "Add relation to jimm.",
-		Doc:     addRelationDoc,
+		Name:     "add",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Add relation to jimm.",
+		Doc:      addRelationDoc,
+		Examples: addRelationExample,
 	})
 }
 
@@ -276,9 +272,11 @@ type removeRelationCommand struct {
 // Info implements the cmd.Command interface.
 func (c *removeRelationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove",
-		Purpose: "Remove relation from jimm.",
-		Doc:     removeRelationDoc,
+		Name:     "remove",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Remove relation from jimm.",
+		Doc:      removeRelationDoc,
+		Examples: removeRelationExample,
 	})
 }
 
@@ -380,9 +378,11 @@ func newCheckRelationCommand() cmd.Command {
 // Info implements the cmd.Command interface.
 func (c *checkRelationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "check",
-		Purpose: "Check access to a resource.",
-		Doc:     checkRelationDoc,
+		Name:     "check",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Check access to a resource.",
+		Doc:      checkRelationDoc,
+		Examples: checkRelationExample,
 	})
 }
 
@@ -507,9 +507,10 @@ type listRelationsCommand struct {
 // Info implements the cmd.Command interface.
 func (c *listRelationsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "list",
-		Purpose: "List relations.",
-		Doc:     listRelationsDoc,
+		Name:     "list",
+		Purpose:  "List relations.",
+		Doc:      listRelationsDoc,
+		Examples: listRelationsExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/removecloudfromcontroller.go
+++ b/cmd/jimmctl/cmd/removecloudfromcontroller.go
@@ -18,13 +18,14 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	removeCloudFromControllerCommandDoc = `
-	remove-cloud-from-controller command removes the specified cloud from the 
-	specified controller in jimm.
+The remove-cloud-from-controller command removes the specified cloud from the 
+specified controller in jimm.
+`
 
-	Example:
-		jimmctl remove-cloud-from-controller <controller_name> <cloud_name> 
+	removeCloudFromControllerCommandExample = `
+    jimmctl remove-cloud-from-controller mycontroller mycloud
 `
 )
 
@@ -63,9 +64,11 @@ type removeCloudFromControllerAPI interface {
 // Info implements Command.Info.
 func (c *removeCloudFromControllerCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove-cloud-from-controller",
-		Purpose: "Remove cloud from specific controller in jimm",
-		Doc:     removeCloudFromControllerCommandDoc,
+		Name:     "remove-cloud-from-controller",
+		Args:     "<controller_name> <cloud_name>",
+		Purpose:  "Remove cloud from specific controller in jimm",
+		Doc:      removeCloudFromControllerCommandDoc,
+		Examples: removeCloudFromControllerCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/removecontroller.go
+++ b/cmd/jimmctl/cmd/removecontroller.go
@@ -15,13 +15,14 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	removeControllerCommandDoc = `
-	remove-controller command removes a controller from jimm.
+The remove-controller command removes a controller from jimm.
+`
 
-	Example:
-		jimmctl remove-controller <name> 
-		jimmctl remove-controller <name> --force
+	removeControllerCommandExample = `
+    jimmctl remove-controller mycontroller 
+    jimmctl remove-controller mycontroller --force
 `
 )
 
@@ -46,9 +47,11 @@ type removeControllerCommand struct {
 
 func (c *removeControllerCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove-controller",
-		Purpose: "Remove controller from jimm",
-		Doc:     removeControllerCommandDoc,
+		Name:     "remove-controller",
+		Args:     "<name>",
+		Purpose:  "Remove controller from jimm",
+		Doc:      removeControllerCommandDoc,
+		Examples: removeControllerCommandExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/revokeauditlogaccess.go
+++ b/cmd/jimmctl/cmd/revokeauditlogaccess.go
@@ -16,12 +16,14 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var revokeAuditLogAccessDoc = `
-	revoke-audit-log-access revokes user access to audit logs.
-
-	Example:
-		jimmctl revoke-audit-log-access <username> 
+const (
+	revokeAuditLogAccessDoc = `
+The revoke-audit-log-access revokes user access to audit logs.
 `
+	revokeAuditLogAccessExample = `
+    jimmctl revoke-audit-log-access user@canonical.com
+`
+)
 
 // NewrevokeAuditLogAccess returns a command used to revoke
 // users access to audit logs.
@@ -45,9 +47,11 @@ type revokeAuditLogAccessCommand struct {
 
 func (c *revokeAuditLogAccessCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "revoke-audit-log-access",
-		Purpose: "revokes access to audit logs.",
-		Doc:     revokeAuditLogAccessDoc,
+		Name:     "revoke-audit-log-access",
+		Args:     "<user>",
+		Purpose:  "revokes access to audit logs.",
+		Doc:      revokeAuditLogAccessDoc,
+		Examples: revokeAuditLogAccessExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/role.go
+++ b/cmd/jimmctl/cmd/role.go
@@ -20,38 +20,39 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var (
+const (
 	roleDoc = `
-role command enables role management for jimm
+The role command enables role management for jimm
 `
 
 	addRoleDoc = `
-add command adds role to jimm.
-
-Example:
-	jimmctl auth role add <name> 
+The add command adds role to jimm.
 `
+
+	addRoleExample = `
+    jimmctl auth role add myrole 
+`
+
 	renameRoleDoc = `
-rename command renames a role in jimm.
-
-Example:
-	jimmctl auth role rename <name> <new name>
+The rename command renames a role in jimm.
 `
+	renameRoleExample = `
+    jimmctl auth role rename myrole newrolename
+`
+
 	removeRoleDoc = `
-rename command removes a role in jimm.
+The remove command removes a role in jimm.
+`
 
-Usage:
--y	Remove role without promping for confirmation
-
-Example:
-	jimmctl auth role remove <name>
+	removeRoleExample = `
+    jimmctl auth role remove myrole
 `
 
 	listRolesDoc = `
-list command lists all roles in jimm.
-
-Example:
-	jimmctl auth role list
+The list command lists all roles in jimm.
+`
+	listRolesExample = `
+    jimmctl auth role list
 `
 )
 
@@ -93,9 +94,11 @@ type addRoleCommand struct {
 // Info implements the cmd.Command interface.
 func (c *addRoleCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add",
-		Purpose: "Add role to jimm.",
-		Doc:     addRoleDoc,
+		Name:     "add",
+		Args:     "<role name>",
+		Purpose:  "Add role to jimm.",
+		Doc:      addRoleDoc,
+		Examples: addRoleExample,
 	})
 }
 
@@ -170,9 +173,11 @@ type renameRoleCommand struct {
 // Info implements the cmd.Command interface.
 func (c *renameRoleCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "rename",
-		Purpose: "Rename a role.",
-		Doc:     renameRoleDoc,
+		Name:     "rename",
+		Args:     "<role name> <new role name>",
+		Purpose:  "Rename a role.",
+		Doc:      renameRoleDoc,
+		Examples: renameRoleExample,
 	})
 }
 
@@ -238,9 +243,11 @@ type removeRoleCommand struct {
 // Info implements the cmd.Command interface.
 func (c *removeRoleCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "remove",
-		Purpose: "Remove a role.",
-		Doc:     removeRoleDoc,
+		Name:     "remove",
+		Args:     "<role name>",
+		Purpose:  "Remove a role.",
+		Doc:      removeRoleDoc,
+		Examples: removeRoleExample,
 	})
 }
 
@@ -331,9 +338,10 @@ type listRolesCommand struct {
 // Info implements the cmd.Command interface.
 func (c *listRolesCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "list",
-		Purpose: "List all roles.",
-		Doc:     listRolesDoc,
+		Name:     "list",
+		Purpose:  "List all roles.",
+		Doc:      listRolesDoc,
+		Examples: listRolesExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/setcontrollerdeprecated.go
+++ b/cmd/jimmctl/cmd/setcontrollerdeprecated.go
@@ -15,12 +15,14 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-var setControllerDeprecatedDoc = `
-	set-controller-deprecated sets the deprecated status of a controller.
-
-	Example:
-		jimmctl set-controller-deprecated <name> --false 
+const (
+	setControllerDeprecatedDoc = `
+The set-controller-deprecated sets the deprecated status of a controller.
 `
+	setControllerDeprecatedExample = `
+    jimmctl set-controller-deprecated mycontroller
+`
+)
 
 // NewSetControllerDeprecatedCommand returns a command used to grant
 // users access to audit logs.
@@ -46,9 +48,11 @@ type setControllerDeprecatedCommand struct {
 
 func (c *setControllerDeprecatedCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "set-controller-deprecated",
-		Purpose: "Sets controller deprecated status.",
-		Doc:     setControllerDeprecatedDoc,
+		Name:     "set-controller-deprecated",
+		Args:     "<controller name>",
+		Purpose:  "Sets controller deprecated status.",
+		Doc:      setControllerDeprecatedDoc,
+		Examples: setControllerDeprecatedExample,
 	})
 }
 

--- a/cmd/jimmctl/cmd/updatemigratedmodel.go
+++ b/cmd/jimmctl/cmd/updatemigratedmodel.go
@@ -15,13 +15,15 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-const updateMigratedModelCommandDoc = `
-	update-migrated-model updates a model known to JIMM that has
-	been migrated externally to a different JAAS controller.
-
-	Example:
-		jimmctl update-migrated-model <controller name> <model-uuid>
+const (
+	updateMigratedModelCommandDoc = `
+The update-migrated-model updates a model known to JIMM that has
+been migrated externally to a different JAAS controller.
 `
+	updateMigratedModelCommandExample = `
+    jimmctl update-migrated-model mycontroller e0bf3abf-7029-4e48-9c26-68a7b6e02947
+`
+)
 
 // NewUpdateMigratedModelCommand returns a command to update the controller
 // running a model.
@@ -45,10 +47,11 @@ type updateMigratedModelCommand struct {
 // Info implements the cmd.Command interface.
 func (c *updateMigratedModelCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "update-migrated-model",
-		Args:    "<controller name> <model uuid>",
-		Purpose: "Update the controller running a model.",
-		Doc:     updateMigratedModelCommandDoc,
+		Name:     "update-migrated-model",
+		Args:     "<controller name> <model uuid>",
+		Purpose:  "Update the controller running a model.",
+		Doc:      updateMigratedModelCommandDoc,
+		Examples: updateMigratedModelCommandExample,
 	})
 }
 


### PR DESCRIPTION
## Description
As part of generating automatic documentation for `jimmctl` commands, this PR fixes some issues that were blocking the way toward automatic doc generation. The fixes here are also useful to the jimmctl->Juju feature since these commands will either be copied to Juju or moved into a plugin (except for any that get removed).

The full changes and reasons:
1. Populate the `Examples` field of all commands for correct documentation generation.
2. Changed examples that contained <controller> to an actual string like mycontroller. I copied Juju's help text e.g. `juju add-cloud -h` uses mycontroller and mycloud in their examples.
3. Populate the `Args` field of all commands for correct documentation generation.
4. Removed indentation from the command's doc string to match Juju's output.
5. Ensure example all have consistent indentation with 4 spaces instead of a tab to match Juju.
6. Nested commands like auth should have the `UsagePrefix` field set.

Partially fixes [JUJU-7172](https://warthogs.atlassian.net/browse/JUJU-7172)

## Engineering checklist
*Check only items that apply*

- [x] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-7172]: https://warthogs.atlassian.net/browse/JUJU-7172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ