### PR TITLE
Juju 7464/reuse dial logic

### DIFF
--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -59,12 +59,12 @@ type sshManager struct {
 func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	zapctx.Info(ctx, "PublicKeyHandler")
 	if ok, err := s.sshKeyManager.VerifyPublicKey(ctx, claimUser, key); !ok || err != nil {
-		return nil, fmt.Errorf("cannot verify key for user %s: %s", claimUser, err.Error())
+		return nil, errors.E(err, "cannot verify key for user")
 	}
 	user, err := s.identityManager.FetchIdentity(ctx, claimUser)
 	if err != nil {
 		zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", claimUser))
-		return nil, fmt.Errorf("cannot find user %s: %s", claimUser, err.Error())
+		return nil, errors.E(err, "cannot find user")
 	}
 	return user, nil
 }
@@ -75,12 +75,12 @@ func (s *sshManager) ResolveAddressesFromModelUUID(ctx context.Context, modelUUI
 
 	model, err := s.modelManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot find model %s", modelUUID)
+		return nil, errors.E(err, "cannot find model")
 	}
 
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return nil, fmt.Errorf("cannot find addresses for model %s", modelUUID)
+		return nil, errors.E(err, "cannot find addresses for model's controller")
 	}
 
 	return addrs, nil

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
 // IdentityManager provides a means to fetch an identity from the identity service.
@@ -66,4 +67,21 @@ func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 		return nil, fmt.Errorf("cannot find user %s: %s", claimUser, err.Error())
 	}
 	return user, nil
+}
+
+// ResolveAddressesFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
+func (s *sshManager) ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error) {
+	zapctx.Info(ctx, "ResolveAddressesFromModelUUID")
+
+	model, err := s.modelManager.GetModel(ctx, modelUUID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find model %s", modelUUID)
+	}
+
+	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("cannot find addresses for model %s", modelUUID)
+	}
+
+	return addrs, nil
 }

--- a/internal/rpc/dial _test.go
+++ b/internal/rpc/dial _test.go
@@ -4,6 +4,8 @@ package rpc_test
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
 	"net/http"
 	"testing"
@@ -64,4 +66,130 @@ func TestDialIPv6(t *testing.T) {
 	}})
 	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{})
 	c.Assert(err, qt.Equals, nil)
