### PR TITLE
add jwt to dial jump server

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -195,8 +195,9 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ResolveAddressesFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
-	ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error)
+	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+	// a valid JWT To connect to the controller.
+	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
 }
 
 // JujuManager is the interface to manage all Juju related operations.
@@ -420,7 +421,7 @@ func New(p Parameters) (*JIMM, error) {
 	}
 	j.sshKeyManager = sshKeyManager
 
-	sshManager, err := ssh.NewSSHManager(j.identityManager, j.jujuManager, j.sshKeyManager)
+	sshManager, err := ssh.NewSSHManager(j.identityManager, j.jujuManager, j.sshKeyManager, j.jujuAuthFactory)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -197,7 +197,7 @@ type SSHManager interface {
 
 	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 	// a valid JWT To connect to the controller.
-	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
+	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error)
 }
 
 // JujuManager is the interface to manage all Juju related operations.

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -195,9 +195,9 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+	// ControllerInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 	// a valid JWT To connect to the controller.
-	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error)
+	ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error)
 }
 
 // JujuManager is the interface to manage all Juju related operations.

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -15,9 +15,12 @@ import (
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
-type ConnInfo struct {
-	Addrs []string
-	JWT   string
+// ControllerInfo is the struct holding the infomation to contact a controller
+type ControllerInfo struct {
+	// addresses to dial the controller
+	Addresses []string
+	// JWT to authenticate to the controller
+	JWT string
 }
 
 // IdentityManager provides a means to fetch an identity from the identity service.
@@ -35,12 +38,13 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-type JWTFactory interface {
+// JWTGeneratorFactory provides a means to create a token generator.
+type JWTGeneratorFactory interface {
 	New() jujuauth.TokenGenerator
 }
 
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager, jwtFactory JWTFactory) (*sshManager, error) {
+func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager, jwtFactory JWTGeneratorFactory) (*sshManager, error) {
 	if identityManager == nil {
 		return nil, errors.E("identityManager cannot be nil")
 	}
@@ -66,7 +70,7 @@ type sshManager struct {
 	modelManager    ModelManager
 	identityManager IdentityManager
 	sshKeyManager   SSHKeyManager
-	jwtFactory      JWTFactory
+	jwtFactory      JWTGeneratorFactory
 }
 
 // PublicKeyHandler is the method to verify the public key of the user. It first checks for the public key and then fetches the user.
@@ -84,27 +88,27 @@ func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 	return user, nil
 }
 
-// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+// ControllerInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 // a valid JWT To connect to the controller.
-func (s *sshManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ConnInfo, error) {
-	zapctx.Info(ctx, "ConnInfoFromModelUUID")
+func (s *sshManager) ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ControllerInfo, error) {
+	zapctx.Info(ctx, "ControllerInfoFromModelUUID")
 	model, err := s.modelManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return ConnInfo{}, errors.E(err, "cannot find model")
+		return ControllerInfo{}, errors.E(err, "cannot find model")
 	}
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return ConnInfo{}, errors.E(err, "cannot find addresses for model's controller")
+		return ControllerInfo{}, errors.E(err, "cannot find addresses for model's controller")
 	}
 	jwtGenerator := s.jwtFactory.New()
 	jwtGenerator.SetTags(model.ResourceTag(), model.Controller.ResourceTag())
 	jwt, err := jwtGenerator.MakeLoginToken(ctx, user)
 	if err != nil {
-		return ConnInfo{}, errors.E(err, "cannot generate jwt")
+		return ControllerInfo{}, errors.E(err, "cannot generate jwt")
 	}
 
-	return ConnInfo{
-		Addrs: addrs,
-		JWT:   string(jwt),
+	return ControllerInfo{
+		Addresses: addrs,
+		JWT:       string(jwt),
 	}, nil
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -15,6 +15,11 @@ import (
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
+type ConnInfo struct {
+	Addrs []string
+	JWT   string
+}
+
 // IdentityManager provides a means to fetch an identity from the identity service.
 type IdentityManager interface {
 	FetchIdentity(ctx context.Context, id string) (*openfga.User, error)
@@ -81,21 +86,25 @@ func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 
 // ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 // a valid JWT To connect to the controller.
-func (s *sshManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+func (s *sshManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ConnInfo, error) {
 	zapctx.Info(ctx, "ConnInfoFromModelUUID")
 	model, err := s.modelManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return nil, "", errors.E(err, "cannot find model")
+		return ConnInfo{}, errors.E(err, "cannot find model")
 	}
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return nil, "", errors.E(err, "cannot find addresses for model's controller")
+		return ConnInfo{}, errors.E(err, "cannot find addresses for model's controller")
 	}
 	jwtGenerator := s.jwtFactory.New()
 	jwtGenerator.SetTags(model.ResourceTag(), model.Controller.ResourceTag())
 	jwt, err := jwtGenerator.MakeLoginToken(ctx, user)
 	if err != nil {
-		return nil, "", errors.E(err, "cannot generate jwt")
+		return ConnInfo{}, errors.E(err, "cannot generate jwt")
 	}
-	return addrs, string(jwt), nil
+
+	return ConnInfo{
+		Addrs: addrs,
+		JWT:   string(jwt),
+	}, nil
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/jujuauth"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
@@ -29,8 +30,12 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
+type JWTFactory interface {
+	New() jujuauth.TokenGenerator
+}
+
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager) (*sshManager, error) {
+func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, sshKeyManager SSHKeyManager, jwtFactory JWTFactory) (*sshManager, error) {
 	if identityManager == nil {
 		return nil, errors.E("identityManager cannot be nil")
 	}
@@ -40,10 +45,14 @@ func NewSSHManager(identityManager IdentityManager, modelManager ModelManager, s
 	if sshKeyManager == nil {
 		return nil, errors.E("sshManager cannot be nil")
 	}
+	if jwtFactory == nil {
+		return nil, errors.E("jwtFactory cannot be nil")
+	}
 	return &sshManager{
 		modelManager:    modelManager,
 		identityManager: identityManager,
 		sshKeyManager:   sshKeyManager,
+		jwtFactory:      jwtFactory,
 	}, nil
 }
 
@@ -52,6 +61,7 @@ type sshManager struct {
 	modelManager    ModelManager
 	identityManager IdentityManager
 	sshKeyManager   SSHKeyManager
+	jwtFactory      JWTFactory
 }
 
 // PublicKeyHandler is the method to verify the public key of the user. It first checks for the public key and then fetches the user.
@@ -69,19 +79,23 @@ func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 	return user, nil
 }
 
-// ResolveAddressesFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
-func (s *sshManager) ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error) {
-	zapctx.Info(ctx, "ResolveAddressesFromModelUUID")
-
+// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+// a valid JWT To connect to the controller.
+func (s *sshManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+	zapctx.Info(ctx, "ConnInfoFromModelUUID")
 	model, err := s.modelManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.E(err, "cannot find model")
+		return nil, "", errors.E(err, "cannot find model")
 	}
-
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return nil, errors.E(err, "cannot find addresses for model's controller")
+		return nil, "", errors.E(err, "cannot find addresses for model's controller")
 	}
-
-	return addrs, nil
+	jwtGenerator := s.jwtFactory.New()
+	jwtGenerator.SetTags(model.ResourceTag(), model.Controller.ResourceTag())
+	jwt, err := jwtGenerator.MakeLoginToken(ctx, user)
+	if err != nil {
+		return nil, "", errors.E(err, "cannot generate jwt")
+	}
+	return addrs, string(jwt), nil
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -3,17 +3,174 @@
 package ssh_test
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"database/sql"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"github.com/juju/names/v5"
+	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm"
+	"github.com/canonical/jimm/v3/internal/jimm/identity"
+	"github.com/canonical/jimm/v3/internal/jimm/jujuauth"
+	"github.com/canonical/jimm/v3/internal/jimm/permissions"
 	"github.com/canonical/jimm/v3/internal/jimm/ssh"
+	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
+	"github.com/canonical/jimm/v3/internal/jimmjwx"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
 )
 
-func TestSSHManagerCreation(t *testing.T) {
-	c := qt.New(t)
-	// TODO(simonedutto): add proper testing when implementing the sshkeymanager VerifyPublicKey method.
-	_, err := ssh.NewSSHManager(&mocks.IdentityManager{}, &mocks.ModelManager{}, &mocks.SSHKeyManager{})
+type sshManagerSuite struct {
+	publicKey             sshkeys.PublicKey
+	allowedModelUUID      string
+	allowedControllerUUID string
+
+	sshManager jimm.SSHManager
+
+	userWithAccess    *openfga.User
+	userWithoutAccess *openfga.User
+}
+
+const testSSHManagerEnv = `
+cloud-credentials:
+- name: test-cred
+  cloud: test
+  owner: alice@canonical.com
+  type: empty
+clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+controllers:
+- name: test
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region
+  public-address: localhost
+
+models:
+- name: test-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  owner: alice@canonical.com
+  cloud: test
+  region: test-region
+  cloud-credential: test-cred
+  controller: test
+  users:
+  - user: alice@canonical.com
+    access: admin
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+`
+
+func (s *sshManagerSuite) Init(c *qt.C) {
+	ctx := context.Background()
+	uuid := "00000002-0000-0000-0000-000000000001"
+	jimmTag := names.NewControllerTag(uuid)
+	// Setup DB
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)
+	// Setup OFGA
+	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
+	c.Assert(err, qt.IsNil)
+
+	identityManager, err := identity.NewIdentityManager(db, ofgaClient)
+	c.Assert(err, qt.IsNil)
+
+	// this is a mock non-mock model manager, bandaid until we have a real model manager to avoid creating a whole jimm.
+	modelManager := mocks.ModelManager{
+		GetModel_: func(ctx context.Context, uuid string) (dbmodel.Model, error) {
+			m := dbmodel.Model{
+				UUID: sql.NullString{
+					String: uuid,
+					Valid:  true,
+				},
+			}
+			err := db.GetModel(ctx, &m)
+			return m, err
+		},
+	}
+	permissionManager, err := permissions.NewManager(db, ofgaClient, uuid, jimmTag)
+	c.Assert(err, qt.IsNil)
+	jwtFactory := jujuauth.NewFactory(db, mocks.JWTService{
+		NewJWT_: func(ctx context.Context, j jimmjwx.JWTParams) ([]byte, error) {
+			return []byte("jwt"), nil
+		},
+	}, permissionManager)
+
+	sshKeyManager, err := sshkeys.NewSSHKeyManager(db)
+	c.Assert(err, qt.IsNil)
+
+	s.sshManager, err = ssh.NewSSHManager(identityManager, &modelManager, sshKeyManager, jwtFactory)
+	c.Assert(err, qt.IsNil)
+	env := jimmtest.ParseEnvironment(c, testSSHManagerEnv)
+	env.PopulateDB(c, db)
+	env.PopulateDBAndPermissions(c, jimmTag, db, ofgaClient)
+	// create a user and set permission for one model
+	s.userWithAccess, err = identityManager.FetchIdentity(ctx, env.Users[0].Username)
+	c.Assert(err, qt.IsNil)
+	s.allowedModelUUID = env.Models[0].UUID
+	s.allowedControllerUUID = env.Controllers[0].UUID
+
+	// create a user without access
+	i2, err := dbmodel.NewIdentity("bob")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.DB.Create(i2).Error, qt.IsNil)
+	s.userWithoutAccess = openfga.NewUser(i2, ofgaClient)
+	// setup public key
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	c.Assert(err, qt.IsNil)
+
+	pubKey, err := gossh.NewPublicKey(&key.PublicKey)
+	c.Assert(err, qt.IsNil)
+	s.publicKey = sshkeys.PublicKey{PublicKey: pubKey, Comment: "myComment"}
+
+	c.Assert(err, qt.IsNil)
+	err = sshKeyManager.AddUserPublicKey(ctx, s.userWithAccess, s.publicKey)
+	c.Assert(err, qt.IsNil)
+}
+
+func (s *sshManagerSuite) TestPublicKeyHandler(c *qt.C) {
+	ctx := context.Background()
+
+	// Test that the PublicKeyHandler returns the correct user when the public key is valid.
+	user, err := s.sshManager.PublicKeyHandler(ctx, s.userWithAccess.Name, s.publicKey.Marshal())
+	c.Assert(err, qt.IsNil)
+	c.Assert(user.Identity.Name, qt.Equals, "alice@canonical.com")
+
+	// Test that the PublicKeyHandler returns an error when the public key is invalid.
+	_, err = s.sshManager.PublicKeyHandler(ctx, s.userWithoutAccess.Name, s.publicKey.Marshal())
+	c.Assert(err, qt.ErrorMatches, `cannot verify key for user`)
+}
+
+func (s *sshManagerSuite) TestConnInfoFromModelUUID(c *qt.C) {
+	ctx := context.Background()
+
+	// Test that the ConnInfoFromModelUUID returns the correct controller address and user when the model UUID is valid.
+	addresses, jwt, err := s.sshManager.ConnInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
+	c.Assert(err, qt.IsNil)
+	c.Assert(addresses, qt.HasLen, 1)
+	c.Assert(jwt, qt.Not(qt.HasLen), 0)
+
+	// Test that the ConnInfoFromModelUUID returns an error when the model UUID is invalid.
+	_, _, err = s.sshManager.ConnInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
+	c.Assert(err, qt.ErrorMatches, ".*cannot find model.*")
+}
+
+func TestSSHManager(t *testing.T) {
+	qtsuite.Run(qt.New(t), &sshManagerSuite{})
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -157,17 +157,17 @@ func (s *sshManagerSuite) TestPublicKeyHandler(c *qt.C) {
 	c.Assert(err, qt.ErrorMatches, `cannot verify key for user`)
 }
 
-func (s *sshManagerSuite) TestConnInfoFromModelUUID(c *qt.C) {
+func (s *sshManagerSuite) TestControllerInfoFromModelUUID(c *qt.C) {
 	ctx := context.Background()
 
-	// Test that the ConnInfoFromModelUUID returns the correct controller address and user when the model UUID is valid.
-	connInfo, err := s.sshManager.ConnInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
+	// Test that the ControllerInfoFromModelUUID returns the correct controller address and user when the model UUID is valid.
+	connInfo, err := s.sshManager.ControllerInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
 	c.Assert(err, qt.IsNil)
-	c.Assert(connInfo.Addrs, qt.HasLen, 1)
+	c.Assert(connInfo.Addresses, qt.HasLen, 1)
 	c.Assert(connInfo.JWT, qt.Not(qt.HasLen), 0)
 
-	// Test that the ConnInfoFromModelUUID returns an error when the model UUID is invalid.
-	_, err = s.sshManager.ConnInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
+	// Test that the ControllerInfoFromModelUUID returns an error when the model UUID is invalid.
+	_, err = s.sshManager.ControllerInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
 	c.Assert(err, qt.ErrorMatches, ".*cannot find model.*")
 }
 

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -161,13 +161,13 @@ func (s *sshManagerSuite) TestConnInfoFromModelUUID(c *qt.C) {
 	ctx := context.Background()
 
 	// Test that the ConnInfoFromModelUUID returns the correct controller address and user when the model UUID is valid.
-	addresses, jwt, err := s.sshManager.ConnInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
+	connInfo, err := s.sshManager.ConnInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
 	c.Assert(err, qt.IsNil)
-	c.Assert(addresses, qt.HasLen, 1)
-	c.Assert(jwt, qt.Not(qt.HasLen), 0)
+	c.Assert(connInfo.Addrs, qt.HasLen, 1)
+	c.Assert(connInfo.JWT, qt.Not(qt.HasLen), 0)
 
 	// Test that the ConnInfoFromModelUUID returns an error when the model UUID is invalid.
-	_, _, err = s.sshManager.ConnInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
+	_, err = s.sshManager.ConnInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
 	c.Assert(err, qt.ErrorMatches, ".*cannot find model.*")
 }
 

--- a/internal/ssh/dial.go
+++ b/internal/ssh/dial.go
@@ -15,11 +15,11 @@ import (
 )
 
 // dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
-func dialControllerSSHServer(connInfo jimmssh.ConnInfo, destPort uint32) (*gossh.Client, error) {
+func dialControllerSSHServer(connInfo jimmssh.ControllerInfo, destPort uint32) (*gossh.Client, error) {
 	var client *gossh.Client
 	var err error
 	var errs []error
-	for _, addr := range connInfo.Addrs {
+	for _, addr := range connInfo.Addresses {
 		dest := net.JoinHostPort(addr, fmt.Sprint(destPort))
 		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
 			//nolint:gosec // this will be removed once we handle hostkeys

--- a/internal/ssh/dial.go
+++ b/internal/ssh/dial.go
@@ -11,21 +11,22 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	jimmssh "github.com/canonical/jimm/v3/internal/jimm/ssh"
 )
 
 // dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
-func dialControllerSSHServer(addrs []string, destPort uint32, jwt string) (*gossh.Client, error) {
+func dialControllerSSHServer(connInfo jimmssh.ConnInfo, destPort uint32) (*gossh.Client, error) {
 	var client *gossh.Client
 	var err error
 	var errs []error
-	for _, addr := range addrs {
+	for _, addr := range connInfo.Addrs {
 		dest := net.JoinHostPort(addr, fmt.Sprint(destPort))
 		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
 			//nolint:gosec // this will be removed once we handle hostkeys
 			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 			Auth: []gossh.AuthMethod{
 				gossh.PasswordCallback(func() (secret string, err error) {
-					return jwt, nil
+					return connInfo.JWT, nil
 				}),
 			},
 			Timeout: 5 * time.Second,

--- a/internal/ssh/dial.go
+++ b/internal/ssh/dial.go
@@ -14,7 +14,7 @@ import (
 )
 
 // dialControllerSSHServer dials the controller ssh server, trying the addresses sequentially and returning a go ssh client.
-func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, error) {
+func dialControllerSSHServer(addrs []string, destPort uint32, jwt string) (*gossh.Client, error) {
 	var client *gossh.Client
 	var err error
 	var errs []error
@@ -25,7 +25,7 @@ func dialControllerSSHServer(addrs []string, destPort uint32) (*gossh.Client, er
 			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 			Auth: []gossh.AuthMethod{
 				gossh.PasswordCallback(func() (secret string, err error) {
-					return "jwt", nil
+					return jwt, nil
 				}),
 			},
 			Timeout: 5 * time.Second,

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -31,8 +31,9 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ResolveAddressesFromModelUUID is the method to resolve the address of the controller to contact given the model UUID.
-	ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error)
+	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+	// a valid JWT To connect to the controller.
+	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -137,18 +138,17 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			return
 		}
 		modelTag := names.NewModelTag(d.DestAddr)
-		// user is now ignored, but it will be needed for the jwt auth next-up.
-		_, err := fetchAndAuthorizeUser(ctx, modelTag)
+		user, err := fetchAndAuthorizeUser(ctx, modelTag)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
 		}
-		addrs, err := sshManager.ResolveAddressesFromModelUUID(ctx, modelTag.Id())
+		addrs, jwt, err := sshManager.ConnInfoFromModelUUID(ctx, modelTag.Id(), user)
 		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, "failed to resolve address from model uuid", err)
+			rejectConnectionAndLogError(ctx, newChan, "failed to get connection info", err)
 			return
 		}
-		client, err := dialControllerSSHServer(addrs, d.DestPort)
+		client, err := dialControllerSSHServer(addrs, d.DestPort, string(jwt))
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("failed to dial controller ssh: %v", err), err)
 			return

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	gossh "golang.org/x/crypto/ssh"
 
+	jimmssh "github.com/canonical/jimm/v3/internal/jimm/ssh"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
@@ -33,7 +34,7 @@ type SSHManager interface {
 
 	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 	// a valid JWT To connect to the controller.
-	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
+	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ConnInfo, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -143,12 +144,12 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
 		}
-		addrs, jwt, err := sshManager.ConnInfoFromModelUUID(ctx, modelTag.Id(), user)
+		connInfo, err := sshManager.ConnInfoFromModelUUID(ctx, modelTag.Id(), user)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to get connection info", err)
 			return
 		}
-		client, err := dialControllerSSHServer(addrs, d.DestPort, string(jwt))
+		client, err := dialControllerSSHServer(connInfo, d.DestPort)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, fmt.Sprintf("failed to dial controller ssh: %v", err), err)
 			return

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -32,9 +32,9 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ConnInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
+	// ControllerInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
 	// a valid JWT To connect to the controller.
-	ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ConnInfo, error)
+	ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ControllerInfo, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -144,7 +144,7 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			rejectConnectionAndLogError(ctx, newChan, err.Error(), err)
 			return
 		}
-		connInfo, err := sshManager.ConnInfoFromModelUUID(ctx, modelTag.Id(), user)
+		connInfo, err := sshManager.ControllerInfoFromModelUUID(ctx, modelTag.Id(), user)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to get connection info", err)
 			return

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -88,6 +88,9 @@ func (s *sshSuite) Init(c *qt.C) {
 				s.received <- true
 			},
 		},
