### PR TITLE
fix(permissionmap): fixes our permission map to actually run the redi…

### DIFF
--- a/internal/jimm/applicationoffer.go
+++ b/internal/jimm/applicationoffer.go
@@ -217,10 +217,6 @@ func (j *JIMM) GetApplicationOfferConsumeDetails(ctx context.Context, user *open
 		ctx,
 		&offer.Model.Controller,
 		names.ModelTag{},
-		permission{
-			resource: names.NewApplicationOfferTag(offer.UUID).String(),
-			relation: accessLevel,
-		},
 	)
 	if err != nil {
 		return errors.E(op, err)
@@ -366,10 +362,6 @@ func (j *JIMM) GetApplicationOffer(ctx context.Context, user *openfga.User, offe
 		ctx,
 		&offer.Model.Controller,
 		names.ModelTag{},
-		permission{
-			resource: names.NewApplicationOfferTag(offer.UUID).String(),
-			relation: accessLevel,
-		},
 	)
 	if err != nil {
 		return nil, errors.E(op, err)
@@ -706,10 +698,6 @@ func (j *JIMM) doApplicationOfferAdmin(ctx context.Context, user *openfga.User, 
 		ctx,
 		&offer.Model.Controller,
 		names.ModelTag{},
-		permission{
-			resource: names.NewApplicationOfferTag(offer.UUID).String(),
-			relation: string(jujuparams.OfferAdminAccess),
-		},
 	)
 	if err != nil {
 		return errors.E(op, err)

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -306,27 +306,18 @@ func (j *JIMM) GetCredentialStore() credentials.CredentialStore {
 	return j.CredentialStore
 }
 
-type permission struct {
-	resource string
-	relation string
-}
-
 // dial dials the controller and model specified by the given Controller
 // and ModelTag. If no Dialer has been configured then an error with a
 // code of CodeConnectionFailed will be returned.
-func (j *JIMM) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, permissons ...permission) (API, error) {
+//
+// It utilises a nil permission map to allow the controller to return
+// the expected permissions back to the caller and then redials
+// the controller with the correct permissions.
+func (j *JIMM) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error) {
 	if j == nil || j.Dialer == nil {
 		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
 	}
-	var permissionMap map[string]string
-	if len(permissons) > 0 {
-		permissionMap = make(map[string]string, len(permissons))
-		for _, p := range permissons {
-			permissionMap[p.resource] = p.relation
-		}
-	}
-
-	return j.Dialer.Dial(ctx, ctl, modelTag, permissionMap)
+	return j.Dialer.Dial(ctx, ctl, modelTag, nil)
 }
 
 // A Dialer provides a connection to a controller.

--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	jujupermission "github.com/juju/juju/core/permission"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
@@ -469,10 +468,6 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 		b.ctx,
 		b.controller,
 		names.ModelTag{},
-		permission{
-			resource: b.cloud.ResourceTag().String(),
-			relation: string(jujupermission.AddModelAccess),
-		},
 	)
 	if err != nil {
 		b.err = errors.E(err)

--- a/internal/jujuclient/allwatcher.go
+++ b/internal/jujuclient/allwatcher.go
@@ -14,7 +14,7 @@ import (
 // WatchAllModels initialises a new AllModelWatcher. On success the watcher
 // ID is returned. This uses the WatchAllModels method on the Controller
 // facade.
-func (c Connection) WatchAllModels(ctx context.Context) (string, error) {
+func (c *Connection) WatchAllModels(ctx context.Context) (string, error) {
 	const op = errors.Op("jujuclient.WatchAllModels")
 	var resp jujuparams.SummaryWatcherID
 	if err := c.CallHighestFacadeVersion(ctx, "Controller", []int{11, 7}, "", "WatchAllModels", nil, &resp); err != nil {
@@ -26,7 +26,7 @@ func (c Connection) WatchAllModels(ctx context.Context) (string, error) {
 // AllModelWatcherNext receives the next set of results from the all-model
 // watcher with the given id. This uses the Next method on the
 // AllModelWatcher facade.
-func (c Connection) AllModelWatcherNext(ctx context.Context, id string) ([]jujuparams.Delta, error) {
+func (c *Connection) AllModelWatcherNext(ctx context.Context, id string) ([]jujuparams.Delta, error) {
 	const op = errors.Op("jujuclient.AllModelWatcherNext")
 	var resp jujuparams.AllWatcherNextResults
 	if err := c.CallHighestFacadeVersion(ctx, "AllModelWatcher", []int{4, 2}, id, "Next", nil, &resp); err != nil {
@@ -37,7 +37,7 @@ func (c Connection) AllModelWatcherNext(ctx context.Context, id string) ([]jujup
 
 // AllModelWatcherStop stops the all-model watcher with the given id. This
 // uses the Stop method on the AllModelWatcher facade.
-func (c Connection) AllModelWatcherStop(ctx context.Context, id string) error {
+func (c *Connection) AllModelWatcherStop(ctx context.Context, id string) error {
 	const op = errors.Op("jujuclient.AllModelWatcherStop")
 	if err := c.CallHighestFacadeVersion(ctx, "AllModelWatcher", []int{4, 2}, id, "Stop", nil, nil); err != nil {
 		return errors.E(op, jujuerrors.Cause(err))

--- a/internal/jujuclient/applicationoffers.go
+++ b/internal/jujuclient/applicationoffers.go
@@ -16,7 +16,7 @@ import (
 
 // Offer creates a new ApplicationOffer on the controller. Offer uses the
 // Offer procedure on the ApplicationOffers facade.
-func (c Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, offer jujuparams.AddApplicationOffer) error {
+func (c *Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, offer jujuparams.AddApplicationOffer) error {
 	const op = errors.Op("jujuclient.Offer")
 	args := jujuparams.AddApplicationOffers{
 		Offers: []jujuparams.AddApplicationOffer{offer},
@@ -64,7 +64,7 @@ func (c Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, off
 // ListApplicationOffers lists ApplicationOffers on the controller matching
 // the given filters. ListApplicationOffers uses the ListApplicationOffers
 // procedure on the ApplicationOffers facade.
-func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+func (c *Connection) ListApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
 	const op = errors.Op("jujuclient.ListApplicationOffers")
 	args := jujuparams.OfferFilters{
 		Filters: filters,
@@ -81,7 +81,7 @@ func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujupar
 // FindApplicationOffers finds ApplicationOffers on the controller matching
 // the given filters. FindApplicationOffers uses the FindApplicationOffers
 // procedure on the ApplicationOffers facade.
-func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+func (c *Connection) FindApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
 	const op = errors.Op("jujuclient.FindApplicationOffers")
 	args := jujuparams.OfferFilters{
 		Filters: filters,
@@ -100,7 +100,7 @@ func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujupar
 // OfferURL the rest of the structure will be filled in by the API request.
 // GetApplicationOffer uses the ApplicationOffers procedure on the
 // ApplicationOffers facade.
-func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.ApplicationOfferAdminDetailsV5) error {
+func (c *Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.ApplicationOfferAdminDetailsV5) error {
 	const op = errors.Op("jujuclient.GetApplicationOffer")
 	args := jujuparams.OfferURLs{
 		OfferURLs: []string{info.OfferURL},
@@ -123,7 +123,7 @@ func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.Ap
 // GrantApplicationOfferAccess grants the specified permission to the
 // given user on the given application offer. GrantApplicationOfferAccess
 // uses the ModifyOfferAccess procedure on the ApplicationOffers facade..
-func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
+func (c *Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
 	const op = errors.Op("jujuclient.GrantApplicationOfferAccess")
 	args := jujuparams.ModifyOfferAccessRequest{
 		Changes: []jujuparams.ModifyOfferAccess{{
@@ -150,7 +150,7 @@ func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL st
 // RevokeApplicationOfferAccess revokes the specified permission from the
 // given user on the given application offer. RevokeApplicationOfferAccess
 // uses the ModifyOfferAccess procedure on the ApplicationOffers facade.
-func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
+func (c *Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
 	const op = errors.Op("jujuclient.RevokeApplicationOfferAccess")
 	args := jujuparams.ModifyOfferAccessRequest{
 		Changes: []jujuparams.ModifyOfferAccess{{
@@ -177,7 +177,7 @@ func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL s
 // DestroyApplicationOffer destroys the given application offer.
 // DestroyApplicationOffer uses the DestroyOffers procedure
 // from the ApplicationOffers facade.
-func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, force bool) error {
+func (c *Connection) DestroyApplicationOffer(ctx context.Context, offer string, force bool) error {
 	const op = errors.Op("jujuclient.DestroyApplicationOffer")
 	args := jujuparams.DestroyApplicationOffers{
 		OfferURLs: []string{offer},
@@ -202,7 +202,7 @@ func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, f
 // must include an Offer.OfferURL and the rest of the structure will be
 // filled in by the API call. GetApplicationOfferConsumeDetails uses the
 // GetConsumeDetails procedure on the ApplicationOffers facade.
-func (c Connection) GetApplicationOfferConsumeDetails(ctx context.Context, user names.UserTag, info *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
+func (c *Connection) GetApplicationOfferConsumeDetails(ctx context.Context, user names.UserTag, info *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
 	const op = errors.Op("jujuclient.GetApplicationOfferConsumeDetails")
 	args := jujuparams.ConsumeOfferDetailsArg{
 		OfferURLs: jujuparams.OfferURLs{

--- a/internal/jujuclient/client.go
+++ b/internal/jujuclient/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Status returns the status of the juju model.
-func (c Connection) Status(ctx context.Context, patterns []string) (*jujuparams.FullStatus, error) {
+func (c *Connection) Status(ctx context.Context, patterns []string) (*jujuparams.FullStatus, error) {
 	const op = errors.Op("jujuclient.Status")
 
 	p := jujuparams.StatusParams{

--- a/internal/jujuclient/cloud.go
+++ b/internal/jujuclient/cloud.go
@@ -17,7 +17,7 @@ import (
 // SupportsCheckCredentialModels reports whether the controller supports
 // the Cloud.CheckCredentialsModels, Cloud.RevokeCredentialsCheckModels,
 // and Cloud.UpdateCredentialsCheckModels methods.
-func (c Connection) SupportsCheckCredentialModels() bool {
+func (c *Connection) SupportsCheckCredentialModels() bool {
 	return c.hasFacadeVersion("Cloud", 3) || c.hasFacadeVersion("Cloud", 7)
 }
 
@@ -26,7 +26,7 @@ func (c Connection) SupportsCheckCredentialModels() bool {
 // credential. This method uses the CheckCredentialsModel procedure on
 // the Cloud. Any error that represents a Juju API
 // failure will be of type *APIError.
-func (c Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+func (c *Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
 	const op = errors.Op("jujuclient.CheckCredentialModels")
 	in := jujuparams.TaggedCredentials{
 		Credentials: []jujuparams.TaggedCredential{cred},
@@ -57,7 +57,7 @@ func (c Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.T
 //
 // Any error that represents a Juju API failure will be of type
 // *APIError.
-func (c Connection) UpdateCredential(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+func (c *Connection) UpdateCredential(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
 	const op = errors.Op("jujuclient.UpdateCredential")
 	creds := jujuparams.TaggedCredentials{
 		Credentials: []jujuparams.TaggedCredential{cred},
@@ -98,7 +98,7 @@ func (c Connection) UpdateCredential(ctx context.Context, cred jujuparams.Tagged
 //
 // Any error that represents a Juju API failure will be of type
 // *APIError.
-func (c Connection) RevokeCredential(ctx context.Context, cred names.CloudCredentialTag) error {
+func (c *Connection) RevokeCredential(ctx context.Context, cred names.CloudCredentialTag) error {
 	const op = errors.Op("jujuclient.RevokeCredential")
 	out := jujuparams.ErrorResults{
 		Results: make([]jujuparams.ErrorResult, 1),
@@ -131,7 +131,7 @@ func (c Connection) RevokeCredential(ctx context.Context, cred names.CloudCreden
 
 // Cloud retrieves information about the given cloud. Cloud uses the
 // Cloud procedure on the Cloud facade.
-func (c Connection) Cloud(ctx context.Context, tag names.CloudTag, cloud *jujuparams.Cloud) error {
+func (c *Connection) Cloud(ctx context.Context, tag names.CloudTag, cloud *jujuparams.Cloud) error {
 	const op = errors.Op("jujuclient.Cloud")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
@@ -154,7 +154,7 @@ func (c Connection) Cloud(ctx context.Context, tag names.CloudTag, cloud *jujupa
 
 // Clouds retrieves information about all available clouds. Clouds uses the
 // Clouds procedure on the Cloud facade.
-func (c Connection) Clouds(ctx context.Context) (map[names.CloudTag]jujuparams.Cloud, error) {
+func (c *Connection) Clouds(ctx context.Context) (map[names.CloudTag]jujuparams.Cloud, error) {
 	const op = errors.Op("jujuclient.Clouds")
 	var resp jujuparams.CloudsResult
 	if err := c.CallHighestFacadeVersion(ctx, "Cloud", []int{7, 1}, "", "Clouds", nil, &resp); err != nil {
@@ -175,7 +175,7 @@ func (c Connection) Clouds(ctx context.Context) (map[names.CloudTag]jujuparams.C
 
 // AddCloud adds the given cloud to a controller with the given name.
 // AddCloud uses the AddCloud procedure on the Cloud facade.
-func (c Connection) AddCloud(ctx context.Context, tag names.CloudTag, cloud jujuparams.Cloud, force bool) error {
+func (c *Connection) AddCloud(ctx context.Context, tag names.CloudTag, cloud jujuparams.Cloud, force bool) error {
 	const op = errors.Op("jujuclient.AddCloud")
 	args := jujuparams.AddCloudArgs{
 		Cloud: cloud,
@@ -190,7 +190,7 @@ func (c Connection) AddCloud(ctx context.Context, tag names.CloudTag, cloud juju
 
 // RemoveCloud removes the given cloud from the controller. RemoveCloud
 // uses the RemoveClouds procedure on the Cloud facade.
-func (c Connection) RemoveCloud(ctx context.Context, tag names.CloudTag) error {
+func (c *Connection) RemoveCloud(ctx context.Context, tag names.CloudTag) error {
 	const op = errors.Op("jujuclient.RemoveCloud")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
@@ -212,7 +212,7 @@ func (c Connection) RemoveCloud(ctx context.Context, tag names.CloudTag) error {
 // GrantCloudAccess gives the given user the given access level on the
 // given cloud. GrantCloudAccess uses the ModifyCloudAccess procedure on
 // the Cloud facade.
-func (c Connection) GrantCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
+func (c *Connection) GrantCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
 	const op = errors.Op("jujuclient.GrantCloudAccess")
 	args := jujuparams.ModifyCloudAccessRequest{
 		Changes: []jujuparams.ModifyCloudAccess{{
@@ -239,7 +239,7 @@ func (c Connection) GrantCloudAccess(ctx context.Context, cloudTag names.CloudTa
 // RevokeCloudAccess revokes the given access level on the given cloud from
 // the given user. RevokeCloudAccess uses the ModifyCloudAccess procedure
 // on the Cloud facade.
-func (c Connection) RevokeCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
+func (c *Connection) RevokeCloudAccess(ctx context.Context, cloudTag names.CloudTag, userTag names.UserTag, access string) error {
 	const op = errors.Op("jujuclient.RevokeCloudAccess")
 	args := jujuparams.ModifyCloudAccessRequest{
 		Changes: []jujuparams.ModifyCloudAccess{{
@@ -265,7 +265,7 @@ func (c Connection) RevokeCloudAccess(ctx context.Context, cloudTag names.CloudT
 
 // CloudInfo retrieves information about the cloud with the given name.
 // CloudInfo uses the CloudInfo procedure on the Cloud facade.
-func (c Connection) CloudInfo(ctx context.Context, tag names.CloudTag, ci *jujuparams.CloudInfo) error {
+func (c *Connection) CloudInfo(ctx context.Context, tag names.CloudTag, ci *jujuparams.CloudInfo) error {
 	const op = errors.Op("jujuclient.CloudInfo")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{Tag: tag.String()}},
@@ -288,7 +288,7 @@ func (c Connection) CloudInfo(ctx context.Context, tag names.CloudTag, ci *jujup
 
 // UpdateCloud updates the given cloud with the given cloud definition.
 // UpdateCloud uses the UpdateCloud procedure on the cloud facade.
-func (c Connection) UpdateCloud(ctx context.Context, tag names.CloudTag, cloud jujuparams.Cloud) error {
+func (c *Connection) UpdateCloud(ctx context.Context, tag names.CloudTag, cloud jujuparams.Cloud) error {
 	const op = errors.Op("jujuclient.UpdateCloud")
 
 	args := jujuparams.UpdateCloudArgs{

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/permission"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
@@ -54,15 +55,13 @@ type Dialer struct {
 	JWTService                 *jimmjwx.JWTService
 }
 
+// createLoginRequest formats a login request for Juju utilising a JWT.
 func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, p map[string]string) (*jujuparams.LoginRequest, error) {
 	// JIMM is automatically given all required permissions
-	permissions := p
-	if permissions == nil {
-		permissions = make(map[string]string)
-	}
-	permissions[ctl.ResourceTag().String()] = "superuser"
-	if modelTag.Id() != "" {
-		permissions[modelTag.String()] = "admin"
+
+	permissions, err := d.maybeCorrectPermissionMap(p, ctl)
+	if err != nil {
+		return nil, err
 	}
 
 	jwt, err := d.JWTService.NewJWT(ctx, jimmjwx.JWTParams{
@@ -80,6 +79,30 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 		ClientVersion: jujuClientVersion,
 		Token:         jwtString,
 	}, nil
+}
+
+func (d *Dialer) maybeCorrectPermissionMap(permissions map[string]string, ctl *dbmodel.Controller) (map[string]string, error) {
+	if permissions == nil {
+		permissions = make(map[string]string)
+	}
+
+	// Check the access level for the controller.
+	access, ok := permissions[ctl.ResourceTag().String()]
+
+	// If a permission cannot be found set a required default.
+	if !ok {
+		// Minimum required permission to connect to a controller
+		// is login.
+		permissions[ctl.ResourceTag().String()] = string(permission.LoginAccess)
+	} else {
+		// If the permission was set ahead of time, we ensure it's a valid controller
+		// permission.
+		if err := permission.ValidateControllerAccess(permission.Access(access)); err != nil {
+			return nil, errors.E(err)
+		}
+	}
+
+	return permissions, nil
 }
 
 // Dial implements jimm.Dialer.
@@ -126,6 +149,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 
 	monitorC := make(chan struct{})
 	broken := new(uint32)
+
 	go pinger(client, ct.Id(), monitorC, broken)
 	return &Connection{
 		ctx:                ctx,
@@ -237,6 +261,7 @@ func (c *Connection) redial(ctx context.Context, requiredPermissions map[string]
 	if err = c.Close(); err != nil {
 		return errors.E(op, err)
 	}
+
 	conn := api.(*Connection)
 	c.client = conn.client
 	c.userTag = conn.userTag

--- a/internal/jujuclient/dial_test.go
+++ b/internal/jujuclient/dial_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 	jujuparams "github.com/juju/juju/rpc/params"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/names/v5"
@@ -90,10 +91,15 @@ func (s *dialSuite) TestDial(c *gc.C) {
 	c.Check(addrs, jc.DeepEquals, info.Addrs)
 }
 
+// TestDialWithJWT tests that JIMM can login to Juju controllers utilising
+// JWTs. The controller upon login returns the expected permissions. Upon receiving
+// the expected permission errors, .Call()'s redial the controller updating the permission map
+// and as such can correctly contact the controller.
 func (s *dialSuite) TestDialWithJWT(c *gc.C) {
 	ctx := context.Background()
 
 	info := s.APIInfo(c)
+
 	ctl := dbmodel.Controller{
 		UUID:          info.ControllerUUID,
 		Name:          s.ControllerConfig.ControllerName(),
@@ -105,17 +111,43 @@ func (s *dialSuite) TestDialWithJWT(c *gc.C) {
 		JWTService: s.JIMM.JWTService,
 	}
 
-	// Check dial is OK
+	// Create a model where we wish to dump its DB.
+	state := s.JujuConnSuite.Factory.MakeModel(c, nil)
+	defer state.Close()
+	model, err := state.Model()
+	c.Assert(err, gc.IsNil)
+
+	// Test 1, no permissions specified at all. And expect login to be amended.
+
+	// Dial Controller with no permissions.
 	api, err := dialer.Dial(ctx, &ctl, names.ModelTag{}, nil)
 	c.Assert(err, gc.Equals, nil)
 	defer api.Close()
-	// Check UUID matches expected
-	c.Check(ctl.UUID, gc.Equals, "deadbeef-1bad-500d-9000-4b1d0d06f00d")
-	// Check agent version matches expected
-	c.Check(ctl.AgentVersion, gc.Equals, jujuversion.Current.String())
-	addrs := make([]string, len(ctl.Addresses))
-	for i, addr := range ctl.Addresses {
-		addrs[i] = fmt.Sprintf("%s:%d", addr[0].Value, addr[0].Port)
-	}
-	c.Check(addrs, gc.DeepEquals, info.Addrs)
+
+	// We use our API dialer as when a permission cannot be found, it redials correcting the permission map.
+	// DumpModelDB requires permission.AdminAccess of a model to do this.
+	_, err = api.DumpModelDB(ctx, model.ModelTag())
+	c.Assert(err, gc.IsNil)
+
+	// Test 2, specify the wrong permission. And expect login to be amended.
+
+	// Now we attempt to dial again, but specify we have a lower level access for this model
+	// due to this, we expect a permission denied error on our call.
+	wrongpermissionapi, err := dialer.Dial(
+		ctx,
+		&ctl,
+		names.ModelTag{},
+		map[string]string{
+			model.ModelTag().String(): string(permission.ReadAccess),
+		},
+	)
+	c.Assert(err, gc.Equals, nil)
+	defer wrongpermissionapi.Close()
+
+	// DumpModelDB requires permission.AdminAccess, but we have specified read.
+	// Because a permission check required will be sent back (as we've requested the wrong
+	// access), Call() will override the wrong permission (ReadAccess) with the correct
+	// permission, in this case, admin.
+	_, err = wrongpermissionapi.DumpModelDB(ctx, model.ModelTag())
+	c.Assert(err, gc.IsNil)
 }

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -19,7 +19,7 @@ import (
 // from the Create model call. If there is an error returned it will be
 // of type *APIError. CreateModel uses the Create model procedure on the
 // ModelManager facade.
-func (c Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreateArgs, info *jujuparams.ModelInfo) error {
+func (c *Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreateArgs, info *jujuparams.ModelInfo) error {
 	const op = errors.Op("jujuclient.CreateModel")
 	if err := c.Call(ctx, "ModelManager", 9, "", "CreateModel", args, info); err != nil {
 		return errors.E(op, jujuerrors.Cause(err))
@@ -33,7 +33,7 @@ func (c Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreat
 // then the resulting error response will be of type *APIError. ModelInfo
 // will use the ModelInfo procedure from the ModelManager version 9
 // facade if it is available, falling back to version 3.
-func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) error {
+func (c *Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) error {
 	const op = errors.Op("jujuclient.ModelInfo")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
@@ -62,7 +62,7 @@ func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) e
 // that is returned from the API will be of type *APIError.
 // GrantJIMMModelAdmin uses the ModifyModelAccess procedure on the
 // ModelManager facade.
-func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
+func (c *Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
 	const op = errors.Op("jujuclient.GrantJIMMModelAdmin")
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
@@ -88,7 +88,7 @@ func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag)
 // DumpModel dumps debugging details for the given model. If the simplied
 // dump is requested then a simplified dump is returned. DumpModel uses the
 // DumpModels method on the ModelManager facade.
-func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (string, error) {
+func (c *Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (string, error) {
 	const op = errors.Op("jujuclient.DumpModel")
 	args := jujuparams.DumpModelRequest{
 		Entities: []jujuparams.Entity{{
@@ -111,7 +111,7 @@ func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplifie
 
 // DumpModelDB dumps the controller database entry given model.
 // DumpModelDB uses the DumpModelsDB method on the ModelManager facade..
-func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+func (c *Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
 	const op = errors.Op("jujuclient.DumpModelDB")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
@@ -134,7 +134,7 @@ func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[st
 // GrantModelAccess gives the given user the given access level on the
 // given model. GrantModelAccess uses the ModifyModelAccess procedure
 // on the ModelManager facade.
-func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
+func (c *Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
 	const op = errors.Op("jujuclient.GrantModelAccess")
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
@@ -161,7 +161,7 @@ func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTa
 // RevokeModelAccess removes the given access level from the given user on
 // the given model. Revoke ModelAccess uses the ModifyModelAccess procedure
 // on the ModelManager facade.
-func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
+func (c *Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
 	const op = errors.Op("jujuclient.RevokeModelAccess")
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
@@ -188,7 +188,7 @@ func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelT
 // ControllerModelSummary retrieves the ModelSummary for the controller
 // model. ControllerModelSummary uses the ListModelSummaries procedure on
 // the ModelManager facade.
-func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelSummary) error {
+func (c *Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelSummary) error {
 	const op = errors.Op("jujuclient.ControllerModelSummary")
 	args := jujuparams.ModelSummariesRequest{
 		UserTag: c.userTag,
@@ -210,7 +210,7 @@ func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.M
 
 // ValidateModelUpgrade validates if a model is allowed to perform an upgrade. It
 // uses ValidateModelUpgrades on the ModelManager facade.
-func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelTag, force bool) error {
+func (c *Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelTag, force bool) error {
 	const op = errors.Op("jujuclient.ValidateModelUpgrade")
 	args := jujuparams.ValidateModelUpgradeParams{
 		Models: []jujuparams.ModelParam{{
@@ -238,7 +238,7 @@ func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelT
 //   - ModelManager(7).DestroyModels
 //   - ModelManager(4).DestroyModels
 //   - ModelManager(2).DestroyModels
-func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStorage *bool, force *bool, maxWait, timeout *time.Duration) error {
+func (c *Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStorage *bool, force *bool, maxWait, timeout *time.Duration) error {
 	const op = errors.Op("jujuclient.DestroyModel")
 	args := jujuparams.DestroyModelsParams{
 		Models: []jujuparams.DestroyModelParams{{
@@ -269,7 +269,7 @@ func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destro
 // API then the resulting error response will be of type *APIError.
 // ModelStatus will use the ModelStatus procedure from the ModelManager
 // version 4 facade if it is available, falling back to version 2.
-func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelStatus) error {
+func (c *Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelStatus) error {
 	const op = errors.Op("jujuclient.ModelStatus")
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
@@ -292,7 +292,7 @@ func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelSta
 }
 
 // ChangeModelCredential replaces cloud credential for a given model with the provided one.
-func (c Connection) ChangeModelCredential(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
+func (c *Connection) ChangeModelCredential(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
 	const op = errors.Op("jujuclient.ChangeModelCredential")
 
 	var out jujuparams.ErrorResults

--- a/internal/jujuclient/modelsummarywatcher.go
+++ b/internal/jujuclient/modelsummarywatcher.go
@@ -13,7 +13,7 @@ import (
 
 // SupportsModelSummaryWatcher reports whether the controller supports
 // the Controller.WatchAllModelSummaries method.
-func (c Connection) SupportsModelSummaryWatcher() bool {
+func (c *Connection) SupportsModelSummaryWatcher() bool {
 	return c.hasFacadeVersion("Controller", 9) || c.hasFacadeVersion("Controller", 11)
 }
 
@@ -21,7 +21,7 @@ func (c Connection) SupportsModelSummaryWatcher() bool {
 // success the watcher ID is returned. If an error is returned it will be
 // of type *APIError. This uses the WatchAllModelSummaries method on the
 // Controller facade version 9.
-func (c Connection) WatchAllModelSummaries(ctx context.Context) (string, error) {
+func (c *Connection) WatchAllModelSummaries(ctx context.Context) (string, error) {
 	const op = errors.Op("jujuclient.WatchAllModelSummaries")
 	var resp jujuparams.SummaryWatcherID
 	if err := c.CallHighestFacadeVersion(ctx, "Controller", []int{11, 9}, "", "WatchAllModelSummaries", nil, &resp); err != nil {
@@ -34,7 +34,7 @@ func (c Connection) WatchAllModelSummaries(ctx context.Context) (string, error) 
 // model summary watcher with the given id. If an error is returned it
 // will be of type *APIError. This uses the Next method on the
 // ModelSummaryWatcher facade version 1.
-func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]jujuparams.ModelAbstract, error) {
+func (c *Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]jujuparams.ModelAbstract, error) {
 	const op = errors.Op("jujuclient.ModelSummaryWatcherNext")
 	var resp jujuparams.SummaryWatcherNextResults
 	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Next", nil, &resp); err != nil {
@@ -47,7 +47,7 @@ func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]j
 // model summary watcher with the given id. If an error is returned it
 // will be of type *APIError. This uses the Stop method on the
 // ModelSummaryWatcher facade version 1.
-func (c Connection) ModelSummaryWatcherStop(ctx context.Context, id string) error {
+func (c *Connection) ModelSummaryWatcherStop(ctx context.Context, id string) error {
 	const op = errors.Op("jujuclient.ModelSummaryWatcherStop")
 	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Stop", nil, nil); err != nil {
 		return errors.E(op, jujuerrors.Cause(err))

--- a/internal/jujuclient/modelwatcher.go
+++ b/internal/jujuclient/modelwatcher.go
@@ -13,7 +13,7 @@ import (
 
 // WatchAll initialises a new ModelWatcher. On success the watcher
 // ID is returned. This uses the WatchAll method on the Client.
-func (c Connection) WatchAll(ctx context.Context) (string, error) {
+func (c *Connection) WatchAll(ctx context.Context) (string, error) {
 	const op = errors.Op("jujuclient.WatchAll")
 	var resp jujuparams.AllWatcherId
 	if err := c.CallHighestFacadeVersion(ctx, "Client", []int{6, 1}, "", "WatchAll", nil, &resp); err != nil {
@@ -25,7 +25,7 @@ func (c Connection) WatchAll(ctx context.Context) (string, error) {
 // ModelWatcherNext receives the next set of results from the model
 // watcher with the given id. This uses the Next method on the
 // AllWatcher facade version 1.
-func (c Connection) ModelWatcherNext(ctx context.Context, id string) ([]jujuparams.Delta, error) {
+func (c *Connection) ModelWatcherNext(ctx context.Context, id string) ([]jujuparams.Delta, error) {
 	const op = errors.Op("jujuclient.ModelWatcherNext")
 	var resp jujuparams.AllWatcherNextResults
 	if err := c.CallHighestFacadeVersion(ctx, "AllWatcher", []int{3, 2, 1}, id, "Next", nil, &resp); err != nil {
@@ -36,7 +36,7 @@ func (c Connection) ModelWatcherNext(ctx context.Context, id string) ([]jujupara
 
 // ModelWatcherStop stops the model watcher with the given id. This
 // uses the Stop method on the AllWatcher facade version 1.
-func (c Connection) ModelWatcherStop(ctx context.Context, id string) error {
+func (c *Connection) ModelWatcherStop(ctx context.Context, id string) error {
 	const op = errors.Op("jujuclient.ModelWatcherStop")
 	if err := c.CallHighestFacadeVersion(ctx, "AllWatcher", []int{3, 2, 1}, id, "Stop", nil, nil); err != nil {
 		return errors.E(op, jujuerrors.Cause(err))

--- a/internal/jujuclient/ping.go
+++ b/internal/jujuclient/ping.go
@@ -10,7 +10,7 @@ import (
 
 // Ping sends a ping message across the connection and waits for a
 // response.
-func (c Connection) Ping(ctx context.Context) error {
+func (c *Connection) Ping(ctx context.Context) error {
 	const op = errors.Op("jujuclient.Ping")
 
 	err := c.Call(ctx, "Pinger", 1, "", "Ping", nil, nil)

--- a/internal/jujuclient/storage.go
+++ b/internal/jujuclient/storage.go
@@ -14,7 +14,7 @@ import (
 
 // ListFilesystems lists filesystems for desired machines.
 // If no machines provided, a list of all filesystems is returned.
-func (c Connection) ListFilesystems(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
+func (c *Connection) ListFilesystems(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
 	const op = errors.Op("jujuclient.ListFilesystems")
 
 	filters := make([]jujuparams.FilesystemFilter, len(machines))
@@ -49,7 +49,7 @@ func (c Connection) ListFilesystems(ctx context.Context, machines []string) ([]j
 
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
-func (c Connection) ListVolumes(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
+func (c *Connection) ListVolumes(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
 	const op = errors.Op("jujuclient.ListVolumes")
 
 	filters := make([]jujuparams.VolumeFilter, len(machines))
@@ -80,7 +80,7 @@ func (c Connection) ListVolumes(ctx context.Context, machines []string) ([]jujup
 }
 
 // ListStorageDetails lists all storage.
-func (c Connection) ListStorageDetails(ctx context.Context) ([]jujuparams.StorageDetails, error) {
+func (c *Connection) ListStorageDetails(ctx context.Context) ([]jujuparams.StorageDetails, error) {
 	const op = errors.Op("jujuclient.ListStorageDetails")
 
 	args := jujuparams.StorageFilters{


### PR DESCRIPTION
…al logic

Originally, when dialing controller we specified superuser for controllers, and admin for models. This was wrong and needed updating.

Now, we dial controllers with the minimum access to receive the "permission check required" error. Upon receiving this error, the redial logic within Call() will run and update the map. If we decide a call is to be "superuser", we do allow this override. 

I've removed where we specify permissions as when redialling, even if we did have permissions and they were wrong (for example read for a DumpModelsDB), juju responds with "permission check required" and due to our redial logic we update the map on the redial. As such, its very likely we don't need to put permissions in ourselves and let the redial logic run. I am really unkeen on how we're having to redial and am going to fix this in a follow up.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers
<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->