### PR TITLE
fix(internal/db/cloud.go): add `virtual` field to CloudRegion

### DIFF
--- a/cmd/jimmctl/cmd/purge_logs_test.go
+++ b/cmd/jimmctl/cmd/purge_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package cmd_test
 
 import (

--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package auth_test
 

--- a/internal/db/applicationoffer_test.go
+++ b/internal/db/applicationoffer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/auditlog_test.go
+++ b/internal/db/auditlog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 
@@ -35,7 +35,8 @@ func (s *dbSuite) TestAddCloud(c *qt.C) {
 		IdentityEndpoint: "https://identity.example.com",
 		StorageEndpoint:  "https://storage.example.com",
 		Regions: []dbmodel.CloudRegion{{
-			Name: "test-cloud-region",
+			Name:    "test-cloud-region",
+			Virtual: true,
 		}},
 		CACertificates: dbmodel.Strings{"CACERT 1", "CACERT 2"},
 	}

--- a/internal/db/clouddefaults_test.go
+++ b/internal/db/clouddefaults_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package db contains routines to store and retrieve data from a database.
 package db

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/export_test.go
+++ b/internal/db/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/identity_test.go
+++ b/internal/db/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/resource_test.go
+++ b/internal/db/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package db_test
 
 import (

--- a/internal/db/role_test.go
+++ b/internal/db/role_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/rootkeys_test.go
+++ b/internal/db/rootkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/db/secrets_test.go
+++ b/internal/db/secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db_test
 

--- a/internal/dbmodel/cloud.go
+++ b/internal/dbmodel/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel
 
@@ -181,6 +181,14 @@ type CloudRegion struct {
 	// Controllers contains any controllers that can provide service for
 	// this cloud-region.
 	Controllers []CloudRegionControllerPriority
+
+	// Virtual, if true, indicates that a cloud was reported to have
+	// no cloud regions so we created a virtual "default" regions for it.
+	// This is necessary because Juju seems inconsistent in how they manage
+	// clouds with no regions; e.g. maas or k8s clouds may not have regions,
+	// yet for some cloud juju creates a "default" region, while for others
+	// it does not.
+	Virtual bool
 }
 
 // ToJujuCloudRegion converts a CloudRegion into a jujuparams.CloudRegion.

--- a/internal/dbmodel/cloudcredential.go
+++ b/internal/dbmodel/cloudcredential.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/cloudcredential_test.go
+++ b/internal/dbmodel/cloudcredential_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/gorm_test.go
+++ b/internal/dbmodel/gorm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/sql/postgres/021_add_virtual_column_to_cloud_regions.up.sql
+++ b/internal/dbmodel/sql/postgres/021_add_virtual_column_to_cloud_regions.up.sql
@@ -1,0 +1,3 @@
+-- adds a boolean column to the cloud_regions table.
+
+ALTER TABLE cloud_regions ADD COLUMN virtual BOOLEAN;

--- a/internal/jimm/applicationoffer.go
+++ b/internal/jimm/applicationoffer.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimm
 

--- a/internal/jimm/cloud.go
+++ b/internal/jimm/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimm
 

--- a/internal/jimm/cloud_test.go
+++ b/internal/jimm/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimm_test
 

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -260,6 +260,7 @@ func (j *JIMM) AddController(ctx context.Context, user *openfga.User, ctl *dbmod
 			dbClouds[i].Regions = []dbmodel.CloudRegion{{
 				CloudName: cloud.Name,
 				Name:      "default",
+				Virtual:   true,
 			}}
 			if cloud.Name == ctl.CloudName {
 				ctl.CloudRegion = "default"

--- a/internal/jimm/service_account.go
+++ b/internal/jimm/service_account.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimm
 

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package jimmhttp_test
 
 import (

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmhttp
 

--- a/internal/jimmhttp/rebac_admin/capabilities_test.go
+++ b/internal/jimmhttp/rebac_admin/capabilities_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package rebac_admin_test
 
 import (

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/roles.go
+++ b/internal/jimmhttp/rebac_admin/roles.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/roles_test.go
+++ b/internal/jimmhttp/rebac_admin/roles_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/jimm_relation.go
+++ b/internal/jujuapi/jimm_relation.go
@@ -1,3 +1,3 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuclient/client_test.go
+++ b/internal/jujuclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package jujuclient_test
 
 import (

--- a/internal/jujuclient/dial_test.go
+++ b/internal/jujuclient/dial_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/ping_test.go
+++ b/internal/jujuclient/ping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/storage_test.go
+++ b/internal/jujuclient/storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package jujuclient_test
 
 import (

--- a/internal/logger/migration_logger.go
+++ b/internal/logger/migration_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package logger
 

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package middleware_test
 

--- a/internal/testutils/cmdtest/jimmsuite.go
+++ b/internal/testutils/cmdtest/jimmsuite.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package cmdtest provides the test suite used for CLI tests
 // as well as helper functions used for integration based CLI tests.

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -344,7 +344,8 @@ type Cloud struct {
 // A CloudRegion represents the definition of a cloud region in a test
 // environment.
 type CloudRegion struct {
-	Name string `json:"name"`
+	Name    string `json:"name"`
+	Virtual bool   `json:"virtual"`
 }
 
 // DBObject returns a database object for the specified cloud, suitable
@@ -359,7 +360,8 @@ func (cl *Cloud) DBObject(c Tester, db *db.Database) dbmodel.Cloud {
 	cl.dbo.HostCloudRegion = cl.HostCloudRegion
 	for _, r := range cl.Regions {
 		cl.dbo.Regions = append(cl.dbo.Regions, dbmodel.CloudRegion{
-			Name: r.Name,
+			Name:    r.Name,
+			Virtual: r.Virtual,
 		})
 	}
 

--- a/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package mocks
 

--- a/local/seed_db/main.go
+++ b/local/seed_db/main.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 package main
 
 import (


### PR DESCRIPTION

## Description

When we add a cloud reports no cloud regions we add a virtual "default" region to keep the
controller lookup logic the same when adding a model. Then only difference is that we do not send
the cloud region name in ModelCreateArgs to the controller.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
