### PR TITLE
chore: add restart policy to jimm container

### DIFF
--- a/docker-compose.common.yaml
+++ b/docker-compose.common.yaml
@@ -97,6 +97,12 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 20s
     labels:
       traefik.enable: true
       traefik.http.routers.jimm.rule: Host(`jimm.localhost`)


### PR DESCRIPTION
## Description
Following up with the previous fix for our docker compose in #1554, the Terraform provider tests are [still failing](https://github.com/juju/terraform-provider-juju/actions/runs/13496651062/job/37799750418?pr=648). Debugging the error this time is different,
```
ERROR   cannot list stores: Get "http://openfga:8080/stores": dial tcp: lookup openfga on 127.0.0.11:53: server misbehav
ing
```
Searching for what this error indicates,

- `lookup openfga on 127.0.0.11:53`

>This indicates that Docker's internal DNS resolver (at 127.0.0.11) is being used to resolve the service name openfga.
The failure suggests that the DNS resolver can't find openfga, possibly because the openfga service isn't up yet.

- `server misbehaving`
>This error comes from Go's DNS resolver, meaning that the DNS server at 127.0.0.11 responded in a way that Go considers invalid or unexpected.

It's unlikely that the OpenFGA server is not running because [the startup script](https://github.com/canonical/jimm/blob/v3/local/openfga/entrypoint.sh#L20) makes a call to the OpenFGA server before marking it as healthy.

And still, when debugging in the Github action, starting the jimm container manually works. So there is likely some timing issue where possibly jimm is starting too early. For this PR we add a restart policy in our docker compose for the jimm container to retry starting up to 3 times.
