### PR TITLE
chore: fix docker compose startup

### DIFF
--- a/local/openfga/Dockerfile
+++ b/local/openfga/Dockerfile
@@ -18,9 +18,11 @@ COPY entrypoint.sh                /app/entrypoint.sh
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 
+# Opt to check for a file rather than the OpenFGA itself
+# because we perform some DB migrations after starting the server.
 HEALTHCHECK \
     --start-period=5s \
     --interval=1s \
-    --timeout=5s \
-    --retries=10 \
-        CMD [ "curl", "http://0.0.0.0:8080/healthz" ]
+    --timeout=1s \
+    --retries=30 \
+        CMD [ "/bin/sh", "-c", "[ -f /tmp/healthy ]" ]

--- a/local/openfga/entrypoint.sh
+++ b/local/openfga/entrypoint.sh
@@ -21,5 +21,8 @@ wget -q -O - --header 'Content-Type: application/json' --header 'Authorization: 
 psql -Atx "$OPENFGA_DATASTORE_URI" -c "INSERT INTO store (id,name,created_at,updated_at) VALUES ('01GP1254CHWJC1MNGVB0WDG1T0','jimm',NOW(),NOW()) ON CONFLICT DO NOTHING;"
 psql -Atx "$OPENFGA_DATASTORE_URI" -c "UPDATE authorization_model SET authorization_model_id = '01GP1EC038KHGB6JJ2XXXXCXKB' WHERE store = '01GP1254CHWJC1MNGVB0WDG1T0';"
 
+# This container is now healthy
+touch /tmp/healthy
+
 # Handle exit signals
 trap 'kill %1' TERM ; wait


### PR DESCRIPTION
## Description
The Terraform provider tests were failing to start JIMM, see here.
When debugging the failure, JIMM's output was the following,
```
15:25:51.577    INFO    jimm info       {"version": "v3.2.2", "commit": "637b67c4b79433067813b0956f3ad1c852ff077e"}
15:25:51.577    INFO    oauth scopes    {"scopes": ["openid", "profile", "email"]}
15:25:51.578    INFO    connecting database
15:25:51.598    INFO    configuring OpenFGA client      {"scheme": "http", "host": "openfga", "port": "8080", "store": "01GP1254CHWJC1MN
GVB0WDG1T0"}
15:25:51.611    ERROR   cannot retrieve store: GetStore validation error for GET GetStore with body {"code":"store_id_not_found","messag
e":"Store ID not found"}
 with error code store_id_not_found error message: Store ID not found
15:25:51.611    ERROR   shutdown        {"error": "cannot retrieve store: GetStore validation error for GET GetStore with body {\"code\"
:\"store_id_not_found\",\"message\":\"Store ID not found\"}\n with error code store_id_not_found error message: Store ID not found"}
```
The error indicates that OpenFGA is not setup properly. Trying to start jimm again manually on the Github runner with `JIMM_VERSION=v3.2.2 docker compose --profile test up` worked successfully so it looks like a timing issue.

I suspect this is inside our OpenFGA dockerfile entrypoint. The entrypoint starts OpenFGA, sleeps 3 seconds, then runs some manual migration steps to use a hardcoded store ID that we hardcode in tests.
Because the health check for the container was polling the OpenFGA server endpoint, it could signal to docker that the OpenFGA container is ready and healthy before we've completed migrations. Then JIMM will start, unable to find the hardcoded store.

This fixes the issue by making the health check based on the existence of a file, exactly the same way our Vault container is marked as healthy.