### PR TITLE
feat: add weekly trivy scan for released container

### DIFF
--- a/.github/workflows/release-server-rock.yaml
+++ b/.github/workflows/release-server-rock.yaml
@@ -47,6 +47,12 @@ jobs:
 
       - name: Push to github package
         run: |
-          new_tag=ghcr.io/canonical/jimm:${{ github.ref_name }}
+          base_tag=ghcr.io/canonical/jimm
+          new_tag=$base_tag:${{ github.ref_name }}
+          latest_tag=$base_tag:latest
+          
           docker tag jimm:latest $new_tag
+          docker tag jimm:latest $latest_tag
+
           docker push $new_tag
+          docker push $latest_tag

--- a/.github/workflows/security-scan-weekly.yaml
+++ b/.github/workflows/security-scan-weekly.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  security-scan:
+  repo-security-scan:
     runs-on: [ubuntu-latest]
-    name: Security Scan
+    name: Repo Security Scan
     strategy:
       matrix:
         branch: [v3]
@@ -23,3 +23,19 @@ jobs:
         with: 
           upload-github-security: "true"
           upload-sarif-artifact: "true"
+
+  container-security-scan:
+    runs-on: [ubuntu-latest]
+    name: Container Security Scan
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: 'ghcr.io/canonical/jimm:latest'
+          format: 'sarif'
+          output: 'container-trivy-results.sarif'
+
+      - name: Upload container Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'container-trivy-results.sarif'

--- a/.github/workflows/security-scan-weekly.yaml
+++ b/.github/workflows/security-scan-weekly.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  repo-security-scan:
+  security-scan:
     runs-on: [ubuntu-latest]
-    name: Repo Security Scan
+    name: Security Scan
     strategy:
       matrix:
         branch: [v3]
@@ -23,19 +23,4 @@ jobs:
         with: 
           upload-github-security: "true"
           upload-sarif-artifact: "true"
-
-  container-security-scan:
-    runs-on: [ubuntu-latest]
-    name: Container Security Scan
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: 'ghcr.io/canonical/jimm:latest'
-          format: 'sarif'
-          output: 'container-trivy-results.sarif'
-
-      - name: Upload container Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'container-trivy-results.sarif'
+          container-name: "ghcr.io/canonical/jimm:latest"


### PR DESCRIPTION
This PR adds to our weekly security workflow to scan the most recently released jimm container.
We also now release a container with the `latest` tag on each release.