+		PasswordHandler: func(ctx gliderssh.Context, password string) bool {
+			return "valid-jwt" == password
+		},
 	}
 	go func() {
 		_ = s.destinationJujuSSHServer.ListenAndServe()
@@ -123,8 +126,11 @@ func (s *sshSuite) Init(c *qt.C) {
 				}
 				return userWithoutAccess, nil
 			},
-			ResolveAddressesFromModelUUID_: func(ctx context.Context, modelUUID string) ([]string, error) {
-				return []string{""}, nil
+			ConnInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+				if user == userWithAccess {
+					return []string{""}, "valid-jwt", nil
+				}
+				return []string{""}, "", nil
 			},
 		})
 	c.Assert(err, qt.IsNil)
@@ -189,47 +195,56 @@ func (s *sshSuite) TestSSHJump(c *qt.C) {
 }
 
 func (s *sshSuite) TestSSHJumpPermissionFail(c *qt.C) {
-	client, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
-		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
-		Auth: []gossh.AuthMethod{
-			gossh.PublicKeys(s.privateKey),
+	tests := []struct {
+		name     string
+		user     string
+		destAddr string
+		errMsg   string
+	}{
+		{
+			name:     "alice not allowed on this model",
+			user:     "alice",
+			destAddr: "982b16d9-a945-4762-b684-fd4fd885aa11",
+			errMsg:   "ssh: rejected: connect failed (user doesn't have permission)",
 		},
-		User: "alice",
-	})
-	c.Assert(err, qt.IsNil)
-	defer client.Close()
-
-	// send forward message
-	msg := ssh.ForwardMessage{
-		DestAddr: "982b16d9-a945-4762-b684-fd4fd885aa11",
-		//nolint:gosec
-		DestPort: uint32(s.destinationServerPort),
-		SrcAddr:  "localhost",
-		SrcPort:  0,
-	}
-	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
-	c.Assert(err, qt.ErrorMatches, ".*user doesn't have permission.*")
-
-	client, err = gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
-		//nolint:gosec // this will be removed once we handle hostkeys
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
-		Auth: []gossh.AuthMethod{
-			gossh.PublicKeys(s.privateKey),
+		{
+			name:     "bob not allowed on this model",
+			user:     "bob",
+			destAddr: s.allowedModelUUID,
+			errMsg:   "ssh: rejected: connect failed (user doesn't have permission)",
 		},
-		User: "bob",
-	})
-	c.Assert(err, qt.IsNil)
-	defer client.Close()
-	// send forward message
-	msg = ssh.ForwardMessage{
-		DestAddr: s.allowedModelUUID,
-		//nolint:gosec
-		DestPort: uint32(s.destinationServerPort),
-		SrcAddr:  "localhost",
-		SrcPort:  0,
+		{
+			name:     "not existing user",
+			user:     "mark",
+			destAddr: s.allowedModelUUID,
+			errMsg:   "ssh: rejected: connect failed (user doesn't have permission)",
+		},
 	}
