### PR TITLE
feat: add ssh key table

### DIFF
--- a/internal/dbmodel/sql/postgres/020_add_ssh_keys_table.up.sql
+++ b/internal/dbmodel/sql/postgres/020_add_ssh_keys_table.up.sql
@@ -1,0 +1,14 @@
+-- Add the ability to store users' SSH public keys
+
+CREATE TABLE ssh_keys (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE,
+    public_key BYTEA NOT NULL,
+    key_comment VARCHAR(255),
+    identity_name TEXT NOT NULL,
+    FOREIGN KEY (identity_name) REFERENCES identities(name),
+    CONSTRAINT unique_identity_ssh_key UNIQUE(identity_name, public_key)
+);
+
+CREATE INDEX idx_ssh_keys_user_id ON ssh_keys (identity_name);

--- a/internal/dbmodel/sshkeys.go
+++ b/internal/dbmodel/sshkeys.go
@@ -1,0 +1,23 @@
+// Copyright 2025 Canonical.
+
+package dbmodel
+
+import "time"
+
+// SSHKey holds a user's public SSH key.
+type SSHKey struct {
+	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
+
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// IdentityName is the unique name (email or client-id) of this entity.
+	IdentityName string   `gorm:"uniqueIndex:unique_identity_ssh_key"`
+	Identity     Identity `gorm:"foreignKey:IdentityName;references:Name"`
+
+	// PublicKey holds the user's public SSH key.
+	PublicKey []byte `gorm:"uniqueIndex:unique_identity_ssh_key"`
+	// KeyComment holds a user provided comment.
+	KeyComment string
+}

--- a/internal/dbmodel/sshkeys_test.go
+++ b/internal/dbmodel/sshkeys_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Canonical.
+
+package dbmodel_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+func TestSSHKeyUniqueConstraint(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+
+	u, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(db.Create(u).Error, qt.IsNil)
+
+	key := dbmodel.SSHKey{
+		PublicKey:  []byte("test"),
+		Identity:   *u,
+		KeyComment: "foo",
+	}
+	c.Assert(db.Create(&key).Error, qt.IsNil)
+
+	newKey := dbmodel.SSHKey{
+		PublicKey:  []byte("test"),
+		Identity:   *u,
+		KeyComment: "bar",
+	}
+	c.Assert(db.Create(&newKey).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"unique_identity_ssh_key\".*")
+}


### PR DESCRIPTION
## Description
This PR adds a database migration and gorm model for users' public SSH keys. I reviewed https://github.com/canonical/jimm/pull/1287 when making this PR

Some justifications for the types chosen:
- `bytea` over `text` for the SSH public key. The Go ssh package has a `PublicKey` [interface](https://pkg.go.dev/golang.org/x/crypto/ssh#PublicKey) with a `Marshal` method returning a []byte. I expect this is what we will store in the database. The marshalled object also stores the key type.
- A separate key comment column allows us to persist the comment (not stored in the object mentioned above).
- No fingerprint column, the key fingerprint is a hash computed from the public key so we don't need to persist this separately.

Fixes [JUJU-7348](https://warthogs.atlassian.net/browse/JUJU-7348)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-7348]: https://warthogs.atlassian.net/browse/JUJU-7348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