### PR TITLE
chore: ensure jimm container depends on vault

### DIFF
--- a/docker-compose.common.yaml
+++ b/docker-compose.common.yaml
@@ -97,6 +97,8 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
+      vault:
+        condition: service_healthy
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
## Description
This PR is a followup to #1555. That PR did not fix the issue with the jimm container failing to start properly on Terraform provider tests. This PR doesn't necessarily fix the issue but adds a missing dependency on the jimm container, as it was not waiting for Vault to be ready before starting.