-	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
-	c.Assert(err, qt.ErrorMatches, ".*user doesn't have permission.*")
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			client, err := gossh.Dial("tcp", fmt.Sprintf(":%d", s.jumpServerPort), &gossh.ClientConfig{
+				HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
+				Auth: []gossh.AuthMethod{
+					gossh.PublicKeys(s.privateKey),
+				},
+				User: test.user,
+			})
+			c.Assert(err, qt.IsNil)
+			defer client.Close()
+
+			// send forward message
+			msg := ssh.ForwardMessage{
+				DestAddr: test.destAddr,
+				//nolint:gosec
+				DestPort: uint32(s.destinationServerPort),
+				SrcAddr:  "localhost",
+				SrcPort:  0,
+			}
+			_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+			c.Assert(err.Error(), qt.Equals, test.errMsg)
+		})
+	}
 }
 
 func (s *sshSuite) TestSSHJumpDialFail(c *qt.C) {

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -127,11 +127,11 @@ func (s *sshSuite) Init(c *qt.C) {
 				}
 				return userWithoutAccess, nil
 			},
-			ConnInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ConnInfo, error) {
+			ControllerInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ControllerInfo, error) {
 				if user == userWithAccess {
-					return jimmssh.ConnInfo{Addrs: []string{""}, JWT: "valid-jwt"}, nil
+					return jimmssh.ControllerInfo{Addresses: []string{""}, JWT: "valid-jwt"}, nil
 				}
-				return jimmssh.ConnInfo{Addrs: []string{""}, JWT: ""}, nil
+				return jimmssh.ControllerInfo{Addresses: []string{""}, JWT: ""}, nil
 			},
 		})
 	c.Assert(err, qt.IsNil)

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	jimmssh "github.com/canonical/jimm/v3/internal/jimm/ssh"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/ssh"
@@ -126,11 +127,11 @@ func (s *sshSuite) Init(c *qt.C) {
 				}
 				return userWithoutAccess, nil
 			},
