### PR TITLE
implement limit connections

### DIFF
--- a/internal/ssh/listener.go
+++ b/internal/ssh/listener.go
@@ -1,4 +1,35 @@
-// Copyright 2025 Canonical.
+// nolint:goheader
+// Copyright 2009 The Go Authors.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   - Redistributions of source code must retain the above copyright
+//
+// notice, this list of conditions and the following disclaimer.
+//   - Redistributions in binary form must reproduce the above
+//
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//   - Neither the name of Google LLC nor the names of its
+//
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package ssh
 
 import (

--- a/internal/ssh/listener.go
+++ b/internal/ssh/listener.go
@@ -4,19 +4,15 @@
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-//
 //   - Redistributions of source code must retain the above copyright
-//
-// notice, this list of conditions and the following disclaimer.
+//     notice, this list of conditions and the following disclaimer.
 //   - Redistributions in binary form must reproduce the above
-//
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
+//     copyright notice, this list of conditions and the following disclaimer
+// 	   in the documentation and/or other materials provided with the
+//     distribution.
 //   - Neither the name of Google LLC nor the names of its
-//
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -42,10 +38,10 @@ import (
 // This is a copypaste of netutil.LimiLister (link: https://cs.opensource.google/go/x/net/+/refs/tags/v0.34.0:netutil/listen.go),
 // but we add a timeout so when we are at the limit we actively close connections instead of waiting indefinetely. (Look at line 44)
 
-// LimitListenerWithTimeout returns a Listener that accepts at most n simultaneous
+// limitListenerWithTimeout returns a Listener that accepts at most n simultaneous
 // connections from the provided Listener, and it timeouts when the max
 // has been reached and no seats has been freed for the timeout period.
-func LimitListenerWithTimeout(l net.Listener, n int, timeout time.Duration) net.Listener {
+func limitListenerWithTimeout(l net.Listener, n int, timeout time.Duration) net.Listener {
 	return &limitListener{
 		Listener: l,
 		sem:      make(chan struct{}, n),

--- a/internal/ssh/listener.go
+++ b/internal/ssh/listener.go
@@ -78,6 +78,7 @@ func (l *limitListener) acquire() bool {
 }
 func (l *limitListener) release() { <-l.sem }
 
+// Accept waits for and returns the next connection to the listener, by checking the semaphore and the timeout.
 func (l *limitListener) Accept() (net.Conn, error) {
 	if !l.acquire() {
 		// If the semaphore isn't acquired because the listener was closed, expect

--- a/internal/ssh/listener.go
+++ b/internal/ssh/listener.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Canonical.
+package ssh
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// N.B.:
+// This is a copypaste of netutil.LimiLister, but we add a timeout so when we are at the limit
+// we actively close connections instead of waiting indefinetely. (Look at line 44)
+
+// LimitListenerWithTimeout returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener, and it timeouts when the max
+// has been reached and no seats has been freed for the timeout period.
+func LimitListenerWithTimeout(l net.Listener, n int, timeout time.Duration) net.Listener {
+	return &limitListener{
+		Listener: l,
+		sem:      make(chan struct{}, n),
+		done:     make(chan struct{}),
+		timeout:  timeout,
+	}
+}
+
+type limitListener struct {
+	net.Listener
+	sem       chan struct{}
+	closeOnce sync.Once     // ensures the done chan is only closed once
+	done      chan struct{} // no values sent; closed when Close is called
+	timeout   time.Duration // timeout for acquiring the connection
+}
+
+// acquire acquires the limiting semaphore. Returns true if successfully
+// acquired, false if the listener is closed and the semaphore is not
+// acquired.
+func (l *limitListener) acquire() bool {
+	select {
+	case <-l.done:
+		return false
+	case l.sem <- struct{}{}:
+		return true
+	// we add a timeout here, so the connection is closed when the timeout has passed instead of waiting.
+	case <-time.After(l.timeout):
+		return false
+	}
+}
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	if !l.acquire() {
+		// If the semaphore isn't acquired because the listener was closed, expect
+		// that this call to accept won't block, but immediately return an error.
+		// If it instead returns a spurious connection (due to a bug in the
+		// Listener, such as https://golang.org/issue/50216), we immediately close
+		// it and try again. Some buggy Listener implementations (like the one in
+		// the aforementioned issue) seem to assume that Accept will be called to
+		// completion, and may otherwise fail to clean up the client end of pending
+		// connections.
+		for {
+			c, err := l.Listener.Accept()
+			if err != nil {
+				return nil, err
+			}
+			c.Close()
+		}
+	}
+
+	c, err := l.Listener.Accept()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+func (l *limitListener) Close() error {
+	err := l.Listener.Close()
+	l.closeOnce.Do(func() { close(l.done) })
+	return err
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}

--- a/internal/ssh/listener.go
+++ b/internal/ssh/listener.go
@@ -8,8 +8,8 @@ import (
 )
 
 // N.B.:
-// This is a copypaste of netutil.LimiLister, but we add a timeout so when we are at the limit
-// we actively close connections instead of waiting indefinetely. (Look at line 44)
+// This is a copypaste of netutil.LimiLister (link: https://cs.opensource.google/go/x/net/+/refs/tags/v0.34.0:netutil/listen.go),
+// but we add a timeout so when we are at the limit we actively close connections instead of waiting indefinetely. (Look at line 44)
 
 // LimitListenerWithTimeout returns a Listener that accepts at most n simultaneous
 // connections from the provided Listener, and it timeouts when the max

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/names/v5"
@@ -19,6 +20,7 @@ import (
 
 // juju_ssh_default_port is the default port we expect the juju controllers to respond on.
 const juju_ssh_default_port = 17022
+const defaultAcceptConnectionTimeout = time.Second
 
 type publicKeySSHUserKey struct{}
 
@@ -47,38 +49,66 @@ type forwardMessage struct {
 type Config struct {
 	Port                     string
 	HostKey                  []byte
-	MaxConcurrentConnections string
+	MaxConcurrentConnections int
+	AcceptConnectionTimeout  time.Duration
+}
+
+type Server struct {
+	*ssh.Server
+
+	MaxConcurrentConnections int
+	AcceptConnectionTimeout  time.Duration
 }
 
 // NewJumpServer creates the jump server struct.
-func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthorizer, sshResolver SSHResolver) (*ssh.Server, error) {
+func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthorizer, sshResolver SSHResolver) (Server, error) {
 	zapctx.Info(ctx, "NewJumpServer")
 
 	if sshResolver == nil {
-		return nil, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
+		return Server{}, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
 	}
-	server := &ssh.Server{
-		Addr: fmt.Sprintf(":%s", config.Port),
-		ChannelHandlers: map[string]ssh.ChannelHandler{
-			"direct-tcpip": directTCPIPHandler(sshResolver),
+	server := Server{
+		Server: &ssh.Server{
+			Addr: fmt.Sprintf(":%s", config.Port),
+			ChannelHandlers: map[string]ssh.ChannelHandler{
+				"direct-tcpip": directTCPIPHandler(sshResolver),
+			},
+			PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+				user, err := sshAuthorizer.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
+				if err != nil {
+					zapctx.Debug(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
+					return false
+				}
+				ctx.SetValue(publicKeySSHUserKey{}, user)
+				return true
+			},
 		},
-		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-			user, err := sshAuthorizer.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
-			if err != nil {
-				zapctx.Debug(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
-				return false
-			}
-			ctx.SetValue(publicKeySSHUserKey{}, user)
-			return true
-		},
+		MaxConcurrentConnections: config.MaxConcurrentConnections,
+		AcceptConnectionTimeout:  config.AcceptConnectionTimeout,
 	}
 	hostKey, err := gossh.ParsePrivateKey([]byte(config.HostKey))
 	if err != nil {
-		return nil, fmt.Errorf("Cannot parse hostkey.")
+		return Server{}, fmt.Errorf("Cannot parse hostkey.")
 	}
 	server.AddHostKey(hostKey)
 
 	return server, nil
+}
+
+// ListenAndServe create a LimitListenerWithTimeout and Serve requests.
+func (srv Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", srv.Addr)
+	if srv.MaxConcurrentConnections == 0 {
+		srv.MaxConcurrentConnections = 100
+	}
+	if srv.AcceptConnectionTimeout == 0 {
+		srv.AcceptConnectionTimeout = defaultAcceptConnectionTimeout
+	}
+	ln = LimitListenerWithTimeout(ln, srv.MaxConcurrentConnections, srv.AcceptConnectionTimeout)
+	if err != nil {
+		return err
+	}
+	return srv.Serve(ln)
 }
 
 func directTCPIPHandler(sshResolver SSHResolver) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -21,6 +21,7 @@ import (
 // jujuSSHDefaultPort is the default port we expect the juju controllers to respond on.
 const jujuSSHDefaultPort = 17022
 const defaultAcceptConnectionTimeout = time.Second
+const defaultMaxConcurrentConnections = 100
 
 type publicKeySSHUserKey struct{}
 
@@ -53,11 +54,12 @@ type Config struct {
 	AcceptConnectionTimeout  time.Duration
 }
 
+// Server is the struct holding the jump server and some
 type Server struct {
 	*ssh.Server
 
-	MaxConcurrentConnections int
-	AcceptConnectionTimeout  time.Duration
+	maxConcurrentConnections int
+	acceptConnectionTimeout  time.Duration
 }
 
 // NewJumpServer creates the jump server struct.
@@ -84,8 +86,8 @@ func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthoriz
 				return true
 			},
 		},
-		MaxConcurrentConnections: config.MaxConcurrentConnections,
-		AcceptConnectionTimeout:  config.AcceptConnectionTimeout,
+		maxConcurrentConnections: config.MaxConcurrentConnections,
+		acceptConnectionTimeout:  config.AcceptConnectionTimeout,
 	}
 	hostKey, err := gossh.ParsePrivateKey([]byte(config.HostKey))
 	if err != nil {
@@ -102,7 +104,7 @@ func setConfigDefaults(config Config) Config {
 		config.Port = fmt.Sprint(jujuSSHDefaultPort)
 	}
 	if config.MaxConcurrentConnections <= 0 {
-		config.MaxConcurrentConnections = 100
+		config.MaxConcurrentConnections = defaultMaxConcurrentConnections
 	}
 	if config.AcceptConnectionTimeout <= 0 {
 		config.AcceptConnectionTimeout = defaultAcceptConnectionTimeout
@@ -113,13 +115,13 @@ func setConfigDefaults(config Config) Config {
 // ListenAndServe create a LimitListenerWithTimeout and Serve requests.
 func (srv Server) ListenAndServe() error {
 	ln, err := net.Listen("tcp", srv.Addr)
-	if srv.MaxConcurrentConnections == 0 {
-		srv.MaxConcurrentConnections = 100
+	if srv.maxConcurrentConnections == 0 {
+		srv.maxConcurrentConnections = 100
 	}
-	if srv.AcceptConnectionTimeout == 0 {
-		srv.AcceptConnectionTimeout = defaultAcceptConnectionTimeout
+	if srv.acceptConnectionTimeout == 0 {
+		srv.acceptConnectionTimeout = defaultAcceptConnectionTimeout
 	}
-	ln = LimitListenerWithTimeout(ln, srv.MaxConcurrentConnections, srv.AcceptConnectionTimeout)
+	ln = limitListenerWithTimeout(ln, srv.maxConcurrentConnections, srv.acceptConnectionTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -115,12 +115,6 @@ func setConfigDefaults(config Config) Config {
 // ListenAndServe create a LimitListenerWithTimeout and Serve requests.
 func (srv Server) ListenAndServe() error {
 	ln, err := net.Listen("tcp", srv.Addr)
-	if srv.maxConcurrentConnections == 0 {
-		srv.maxConcurrentConnections = 100
-	}
-	if srv.acceptConnectionTimeout == 0 {
-		srv.acceptConnectionTimeout = defaultAcceptConnectionTimeout
-	}
 	ln = limitListenerWithTimeout(ln, srv.maxConcurrentConnections, srv.acceptConnectionTimeout)
 	if err != nil {
 		return err

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -18,8 +18,8 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
-// juju_ssh_default_port is the default port we expect the juju controllers to respond on.
-const juju_ssh_default_port = 17022
+// jujuSSHDefaultPort is the default port we expect the juju controllers to respond on.
+const jujuSSHDefaultPort = 17022
 const defaultAcceptConnectionTimeout = time.Second
 
 type publicKeySSHUserKey struct{}
@@ -67,6 +67,7 @@ func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthoriz
 	if sshResolver == nil {
 		return Server{}, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
 	}
+	config = setConfigDefaults(config)
 	server := Server{
 		Server: &ssh.Server{
 			Addr: fmt.Sprintf(":%s", config.Port),
@@ -95,6 +96,20 @@ func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthoriz
 	return server, nil
 }
 
+// setConfigDefaults sets the default values for the configuration.
+func setConfigDefaults(config Config) Config {
+	if config.Port == "" {
+		config.Port = fmt.Sprint(jujuSSHDefaultPort)
+	}
+	if config.MaxConcurrentConnections <= 0 {
+		config.MaxConcurrentConnections = 100
+	}
+	if config.AcceptConnectionTimeout <= 0 {
+		config.AcceptConnectionTimeout = defaultAcceptConnectionTimeout
+	}
+	return config
+}
+
 // ListenAndServe create a LimitListenerWithTimeout and Serve requests.
 func (srv Server) ListenAndServe() error {
 	ln, err := net.Listen("tcp", srv.Addr)
@@ -121,7 +136,7 @@ func directTCPIPHandler(sshResolver SSHResolver) func(srv *ssh.Server, conn *gos
 			return
 		}
 		if d.DestPort == 0 {
-			d.DestPort = juju_ssh_default_port
+			d.DestPort = jujuSSHDefaultPort
 		}
 		if !names.IsValidModel(d.DestAddr) {
 			rejectConnectionAndLogError(ctx, newChan, "invalid model uuid", nil)

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -285,7 +285,7 @@ func (s *sshSuite) TestMaxConcurrentConnections(c *qt.C) {
 		c.Check(err, qt.IsNil)
 		clients = append(clients, client)
 	}
-	// this connection is sent when we are at maximum connection>
+	// this connection is dropped when we are at maximum connections
 	_, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
 		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
 		Auth: []gossh.AuthMethod{

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -32,7 +32,7 @@ import (
 type sshSuite struct {
 	destinationJujuSSHServer *gliderssh.Server
 	destinationServerPort    int
-	jumpSSHServer            *gliderssh.Server
+	jumpSSHServer            ssh.Server
 	jumpServerPort           int
 	privateKey               gossh.Signer
 	hostKey                  gossh.Signer
@@ -112,8 +112,9 @@ func (s *sshSuite) Init(c *qt.C) {
 
 	jumpServer, err := ssh.NewJumpServer(context.Background(),
 		ssh.Config{
-			Port:    fmt.Sprint(port),
-			HostKey: hostKey,
+			Port:                     fmt.Sprint(port),
+			HostKey:                  hostKey,
+			MaxConcurrentConnections: 10,
 		},
 		mocks.SSHAuthorizer{
 			PublicKeyHandler_: func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -267,6 +268,36 @@ func (s *sshSuite) TestSSHFinalDestinationDialFail(c *qt.C) {
 	}
 	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
 	c.Assert(err, qt.ErrorMatches, ".*connect failed.*")
+}
+
+func (s *sshSuite) TestMaxConcurrentConnections(c *qt.C) {
+	// fill the max of concurrent connection
+	maxConcurrentConnections := 10
+	clients := make([]*gossh.Client, 0)
+	for range maxConcurrentConnections {
+		client, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
+			HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
+			Auth: []gossh.AuthMethod{
+				gossh.PublicKeys(s.privateKey),
+			},
+			User: "alice",
+		})
+		c.Check(err, qt.IsNil)
+		clients = append(clients, client)
+	}
+	// this connection is sent when we are at maximum connection>
+	_, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
+		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
+		Auth: []gossh.AuthMethod{
+			gossh.PublicKeys(s.privateKey),
+		},
+		User:    "alice",
+		Timeout: 50 * time.Millisecond,
+	})
+	c.Check(err, qt.ErrorMatches, ".*connection reset.*")
+	for _, client := range clients {
+		client.Close()
+	}
 }
 
 func TestIdentityManager(t *testing.T) {


### PR DESCRIPTION
## Description
This is an implementation of the MaxConcurrentRequest for the ssh server.
The implementation is a copy/paste of https://cs.opensource.google/go/x/net/+/refs/tags/v0.34.0:netutil/listen.go with an additional timeout.
In fact the LimitListener hangs forever the `Accept()` until a seat is made available, making it hard to test and also counter intuitive, because we want to close connection when we reach the limit.

The error from the SSH client is:
![image](https://github.com/user-attachments/assets/33f8bf4f-9077-4e71-95d0-b0634b31f240)


> [!NOTE]  
> This is the first simple implementation until we get a better way of doing it by interacting with the gliderlab/ssh server. I am working on a issue + pr to make it possible.


## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
