### PR TITLE
fix: remove eager session deletion

### DIFF
--- a/internal/auth/oauth2.go
+++ b/internal/auth/oauth2.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package auth provides means to authenticate users into JIMM.
 //
@@ -493,9 +493,9 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	err = as.validateAndUpdateAccessToken(ctx, identityId)
 	if err != nil {
-		if err := as.deleteSession(session, w, req); err != nil {
-			return ctx, errors.E(op, err, "failed to delete session after getting an invalid token")
-		}
+		// If the user's access token AND refresh token have expired
+		// then we will fail authentication here.
+		zapctx.Error(ctx, "failed to validate and update status token", zap.Error(err))
 		return ctx, errors.E(op, err)
 	}
 
@@ -636,11 +636,11 @@ func (as *AuthenticationService) refreshIdentitiesToken(ctx context.Context, ema
 	// Get a new access and refresh token (token source only has Token())
 	newToken, err := tSrc.Token()
 	if err != nil {
-		return errors.E(op, err, "failed to refresh token")
+		return errors.E(op, err, fmt.Errorf("failed to refresh token: %w", err))
 	}
 
 	if err := as.UpdateIdentity(ctx, email, newToken); err != nil {
-		return errors.E(op, err, "failed to update identity")
+		return errors.E(op, err, fmt.Errorf("failed to update identity: %w", err))
 	}
 
 	return nil

--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -498,17 +498,7 @@ func TestAuthenticateBrowserSessionHandlesMissingOrExpiredRefreshTokens(t *testi
 	err = db.UpdateIdentity(ctx, u)
 	c.Assert(err, qt.IsNil)
 
-	// AuthenticateBrowserSession should fail to refresh the users session and delete
-	// the current session, giving us the same cookie back with a max-age of -1.
+	// AuthenticateBrowserSession should fail to refresh the users session.
 	_, err = authSvc.AuthenticateBrowserSession(ctx, rec, req)
-	c.Assert(err, qt.ErrorMatches, ".*failed to refresh token.*")
-
-	// Assert that the header to delete the session is set correctly based
-	// on a failed access token refresh due to refresh token issues.
-	setCookieCookies := rec.Header().Get("Set-Cookie")
-	c.Assert(
-		setCookieCookies,
-		qt.Equals,
-		"jimm-browser-session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; HttpOnly; SameSite=None",
-	)
+	c.Assert(err, qt.ErrorMatches, ".*failed to refresh token: oauth2: token expired and refresh token is not set")
 }


### PR DESCRIPTION
## Description
When the backend encountered an error during the validateAndUpdateAccessToken method, the session would be deleted. The error could have many causes
- Context cancelled
- DB down
- Failed to reach identity provider 

This was causing the Juju dashboard to frequently become logged out. So we shouldn't delete the session unless we have a sure way of knowing that this user should be logged out.

Fixes [JUJU-7460](https://warthogs.atlassian.net/browse/JUJU-7460)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->


[JUJU-7460]: https://warthogs.atlassian.net/browse/JUJU-7460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