-			ConnInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+			ConnInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ConnInfo, error) {
 				if user == userWithAccess {
-					return []string{""}, "valid-jwt", nil
+					return jimmssh.ConnInfo{Addrs: []string{""}, JWT: "valid-jwt"}, nil
 				}
-				return []string{""}, "", nil
+				return jimmssh.ConnInfo{Addrs: []string{""}, JWT: ""}, nil
 			},
 		})
 	c.Assert(err, qt.IsNil)
@@ -174,19 +175,12 @@ func (s *sshSuite) TestSSHJump(c *qt.C) {
 	defer client.Close()
 
 	// send forward message
-	msg := ssh.ForwardMessage{
-		DestAddr: s.allowedModelUUID,
-		//nolint:gosec
-		DestPort: uint32(s.destinationServerPort),
-		SrcAddr:  "localhost",
-		SrcPort:  0,
-	}
 	s.testInDestinationServerF = func(fm ssh.ForwardMessage) {
 		c.Check(fm.DestAddr, qt.Equals, s.allowedModelUUID)
 	}
-	ch, _, err := client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+	conn, err := client.Dial("tcp", fmt.Sprintf("%s:%d", s.allowedModelUUID, s.destinationServerPort))
 	c.Check(err, qt.IsNil)
-	defer ch.Close()
+	defer conn.Close()
 	select {
 	case <-s.received:
 	case <-time.After(100 * time.Millisecond):
@@ -233,15 +227,7 @@ func (s *sshSuite) TestSSHJumpPermissionFail(c *qt.C) {
 			c.Assert(err, qt.IsNil)
 			defer client.Close()
 
-			// send forward message
-			msg := ssh.ForwardMessage{
-				DestAddr: test.destAddr,
-				//nolint:gosec
-				DestPort: uint32(s.destinationServerPort),
-				SrcAddr:  "localhost",
-				SrcPort:  0,
-			}
-			_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+			_, err = client.Dial("tcp", fmt.Sprintf("%s:%d", test.destAddr, s.destinationServerPort))
 			c.Assert(err.Error(), qt.Equals, test.errMsg)
 		})
 	}
