### PR TITLE
fix: improve model import

### DIFF
--- a/cmd/jimmctl/cmd/importmodel.go
+++ b/cmd/jimmctl/cmd/importmodel.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package cmd
 
@@ -64,7 +64,6 @@ func (c *importModelCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *importModelCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.StringVar(&c.req.Owner, "owner", "", "switch the model owner to the desired user")
 }
 
 // Init implements the cmd.Command interface.

--- a/cmd/jimmctl/cmd/relation_test.go
+++ b/cmd/jimmctl/cmd/relation_test.go
@@ -316,7 +316,7 @@ func initializeEnvironment(c *gc.C, ctx context.Context, db *db.Database, u dbmo
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 	}
 	err = db.AddModel(ctx, &model)
 	c.Assert(err, gc.IsNil)
@@ -539,7 +539,7 @@ func (s *relationSuite) TestCheckRelationViaSuperuser(c *gc.C) {
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              "alive",
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/juju/schema v1.2.0 // indirect
 	github.com/juju/txn/v3 v3.0.2 // indirect
 	github.com/juju/usso v1.0.1 // indirect
-	github.com/juju/utils/v3 v3.2.0 // indirect
+	github.com/juju/utils/v3 v3.2.0
 	github.com/juju/viddy v0.0.0-beta5 // indirect
 	github.com/juju/webbrowser v1.0.0 // indirect
 	github.com/juju/worker/v3 v3.5.0 // indirect

--- a/internal/db/applicationoffer_test.go
+++ b/internal/db/applicationoffer_test.go
@@ -80,7 +80,7 @@ func initTestEnvironment(c *qt.C, db *db.Database) testEnvironment {
 		Owner:           env.u,
 		Controller:      env.controller,
 		CloudRegion:     env.cloud.Regions[0],
-		CloudCredential: env.cred,
+		CloudCredential: &env.cred,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.DB.Create(&env.model).Error, qt.IsNil)
@@ -94,7 +94,7 @@ func initTestEnvironment(c *qt.C, db *db.Database) testEnvironment {
 		Owner:           env.u,
 		Controller:      env.controller,
 		CloudRegion:     env.cloud.Regions[0],
-		CloudCredential: env.cred,
+		CloudCredential: &env.cred,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.DB.Create(&env.model1).Error, qt.IsNil)

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -70,7 +70,7 @@ func (s *dbSuite) TestAddModel(c *qt.C) {
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 	m1 := model
@@ -135,8 +135,8 @@ func (s *dbSuite) TestGetModel(c *qt.C) {
 		Controller:        controller,
 		CloudRegionID:     cloud.Regions[0].ID,
 		CloudRegion:       cloud.Regions[0],
-		CloudCredentialID: cred.ID,
-		CloudCredential:   cred,
+		CloudCredentialID: &cred.ID,
+		CloudCredential:   &cred,
 		Life:              state.Alive.String(),
 	}
 	model.CloudCredential.Cloud = dbmodel.Cloud{}
@@ -220,7 +220,7 @@ func (s *dbSuite) TestUpdateModel(c *qt.C) {
 		OwnerIdentityName: i.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 	err = s.Database.AddModel(context.Background(), &model)
@@ -288,7 +288,7 @@ func (s *dbSuite) TestDeleteModel(c *qt.C) {
 		ControllerID:      controller.ID,
 		Controller:        controller,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 
@@ -362,7 +362,7 @@ func (s *dbSuite) TestGetModelsUsingCredential(c *qt.C) {
 		OwnerIdentityName: i.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred1.ID,
+		CloudCredentialID: &cred1.ID,
 		Life:              state.Alive.String(),
 	}
 	err = s.Database.AddModel(context.Background(), &model1)
@@ -377,7 +377,7 @@ func (s *dbSuite) TestGetModelsUsingCredential(c *qt.C) {
 		OwnerIdentityName: i.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred2.ID,
+		CloudCredentialID: &cred2.ID,
 		Life:              state.Alive.String(),
 	}
 	err = s.Database.AddModel(context.Background(), &model2)
@@ -398,7 +398,7 @@ func (s *dbSuite) TestGetModelsUsingCredential(c *qt.C) {
 		ControllerID:      controller.ID,
 		Controller:        controller,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred1.ID,
+		CloudCredentialID: &cred1.ID,
 		Life:              state.Alive.String(),
 	}})
 
@@ -622,7 +622,7 @@ func (s *dbSuite) TestGetModelsByController(c *qt.C) {
 		Owner:           *u,
 		Controller:      controller,
 		CloudRegion:     cloud.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 		Life:            state.Alive.String(),
 	}, {
 		Name: "test-model-2",
@@ -633,7 +633,7 @@ func (s *dbSuite) TestGetModelsByController(c *qt.C) {
 		Owner:           *u,
 		Controller:      controller,
 		CloudRegion:     cloud.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 		Life:            state.Alive.String(),
 	}}
 	for _, m := range models {

--- a/internal/db/resource_test.go
+++ b/internal/db/resource_test.go
@@ -52,7 +52,7 @@ func SetupDB(c *qt.C, database *db.Database) (dbmodel.Model, dbmodel.Controller,
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 	err = database.AddModel(context.Background(), &model)

--- a/internal/dbmodel/applicationoffer_test.go
+++ b/internal/dbmodel/applicationoffer_test.go
@@ -42,7 +42,7 @@ func TestApplicationOfferUniqueConstraint(t *testing.T) {
 		Owner:           u,
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)

--- a/internal/dbmodel/controller_test.go
+++ b/internal/dbmodel/controller_test.go
@@ -86,7 +86,7 @@ func TestControllerModels(t *testing.T) {
 		Owner:           u1,
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 	}
 	c.Assert(db.Create(&m1).Error, qt.IsNil)
 	u2, err := dbmodel.NewIdentity("charlie@canonical.com")
@@ -103,7 +103,7 @@ func TestControllerModels(t *testing.T) {
 		Owner:           *u2,
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 	}
 	c.Assert(db.Create(&m2).Error, qt.IsNil)
 

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -40,8 +40,8 @@ type Model struct {
 	CloudRegion   CloudRegion
 
 	// CloudCredential is the credential used with the model.
-	CloudCredentialID uint
-	CloudCredential   CloudCredential `gorm:"foreignkey:CloudCredentialID;references:ID"`
+	CloudCredentialID *uint
+	CloudCredential   *CloudCredential `gorm:"foreignkey:CloudCredentialID;references:ID"`
 
 	// Life holds the life status of the model.
 	Life string
@@ -102,15 +102,11 @@ func (m *Model) FromJujuModelInfo(info jujuparams.ModelInfo) error {
 		}
 		m.CloudRegion.Cloud.Name = ct.Id()
 	}
-	if info.CloudCredentialTag != "" {
-		cct, err := names.ParseCloudCredentialTag(info.CloudCredentialTag)
-		if err != nil {
-			return errors.E(err)
-		}
-		m.CloudCredential.Name = cct.Name()
-		m.CloudCredential.CloudName = cct.Cloud().Id()
-		m.CloudCredential.Owner.Name = cct.Owner().Id()
-	}
+	// Note that we ignore the cloud-credential from
+	// the controller here because in all cases JIMM
+	// either knows the credential used (because it
+	// created the model) or it doesn't have access
+	// to the credential and doesn't care (imported models).
 
 	return nil
 }
@@ -134,6 +130,8 @@ func (m Model) ToJujuModel() jujuparams.Model {
 // It uses the info from the controller and JIMM's db to fill the jujuparams.ModelSummary.
 // maskingControllerUUID is used to mask the controllerUUID with the JIMM's one.
 // access is the user access level got from JIMM.
+// This function indicates which fields JIMM is authoritative and which can come directly
+// from Juju.
 func (m Model) MergeModelSummaryFromController(modelSummaryFromController *jujuparams.ModelSummary, maskingControllerUUID string, access jujuparams.UserAccessPermission) jujuparams.ModelSummary {
 	if modelSummaryFromController == nil {
 		modelSummaryFromController = &jujuparams.ModelSummary{}
@@ -148,7 +146,7 @@ func (m Model) MergeModelSummaryFromController(modelSummaryFromController *jujup
 	modelSummaryFromController.ProviderType = m.CloudRegion.Cloud.Type
 	modelSummaryFromController.CloudTag = m.CloudRegion.Cloud.Tag().String()
 	modelSummaryFromController.CloudRegion = m.CloudRegion.Name
-	modelSummaryFromController.CloudCredentialTag = m.CloudCredential.Tag().String()
+	// modelSummaryFromController.CloudCredentialTag = m.CloudCredential.Tag().String()
 	modelSummaryFromController.OwnerTag = m.Owner.Tag().String()
 	modelSummaryFromController.Life = life.Value(m.Life)
 	modelSummaryFromController.UserAccess = access

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel
 
@@ -146,7 +146,6 @@ func (m Model) MergeModelSummaryFromController(modelSummaryFromController *jujup
 	modelSummaryFromController.ProviderType = m.CloudRegion.Cloud.Type
 	modelSummaryFromController.CloudTag = m.CloudRegion.Cloud.Tag().String()
 	modelSummaryFromController.CloudRegion = m.CloudRegion.Name
-	// modelSummaryFromController.CloudCredentialTag = m.CloudCredential.Tag().String()
 	modelSummaryFromController.OwnerTag = m.Owner.Tag().String()
 	modelSummaryFromController.Life = life.Value(m.Life)
 	modelSummaryFromController.UserAccess = access

--- a/internal/dbmodel/model_test.go
+++ b/internal/dbmodel/model_test.go
@@ -46,7 +46,7 @@ func TestRecreateDeletedModel(t *testing.T) {
 		Name:            "test-1",
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 	}
 	c.Assert(db.Create(&m1).Error, qt.IsNil)
 
@@ -55,7 +55,7 @@ func TestRecreateDeletedModel(t *testing.T) {
 		Name:            "test-1",
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 	}
 	c.Check(db.Create(&m2).Error, qt.ErrorMatches, `.*violates unique constraint "unique_model_names".*`)
 
@@ -78,7 +78,7 @@ func TestModel(t *testing.T) {
 		Owner:           u,
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)
@@ -131,7 +131,7 @@ func TestModelUniqueConstraint(t *testing.T) {
 		Owner:           u,
 		Controller:      ctl1,
 		CloudRegion:     cl1.Regions[0],
-		CloudCredential: cred1,
+		CloudCredential: &cred1,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.Create(&m1).Error, qt.IsNil)
@@ -145,7 +145,7 @@ func TestModelUniqueConstraint(t *testing.T) {
 		Owner:           u,
 		Controller:      ctl2,
 		CloudRegion:     cl2.Regions[0],
-		CloudCredential: cred2,
+		CloudCredential: &cred2,
 		Life:            state.Alive.String(),
 	}
 	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, `ERROR: duplicate key value violates unique constraint .*`)
@@ -178,7 +178,7 @@ func TestToJujuModel(t *testing.T) {
 		Owner:             u,
 		Controller:        ctl,
 		CloudRegion:       cl.Regions[0],
-		CloudCredential:   cred,
+		CloudCredential:   &cred,
 		Life:              state.Alive.String(),
 	}
 	m.CloudRegion.Cloud = cl
@@ -205,7 +205,7 @@ func TestToJujuModelSummary(t *testing.T) {
 		Owner:           u,
 		Controller:      ctl,
 		CloudRegion:     cl.Regions[0],
-		CloudCredential: cred,
+		CloudCredential: &cred,
 		Life:            state.Alive.String(),
 	}
 	m.CloudRegion.Cloud = cl
@@ -376,11 +376,7 @@ func TestModelFromJujuModelInfo(t *testing.T) {
 				Name: "test-cloud",
 			},
 		},
-		CloudCredential: dbmodel.CloudCredential{
-			Name:      "test-cred",
-			CloudName: "test-cloud",
-			Owner:     *i,
-		},
+		CloudCredential:   nil,
 		OwnerIdentityName: "bob@canonical.com",
 		Life:              state.Alive.String(),
 	})

--- a/internal/jimm/applicationoffer_test.go
+++ b/internal/jimm/applicationoffer_test.go
@@ -132,7 +132,7 @@ var initializeEnvironment = func(c *qt.C, ctx context.Context, db *db.Database, 
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 	}
 	err = db.AddModel(ctx, &model)
 	c.Assert(err, qt.IsNil)
@@ -252,7 +252,7 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 	}
 	err = db.AddModel(ctx, &model)
 	c.Assert(err, qt.IsNil)
@@ -541,7 +541,7 @@ func TestGetApplicationOffer(t *testing.T) {
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 	}
 	err = j.Database.AddModel(ctx, &model)
 	c.Assert(err, qt.IsNil)
@@ -750,7 +750,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -840,7 +840,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -960,7 +960,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -1052,7 +1052,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -1139,7 +1139,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -1226,7 +1226,7 @@ func TestOffer(t *testing.T) {
 				OwnerIdentityName: u.Name,
 				ControllerID:      controller.ID,
 				CloudRegionID:     cloud.Regions[0].ID,
-				CloudCredentialID: cred.ID,
+				CloudCredentialID: &cred.ID,
 			}
 			err = db.AddModel(ctx, &model)
 			c.Assert(err, qt.IsNil)
@@ -1345,7 +1345,7 @@ func TestOfferAssertOpenFGARelationsExist(t *testing.T) {
 			OwnerIdentityName: u.Name,
 			ControllerID:      controller.ID,
 			CloudRegionID:     cloud.Regions[0].ID,
-			CloudCredentialID: cred.ID,
+			CloudCredentialID: &cred.ID,
 		}
 		err = db.AddModel(ctx, &model)
 		c.Assert(err, qt.IsNil)

--- a/internal/jimm/cloudcredential_test.go
+++ b/internal/jimm/cloudcredential_test.go
@@ -144,7 +144,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 			// TODO(mhilton) don't fetch these in the first place.
 			m.Owner = dbmodel.Identity{}
 			m.Controller = dbmodel.Controller{}
-			m.CloudCredential = dbmodel.CloudCredential{}
+			m.CloudCredential = nil
 			m.CloudRegion = dbmodel.CloudRegion{}
 
 			expectedCredential.Models = []dbmodel.Model{m}
@@ -431,7 +431,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 			// TODO(mhilton) don't fetch these in the first place.
 			m.Owner = dbmodel.Identity{}
 			m.Controller = dbmodel.Controller{}
-			m.CloudCredential = dbmodel.CloudCredential{}
+			m.CloudCredential = nil
 			m.CloudRegion = dbmodel.CloudRegion{}
 
 			return u, arg, dbmodel.CloudCredential{
@@ -550,7 +550,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 			// TODO(mhilton) don't fetch these in the first place.
 			m.Owner = dbmodel.Identity{}
 			m.Controller = dbmodel.Controller{}
-			m.CloudCredential = dbmodel.CloudCredential{}
+			m.CloudCredential = nil
 			m.CloudRegion = dbmodel.CloudRegion{}
 			expectedCredential.Models = []dbmodel.Model{m}
 
@@ -656,7 +656,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 			// TODO(mhilton) don't fetch these in the first place.
 			m.Owner = dbmodel.Identity{}
 			m.Controller = dbmodel.Controller{}
-			m.CloudCredential = dbmodel.CloudCredential{}
+			m.CloudCredential = nil
 			m.CloudRegion = dbmodel.CloudRegion{}
 			cred.Models = []dbmodel.Model{m}
 

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -535,7 +535,7 @@ func (m *modelImporter) save(ctx context.Context) error {
 
 // ImportModel imports a model and existing offers into JIMM.  A new owner  must be set to
 // represent the external user who will own this model (if the original owner is a local user).
-func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
+func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag) error {
 	const op = errors.Op("jimm.ImportModel")
 
 	if err := j.checkJimmAdmin(user); err != nil {

--- a/internal/jimm/controller.go
+++ b/internal/jimm/controller.go
@@ -357,27 +357,17 @@ func (j *JIMM) EarliestControllerVersion(ctx context.Context) (version.Number, e
 }
 
 type modelImporter struct {
-	jimm      *JIMM
-	model     dbmodel.Model
-	modelInfo jujuparams.ModelInfo
-	// newOwner may be nil if the user wants to keep the original owner.
-	newOwner      *names.UserTag
-	originalOwner names.UserTag
-	offersToAdd   []jujuparams.ApplicationOfferAdminDetailsV5
+	jimm        *JIMM
+	model       dbmodel.Model
+	modelInfo   jujuparams.ModelInfo
+	owner       names.UserTag
+	offersToAdd []jujuparams.ApplicationOfferAdminDetailsV5
 }
 
-func newModelImporter(jimm *JIMM, newOwner string) (modelImporter, error) {
+func newModelImporter(jimm *JIMM) (modelImporter, error) {
 	modelImporter := modelImporter{
 		jimm: jimm,
 	}
-	if newOwner == "" {
-		return modelImporter, nil
-	}
-	if !names.IsValidUser(newOwner) {
-		return modelImporter, errors.E(errors.CodeBadRequest, "invalid new username for new model owner")
-	}
-	newOwnerTag := names.NewUserTag(newOwner)
-	modelImporter.newOwner = &newOwnerTag
 	return modelImporter, nil
 }
 
@@ -401,14 +391,14 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName strin
 		return err
 	}
 
-	m.originalOwner, err = names.ParseUserTag(m.modelInfo.OwnerTag)
+	m.owner, err = names.ParseUserTag(m.modelInfo.OwnerTag)
 	if err != nil {
 		return errors.E(fmt.Sprintf("invalid username %s from original model owner", m.modelInfo.OwnerTag))
 	}
 
 	m.offersToAdd, err = api.ListApplicationOffers(ctx, []jujuparams.OfferFilter{
 		{
-			OwnerName: m.originalOwner.Id(),
+			OwnerName: m.owner.Id(),
 			ModelName: m.modelInfo.Name,
 		},
 	})
@@ -427,19 +417,9 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName strin
 	return nil
 }
 
-func (m *modelImporter) setModelOwner(ctx context.Context) error {
-	var ownerTag names.UserTag
-	if m.newOwner != nil {
-		ownerTag = *m.newOwner
-	} else {
-		ownerTag = m.originalOwner
-	}
-
-	if ownerTag.IsLocal() {
-		return errors.E("cannot import model from local user, try --owner to switch the model owner")
-	}
+func (m *modelImporter) ensureModelOwner(ctx context.Context) error {
 	owner := dbmodel.Identity{}
-	owner.SetTag(ownerTag)
+	owner.SetTag(m.owner)
 
 	err := m.jimm.Database.GetIdentity(ctx, &owner)
 	if err != nil {
@@ -453,8 +433,8 @@ func (m *modelImporter) setModelOwner(ctx context.Context) error {
 // addPermissions grants the model owner with admin access to the model
 // and, in turn, admin access to any offers within the model.
 func (m *modelImporter) addPermissions(ctx context.Context) error {
-	// Note that only the new owner is given access. All previous users that had access according to Juju
-	// are discarded as access must now be governed by JIMM and OpenFGA.
+	// Note that only the new owner is given access. All local Juju users' access
+	// is not modelled in JIMM and access must now be governed by JIMM and OpenFGA.
 	ofgaUser := openfga.NewUser(&m.model.Owner, m.jimm.OpenFGAClient)
 	controllerTag := m.model.Controller.ResourceTag()
 
@@ -473,28 +453,31 @@ func (m *modelImporter) addPermissions(ctx context.Context) error {
 }
 
 func (m *modelImporter) setCloudCredential(ctx context.Context) error {
-	// fetch cloud credential used by the model
-	cloudTag, err := names.ParseCloudTag(m.modelInfo.CloudTag)
+	// To support imports of models created by local users, we
+	// don't enforce that a cloud-credential exists in JIMM.
+	if m.owner.IsLocal() {
+		m.model.CloudCredentialID = nil
+		m.model.CloudCredential = nil
+		return nil
+	}
+
+	cloudCredTag, err := names.ParseCloudCredentialTag(m.modelInfo.CloudCredentialTag)
 	if err != nil {
 		return err
 	}
 
-	// Note that the model already has a cloud credential configured which it will use when deploying new
-	// applications. JIMM needs some cloud credential reference to be able to import the model so use any
-	// credential against the cloud the model is deployed against. Even using the correct cloud for the
-	// credential is not strictly necessary, but will help prevent the user thinking they can create new
-	// models on the incoming cloud.
-	allCredentials, err := m.jimm.Database.GetIdentityCloudCredentials(ctx, &m.model.Owner, cloudTag.Id())
-	if err != nil {
-		return err
-	}
-	if len(allCredentials) == 0 {
-		return errors.E(errors.CodeNotFound, fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, cloudTag.Id()))
-	}
-	cloudCredential := allCredentials[0]
+	cc := dbmodel.CloudCredential{}
+	cc.SetTag(cloudCredTag)
 
-	m.model.CloudCredentialID = cloudCredential.ID
-	m.model.CloudCredential = cloudCredential
+	// When importing a model from an external user (e.g. bob@canonical.com), check that we have the model's
+	// cloud credential, as the model may have been removed from JIMM then re-added.
+	err = m.jimm.Database.GetCloudCredential(ctx, &cc)
+	if err != nil {
+		return errors.E(err, fmt.Sprintf("Failed to find cloud credential %s for user %s on cloud %s: %s", cloudCredTag.Name(), cloudCredTag.Owner().Id(), cloudCredTag.Cloud().Id(), err.Error()))
+	}
+
+	m.model.CloudCredentialID = &cc.ID
+	m.model.CloudCredential = &cc
 
 	return nil
 }
@@ -559,7 +542,7 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 		return err
 	}
 
-	importer, err := newModelImporter(j, newOwner)
+	importer, err := newModelImporter(j)
 	if err != nil {
 		return errors.E(op, err)
 	}
@@ -568,7 +551,7 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 		return errors.E(op, err)
 	}
 
-	if err := importer.setModelOwner(ctx); err != nil {
+	if err := importer.ensureModelOwner(ctx); err != nil {
 		return errors.E(op, err)
 	}
 
@@ -576,10 +559,6 @@ func (j *JIMM) ImportModel(ctx context.Context, user *openfga.User, controllerNa
 		return errors.E(op, err)
 	}
 
-	// TODO(CSS-5458): Remove the below section on cloud credentials once we no longer persist the relation between
-	// cloud credentials and models.
-	// Update: We need to investigate this further, if a user updates their cloud-credential it will update the credential
-	// on this model.
 	if err := importer.setCloudCredential(ctx); err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -668,7 +668,7 @@ func TestImportModel(t *testing.T) {
 				},
 				Name: "test-region",
 			},
-			CloudCredential: dbmodel.CloudCredential{
+			CloudCredential: &dbmodel.CloudCredential{
 				Name: "test-credential",
 			},
 			Life: state.Alive.String(),
@@ -677,7 +677,7 @@ func TestImportModel(t *testing.T) {
 		about:          "model from local user imported",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "alice@canonical.com",
+		newOwner:       "local-user",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -724,8 +724,11 @@ func TestImportModel(t *testing.T) {
 				Valid:  true,
 			},
 			Owner: dbmodel.Identity{
-				Name:        "alice@canonical.com",
-				DisplayName: "Alice",
+				Name: "local-user",
+				// TODO: Fix how we create users so that this field gets populated
+				// Not a big deal for local users since this field is only used
+				// on login and we never allow login for local users in JIMM.
+				DisplayName: "",
 			},
 			Controller: dbmodel.Controller{
 				Name:         "test-controller",
@@ -741,55 +744,8 @@ func TestImportModel(t *testing.T) {
 				},
 				Name: "test-region",
 			},
-			CloudCredential: dbmodel.CloudCredential{
-				Name: "test-credential",
-			},
-			Life: state.Alive.String(),
-		},
-	}, {
-		about:          "new model owner is local user",
-		user:           "alice@canonical.com",
-		controllerName: "test-controller",
-		newOwner:       "bob",
-		modelUUID:      "00000002-0000-0000-0000-000000000001",
-		expectedError:  "cannot import model from local user, try --owner to switch the model owner",
-		jimmAdmin:      true,
-		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
-			info.Name = "test-model"
-			info.Type = "test-type"
-			info.UUID = "00000002-0000-0000-0000-000000000001"
-			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
-			info.DefaultSeries = "test-series"
-			info.CloudTag = names.NewCloudTag("test-cloud").String()
-			info.CloudRegion = "test-region"
-			info.CloudCredentialTag = names.NewCloudCredentialTag("test-cloud/local-user/test-credential").String()
-			info.CloudCredentialValidity = &trueValue
-			info.OwnerTag = names.NewUserTag("local-user").String()
-			info.Life = life.Alive
-			info.Status = jujuparams.EntityStatus{
-				Status: status.Status("available"),
-				Info:   "test-info",
-				Since:  &now,
-			}
-			info.Users = []jujuparams.ModelUserInfo{{
-				UserName: "local-user",
-				Access:   jujuparams.ModelAdminAccess,
-			}, {
-				UserName: "another-user",
-				Access:   jujuparams.ModelReadAccess,
-			}}
-			info.Machines = []jujuparams.ModelMachineInfo{{
-				Id:          "test-machine",
-				DisplayName: "Test machine",
-				Status:      "test-status",
-				Message:     "test-message",
-			}}
-			info.SLA = &jujuparams.ModelSLAInfo{
-				Level: "essential",
-				Owner: "local-user",
-			}
-			info.AgentVersion = newVersion("2.1.0")
-			return nil
+			CloudCredential: nil,
+			Life:            state.Alive.String(),
 		},
 	}, {
 		about:          "model not found",
@@ -802,27 +758,6 @@ func TestImportModel(t *testing.T) {
 			return errors.E(errors.CodeNotFound, "model not found")
 		},
 		expectedError: "model not found",
-	}, {
-		about:          "fail import from local user without newOwner flag",
-		user:           "alice@canonical.com",
-		controllerName: "test-controller",
-		newOwner:       "",
-		modelUUID:      "00000002-0000-0000-0000-000000000001",
-		jimmAdmin:      true,
-		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
-			info.Name = "test-model"
-			info.Type = "test-type"
-			info.UUID = "00000002-0000-0000-0000-000000000001"
-			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
-			info.DefaultSeries = "test-series"
-			info.CloudTag = names.NewCloudTag("test-cloud").String()
-			info.CloudRegion = "test-region"
-			info.CloudCredentialTag = names.NewCloudCredentialTag("test-cloud/alice@canonical.com/unknown-credential").String()
-			info.CloudCredentialValidity = &trueValue
-			info.OwnerTag = names.NewUserTag("local-user").String()
-			return nil
-		},
-		expectedError: `cannot import model from local user, try --owner to switch the model owner`,
 	}, {
 		about:          "cloud credentials not found",
 		user:           "alice@canonical.com",
@@ -843,7 +778,7 @@ func TestImportModel(t *testing.T) {
 			info.OwnerTag = names.NewUserTag("alice@canonical.com").String()
 			return nil
 		},
-		expectedError: `Failed to find cloud credential for user alice@canonical.com on cloud invalid-cloud`,
+		expectedError: `Failed to find cloud credential unknown-credential for user alice@canonical.com on cloud invalid-cloud: cloudcredential .* not found`,
 	}, {
 		about:          "cloud region not found",
 		user:           "alice@canonical.com",
@@ -962,7 +897,7 @@ func TestImportModel(t *testing.T) {
 				},
 				Name: "test-region",
 			},
-			CloudCredential: dbmodel.CloudCredential{
+			CloudCredential: &dbmodel.CloudCredential{
 				Name: "test-credential",
 			},
 			Life: state.Alive.String(),

--- a/internal/jimm/controller_test.go
+++ b/internal/jimm/controller_test.go
@@ -537,7 +537,6 @@ func TestImportModel(t *testing.T) {
 		controllerName string
 		modelUUID      string
 		modelInfo      func(context.Context, *jujuparams.ModelInfo) error
-		newOwner       string
 		jimmAdmin      bool
 		expectedModel  dbmodel.Model
 		expectedError  string
@@ -547,7 +546,6 @@ func TestImportModel(t *testing.T) {
 		about:          "model imported",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -677,7 +675,6 @@ func TestImportModel(t *testing.T) {
 		about:          "model from local user imported",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "local-user",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -751,7 +748,6 @@ func TestImportModel(t *testing.T) {
 		about:          "model not found",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -762,7 +758,6 @@ func TestImportModel(t *testing.T) {
 		about:          "cloud credentials not found",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -783,7 +778,6 @@ func TestImportModel(t *testing.T) {
 		about:          "cloud region not found",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -804,7 +798,6 @@ func TestImportModel(t *testing.T) {
 		about:          "not allowed if not superuser",
 		user:           "bob@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      false,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -825,7 +818,6 @@ func TestImportModel(t *testing.T) {
 		about:          "model already exists",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000002",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -846,7 +838,6 @@ func TestImportModel(t *testing.T) {
 		about:          "import model with offers",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
-		newOwner:       "",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(_ context.Context, info *jujuparams.ModelInfo) error {
@@ -956,7 +947,7 @@ func TestImportModel(t *testing.T) {
 			user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 			user.JimmAdmin = test.jimmAdmin
 
-			err := j.ImportModel(ctx, user, test.controllerName, names.NewModelTag(test.modelUUID), test.newOwner)
+			err := j.ImportModel(ctx, user, test.controllerName, names.NewModelTag(test.modelUUID))
 			if test.expectedError == "" {
 				c.Assert(err, qt.IsNil)
 

--- a/internal/jimm/model.go
+++ b/internal/jimm/model.go
@@ -365,7 +365,6 @@ func (j *JIMM) mergeModelInfo(ctx context.Context, user *openfga.User, modelInfo
 	const op = errors.Op("jimm.mergeModelInfo")
 	zapctx.Info(ctx, string(op))
 
-	modelInfo.CloudCredentialTag = jimmModel.CloudCredential.Tag().String()
 	modelInfo.ControllerUUID = jimmModel.Controller.UUID
 	modelInfo.OwnerTag = jimmModel.Owner.Tag().String()
 
@@ -699,8 +698,8 @@ func (j *JIMM) ChangeModelCredential(ctx context.Context, user *openfga.User, mo
 		return errors.E(op, err)
 	}
 
-	m.CloudCredential = credential
-	m.CloudCredentialID = credential.ID
+	m.CloudCredential = &credential
+	m.CloudCredentialID = &credential.ID
 	err = j.Database.UpdateModel(ctx, m)
 	if err != nil {
 		return errors.E(op, err)

--- a/internal/jimm/model_test.go
+++ b/internal/jimm/model_test.go
@@ -242,7 +242,7 @@ users:
 			},
 			Name: "test-region-1",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -347,7 +347,7 @@ users:
 			},
 			Name: "test-region-1",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -451,7 +451,7 @@ users:
 			},
 			Name: "test-region-1",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -547,7 +547,7 @@ users:
 			},
 			Name: "test-region-1",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -968,7 +968,7 @@ users:
 			},
 			Name: "test-region-1",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -1148,7 +1148,7 @@ users:
 			Name:    "default",
 			Virtual: true,
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name:     "test-credential-1",
 			AuthType: "empty",
 		},
@@ -2701,7 +2701,7 @@ var updateModelCredentialTests = []struct {
 			},
 			Name: "test-cloud-region",
 		},
-		CloudCredential: dbmodel.CloudCredential{
+		CloudCredential: &dbmodel.CloudCredential{
 			Name: "cred-2",
 		},
 	},

--- a/internal/jimm/modelbuilder.go
+++ b/internal/jimm/modelbuilder.go
@@ -284,7 +284,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 		Name:              b.name,
 		ControllerID:      b.controller.ID,
 		Owner:             *b.owner,
-		CloudCredentialID: b.credential.ID,
+		CloudCredentialID: &b.credential.ID,
 		CloudRegionID:     b.cloudRegionID,
 	}
 
@@ -334,9 +334,9 @@ func (b *modelBuilder) UpdateDatabaseModel() *modelBuilder {
 	// we know which credentials and cloud region was used
 	// - ignore this information returned by the controller
 	//   because we need IDs to properly update the model
-	b.model.CloudCredentialID = b.credential.ID
+	b.model.CloudCredentialID = &b.credential.ID
 	b.model.CloudRegionID = b.cloudRegionID
-	b.model.CloudCredential = dbmodel.CloudCredential{}
+	b.model.CloudCredential = b.credential
 	b.model.CloudRegion = dbmodel.CloudRegion{}
 
 	err = b.jimm.Database.UpdateModel(b.ctx, b.model)

--- a/internal/jujuapi/access_control_test.go
+++ b/internal/jujuapi/access_control_test.go
@@ -1514,7 +1514,7 @@ func createTestControllerEnvironment(ctx context.Context, c *gc.C, s *accessCont
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -443,7 +443,7 @@ func (r *controllerRoot) ImportModel(ctx context.Context, req apiparams.ImportMo
 		return errors.E(op, err, errors.CodeBadRequest)
 	}
 
-	err = r.jimm.ImportModel(ctx, r.user, req.Controller, mt, req.Owner)
+	err = r.jimm.ImportModel(ctx, r.user, req.Controller, mt)
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -604,7 +604,6 @@ func (s *jimmSuite) TestImportModel(c *gc.C) {
 	req := apiparams.ImportModelRequest{
 		Controller: "controller-1",
 		ModelTag:   s.Model2.Tag().String(),
-		Owner:      "",
 	}
 	err = conn.APICall("JIMM", 4, "", "ImportModel", &req, nil)
 	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -68,7 +68,7 @@ type ModelManager interface {
 	ForEachUserModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
 	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
-	ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error
+	ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag) error
 	ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelInfo, error)
 	ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) (jujuparams.ModelSummaryResults, error)

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -497,7 +497,8 @@ func (m *Model) DBObject(c Tester, db *db.Database) dbmodel.Model {
 		migrationControllerID.Valid = true
 	}
 	m.dbo.CloudRegion = m.env.Cloud(m.Cloud).DBObject(c, db).Region(m.CloudRegion)
-	m.dbo.CloudCredential = m.env.CloudCredential(m.Owner, m.Cloud, m.CloudCredential).DBObject(c, db)
+	cc := m.env.CloudCredential(m.Owner, m.Cloud, m.CloudCredential).DBObject(c, db)
+	m.dbo.CloudCredential = &cc
 
 	m.dbo.Life = m.Life
 

--- a/internal/testutils/jimmtest/fixture.go
+++ b/internal/testutils/jimmtest/fixture.go
@@ -91,7 +91,7 @@ func CreateTestControllerEnvironment(ctx context.Context, c *qt.C, db *db.Databa
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 

--- a/internal/testutils/jimmtest/mocks/model.go
+++ b/internal/testutils/jimmtest/mocks/model.go
@@ -1,4 +1,5 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package mocks
 
 import (
@@ -27,7 +28,7 @@ type ModelManager struct {
 	FullModelStatus_        func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
 	ListModelSummaries_     func(ctx context.Context, user *openfga.User, maskingControllerUUID string) (jujuparams.ModelSummaryResults, error)
 	GetModel_               func(ctx context.Context, uuid string) (dbmodel.Model, error)
-	ImportModel_            func(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error
+	ImportModel_            func(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag) error
 	IdentityModelDefaults_  func(ctx context.Context, user *dbmodel.Identity) (map[string]interface{}, error)
 	ModelDefaultsForCloud_  func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo_              func(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelInfo, error)
@@ -102,11 +103,11 @@ func (j *ModelManager) GetModel(ctx context.Context, uuid string) (dbmodel.Model
 	return j.GetModel_(ctx, uuid)
 }
 
-func (j *ModelManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
+func (j *ModelManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag) error {
 	if j.ImportModel_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.ImportModel_(ctx, user, controllerName, modelTag, newOwner)
+	return j.ImportModel_(ctx, user, controllerName, modelTag)
 }
 
 func (j *ModelManager) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error) {

--- a/local/seed_db/main.go
+++ b/local/seed_db/main.go
@@ -102,7 +102,7 @@ func main() {
 		OwnerIdentityName: u.Name,
 		ControllerID:      controller.ID,
 		CloudRegionID:     cloud.Regions[0].ID,
-		CloudCredentialID: cred.ID,
+		CloudCredentialID: &cred.ID,
 		Life:              state.Alive.String(),
 	}
 	if err = db.AddModel(ctx, &model); err != nil {

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -262,10 +262,6 @@ type ImportModelRequest struct {
 
 	// ModelTag is the tag of the model that is to be imported.
 	ModelTag string `json:"model-tag"`
-
-	// Owner specifies the new owner of the model after import.
-	// Can be empty to skip switching the owner.
-	Owner string `json:"owner"`
 }
 
 // Authorisation request parameters / responses:


### PR DESCRIPTION
## Description
This PR aims to fix issues recently noticed with imported models created by local users.

Importing a model into JIMM that is owned by a local Juju user requires the use of the `--switch-owner` CLI flag to change the model owner in jimm to a new external user. This change doesn't propagate to the Juju controller so extra logic needs to exist to ensure we alias the old user to the new one.

That was not being done and as a result, things like listing application offers were not working. This change allows models created by local Juju users to keep their model owner tag in JIMM. Although JIMM normally deals with external users, there is no reason it can't also hold local users for cases of model imports.

To handle the cloud-credential of an imported model where JIMM is not aware of the local user's credentials, we allow the value of the cloud-credential in JIMM to be nil. This works out because we fetch model info from the controller anyway.

This change simultaneously fixes the same issue addressed in https://github.com/canonical/jimm/pull/1533 where application offers that have already been consumed in a Juju model are being authorized by checking JIMM through the use of the JAAS macaroon discharger. If we can combine this change with the idea in #1533 to store the permissions of existing consumers of an app offer (**including** local users) we can solve both challenges.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
