### PR TITLE
feat(internal/discharger/discharger.go): check controller for local offer users

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -556,7 +556,7 @@ func (s *Service) setupDischarger(p Params) (*discharger.MacaroonDischarger, err
 		MacaroonExpiryDuration: p.MacaroonExpiryDuration,
 		ControllerUUID:         p.ControllerUUID,
 	}
-	MacaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, s.jimm.Database, s.jimm.OpenFGAClient)
+	MacaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, s.jimm.Database, s.jimm.OpenFGAClient, s.jimm.Dialer)
 	if err != nil {
 		return nil, errors.E(err)
 	}

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package discharger
 
@@ -13,6 +13,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	jjmacaroon "github.com/juju/juju/core/macaroon"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -20,11 +21,18 @@ import (
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
 var defaultDischargeExpiry = 15 * time.Minute
+
+// A Dialer provides a connection to a controller and returns a client
+// that may be used to get information on application offers.
+type Dialer interface {
+	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, requiredPermissions map[string]string) (jimm.API, error)
+}
 
 type MacaroonDischargerConfig struct {
 	PublicKey              string
@@ -33,7 +41,7 @@ type MacaroonDischargerConfig struct {
 	ControllerUUID         string
 }
 
-func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, ofgaClient *openfga.OFGAClient) (*MacaroonDischarger, error) {
+func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, ofgaClient *openfga.OFGAClient, dialer Dialer) (*MacaroonDischarger, error) {
 	var kp bakery.KeyPair
 	if cfg.PublicKey == "" || cfg.PrivateKey == "" {
 		return nil, errors.E("missing bakery private/public key")
@@ -65,6 +73,8 @@ func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, ofgaCl
 		ofgaClient: ofgaClient,
 		bakery:     b,
 		kp:         kp,
+		dialer:     dialer,
+		db:         db,
 	}, nil
 }
 
@@ -72,6 +82,8 @@ type MacaroonDischarger struct {
 	ofgaClient *openfga.OFGAClient
 	bakery     *bakery.Bakery
 	kp         bakery.KeyPair
+	dialer     Dialer
+	db         *db.Database
 }
 
 // GetDischargerMux returns a mux that can handle macaroon bakery requests for the provided discharger.
@@ -121,6 +133,20 @@ func (md *MacaroonDischarger) CheckThirdPartyCaveat(ctx context.Context, req *ht
 
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 
+	// if we are checking for a local user, we dial the controller and check if the user still has
+	// consume access to the offer
+	if userTag.Domain() == "" {
+		err = md.checkControllerForConsumeAccess(ctx, userTag.Id(), offerUUID)
+		if err != nil {
+			return nil, err
+		}
+
+		return []checkers.Caveat{
+			checkers.DeclaredCaveat("offer-uuid", offerUUID),
+			checkers.TimeBeforeCaveat(time.Now().Add(defaultDischargeExpiry)),
+		}, nil
+	}
+
 	i, err := dbmodel.NewIdentity(userTag.Id())
 	if err != nil {
 		return nil, err
@@ -144,4 +170,40 @@ func (md *MacaroonDischarger) CheckThirdPartyCaveat(ctx context.Context, req *ht
 	}
 	zapctx.Debug(ctx, "macaroon dishcharge denied", zap.String("user", user.Name), zap.String("offer", offerUUID))
 	return nil, httpbakery.ErrPermissionDenied
+}
+
+// checkControllerForConsumeAccess dials the controller offering the application offer and checks if the stated user
+// has at least consume access to the offer. If the user has consume access it returns nil, otherwise it returns an error.
+func (md *MacaroonDischarger) checkControllerForConsumeAccess(ctx context.Context, username string, offerUUID string) error {
+	offer := dbmodel.ApplicationOffer{
+		UUID: offerUUID,
+	}
+	err := md.db.GetApplicationOffer(ctx, &offer)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	apiClient, err := md.dialer.Dial(ctx, &offer.Model.Controller, names.ModelTag{}, nil)
+	if err != nil {
+		return errors.E(err)
+	}
+	offerDetails := jujuparams.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+			OfferURL: offer.URL,
+		},
+	}
+	err = apiClient.GetApplicationOffer(ctx, &offerDetails)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	for _, user := range offerDetails.Users {
+		if username == user.UserName {
+			if user.Access == "admin" || user.Access == "consume" {
+				return nil
+			}
+			break
+		}
+	}
+	return errors.E("unauthorized")
 }

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -394,7 +394,8 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName strin
 	defer api.Close()
 
 	m.modelInfo = jujuparams.ModelInfo{
-		UUID: modelTag.Id(),
+		UUID:           modelTag.Id(),
+		ControllerUUID: controller.UUID,
 	}
 	err = api.ModelInfo(ctx, &m.modelInfo)
 	if err != nil {
@@ -466,6 +467,37 @@ func (m *modelImporter) addPermissions(ctx context.Context) error {
 		err := m.jimm.OpenFGAClient.AddModelApplicationOffer(ctx, m.model.ResourceTag(), names.NewApplicationOfferTag(offer.OfferUUID))
 		if err != nil {
 			return err
+		}
+		// we also set access for all users that have access to the imported application offer
+		for _, user := range offer.Users {
+			userTag, err := names.ParseUserTag(user.UserName)
+			if err != nil {
+				zapctx.Warn(ctx, "failed to parse offer user", zap.String("username", user.UserName))
+				continue
+			}
+
+			// if this is a local juju user we skip it, since the controller remains the source of truth for local
+			// user access
+			if userTag.Domain() == "" {
+				continue
+			}
+			u := openfga.NewUser(
+				&dbmodel.Identity{
+					Name: userTag.Id(),
+				},
+				m.jimm.OpenFGAClient,
+			)
+			relation, err := ofganames.ConvertJujuRelation(user.Access)
+			if err != nil {
+				zapctx.Warn(ctx, "unknown offer access level", zap.String("access", user.Access), zap.String("username", user.UserName), zap.String("offer", offer.OfferUUID))
+				continue
+			}
+
+			err = u.SetApplicationOfferAccess(ctx, names.NewApplicationOfferTag(offer.OfferUUID), relation)
+			if err != nil {
+				zapctx.Warn(ctx, "failed to set offer access", zap.String("username", user.UserName), zap.String("level", user.Access), zap.String("offer", offer.OfferUUID))
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
When we import a model, its application offers are imported with it. For imported models JIMM
becomes the source of truth for access to application offers and is expected to discharge 3rd party
macaroons addressed to it about offer access.  If an offer has already been consumed by a local
user, those 3rd party caveats will contain local juju users and JIMM has no control over local
users. In this PR I propose the source of truth for those users remains  the Juju controller. So in
the discharge method we dial the controller and check, if the user still hass consume access to the
offer before discharging the 3rd party caveat.

For completenes i also propose we add relations for non-local users (if any) to imported application offers.

## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
