### PR TITLE
chore: extract security scan workflow into jimm

### DIFF
--- a/.github/workflows/security-scan-weekly.yaml
+++ b/.github/workflows/security-scan-weekly.yaml
@@ -6,21 +6,79 @@ on:
   workflow_dispatch:
 
 jobs:
-  security-scan:
+  repo-security-scan:
     runs-on: [ubuntu-latest]
-    name: Security Scan
-    strategy:
-      matrix:
-        branch: [v3]
+    name: Repo Security Scan
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
 
-      - name: Security scan
-        uses: canonical/comsys-build-tools/.github/actions/security-scan-upload@main
-        with: 
-          upload-github-security: "true"
-          upload-sarif-artifact: "true"
-          container-name: "ghcr.io/canonical/jimm:latest"
+      #########
+      # Trivy #
+      #########
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: 'fs'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/canonical/comsys-build-tools/trivy-db:2
+  
+      - name: Upload trivy scan results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-security-scan-results
+          path: 'trivy-results.sarif'
+  
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+  
+      ##########
+      # Govuln #
+      ##########
+      - name: Go Vulnerability Check
+        id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          output-format: 'sarif'
+          output-file: 'govuln-results.sarif'
+          go-version-file: go.mod
+          repo-checkout: false
+  
+      - name: Upload govuln scan results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: govuln-security-scan-results
+          path: 'govuln-results.sarif'
+  
+      - name: Upload govuln scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'govuln-results.sarif'
+
+  container-security-scan:
+    runs-on: [ubuntu-latest]
+    name: Container Security Scan
+    steps:
+      - name: Run Trivy container scanner for the latest JIMM image
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: 'ghcr.io/canonical/jimm:latest'
+          format: 'sarif'
+          output: 'jimm-container-trivy-results.sarif'
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/canonical/comsys-build-tools/trivy-db:2
+
+      - name: Upload container scan results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jimm-container-scan-results
+          path: 'jimm-container-trivy-results.sarif'
+
+      - name: Upload container Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'jimm-container-trivy-results.sarif'


### PR DESCRIPTION
## Description
This PR removes the dependency on the comsys-build-tools repo and place the security scanning steps directly into JIMM's repo. This reduces the coupling to that repo and lowers the complexity with less branching logic based on input parameters.