### PR TITLE
fix(internal/jimm/juju/modelbuilder.go): obey controller's 'Deprecated' field when adding models

### DIFF
--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1154,6 +1154,76 @@ users:
 		},
 		Life: state.Alive.String(),
 	},
+}, {
+	name: "CreateModelWithDeprecatedControllers",
+	env: `
+clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region-1
+  users:
+  - user: alice@canonical.com
+    access: add-model
+cloud-defaults:
+- user: alice@canonical.com
+  cloud: test-cloud
+  region: test-region-1
+  defaults:
+    key1: value1
+    key2: value2
+- user: alice@canonical.com
+  cloud: test-cloud
+  defaults:
+    key3: value3
+cloud-credentials:
+- name: test-credential-1
+  owner: alice@canonical.com
+  cloud: test-cloud
+  auth-type: empty
+controllers:
+- name: controller-1
+  uuid: 00000000-0000-0000-0000-0000-0000000000001
+  cloud: test-cloud
+  region: test-region-1
+  deprecated: true
+  cloud-regions:
+  - cloud: test-cloud
+    region: test-region-1
+    priority: 0
+`[1:],
+	updateCredential: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+		return nil, nil
+	},
+	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
+		return nil
+	},
+	createModel: assertConfig(map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}, createModel(`
+uuid: 00000001-0000-0000-0000-0000-000000000001
+status:
+  status: started
+  info: running a test
+life: alive
+users:
+- user: alice@canonical.com
+  access: admin
+- user: bob
+  access: read
+`[1:])),
+	username:     "alice@canonical.com",
+	jimmAdmin:    true,
+	cloudCredTag: names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential-1"),
+	args: jujuparams.ModelCreateArgs{
+		Name:        "test-model",
+		OwnerTag:    names.NewUserTag("alice@canonical.com").String(),
+		CloudTag:    names.NewCloudTag("test-cloud").String(),
+		CloudRegion: "test-region-1",
+	},
+	expectError: "unsupported cloud region test-cloud/test-region-1",
 }}
 
 func TestAddModel(t *testing.T) {

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -193,8 +193,13 @@ func (b *modelBuilder) WithCloudRegion(region string) *modelBuilder {
 		if r.Name != region {
 			continue
 		}
-		// consider all possible controllers for that region
-		regionControllers := r.Controllers
+		// consider all non-deprecated controller for the region
+		var regionControllers []dbmodel.CloudRegionControllerPriority
+		for _, ctrl := range r.Controllers {
+			if !ctrl.Controller.Deprecated {
+				regionControllers = append(regionControllers, ctrl)
+			}
+		}
 		if len(regionControllers) == 0 {
 			b.err = errors.E(errors.CodeBadRequest, fmt.Sprintf("unsupported cloud region %s/%s", b.cloud.Name, region))
 			return b

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -413,6 +413,7 @@ type Controller struct {
 	CloudRegion  string                          `json:"region"`
 	CloudRegions []CloudRegionControllerPriority `json:"cloud-regions"`
 	AgentVersion string                          `json:"agent-version"`
+	Deprecated   bool                            `json:"deprecated,omitempty"`
 
 	env *Environment
 	dbo dbmodel.Controller
@@ -428,6 +429,7 @@ func (ctl *Controller) DBObject(c Tester, db *db.Database) dbmodel.Controller {
 	ctl.dbo.CloudName = ctl.Cloud
 	ctl.dbo.CloudRegion = ctl.CloudRegion
 	ctl.dbo.CloudRegions = make([]dbmodel.CloudRegionControllerPriority, len(ctl.CloudRegions))
+	ctl.dbo.Deprecated = ctl.Deprecated
 	for i, cr := range ctl.CloudRegions {
 		cl := ctl.env.Cloud(cr.Cloud).DBObject(c, db)
 		ctl.dbo.CloudRegions[i] = dbmodel.CloudRegionControllerPriority{


### PR DESCRIPTION
## Description

When we are selecting a controller to host a new model, we should not consider adding models to
`deprecated` controllers.
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [*] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
