### PR TITLE
fix: ensure backticks are preserved through echo

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -36,7 +36,7 @@ jobs:
       # We do this because the original doc doesn't have a top level heading.: 
     - name: Create final doc with title
       run: |
-        echo "``jimmctl`` Reference" > jimmctl-reference.rst
+        echo "\`\`jimmctl\`\` Reference" > jimmctl-reference.rst
         echo "#####################" >> jimmctl-reference.rst
         echo "" >> jimmctl-reference.rst
         cat documentation.rst >> jimmctl-reference.rst
@@ -59,5 +59,7 @@ jobs:
         path: ./jaas-documentation
         branch: update-jimmctl-${{ github.run_number }}
         title: Update jimmctl reference doc
-        body: This PR updates the jimmctl reference doc.
+        body: |
+          This PR contains a generated documentation reference
+          for the jimmctl CLI tool for release ${{ github.event.ref }}.
         commit-message: Updated jimmctl reference for release ${{ github.event.ref }}


### PR DESCRIPTION
## Description
This PR ensures that backticks are preserved when we create out generated jimmctl reference documentation. It also adds a minor update to the body of the PR that is created.