@@ -267,19 +253,10 @@ func (s *sshSuite) TestSSHFinalDestinationDialFail(c *qt.C) {
 		User: "alice",
 	})
 	c.Assert(err, qt.IsNil)
-
-	// send forward message
-	msg := ssh.ForwardMessage{
-		DestAddr: "model1",
-		//nolint:gosec
-		DestPort: 1, // the test fails because there is no ssh server on this port.
-		SrcAddr:  "localhost",
-		SrcPort:  0,
-	}
 	s.testInDestinationServerF = func(fm ssh.ForwardMessage) {
 		c.Check(fm.DestAddr, qt.Equals, "model1")
 	}
-	_, _, err = client.OpenChannel("direct-tcpip", gossh.Marshal(&msg))
+	_, err = client.Dial("tcp", fmt.Sprintf("%s:%d", "model1", 1))
 	c.Assert(err, qt.ErrorMatches, ".*connect failed.*")
 }
 

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -407,13 +407,14 @@ func (cc *CloudCredential) DBObject(c Tester, db *db.Database) dbmodel.CloudCred
 // A Controller represents the definition of a controller in a test
 // environment.
 type Controller struct {
-	Name         string                          `json:"name"`
-	UUID         string                          `json:"uuid"`
-	Cloud        string                          `json:"cloud"`
-	CloudRegion  string                          `json:"region"`
-	CloudRegions []CloudRegionControllerPriority `json:"cloud-regions"`
-	AgentVersion string                          `json:"agent-version"`
-	Deprecated   bool                            `json:"deprecated,omitempty"`
+	Name          string                          `json:"name"`
+	UUID          string                          `json:"uuid"`
+	Cloud         string                          `json:"cloud"`
+	CloudRegion   string                          `json:"region"`
+	CloudRegions  []CloudRegionControllerPriority `json:"cloud-regions"`
+	AgentVersion  string                          `json:"agent-version"`
+	PublicAddress string                          `json:"public-address"`
+	Deprecated    bool                            `json:"deprecated,omitempty"`
 
 	env *Environment
 	dbo dbmodel.Controller
@@ -428,6 +429,7 @@ func (ctl *Controller) DBObject(c Tester, db *db.Database) dbmodel.Controller {
 	ctl.dbo.AgentVersion = ctl.AgentVersion
 	ctl.dbo.CloudName = ctl.Cloud
 	ctl.dbo.CloudRegion = ctl.CloudRegion
+	ctl.dbo.PublicAddress = ctl.PublicAddress
 	ctl.dbo.CloudRegions = make([]dbmodel.CloudRegionControllerPriority, len(ctl.CloudRegions))
 	ctl.dbo.Deprecated = ctl.Deprecated
 	for i, cr := range ctl.CloudRegions {

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -6,13 +6,14 @@ import (
 	"context"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/ssh"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
 // SSHManager is an implementation of the SshManager interface.
 type SSHManager struct {
 	PublicKeyHandler_      func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-	ConnInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
+	ConnInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error)
 }
 
 func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -22,9 +23,9 @@ func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key 
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
-func (j SSHManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+func (j SSHManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error) {
 	if j.ConnInfoFromModelUUID_ == nil {
-		return nil, "", errors.E(errors.CodeNotImplemented)
+		return ssh.ConnInfo{}, errors.E(errors.CodeNotImplemented)
 	}
 	return j.ConnInfoFromModelUUID_(ctx, modelUUID, user)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -12,8 +12,8 @@ import (
 
 // SSHManager is an implementation of the SshManager interface.
 type SSHManager struct {
-	PublicKeyHandler_      func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-	ConnInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error)
+	PublicKeyHandler_            func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+	ControllerInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error)
 }
 
 func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -23,9 +23,9 @@ func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key 
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
-func (j SSHManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ConnInfo, error) {
-	if j.ConnInfoFromModelUUID_ == nil {
-		return ssh.ConnInfo{}, errors.E(errors.CodeNotImplemented)
+func (j SSHManager) ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error) {
+	if j.ControllerInfoFromModelUUID_ == nil {
+		return ssh.ControllerInfo{}, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ConnInfoFromModelUUID_(ctx, modelUUID, user)
+	return j.ControllerInfoFromModelUUID_(ctx, modelUUID, user)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -11,8 +11,8 @@ import (
 
 // SSHManager is an implementation of the SshManager interface.
 type SSHManager struct {
-	PublicKeyHandler_              func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-	ResolveAddressesFromModelUUID_ func(ctx context.Context, modelUUID string) ([]string, error)
+	PublicKeyHandler_      func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+	ConnInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error)
 }
 
 func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -22,9 +22,9 @@ func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key 
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
-func (j SSHManager) ResolveAddressesFromModelUUID(ctx context.Context, modelUUID string) ([]string, error) {
-	if j.ResolveAddressesFromModelUUID_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+func (j SSHManager) ConnInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) ([]string, string, error) {
+	if j.ConnInfoFromModelUUID_ == nil {
+		return nil, "", errors.E(errors.CodeNotImplemented)
 	}
-	return j.ResolveAddressesFromModelUUID_(ctx, modelUUID)
+	return j.ConnInfoFromModelUUID_(ctx, modelUUID, user)
 }

--- a/internal/testutils/jimmtest/mocks/jwt_service_mock.go
+++ b/internal/testutils/jimmtest/mocks/jwt_service_mock.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Canonical.
+package mocks
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimmjwx"
+)
+
+type JWTService struct {
+	NewJWT_ func(context.Context, jimmjwx.JWTParams) ([]byte, error)
+}
+
+func (j JWTService) NewJWT(ctx context.Context, params jimmjwx.JWTParams) ([]byte, error) {
+	if j.NewJWT_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return j.NewJWT_(ctx, params)
+}


### PR DESCRIPTION
## Description
In this PR we add the jwt when dial controller's ssh server.
The JWT is created together when resolving the controller's addresses.

> I've added some tests for the ssh manager and ssh jump server.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
