### PR TITLE
chore: improve keycloak health check

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/test-server
         with:
           jimm-version: dev
-          juju-channel: "3/stable"
+          juju-channel: "3/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start JIMM (manual run)
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/test-server
         with:
           jimm-version: ${{ inputs.jimm-version }}
-          juju-channel: "3/stable"
+          juju-channel: "3/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a model, deploy an application and run juju status

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -129,7 +129,8 @@ services:
     ports:
       - "8082:8082"
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8082/health/ready" ]
+      # Ensure we only return exit code 0 on Status 200 https://www.keycloak.org/observability/health#_curl
+      test: [ "CMD", "curl", "--head", "-fsS", "http://localhost:8082/health/ready" ]
       interval: 5s
       timeout: 10s
       retries: 30


### PR DESCRIPTION
## Description
The JIMM setup action is failing in [this run](https://github.com/canonical/jimm/actions/runs/13569913017/job/37932001275?pr=1560) due to a failure contacting Keycloak. The issue possibly comes from our Keycloak container health check. From Keycloak [docs](https://www.keycloak.org/observability/health):
>These endpoints respond with HTTP status 200 OK on success or 503 Service Unavailable on failure

Using `curl` without any flags will return an exit code of 0 when the server responds, regardless of the HTTP code. The linked docs above provide a suggested set of curl flags to only exit with code 0 when when a 200 status code is received.