+}
+
+func TestGetAddressesAndTLSConfig(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		controller     dbmodel.Controller
+		expectedAddrs  []string
+		expectedTLSCfg *tls.Config
+	}{
+		{
+			name: "With CACertificate and PublicAddress",
+			controller: dbmodel.Controller{
+				CACertificate: "test-ca-cert",
+				PublicAddress: "public.address.com",
+				TLSHostname:   "tls.hostname.com",
+			},
+			expectedAddrs: []string{"public.address.com"},
+			expectedTLSCfg: &tls.Config{
+				RootCAs:    x509.NewCertPool(),
+				ServerName: "tls.hostname.com",
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+		{
+			name: "With IPv4 Address",
+			controller: dbmodel.Controller{
+				Addresses: [][]jujuparams.HostPort{
+					{
+						{
+							Address: jujuparams.Address{
+								Value: "192.168.1.1",
+								Type:  "ipv4",
+							},
+							Port: 8080,
+						},
+						{
+							Address: jujuparams.Address{
+								Value: "192.168.1.1",
+								Type:  "ipv4",
+								Scope: "non-exisiting-scope",
+							},
+							Port: 8080,
+						},
+					},
+				},
+			},
+			expectedAddrs:  []string{"192.168.1.1:8080"},
+			expectedTLSCfg: nil,
+		},
+		{
+			name: "With IPv6 Address",
+			controller: dbmodel.Controller{
+				Addresses: [][]jujuparams.HostPort{
+					{
+						{
+							Address: jujuparams.Address{
+								Value: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+								Type:  "ipv6",
+							},
+							Port: 8080,
+						},
+						{
+							Address: jujuparams.Address{
+								Value: "2001:0db8:85a3:0000:0000:8a2e:0370:7335",
+								Type:  "ipv6",
+								Scope: string(network.ScopePublic),
+							},
+							Port: 8080,
+						},
+					},
+				},
+			},
+			expectedAddrs:  []string{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8080", "[2001:0db8:85a3:0000:0000:8a2e:0370:7335]:8080"},
+			expectedTLSCfg: nil,
+		},
+		{
+			name: "With Both IPv4 and IPv6 Addresses",
+			controller: dbmodel.Controller{
+				Addresses: [][]jujuparams.HostPort{
+					{
+						{
+							Address: jujuparams.Address{
+								Value: "192.168.1.1",
+								Type:  "ipv4",
+							},
+							Port: 8080,
+						},
+						{
+							Address: jujuparams.Address{
+								Value: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+								Type:  "ipv6",
+							},
+							Port: 8080,
+						},
+					},
+				},
+			},
+			expectedAddrs:  []string{"192.168.1.1:8080", "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8080"},
+			expectedTLSCfg: nil,
+		},
+		{
+			name: "No Addresses",
+			controller: dbmodel.Controller{
+				Addresses: [][]jujuparams.HostPort{},
+			},
+			expectedAddrs:  nil,
+			expectedTLSCfg: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addrs, tlsCfg := rpc.GetAddressesAndTLSConfig(ctx, &tt.controller)
+			c.Assert(addrs, qt.DeepEquals, tt.expectedAddrs)
+			if tt.expectedTLSCfg != nil {
+				c.Assert(tlsCfg, qt.Not(qt.IsNil))
+				c.Assert(tlsCfg.ServerName, qt.Equals, tt.expectedTLSCfg.ServerName)
+				c.Assert(tlsCfg.MinVersion, qt.Equals, tt.expectedTLSCfg.MinVersion)
+			} else {
+				c.Assert(tlsCfg, qt.IsNil)
+			}
+		})
+	}
 }

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rpc
 
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -54,10 +53,8 @@ func (d Dialer) DialWebsocket(ctx context.Context, url string, headers http.Head
 	return conn, nil
 }
 
-// Dial connects to the controller/model and returns a raw websocket
-// that can be used as is.
-// It accepts the endpoints to dial, normally /api or /commands.
-func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, finalPath string, headers http.Header) (*websocket.Conn, error) {
+// GetAddressesAndTLSConfig returns the addresses and TLS configuration for the given controller.
+func GetAddressesAndTLSConfig(ctx context.Context, ctl *dbmodel.Controller) ([]string, *tls.Config) {
 	var tlsConfig *tls.Config
 	if ctl.CACertificate != "" {
 		cp := x509.NewCertPool()
@@ -71,21 +68,14 @@ func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag,
 			MinVersion: tls.VersionTLS12,
 		}
 	}
-	dialer := Dialer{
-		TLSConfig: tlsConfig,
-	}
 
 	if ctl.PublicAddress != "" {
 		// If there is a public-address configured it is almost
-		// certainly the one we want to use, try it first.
-		conn, err := dialer.DialWebsocket(ctx, websocketURL(ctl.PublicAddress, modelTag, finalPath), headers)
-		if err != nil {
-			zapctx.Error(ctx, "failed to dial public address", zaputil.Error(err))
-		} else {
-			return conn, nil
-		}
+		// certainly the one we want to use.
+		return []string{ctl.PublicAddress}, tlsConfig
 	}
-	var urls []string
+
+	var addrs []string
 	for _, hps := range ctl.Addresses {
 		for _, hp := range hps {
 			if maybeReachable(hp.Scope) {
@@ -95,12 +85,27 @@ func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag,
 				} else {
 					ip = fmt.Sprintf("%s:%d", hp.Value, hp.Port)
 				}
-				urls = append(urls, websocketURL(ip, modelTag, finalPath))
+				addrs = append(addrs, ip)
 			}
 		}
 	}
-	zapctx.Debug(ctx, "Dialling all URLs", zap.Any("urls", urls))
-	conn, err := dialAll(ctx, &dialer, urls, headers)
+	return addrs, tlsConfig
+}
+
+// Dial connects to the controller/model and returns a raw websocket
+// that can be used as is.
+// It accepts the endpoints to dial, normally /api or /commands.
+func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, finalPath string, headers http.Header) (*websocket.Conn, error) {
+	addrs, tlsConfig := GetAddressesAndTLSConfig(ctx, ctl)
+	dialer := Dialer{
+		TLSConfig: tlsConfig,
+	}
+	var websocketUrls []string
+	for _, addr := range addrs {
+		websocketUrls = append(websocketUrls, websocketURL(addr, modelTag, finalPath))
+	}
+	zapctx.Debug(ctx, "Dialling all URLs", zap.Any("urls", websocketUrls))
+	conn, err := dialAll(ctx, &dialer, websocketUrls, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ssh/dial.go
+++ b/internal/ssh/dial.go
@@ -2,24 +2,12 @@
 package ssh
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"time"
 
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
 	gossh "golang.org/x/crypto/ssh"
 )
-
-// rejectConnectionAndLogError logs the error and rejects the channel with a message.
-func rejectConnectionAndLogError(ctx context.Context, newChan gossh.NewChannel, msg string, err error) {
-	zapctx.Error(ctx, msg, zap.Error(err))
-	err = newChan.Reject(gossh.ConnectionFailed, msg)
-	if err != nil {
-		zapctx.Error(ctx, msg, zap.Error(err))
-	}
-}
 
 // dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
 func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, error) {

--- a/internal/ssh/dial.go
+++ b/internal/ssh/dial.go
@@ -1,19 +1,23 @@
 // Copyright 2025 Canonical.
+
 package ssh
 
 import (
+	goerr "errors"
 	"fmt"
 	"net"
 	"time"
 
 	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 // dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
 func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, error) {
 	var client *gossh.Client
 	var err error
-	var errors []error
+	var errs []error
 	for _, addr := range addrs {
 		dest := net.JoinHostPort(addr, fmt.Sprint(destPort))
 		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
@@ -27,11 +31,11 @@ func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, er
 			Timeout: 5 * time.Second,
 		})
 		if err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 	}
 	if client == nil {
-		return nil, fmt.Errorf("failed to dial controller ssh server: %v", errors)
+		return nil, errors.E(goerr.Join(errs...), "cannot dial controller")
 	}
 	return client, nil
 }

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/names/v5"
@@ -22,17 +21,13 @@ const juju_ssh_default_port = 17022
 
 type publicKeySSHUserKey struct{}
 
