### PR TITLE
fix action logs not being shown when tests fail

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -147,7 +147,7 @@ runs:
       shell: bash
     
     - name: Dump JIMM container logs
-      if: failure() || inputs.dump-logs == 'true'
+      if: always() && inputs.dump-logs == 'true'
       uses: gacts/run-and-post-run@v1
       with:
         post: docker logs ${{ env.container_name }}


### PR DESCRIPTION
## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->
`failure()` doesn't play nice with the custom action to execute something at the end.
In fact logs were not displayed at failure time.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
