### PR TITLE
implement auth in jump server

### DIFF
--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Canonical.
+
+package ssh
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+type identityManager interface {
+	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
+}
+
+type modelManager interface {
+	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
+}
+
+type sshKeyManager interface {
+	VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+}
+
+// sshManager provides a means to manage ssh server within JIMM.
+type sshManager struct {
+	modelManager
+	identityManager
+	sshKeyManager
+}
+
+// NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
+func NewSSHManager(identityManager identityManager, modelManager modelManager, sshKeyManager sshKeyManager) (*sshManager, error) {
+	if identityManager == nil {
+		return nil, errors.E("identityManager cannot be nil")
+	}
+	if modelManager == nil {
+		return nil, errors.E("modelManager cannot be nil")
+	}
+	if sshKeyManager == nil {
+		return nil, errors.E("sshManager cannot be nil")
+	}
+	return &sshManager{
+		modelManager:    modelManager,
+		identityManager: identityManager,
+		sshKeyManager:   sshKeyManager,
+	}, nil
+}

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -10,27 +10,30 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
-type identityManager interface {
+// IdentityManager provides a means to fetch an identity from the identity service.
+type IdentityManager interface {
 	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
 }
 
-type modelManager interface {
+// ModelManager provides a means to fetch a model from the model service.
+type ModelManager interface {
 	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
 }
 
-type sshKeyManager interface {
-	VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+// SSHKeyManager provides a means to manage ssh keys within JIMM.
+type SSHKeyManager interface {
+	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 // sshManager provides a means to manage ssh server within JIMM.
 type sshManager struct {
-	modelManager
-	identityManager
-	sshKeyManager
+	ModelManager
+	IdentityManager
+	SSHKeyManager
 }
 
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(identityManager identityManager, modelManager modelManager, sshKeyManager sshKeyManager) (*sshManager, error) {
+func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager) (*sshManager, error) {
 	if identityManager == nil {
 		return nil, errors.E("identityManager cannot be nil")
 	}
@@ -41,8 +44,8 @@ func NewSSHManager(identityManager identityManager, modelManager modelManager, s
 		return nil, errors.E("sshManager cannot be nil")
 	}
 	return &sshManager{
-		modelManager:    modelManager,
-		identityManager: identityManager,
-		sshKeyManager:   sshKeyManager,
+		ModelManager:    modelManager,
+		IdentityManager: identityManager,
+		SSHKeyManager:   sshKeyManager,
 	}, nil
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -53,6 +53,8 @@ type sshManager struct {
 	sshKeyManager   SSHKeyManager
 }
 
+// PublicKeyHandler is the method to verify the public key of the user. It first checks for the public key and then fetches the user.
+// It returns a user if successful.
 func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	zapctx.Info(ctx, "PublicKeyHandler")
 	if ok, err := s.sshKeyManager.VerifyPublicKey(ctx, claimUser, key); !ok || err != nil {

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -4,6 +4,9 @@ package ssh
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -25,13 +28,6 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-// sshManager provides a means to manage ssh server within JIMM.
-type sshManager struct {
-	ModelManager
-	IdentityManager
-	SSHKeyManager
-}
-
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
 func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager) (*sshManager, error) {
 	if identityManager == nil {
@@ -44,8 +40,28 @@ func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, s
 		return nil, errors.E("sshManager cannot be nil")
 	}
 	return &sshManager{
-		ModelManager:    modelManager,
-		IdentityManager: identityManager,
-		SSHKeyManager:   sshKeyManager,
+		modelManager:    modelManager,
+		identityManager: identityManager,
+		sshKeyManager:   sshKeyManager,
 	}, nil
+}
+
+// sshManager provides a means to manage ssh server within JIMM.
+type sshManager struct {
+	modelManager    ModelManager
+	identityManager IdentityManager
+	sshKeyManager   SSHKeyManager
+}
+
+func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
+	zapctx.Info(ctx, "PublicKeyHandler")
+	if ok, err := s.sshKeyManager.VerifyPublicKey(ctx, claimUser, key); !ok || err != nil {
+		return nil, fmt.Errorf("cannot verify key for user %s: %s", claimUser, err.Error())
+	}
+	user, err := s.identityManager.FetchIdentity(ctx, claimUser)
+	if err != nil {
+		zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", claimUser))
+		return nil, fmt.Errorf("cannot find user %s: %s", claimUser, err.Error())
+	}
+	return user, nil
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Canonical.
+
+package ssh_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/jimm/ssh"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+func TestSSHManagerCreation(t *testing.T) {
+	c := qt.New(t)
+	_, err := ssh.NewSSHManager(&mocks.IdentityManager{}, &mocks.ModelManager{}, &mocks.SSHKeyManager{})
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestSSHManagerCreation(t *testing.T) {
 	c := qt.New(t)
+	// TODO(simonedutto): add proper testing when implementing the sshkeymanager VerifyPublicKey method.
 	_, err := ssh.NewSSHManager(&mocks.IdentityManager{}, &mocks.ModelManager{}, &mocks.SSHKeyManager{})
 	c.Assert(err, qt.IsNil)
 }

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -31,7 +31,7 @@ type SSHManager interface {
 	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
 
 	// VerifyPublicKey verifies the identityName is
-	VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -70,13 +70,14 @@ func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (S
 				"direct-tcpip": directTCPIPHandler(sshManager),
 			},
 			PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-				user, err := sshManager.FetchIdentity(ctx, ctx.User())
-				if err != nil {
-					zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", ctx.User()))
+				claimUser := ctx.User()
+				if ok, err := sshManager.VerifyPublicKey(ctx, claimUser, key.Marshal()); !ok || err != nil {
+					zapctx.Info(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
 					return false
 				}
-				if ok, err := sshManager.VerifyPublicKey(ctx, user, gossh.FingerprintSHA256(key)); !ok || err != nil {
-					zapctx.Info(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
+				user, err := sshManager.FetchIdentity(ctx, claimUser)
+				if err != nil {
+					zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", ctx.User()))
 					return false
 				}
 				ctx.SetValue(publicKeySSHUserKey{}, user)
@@ -111,7 +112,7 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			return
 		}
 		modelTag := names.NewModelTag(d.DestAddr)
-		user, err := fetchAndVerifySSHUser(ctx, modelTag)
+		user, err := fetchAndAuthorizeUser(ctx, modelTag)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
@@ -175,8 +176,8 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 	}
 }
 
-// fetchAndVerifySSHUser extracts the user from the context and checks the user has permission to ssh.
-func fetchAndVerifySSHUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.User, error) {
+// fetchAndAuthorizeUser extracts the user from the context and checks the user has permission to ssh.
+func fetchAndAuthorizeUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.User, error) {
 	user, ok := ctx.Value(publicKeySSHUserKey{}).(*openfga.User)
 	if !ok {
 		return nil, fmt.Errorf("fo user in the context")

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/gliderlabs/ssh"
+	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 	gossh "golang.org/x/crypto/ssh"
@@ -19,10 +20,18 @@ import (
 // juju_ssh_default_port is the default port we expect the juju controllers to respond on.
 const juju_ssh_default_port = 17022
 
-// Resolver is the interface with the methods needed by the ssh jump server to route request.
-type Resolver interface {
+type publicKeySSHUserKey struct{}
+
+// SSHManager is the interface with the methods needed by the ssh jump server to route request.
+type SSHManager interface {
 	// AddrFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
-	AddrFromModelUUID(ctx context.Context, user openfga.User, modelUUID string) (string, error)
+	AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
+
+	// FetchIdentity
+	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
+
+	// VerifyPublicKey verifies the identityName is
+	VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -33,11 +42,11 @@ type forwardMessage struct {
 	SrcPort  uint32
 }
 
-// Server is the custom struct to embed the gliderlabs.ssh server and a resolver.
+// Server is the custom struct to embed the gliderlabs.ssh server and a sshManager.
 type Server struct {
 	*ssh.Server
 
-	resolver Resolver
+	sshManager SSHManager
 }
 
 // Config is the struct holding the configuration for the jump server.
@@ -48,23 +57,33 @@ type Config struct {
 }
 
 // NewJumpServer creates the jump server struct.
-func NewJumpServer(ctx context.Context, config Config, resolver Resolver) (Server, error) {
+func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (Server, error) {
 	zapctx.Info(ctx, "NewJumpServer")
 
-	if resolver == nil {
+	if sshManager == nil {
 		return Server{}, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
 	}
 	server := Server{
 		Server: &ssh.Server{
 			Addr: fmt.Sprintf(":%s", config.Port),
 			ChannelHandlers: map[string]ssh.ChannelHandler{
-				"direct-tcpip": directTCPIPHandler(resolver),
+				"direct-tcpip": directTCPIPHandler(sshManager),
 			},
 			PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+				user, err := sshManager.FetchIdentity(ctx, ctx.User())
+				if err != nil {
+					zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", ctx.User()))
+					return false
+				}
+				if ok, err := sshManager.VerifyPublicKey(ctx, user, gossh.FingerprintSHA256(key)); !ok || err != nil {
+					zapctx.Info(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
+					return false
+				}
+				ctx.SetValue(publicKeySSHUserKey{}, user)
 				return true
 			},
 		},
-		resolver: resolver,
+		sshManager: sshManager,
 	}
 	s, err := gossh.ParsePrivateKey([]byte(config.HostKey))
 	if err != nil {
@@ -75,22 +94,31 @@ func NewJumpServer(ctx context.Context, config Config, resolver Resolver) (Serve
 	return server, nil
 }
 
-func directTCPIPHandler(resolver Resolver) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
+func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 	return func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 		d := forwardMessage{}
-
 		k := newChan.ExtraData()
 
 		if err := gossh.Unmarshal(k, &d); err != nil {
-			rejectConnectionAndLogError(ctx, newChan, "Failed to parse channel data", err)
+			rejectConnectionAndLogError(ctx, newChan, "failed to parse channel data", err)
 			return
 		}
 		if d.DestPort == 0 {
 			d.DestPort = juju_ssh_default_port
 		}
-		addr, err := resolver.AddrFromModelUUID(ctx, openfga.User{}, d.DestAddr)
+		if !names.IsValidModel(d.DestAddr) {
+			rejectConnectionAndLogError(ctx, newChan, "invalid model uuid", nil)
+			return
+		}
+		modelTag := names.NewModelTag(d.DestAddr)
+		user, err := fetchAndVerifySSHUser(ctx, modelTag)
 		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, "Failed to resolve address from model uuid", err)
+			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
+			return
+		}
+		addr, err := sshManager.AddrFromModelUUID(ctx, user, modelTag)
+		if err != nil {
+			rejectConnectionAndLogError(ctx, newChan, "failed to resolve address from model uuid", err)
 			return
 		}
 		dest := net.JoinHostPort(addr, fmt.Sprint(d.DestPort))
@@ -105,13 +133,13 @@ func directTCPIPHandler(resolver Resolver) func(srv *ssh.Server, conn *gossh.Ser
 			},
 		})
 		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("Failed to connect to %s: %v", dest, err), err)
+			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("failed to connect to %s: %v", dest, err), err)
 			return
 		}
 
 		dstChan, reqs, err := client.OpenChannel("direct-tcpip", gossh.Marshal(d))
 		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, "Failed to open destination channel", err)
+			rejectConnectionAndLogError(ctx, newChan, "failed to open destination channel", err)
 			return
 		}
 		// gossh.Request are requests sent outside of the normal stream of data (ex. pty-req for an interactive session).
@@ -132,7 +160,7 @@ func directTCPIPHandler(resolver Resolver) func(srv *ssh.Server, conn *gossh.Ser
 			defer dstChan.Close()
 			_, err := io.Copy(srcDest, dstChan)
 			if err != nil {
-				rejectConnectionAndLogError(ctx, newChan, "Failed to copy data from src to dts", err)
+				rejectConnectionAndLogError(ctx, newChan, "failed to copy data from src to dts", err)
 			}
 		}()
 		go func() {
@@ -140,13 +168,30 @@ func directTCPIPHandler(resolver Resolver) func(srv *ssh.Server, conn *gossh.Ser
 			defer dstChan.Close()
 			_, err := io.Copy(dstChan, srcDest)
 			if err != nil {
-				rejectConnectionAndLogError(ctx, newChan, "Failed to copy data from dst to src", err)
+				rejectConnectionAndLogError(ctx, newChan, "failed to copy data from dst to src", err)
 			}
 		}()
 		zapctx.Info(ctx, fmt.Sprintf("Proxying connection from %s:%d to %s:%d \n", d.SrcAddr, d.SrcPort, d.DestAddr, d.DestPort))
 	}
 }
 
+// fetchAndVerifySSHUser extracts the user from the context and checks the user has permission to ssh.
+func fetchAndVerifySSHUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.User, error) {
+	user, ok := ctx.Value(publicKeySSHUserKey{}).(*openfga.User)
+	if !ok {
+		return nil, fmt.Errorf("fo user in the context")
+	}
+	ok, err := user.IsModelWriter(ctx, modelTag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve address from model uuid")
+	}
+	if !ok {
+		return nil, fmt.Errorf("user doesn't have permission")
+	}
+	return user, nil
+}
+
+// rejectConnectionAndLogError logs the error and rejects the channel with a message.
 func rejectConnectionAndLogError(ctx context.Context, newChan gossh.NewChannel, msg string, err error) {
 	zapctx.Error(ctx, msg, zap.Error(err))
 	err = newChan.Reject(gossh.ConnectionFailed, msg)

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -22,16 +22,17 @@ const juju_ssh_default_port = 17022
 
 type publicKeySSHUserKey struct{}
 
-// SSHManager is the interface with the methods needed by the ssh jump server to route request.
-type SSHManager interface {
+// SSHAuthorizer is the interface to authorize users via public key.
+type SSHAuthorizer interface {
+	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
+	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+}
+
+// TODO(simonedutto): this is going to change to reuse as much as our dial logic as we possibly can.
+// SSHResolver is the interface to resolve controller's addresses.
+type SSHResolver interface {
 	// AddrFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
 	AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
-
-	// FetchIdentity
-	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
-
-	// VerifyPublicKey verifies the identityName is
-	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -42,13 +43,6 @@ type forwardMessage struct {
 	SrcPort  uint32
 }
 
-// Server is the custom struct to embed the gliderlabs.ssh server and a sshManager.
-type Server struct {
-	*ssh.Server
-
-	sshManager SSHManager
-}
-
 // Config is the struct holding the configuration for the jump server.
 type Config struct {
 	Port                     string
@@ -57,45 +51,37 @@ type Config struct {
 }
 
 // NewJumpServer creates the jump server struct.
-func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (Server, error) {
+func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthorizer, sshResolver SSHResolver) (*ssh.Server, error) {
 	zapctx.Info(ctx, "NewJumpServer")
 
-	if sshManager == nil {
-		return Server{}, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
+	if sshResolver == nil {
+		return nil, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
 	}
-	server := Server{
-		Server: &ssh.Server{
-			Addr: fmt.Sprintf(":%s", config.Port),
-			ChannelHandlers: map[string]ssh.ChannelHandler{
-				"direct-tcpip": directTCPIPHandler(sshManager),
-			},
-			PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-				claimUser := ctx.User()
-				if ok, err := sshManager.VerifyPublicKey(ctx, claimUser, key.Marshal()); !ok || err != nil {
-					zapctx.Info(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
-					return false
-				}
-				user, err := sshManager.FetchIdentity(ctx, claimUser)
-				if err != nil {
-					zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", ctx.User()))
-					return false
-				}
-				ctx.SetValue(publicKeySSHUserKey{}, user)
-				return true
-			},
+	server := &ssh.Server{
+		Addr: fmt.Sprintf(":%s", config.Port),
+		ChannelHandlers: map[string]ssh.ChannelHandler{
+			"direct-tcpip": directTCPIPHandler(sshResolver),
 		},
-		sshManager: sshManager,
+		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+			user, err := sshAuthorizer.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
+			if err != nil {
+				zapctx.Debug(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
+				return false
+			}
+			ctx.SetValue(publicKeySSHUserKey{}, user)
+			return true
+		},
 	}
-	s, err := gossh.ParsePrivateKey([]byte(config.HostKey))
+	hostKey, err := gossh.ParsePrivateKey([]byte(config.HostKey))
 	if err != nil {
-		return Server{}, fmt.Errorf("Cannot parse hostkey.")
+		return nil, fmt.Errorf("Cannot parse hostkey.")
 	}
-	server.AddHostKey(s)
+	server.AddHostKey(hostKey)
 
 	return server, nil
 }
 
-func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
+func directTCPIPHandler(sshResolver SSHResolver) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 	return func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 		d := forwardMessage{}
 		k := newChan.ExtraData()
@@ -117,7 +103,7 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
 		}
-		addr, err := sshManager.AddrFromModelUUID(ctx, user, modelTag)
+		addr, err := sshResolver.AddrFromModelUUID(ctx, user, modelTag)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to resolve address from model uuid", err)
 			return

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 type sshSuite struct {
-	destinationJujuSSHServer gliderssh.Server
+	destinationJujuSSHServer *gliderssh.Server
 	destinationServerPort    int
-	jumpSSHServer            ssh.Server
+	jumpSSHServer            *gliderssh.Server
 	jumpServerPort           int
 	privateKey               gossh.Signer
 	hostKey                  gossh.Signer
@@ -72,7 +72,7 @@ func (s *sshSuite) Init(c *qt.C) {
 	port, err := jimmtest.GetFreePort()
 	c.Assert(err, qt.IsNil)
 	s.destinationServerPort = port
-	s.destinationJujuSSHServer = gliderssh.Server{
+	s.destinationJujuSSHServer = &gliderssh.Server{
 		Addr: fmt.Sprintf(":%d", port),
 		ChannelHandlers: map[string]gliderssh.ChannelHandler{
 			"direct-tcpip": func(srv *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
@@ -110,25 +110,26 @@ func (s *sshSuite) Init(c *qt.C) {
 	s.hostKey, err = gossh.ParsePrivateKey(hostKey)
 	c.Assert(err, qt.IsNil)
 
-	s.jumpSSHServer, err = ssh.NewJumpServer(context.Background(),
+	jumpServer, err := ssh.NewJumpServer(context.Background(),
 		ssh.Config{
 			Port:    fmt.Sprint(port),
-			HostKey: hostKey},
-		mocks.SSHManager{
+			HostKey: hostKey,
+		},
+		mocks.SSHAuthorizer{
+			PublicKeyHandler_: func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
+				if claimUser == "alice" {
+					return userWithAccess, nil
+				}
+				return userWithoutAccess, nil
+			},
+		},
+		mocks.SSHResolver{
 			AddrFromModelUUID_: func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
 				return "", nil
 			},
-			FetchIdentity_: func(ctx context.Context, id string) (*openfga.User, error) {
-				if id == "alice" {
-					return userWithAccess, nil
-				} else {
-					return userWithoutAccess, nil
-				}
-			},
-			VerifyPublicKey_: func(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
-				return true, nil
-			},
 		})
+	c.Assert(err, qt.IsNil)
+	s.jumpSSHServer = jumpServer
 	c.Assert(err, qt.IsNil)
 	go func() {
 		_ = s.jumpSSHServer.ListenAndServe()

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -17,18 +17,17 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
 	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/juju/names/v5"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/ssh"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
 )
-
-type resolver struct{}
-
-func (r resolver) AddrFromModelUUID(ctx context.Context, user openfga.User, modelName string) (string, error) {
-	return "", nil
-}
 
 type sshSuite struct {
 	destinationJujuSSHServer gliderssh.Server
@@ -39,9 +38,36 @@ type sshSuite struct {
 	hostKey                  gossh.Signer
 	testInDestinationServerF func(fm ssh.ForwardMessage)
 	received                 chan bool
+
+	allowedModelUUID string
 }
 
 func (s *sshSuite) Init(c *qt.C) {
+	ctx := context.Background()
+	// Setup DB
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	err := db.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	// Setup OFGA
+	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
+	c.Assert(err, qt.IsNil)
+
+	// create a user and set permission for one model
+	i1, err := dbmodel.NewIdentity("alice")
+	c.Assert(err, qt.IsNil)
+	userWithAccess := openfga.NewUser(i1, ofgaClient)
+	s.allowedModelUUID = "deadbeef-1bad-500d-9000-4b1d0d06f00d"
+	err = userWithAccess.SetModelAccess(ctx, names.NewModelTag(s.allowedModelUUID), ofganames.WriterRelation)
+	c.Assert(err, qt.IsNil)
+	// create a user and don't set any permission
+	i2, err := dbmodel.NewIdentity("bob")
+	c.Assert(err, qt.IsNil)
+	userWithoutAccess := openfga.NewUser(i2, ofgaClient)
+
+	// setup destination server
 	s.received = make(chan bool)
 	port, err := jimmtest.GetFreePort()
 	c.Assert(err, qt.IsNil)
@@ -69,6 +95,7 @@ func (s *sshSuite) Init(c *qt.C) {
 	s.destinationServerPort, err = strconv.Atoi(strings.Split(s.destinationJujuSSHServer.Addr, ":")[1])
 	c.Assert(err, qt.IsNil)
 
+	// setup jump server
 	port, err = jimmtest.GetFreePort()
 	c.Assert(err, qt.IsNil)
 	s.jumpServerPort = port
@@ -87,13 +114,27 @@ func (s *sshSuite) Init(c *qt.C) {
 		ssh.Config{
 			Port:    fmt.Sprint(port),
 			HostKey: hostKey},
-		resolver{},
-	)
+		mocks.SSHManager{
+			AddrFromModelUUID_: func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
+				return "", nil
+			},
+			FetchIdentity_: func(ctx context.Context, id string) (*openfga.User, error) {
+				if id == "alice" {
+					return userWithAccess, nil
+				} else {
+					return userWithoutAccess, nil
+				}
+			},
+			VerifyPublicKey_: func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+				return true, nil
+			},
+		})
 	c.Assert(err, qt.IsNil)
 	go func() {
 		_ = s.jumpSSHServer.ListenAndServe()
 	}()
 
+	// setup private key
 	k, err = rsa.GenerateKey(rand.Reader, 2048)
 	c.Assert(err, qt.IsNil)
 	keyPEM := pem.EncodeToMemory(
@@ -105,6 +146,8 @@ func (s *sshSuite) Init(c *qt.C) {
 
 	s.privateKey, err = gossh.ParsePrivateKey(keyPEM)
 	c.Assert(err, qt.IsNil)
+
+	// cleanup
 	c.Cleanup(func() {
 		err := s.destinationJujuSSHServer.Close()
 		c.Check(err, qt.IsNil)
@@ -119,20 +162,21 @@ func (s *sshSuite) TestSSHJump(c *qt.C) {
 		Auth: []gossh.AuthMethod{
 			gossh.PublicKeys(s.privateKey),
 		},
+		User: "alice",
 	})
 	c.Assert(err, qt.IsNil)
 	defer client.Close()
 
 	// send forward message
 	msg := ssh.ForwardMessage{
-		DestAddr: "model1",
+		DestAddr: s.allowedModelUUID,
 		//nolint:gosec
 		DestPort: uint32(s.destinationServerPort),
 		SrcAddr:  "localhost",
 		SrcPort:  0,
 	}
 	s.testInDestinationServerF = func(fm ssh.ForwardMessage) {
-		c.Check(fm.DestAddr, qt.Equals, "model1")
+		c.Check(fm.DestAddr, qt.Equals, s.allowedModelUUID)
 	}
 	ch, _, err := client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
 	c.Check(err, qt.IsNil)
@@ -144,23 +188,68 @@ func (s *sshSuite) TestSSHJump(c *qt.C) {
 	}
 }
 
+func (s *sshSuite) TestSSHJumpPermissionFail(c *qt.C) {
+	client, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
+		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
+		Auth: []gossh.AuthMethod{
+			gossh.PublicKeys(s.privateKey),
+		},
+		User: "alice",
+	})
+	c.Assert(err, qt.IsNil)
+	defer client.Close()
+
+	// send forward message
+	msg := ssh.ForwardMessage{
+		DestAddr: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		//nolint:gosec
+		DestPort: uint32(s.destinationServerPort),
+		SrcAddr:  "localhost",
+		SrcPort:  0,
+	}
+	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+	c.Assert(err, qt.ErrorMatches, ".*user doesn't have permission.*")
+
+	client, err = gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
+		//nolint:gosec // this will be removed once we handle hostkeys
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Auth: []gossh.AuthMethod{
+			gossh.PublicKeys(s.privateKey),
+		},
+		User: "bob",
+	})
+	c.Assert(err, qt.IsNil)
+	defer client.Close()
+	// send forward message
+	msg = ssh.ForwardMessage{
+		DestAddr: s.allowedModelUUID,
+		//nolint:gosec
+		DestPort: uint32(s.destinationServerPort),
+		SrcAddr:  "localhost",
+		SrcPort:  0,
+	}
+	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+	c.Assert(err, qt.ErrorMatches, ".*user doesn't have permission.*")
+}
+
 func (s *sshSuite) TestSSHJumpDialFail(c *qt.C) {
 	_, err := gossh.Dial("tcp", fmt.Sprintf(":%d", 1), &gossh.ClientConfig{
 		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
 		Auth: []gossh.AuthMethod{
 			gossh.PublicKeys(s.privateKey),
 		},
+		User: "alice",
 	})
 	c.Assert(err, qt.ErrorMatches, ".*connect: connection refused.*")
 }
 
 func (s *sshSuite) TestSSHFinalDestinationDialFail(c *qt.C) {
-
 	client, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
 		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
 		Auth: []gossh.AuthMethod{
 			gossh.PublicKeys(s.privateKey),
 		},
+		User: "alice",
 	})
 	c.Assert(err, qt.IsNil)
 
@@ -177,7 +266,6 @@ func (s *sshSuite) TestSSHFinalDestinationDialFail(c *qt.C) {
 	}
 	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
 	c.Assert(err, qt.ErrorMatches, ".*connect failed.*")
-
 }
 
 func TestIdentityManager(t *testing.T) {

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -125,7 +125,7 @@ func (s *sshSuite) Init(c *qt.C) {
 					return userWithoutAccess, nil
 				}
 			},
-			VerifyPublicKey_: func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+			VerifyPublicKey_: func(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 				return true, nil
 			},
 		})

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -11,30 +11,26 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
-// SSHManager is an implementation of the sshManager interface.
-type SSHManager struct {
+// SSHResolver is an implementation of the sshResolver interface.
+type SSHResolver struct {
 	AddrFromModelUUID_ func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
-	FetchIdentity_     func(ctx context.Context, id string) (*openfga.User, error)
-	VerifyPublicKey_   func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-func (j SSHManager) FetchIdentity(ctx context.Context, id string) (*openfga.User, error) {
-	if j.FetchIdentity_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
-	}
-	return j.FetchIdentity_(ctx, id)
-}
-
-func (j SSHManager) AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
+func (j SSHResolver) AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
 	if j.AddrFromModelUUID_ == nil {
 		return "", errors.E(errors.CodeNotImplemented)
 	}
 	return j.AddrFromModelUUID_(ctx, user, modelTag)
 }
 
-func (j SSHManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
-	if j.VerifyPublicKey_ == nil {
-		return true, errors.E(errors.CodeNotImplemented)
+// SSHResolver is an implementation of the sshResolver interface.
+type SSHAuthorizer struct {
+	PublicKeyHandler_ func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+}
+
+func (j SSHAuthorizer) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
+	if j.PublicKeyHandler_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.VerifyPublicKey_(ctx, claimUser, publicKey)
+	return j.PublicKeyHandler_(ctx, claimUser, key)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/juju/names/v5"
 
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
@@ -14,26 +15,26 @@ import (
 type SSHManager struct {
 	AddrFromModelUUID_ func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
 	FetchIdentity_     func(ctx context.Context, id string) (*openfga.User, error)
-	VerifyPublicKey_   func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+	VerifyPublicKey_   func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 func (j SSHManager) FetchIdentity(ctx context.Context, id string) (*openfga.User, error) {
 	if j.FetchIdentity_ == nil {
-		return nil, nil
+		return nil, errors.E(errors.CodeNotImplemented)
 	}
 	return j.FetchIdentity_(ctx, id)
 }
 
 func (j SSHManager) AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
 	if j.AddrFromModelUUID_ == nil {
-		return "", nil
+		return "", errors.E(errors.CodeNotImplemented)
 	}
 	return j.AddrFromModelUUID_(ctx, user, modelTag)
 }
 
-func (j SSHManager) VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+func (j SSHManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 	if j.VerifyPublicKey_ == nil {
-		return true, nil
+		return true, errors.E(errors.CodeNotImplemented)
 	}
-	return j.VerifyPublicKey_(ctx, user, fingerprint)
+	return j.VerifyPublicKey_(ctx, claimUser, publicKey)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Canonical.
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+// SSHManager is an implementation of the sshManager interface.
+type SSHManager struct {
+	AddrFromModelUUID_ func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
+	FetchIdentity_     func(ctx context.Context, id string) (*openfga.User, error)
+	VerifyPublicKey_   func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+}
+
+func (j SSHManager) FetchIdentity(ctx context.Context, id string) (*openfga.User, error) {
+	if j.FetchIdentity_ == nil {
+		return nil, nil
+	}
+	return j.FetchIdentity_(ctx, id)
+}
+
+func (j SSHManager) AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
+	if j.AddrFromModelUUID_ == nil {
+		return "", nil
+	}
+	return j.AddrFromModelUUID_(ctx, user, modelTag)
+}
+
+func (j SSHManager) VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+	if j.VerifyPublicKey_ == nil {
+		return true, nil
+	}
+	return j.VerifyPublicKey_(ctx, user, fingerprint)
+}

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -14,7 +14,7 @@ type SSHKeyManager struct {
 	ListUserPublicKeys_         func(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error)
 	RemoveUserKeyByComment_     func(ctx context.Context, user *openfga.User, comment string) error
 	RemoveUserKeyByFingerprint_ func(ctx context.Context, user *openfga.User, fingerprint string) error
-	VerifyPublicKey_            func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
+	VerifyPublicKey_            func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error {
@@ -42,9 +42,9 @@ func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *op
 	return j.RemoveUserKeyByFingerprint_(ctx, user, fingerprint)
 }
 
-func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 	if j.VerifyPublicKey_ == nil {
 		return true, nil
 	}
-	return j.VerifyPublicKey_(ctx, user, fingerprint)
+	return j.VerifyPublicKey_(ctx, claimUser, publicKey)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -14,6 +14,7 @@ type SSHKeyManager struct {
 	ListUserPublicKeys_         func(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error)
 	RemoveUserKeyByComment_     func(ctx context.Context, user *openfga.User, comment string) error
 	RemoveUserKeyByFingerprint_ func(ctx context.Context, user *openfga.User, fingerprint string) error
+	VerifyPublicKey_            func(ctx context.Context, user *openfga.User, fingerprint string) (bool, error)
 }
 
 func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error {
@@ -39,4 +40,11 @@ func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *op
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return j.RemoveUserKeyByFingerprint_(ctx, user, fingerprint)
+}
+
+func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, user *openfga.User, fingerprint string) (bool, error) {
+	if j.VerifyPublicKey_ == nil {
+		return true, nil
+	}
+	return j.VerifyPublicKey_(ctx, user, fingerprint)
 }


### PR DESCRIPTION
## Description
In this PR we implement the authentication and authorization checks inside of the ssh jump server.
To do so:
- we require an ssh manager, able to interact with Jimm's state
- a new method in the ssh key manager to verify a public key fingerprint (the implementation will be done in a follow-up pr)