-// SSHAuthorizer is the interface to authorize users via public key.
-type SSHAuthorizer interface {
+// SSHManager is the interface to
+type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-}
 
-// TODO(simonedutto): this is going to change to reuse as much as our dial logic as we possibly can.
-// SSHResolver is the interface to resolve controller's addresses.
-type SSHResolver interface {
-	// AddrFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
-	AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
+	// ResolveAddressesFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
+	ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -51,19 +46,19 @@ type Config struct {
 }
 
 // NewJumpServer creates the jump server struct.
-func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthorizer, sshResolver SSHResolver) (*ssh.Server, error) {
+func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (*ssh.Server, error) {
 	zapctx.Info(ctx, "NewJumpServer")
 
-	if sshResolver == nil {
-		return nil, fmt.Errorf("Cannot create JumpSSHServer with a nil resolver.")
+	if sshManager == nil {
+		return nil, fmt.Errorf("Cannot create JumpSSHServer with a nil ssh manager.")
 	}
 	server := &ssh.Server{
 		Addr: fmt.Sprintf(":%s", config.Port),
 		ChannelHandlers: map[string]ssh.ChannelHandler{
-			"direct-tcpip": directTCPIPHandler(sshResolver),
+			"direct-tcpip": directTCPIPHandler(sshManager),
 		},
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-			user, err := sshAuthorizer.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
+			user, err := sshManager.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
 			if err != nil {
 				zapctx.Debug(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
 				return false
@@ -81,7 +76,7 @@ func NewJumpServer(ctx context.Context, config Config, sshAuthorizer SSHAuthoriz
 	return server, nil
 }
 
-func directTCPIPHandler(sshResolver SSHResolver) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
+func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 	return func(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 		d := forwardMessage{}
 		k := newChan.ExtraData()
@@ -98,29 +93,20 @@ func directTCPIPHandler(sshResolver SSHResolver) func(srv *ssh.Server, conn *gos
 			return
 		}
 		modelTag := names.NewModelTag(d.DestAddr)
-		user, err := fetchAndAuthorizeUser(ctx, modelTag)
+		// user is now ignored, but it will be needed for the jwt auth next-up.
+		_, err := fetchAndAuthorizeUser(ctx, modelTag)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
 		}
-		addr, err := sshResolver.AddrFromModelUUID(ctx, user, modelTag)
+		addrs, err := sshManager.ResolveAddressesFromModelUUID(ctx, modelTag.Id())
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to resolve address from model uuid", err)
 			return
 		}
-		dest := net.JoinHostPort(addr, fmt.Sprint(d.DestPort))
-		// this is temporary. The way we dial to the controller will heavily change.
-		client, err := gossh.Dial("tcp", dest, &gossh.ClientConfig{
-			//nolint:gosec // this will be removed once we handle hostkeys
-			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
-			Auth: []gossh.AuthMethod{
-				gossh.PasswordCallback(func() (secret string, err error) {
-					return "jwt", nil
-				}),
-			},
-		})
+		client, err := dialControllerSSHServer(addrs, d.DestPort)
 		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("failed to connect to %s: %v", dest, err), err)
+			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("failed to dial controller ssh: %v", err), err)
 			return
 		}
 
@@ -176,13 +162,4 @@ func fetchAndAuthorizeUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.U
 		return nil, fmt.Errorf("user doesn't have permission")
 	}
 	return user, nil
-}
-
-// rejectConnectionAndLogError logs the error and rejects the channel with a message.
-func rejectConnectionAndLogError(ctx context.Context, newChan gossh.NewChannel, msg string, err error) {
-	zapctx.Error(ctx, msg, zap.Error(err))
-	err = newChan.Reject(gossh.ConnectionFailed, msg)
-	if err != nil {
-		zapctx.Error(ctx, msg, zap.Error(err))
-	}
 }

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -21,7 +21,8 @@ const juju_ssh_default_port = 17022
 
 type publicKeySSHUserKey struct{}
 
