### PR TITLE
chore: remove unneeded pgsession cleanup

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/test-server
         with:
           jimm-version: dev
-          juju-channel: "3/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
+          juju-channel: "3.6/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start JIMM (manual run)
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/test-server
         with:
           jimm-version: ${{ inputs.jimm-version }}
-          juju-channel: "3/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
+          juju-channel: "3.6/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a model, deploy an application and run juju status

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -61,9 +61,6 @@ func TestBrowserLoginAndLogout(t *testing.T) {
 	// Login
 	db, sessionStore := setupDbAndSessionStore(c)
 
-	pgSession := sessionStore.(*pgstore.PGStore)
-	pgSession.Cleanup(time.Nanosecond)
-
 	cookie, jimmHTTPServer, err := jimmtest.RunBrowserLoginAndKeepServerRunning(
 		db,
 		sessionStore,


### PR DESCRIPTION
## Description
This PR removes an unnecessary `pgSession.Cleanup()` call in a test. The test works without it but including it and at a frequency of every nanosecond exploded our logs when we had failures. The logs were filled with the line `pgstore: unable to delete expired sessions: sql: database is closed`. For comparison the log file was ~65MB and after removing the duplicate log lines was reduced to ~1.2MB.