### PR TITLE
chore: fix docs publishing workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
       with:
-        token: ${{ secrets.JIMM_GO_SDK_PAT }}
+        token: ${{ secrets.JIMM_DOCS_TOKEN }}
         path: ./jaas-documentation
         branch: update-jimmctl-${{ github.run_number }}
         title: Update jimmctl reference doc


### PR DESCRIPTION
## Description

Fixes the docs publishing workflow to use a different token from the `JIMM_GO_SDK_PAT`. The [workflow run](https://github.com/canonical/jimm/actions/runs/12180774024/job/33975857745) succeeded up to the point where it makes a PR to the jaas-documentation repo, failing due to a [403 error](https://github.com/canonical/jimm/actions/runs/12180774024/job/33975857745#step:11:90).

Fixes [JUJU-7172](https://warthogs.atlassian.net/browse/JUJU-7172)


[JUJU-7172]: https://warthogs.atlassian.net/browse/JUJU-7172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