-// SSHManager is the interface to
+// SSHManager is the interface to enable the ssh server to operate. Performing public key verification and
+// resolving addresses from model uuids.
 type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
@@ -162,4 +163,13 @@ func fetchAndAuthorizeUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.U
 		return nil, fmt.Errorf("user doesn't have permission")
 	}
 	return user, nil
+}
+
+// rejectConnectionAndLogError logs the error and rejects the channel with a message.
+func rejectConnectionAndLogError(ctx context.Context, newChan gossh.NewChannel, msg string, err error) {
+	zapctx.Error(ctx, msg, zap.Error(err))
+	err = newChan.Reject(gossh.ConnectionFailed, msg)
+	if err != nil {
+		zapctx.Error(ctx, msg, zap.Error(err))
+	}
 }

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -115,17 +115,15 @@ func (s *sshSuite) Init(c *qt.C) {
 			Port:    fmt.Sprint(port),
 			HostKey: hostKey,
 		},
-		mocks.SSHAuthorizer{
+		mocks.SSHManager{
 			PublicKeyHandler_: func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 				if claimUser == "alice" {
 					return userWithAccess, nil
 				}
 				return userWithoutAccess, nil
 			},
-		},
-		mocks.SSHResolver{
-			AddrFromModelUUID_: func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
-				return "", nil
+			ResolveAddressesFromModelUUID_: func(ctx context.Context, modelUUID string) ([]string, error) {
+				return []string{""}, nil
 			},
 		})
 	c.Assert(err, qt.IsNil)

--- a/internal/ssh/utils.go
+++ b/internal/ssh/utils.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Canonical.
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// rejectConnectionAndLogError logs the error and rejects the channel with a message.
+func rejectConnectionAndLogError(ctx context.Context, newChan gossh.NewChannel, msg string, err error) {
+	zapctx.Error(ctx, msg, zap.Error(err))
+	err = newChan.Reject(gossh.ConnectionFailed, msg)
+	if err != nil {
+		zapctx.Error(ctx, msg, zap.Error(err))
+	}
+}
+
+// dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
+func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, error) {
+	var client *gossh.Client
+	var err error
+	var errors []error
+	for _, addr := range addrs {
+		dest := net.JoinHostPort(addr, fmt.Sprint(destPort))
+		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
+			//nolint:gosec // this will be removed once we handle hostkeys
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+			Auth: []gossh.AuthMethod{
+				gossh.PasswordCallback(func() (secret string, err error) {
+					return "jwt", nil
+				}),
+			},
+			Timeout: 5 * time.Second,
+		})
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	if client == nil {
+		return nil, fmt.Errorf("failed to dial controller ssh server: %v", errors)
+	}
+	return client, nil
+}

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -5,32 +5,26 @@ package mocks
 import (
 	"context"
 
-	"github.com/juju/names/v5"
-
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
-// SSHResolver is an implementation of the sshResolver interface.
-type SSHResolver struct {
-	AddrFromModelUUID_ func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error)
+// SSHManager is an implementation of the SshManager interface.
+type SSHManager struct {
+	PublicKeyHandler_              func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+	ResolveAddressesFromModelUUID_ func(ctx context.Context, modelUUID string) ([]string, error)
 }
 
-func (j SSHResolver) AddrFromModelUUID(ctx context.Context, user *openfga.User, modelTag names.ModelTag) (string, error) {
-	if j.AddrFromModelUUID_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
-	}
-	return j.AddrFromModelUUID_(ctx, user, modelTag)
-}
-
-// SSHResolver is an implementation of the sshResolver interface.
-type SSHAuthorizer struct {
-	PublicKeyHandler_ func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-}
-
-func (j SSHAuthorizer) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
+func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	if j.PublicKeyHandler_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
 	return j.PublicKeyHandler_(ctx, claimUser, key)
+}
+
+func (j SSHManager) ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error) {
+	if j.ResolveAddressesFromModelUUID_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return j.ResolveAddressesFromModelUUID_(ctx, modelUUID)
 }


### PR DESCRIPTION
## Description
In this PR we reuse some logic from the rpc dial pkg to get addresses from Controller.

First commit is just extracting the GetAddressesAndTLSConfig from the Dial method and add some tests for it.

> I have decided to use a single SSHManager interface, because we don't even need two different interfaces for it. it's overengineering for 2 methods.



## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
