### PR TITLE
add model uuid to ssh key

### DIFF
--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -22,13 +22,18 @@ func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err e
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if err := d.DB.WithContext(ctx).Create(sshKey).Error; err != nil {
-		return errors.E(op, dbError(err))
+		dbErr := dbError(err)
+		if errors.ErrorCode(dbErr) == errors.CodeAlreadyExists {
+			// we don't return an error if a user tries to add the same key twice.
+			return nil
+		}
+		return errors.E(op, dbErr)
 	}
 	return nil
 }
 
 // RemoveSSHKeyByFingerprint removes a user's ssh key identified by its fingerprint.
-func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName string, fingerprint string) (err error) {
+func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName string, model SSHKeyModelFilter, fingerprint string) (err error) {
 	const op = errors.Op("db.RemoveSSHKeyByFingerprint")
 
 	if err := d.ready(); err != nil {
@@ -40,6 +45,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	query := d.DB.Where("identity_name = ?", identityName).
+		Where("model_uuid = ?", model.ModelUUID).
 		Where("md5_fingerprint = ?", fingerprint).
 		Delete(&dbmodel.SSHKey{})
 
@@ -55,7 +61,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 }
 
 // RemoveSSHKeyByComment removes a user's ssh key identified by its comment.
-func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName string, comment string) (err error) {
+func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName string, model SSHKeyModelFilter, comment string) (err error) {
 	const op = errors.Op("db.RemoveSSHKeyByComment")
 
 	if err := d.ready(); err != nil {
@@ -66,7 +72,9 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
-	query := d.DB.Where("key_comment = ?", comment).Delete(&dbmodel.SSHKey{})
+	query := d.DB.Where("key_comment = ?", comment).
+		Where("model_uuid = ?", model.ModelUUID).
+		Delete(&dbmodel.SSHKey{})
 	if err := query.Error; err != nil {
 		return errors.E(op, dbError(err))
 	}
@@ -78,8 +86,8 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	return nil
 }
 
-// ListSSHKeysForUser lists all user's SSH keys.
-func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string) (keys []dbmodel.SSHKey, err error) {
+// ListSSHKeysForUser lists all user's SSH keys per model.
+func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, model SSHKeyModelFilter) (keys []dbmodel.SSHKey, err error) {
 	const op = errors.Op("db.ListSSHKeysForUser")
 
 	if err := d.ready(); err != nil {
@@ -89,10 +97,20 @@ func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string) 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
-
-	if err := d.DB.Where("identity_name = ?", identityName).Find(&keys).Error; err != nil {
+	query := d.DB.Where("identity_name = ?", identityName)
+	if !model.All {
+		query = query.Where("model_uuid = ?", model.ModelUUID)
+	}
+	if err := query.
+		Find(&keys).Error; err != nil {
 		return nil, errors.E(op, dbError(err))
 	}
 
 	return keys, nil
+}
+
+// SSHKeyModelFilter holds the model UUID for the SSH Key or a flag to list all keys independent of the model.
+type SSHKeyModelFilter struct {
+	ModelUUID string
+	All       bool
 }

--- a/internal/db/sshkeys_test.go
+++ b/internal/db/sshkeys_test.go
@@ -6,83 +6,90 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"database/sql"
+	"testing"
+	"time"
 
+	petname "github.com/dustinkirkland/golang-petname"
 	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"github.com/google/uuid"
+	"github.com/juju/juju/state"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
-func (s *dbSuite) TestCreateSSHKey(c *qt.C) {
+type sshKeysSuite struct {
+	Database *db.Database
+	User     dbmodel.Identity
+	Model    dbmodel.Model
+	Model2   dbmodel.Model
+}
+
+func (s *sshKeysSuite) Init(c *qt.C) {
+	ctx := context.Background()
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	s.Database = db
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
-
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
+	err = s.Database.Migrate(ctx)
+	c.Assert(err, qt.Equals, nil)
+	user, _, controller, model, _, cloud, cloudCred, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.Database)
+	id, _ := uuid.NewRandom()
+	model2 := dbmodel.Model{
+		Name: petname.Generate(2, "-"),
+		UUID: sql.NullString{
+			String: id.String(),
+			Valid:  true,
+		},
+		OwnerIdentityName: user.Name,
+		ControllerID:      controller.ID,
+		CloudRegionID:     cloud.Regions[0].ID,
+		CloudCredentialID: cloudCred.ID,
+		Life:              state.Alive.String(),
+	}
+	err = s.Database.AddModel(ctx, &model2)
 	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u).Error, qt.IsNil)
+	s.User = user
+	s.Model = model
+	s.Model2 = model2
+}
 
+func (s *sshKeysSuite) TestCreateSSHKey(c *qt.C) {
+	ctx := context.Background()
 	key := dbmodel.SSHKey{
-		Identity:       *u,
+		Identity:       s.User,
 		PublicKey:      []byte("foo"),
 		KeyComment:     "bar",
 		MD5Fingerprint: "fake-fingerprint",
+		Model:          s.Model,
 	}
-	err = s.Database.AddSSHKey(context.Background(), &key)
+	err := s.Database.AddSSHKey(ctx, &key)
 	c.Assert(err, qt.IsNil)
 
-	var gotKey dbmodel.SSHKey
-	c.Assert(s.Database.DB.First(&gotKey).Error, qt.IsNil)
-	c.Assert(gotKey.ID, qt.Not(qt.Equals), 0)
-	c.Assert(gotKey.IdentityName, qt.Equals, "bob@canonical.com")
-	c.Assert(string(gotKey.PublicKey), qt.Equals, "foo")
-	c.Assert(gotKey.KeyComment, qt.Equals, "bar")
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 1)
+	c.Assert(keys[0].IdentityName, qt.Equals, s.User.Name)
+	c.Assert(keys[0].ModelUUID, qt.Equals, s.Model.UUID.String)
 
-	err = s.Database.AddSSHKey(context.Background(), &key)
-	c.Assert(err, qt.ErrorMatches, `.*duplicate key value violates unique constraint.*`)
+	// add the same key twice, expect no error
+	err = s.Database.AddSSHKey(ctx, &key)
+	c.Assert(err, qt.IsNil)
+
+	// add the same key to another model, expect no error
+	key.Model = s.Model2
+	err = s.Database.AddSSHKey(ctx, &key)
+	c.Assert(err, qt.IsNil)
 }
 
-func (s *dbSuite) TestListSSHKeysForUser(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u).Error, qt.IsNil)
-
-	u2, err := dbmodel.NewIdentity("alice@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u2).Error, qt.IsNil)
-
-	key := dbmodel.SSHKey{Identity: *u, PublicKey: []byte("foo"), KeyComment: "bar", MD5Fingerprint: "fake-fingerprint"}
-	c.Assert(s.Database.DB.Create(&key).Error, qt.IsNil)
-
-	key2 := dbmodel.SSHKey{Identity: *u, PublicKey: []byte("foo2"), KeyComment: "bar2", MD5Fingerprint: "fake-fingerprint"}
-	c.Assert(s.Database.DB.Create(&key2).Error, qt.IsNil)
-
-	// Key3 is owned by Alice and should not be returned.
-	key3 := dbmodel.SSHKey{Identity: *u2, PublicKey: []byte("foo3"), KeyComment: "bar3", MD5Fingerprint: "fake-fingerprint"}
-	c.Assert(s.Database.DB.Create(&key3).Error, qt.IsNil)
-
-	gotKeys, err := s.Database.ListSSHKeysForUser(context.Background(), "bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(gotKeys, qt.HasLen, 2)
-	c.Assert(gotKeys[0].IdentityName, qt.Equals, "bob@canonical.com")
-	c.Assert(gotKeys[0].KeyComment, qt.Equals, "bar")
-	c.Assert(gotKeys[0].MD5Fingerprint, qt.Equals, "fake-fingerprint")
-	c.Assert(string(gotKeys[0].PublicKey), qt.Equals, "foo")
-	c.Assert(gotKeys[1].IdentityName, qt.Equals, "bob@canonical.com")
-	c.Assert(gotKeys[1].KeyComment, qt.Equals, "bar2")
-	c.Assert(gotKeys[1].MD5Fingerprint, qt.Equals, "fake-fingerprint")
-	c.Assert(string(gotKeys[1].PublicKey), qt.Equals, "foo2")
-}
-
-func (s *dbSuite) TestRemoveSSHKeyByFingerprint(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u).Error, qt.IsNil)
+func (s *sshKeysSuite) TestRemoveSSHKeyByFingerprint(c *qt.C) {
+	ctx := context.Background()
 
 	u2, err := dbmodel.NewIdentity("alice@canonical.com")
 	c.Assert(err, qt.IsNil)
@@ -94,67 +101,101 @@ func (s *dbSuite) TestRemoveSSHKeyByFingerprint(c *qt.C) {
 	publicKey, err := gossh.NewPublicKey(&rsaKey.PublicKey)
 	c.Assert(err, qt.IsNil)
 
-	key := dbmodel.SSHKey{Identity: *u, PublicKey: publicKey.Marshal(), KeyComment: "bar", MD5Fingerprint: gossh.FingerprintLegacyMD5(publicKey)}
-	c.Assert(s.Database.DB.Create(&key).Error, qt.IsNil)
+	key := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      publicKey.Marshal(),
+		KeyComment:     "bar",
+		MD5Fingerprint: gossh.FingerprintLegacyMD5(publicKey),
+		Model:          s.Model,
+	}
+	c.Assert(s.Database.AddSSHKey(ctx, &key), qt.IsNil)
 
 	// key2 with the same public-key but different owner should not be deleted.
-	key2 := dbmodel.SSHKey{Identity: *u2, PublicKey: publicKey.Marshal(), KeyComment: "bar", MD5Fingerprint: gossh.FingerprintLegacyMD5(publicKey)}
-	c.Assert(s.Database.DB.Create(&key2).Error, qt.IsNil)
+	key2 := dbmodel.SSHKey{
+		Identity:       *u2,
+		PublicKey:      publicKey.Marshal(),
+		KeyComment:     "bar",
+		MD5Fingerprint: gossh.FingerprintLegacyMD5(publicKey),
+		Model:          s.Model,
+	}
+	c.Assert(s.Database.AddSSHKey(ctx, &key2), qt.IsNil)
 
-	var keyCount int64
-	c.Assert(s.Database.DB.Model(&dbmodel.SSHKey{}).Count(&keyCount).Error, qt.IsNil)
-	c.Assert(keyCount, qt.Equals, int64(2))
-
-	err = s.Database.RemoveSSHKeyByFingerprint(context.Background(), "bob@canonical.com", gossh.FingerprintLegacyMD5(publicKey))
+	err = s.Database.RemoveSSHKeyByFingerprint(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String}, gossh.FingerprintLegacyMD5(publicKey))
 	c.Assert(err, qt.IsNil)
 
-	var keys []dbmodel.SSHKey
-	c.Assert(s.Database.DB.Find(&keys).Error, qt.IsNil)
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 0)
+
+	keys, err = s.Database.ListSSHKeysForUser(ctx, u2.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
 	c.Assert(keys, qt.HasLen, 1)
-	c.Assert(keys[0].IdentityName, qt.Equals, "alice@canonical.com")
-	c.Assert(keys[0].PublicKey, qt.DeepEquals, publicKey.Marshal())
 }
 
-func (s *dbSuite) TestRemoveSSHKeyByComment(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
+func (s *sshKeysSuite) TestListSSHKeysForUser(c *qt.C) {
+	ctx := context.Background()
 
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u).Error, qt.IsNil)
-
-	// key is expected to be removed.
-	key := dbmodel.SSHKey{Identity: *u, PublicKey: []byte("foo"), KeyComment: "aaa"}
-	c.Assert(s.Database.DB.Create(&key).Error, qt.IsNil)
-
-	// key2 belongs to the same user as key but is not expected to be removed.
-	key2 := dbmodel.SSHKey{Identity: *u, PublicKey: []byte("hello"), KeyComment: "bbb"}
-	c.Assert(s.Database.DB.Create(&key2).Error, qt.IsNil)
-
-	u2, err := dbmodel.NewIdentity("alice@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(u2).Error, qt.IsNil)
-
-	// key3 belongs to a different user and has the same comment as key.
-	key3 := dbmodel.SSHKey{Identity: *u2, PublicKey: []byte("foo"), KeyComment: "ccc"}
-	c.Assert(s.Database.DB.Create(&key3).Error, qt.IsNil)
-
-	var keyCount int64
-	c.Assert(s.Database.DB.Model(&dbmodel.SSHKey{}).Count(&keyCount).Error, qt.IsNil)
-	c.Assert(keyCount, qt.Equals, int64(3))
-
-	err = s.Database.RemoveSSHKeyByComment(context.Background(), "bob@canonical.com", "aaa")
+	key := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      []byte("foo"),
+		KeyComment:     "bar",
+		MD5Fingerprint: "fake-fingerprint",
+		Model:          s.Model,
+	}
+	err := s.Database.AddSSHKey(ctx, &key)
 	c.Assert(err, qt.IsNil)
 
-	var keys []dbmodel.SSHKey
-	c.Assert(s.Database.DB.Order("key_comment DESC").Find(&keys).Error, qt.IsNil)
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 1)
+	c.Assert(keys[0].IdentityName, qt.Equals, s.User.Name)
+	c.Assert(keys[0].ModelUUID, qt.Equals, s.Model.UUID.String)
+	key2 := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      []byte("foo1"),
+		KeyComment:     "bar",
+		MD5Fingerprint: "fake-fingerprint",
+		Model:          s.Model2,
+	}
+	c.Assert(s.Database.AddSSHKey(ctx, &key2), qt.IsNil)
+	keys, err = s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model2.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 1)
+	c.Assert(keys[0].IdentityName, qt.Equals, s.User.Name)
+	c.Assert(keys[0].ModelUUID, qt.Equals, s.Model2.UUID.String)
+
+	keys, err = s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{All: true})
+	c.Assert(err, qt.IsNil)
 	c.Assert(keys, qt.HasLen, 2)
-	c.Assert(keys[0].KeyComment, qt.Equals, "ccc")
-	c.Assert(keys[0].IdentityName, qt.Equals, "alice@canonical.com")
-	c.Assert(keys[1].KeyComment, qt.Equals, "bbb")
-	c.Assert(keys[1].IdentityName, qt.Equals, "bob@canonical.com")
 
-	// Removal with no key should return an error.
-	err = s.Database.RemoveSSHKeyByComment(context.Background(), "bob@canonical.com", "fake-key")
-	c.Assert(err, qt.ErrorMatches, "key not found")
+	keys, err = s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: "not-existing"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 0)
+}
+
+func (s *sshKeysSuite) TestCascadeDeleteModel(c *qt.C) {
+	ctx := context.Background()
+	key := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      []byte("foo"),
+		KeyComment:     "bar",
+		MD5Fingerprint: "fake-fingerprint",
+		Model:          s.Model,
+	}
+	err := s.Database.AddSSHKey(ctx, &key)
+	c.Assert(err, qt.IsNil)
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 1)
+	// check that deleting the model delete the ssh key
+	err = s.Database.DeleteModel(ctx, &s.Model)
+	c.Assert(err, qt.IsNil)
+	keys, err = s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 0)
+
+}
+
+func TestKeyManagerFacade(t *testing.T) {
+	qtsuite.Run(qt.New(t), &sshKeysSuite{})
 }

--- a/internal/dbmodel/sql/postgres/023_add_model_ssh_keys.up.sql
+++ b/internal/dbmodel/sql/postgres/023_add_model_ssh_keys.up.sql
@@ -1,0 +1,8 @@
+-- add model association to user ssh keys
+ALTER TABLE ssh_keys DROP CONSTRAINT unique_identity_ssh_key;
+
+ALTER TABLE ssh_keys 
+    ADD COLUMN model_uuid TEXT,
+    ADD CONSTRAINT fk FOREIGN KEY(model_uuid) REFERENCES models(uuid) ON DELETE CASCADE;
+
+ALTER TABLE ssh_keys ADD CONSTRAINT unique_identity_ssh_key UNIQUE(identity_name, public_key, model_uuid);

--- a/internal/dbmodel/sshkeys.go
+++ b/internal/dbmodel/sshkeys.go
@@ -16,6 +16,10 @@ type SSHKey struct {
 	IdentityName string   `gorm:"uniqueIndex:unique_identity_ssh_key"`
 	Identity     Identity `gorm:"foreignKey:IdentityName;references:Name"`
 
+	// IdentityName is the unique name (email or client-id) of this entity.
+	ModelUUID string `gorm:"uniqueIndex:unique_identity_ssh_key"`
+	Model     Model  `gorm:"foreignKey:ModelUUID;references:uuid"`
+
 	// PublicKey holds the user's public SSH key.
 	PublicKey []byte `gorm:"uniqueIndex:unique_identity_ssh_key"`
 	// MD5Fingerprint is the MD5 fingerprint of the public key.

--- a/internal/dbmodel/sshkeys_test.go
+++ b/internal/dbmodel/sshkeys_test.go
@@ -3,9 +3,11 @@
 package dbmodel_test
 
 import (
+	"database/sql"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/state"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
@@ -13,23 +15,34 @@ import (
 func TestSSHKeyUniqueConstraint(t *testing.T) {
 	c := qt.New(t)
 	db := gormDB(c)
-
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-
-	c.Assert(db.Create(u).Error, qt.IsNil)
-
+	cl, cred, ctl, u := initModelEnv(c, db)
+	m := dbmodel.Model{
+		Name: "test-model",
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		Owner:           u,
+		Controller:      ctl,
+		CloudRegion:     cl.Regions[0],
+		CloudCredential: cred,
+		Life:            state.Alive.String(),
+	}
+	c.Assert(db.Create(&m).Error, qt.IsNil)
 	key := dbmodel.SSHKey{
 		PublicKey:  []byte("test"),
-		Identity:   *u,
+		Identity:   u,
 		KeyComment: "foo",
+		Model:      m,
 	}
 	c.Assert(db.Create(&key).Error, qt.IsNil)
 
 	newKey := dbmodel.SSHKey{
 		PublicKey:  []byte("test"),
-		Identity:   *u,
+		Identity:   u,
 		KeyComment: "bar",
+		Model:      m,
 	}
+	// here we expect an error, which will be ignored then at the db level.
 	c.Assert(db.Create(&newKey).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"unique_identity_ssh_key\".*")
 }

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -179,13 +179,13 @@ type ServiceAccountManager interface {
 // SSHKeyManager provides a means to manage SSH keys within JIMM.
 type SSHKeyManager interface {
 	// AddUserPublicKey saves a user's public key.
-	AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error
+	AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
 	// ListUserPublicKeys lists a user's public keys.
-	ListUserPublicKeys(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error)
+	ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
 	// RemoveUserKeyByComment removes a user's public key(s) by the key comment.
-	RemoveUserKeyByComment(ctx context.Context, user *openfga.User, comment string) error
+	RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error
 	// RemoveUserKeyByFingerprint removes a user's public key(s) by the key fingerprint.
-	RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, fingerprint string) error
+	RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error
 	// VerifyPublicKey lists the key for a user and compares the key to find a match.
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -78,16 +78,17 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	uuid := "00000002-0000-0000-0000-000000000001"
 	jimmTag := names.NewControllerTag(uuid)
 	// Setup DB
-	db := &db.Database{
+
+	database := &db.Database{
 		DB: jimmtest.PostgresDB(c, time.Now),
 	}
-	err := db.Migrate(context.Background())
+	err := database.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)
 	// Setup OFGA
 	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	identityManager, err := identity.NewIdentityManager(db, ofgaClient)
+	identityManager, err := identity.NewIdentityManager(database, ofgaClient)
 	c.Assert(err, qt.IsNil)
 
 	// this is a mock non-mock model manager, bandaid until we have a real model manager to avoid creating a whole jimm.
@@ -99,26 +100,26 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 					Valid:  true,
 				},
 			}
-			err := db.GetModel(ctx, &m)
+			err := database.GetModel(ctx, &m)
 			return m, err
 		},
 	}
-	permissionManager, err := permissions.NewManager(db, ofgaClient, uuid, jimmTag)
+	permissionManager, err := permissions.NewManager(database, ofgaClient, uuid, jimmTag)
 	c.Assert(err, qt.IsNil)
-	jwtFactory := jujuauth.NewFactory(db, mocks.JWTService{
+	jwtFactory := jujuauth.NewFactory(database, mocks.JWTService{
 		NewJWT_: func(ctx context.Context, j jimmjwx.JWTParams) ([]byte, error) {
 			return []byte("jwt"), nil
 		},
 	}, permissionManager)
 
-	sshKeyManager, err := sshkeys.NewSSHKeyManager(db)
+	sshKeyManager, err := sshkeys.NewSSHKeyManager(database)
 	c.Assert(err, qt.IsNil)
 
 	s.sshManager, err = ssh.NewSSHManager(identityManager, &modelManager, sshKeyManager, jwtFactory)
 	c.Assert(err, qt.IsNil)
 	env := jimmtest.ParseEnvironment(c, testSSHManagerEnv)
-	env.PopulateDB(c, db)
-	env.PopulateDBAndPermissions(c, jimmTag, db, ofgaClient)
+	env.PopulateDB(c, database)
+	env.PopulateDBAndPermissions(c, jimmTag, database, ofgaClient)
 	// create a user and set permission for one model
 	s.userWithAccess, err = identityManager.FetchIdentity(ctx, env.Users[0].Username)
 	c.Assert(err, qt.IsNil)
@@ -128,7 +129,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	// create a user without access
 	i2, err := dbmodel.NewIdentity("bob")
 	c.Assert(err, qt.IsNil)
-	c.Assert(db.DB.Create(i2).Error, qt.IsNil)
+	c.Assert(database.DB.Create(i2).Error, qt.IsNil)
 	s.userWithoutAccess = openfga.NewUser(i2, ofgaClient)
 	// setup public key
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -139,7 +140,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	s.publicKey = sshkeys.PublicKey{PublicKey: pubKey, Comment: "myComment"}
 
 	c.Assert(err, qt.IsNil)
-	err = sshKeyManager.AddUserPublicKey(ctx, s.userWithAccess, s.publicKey)
+	err = sshKeyManager.AddUserPublicKey(ctx, s.userWithAccess, db.SSHKeyModelFilter{ModelUUID: s.allowedModelUUID}, s.publicKey)
 	c.Assert(err, qt.IsNil)
 }
 

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -28,7 +28,7 @@ func NewSSHKeyManager(store *db.Database) (*sshKeyManager, error) {
 }
 
 // AddUserPublicKey saves a user's public key.
-func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey PublicKey) error {
+func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey PublicKey) error {
 	const op = errors.Op("sshkeys.AddUserPublicKey")
 
 	if ok, reason := publicKey.valid(); !ok {
@@ -37,6 +37,7 @@ func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.Use
 
 	k := dbmodel.SSHKey{
 		IdentityName:   user.Name,
+		ModelUUID:      model.ModelUUID,
 		PublicKey:      publicKey.Marshal(),
 		MD5Fingerprint: gossh.FingerprintLegacyMD5(publicKey),
 		KeyComment:     publicKey.Comment,
@@ -52,7 +53,7 @@ func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.Use
 func (sm *sshKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 	const op = errors.Op("sshkeys.VerifyPublicKey")
 
-	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, claimUser)
+	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, claimUser, db.SSHKeyModelFilter{All: true})
 	if err != nil {
 		return false, errors.E(op, err)
 	}
@@ -74,10 +75,10 @@ func (sm *sshKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, 
 }
 
 // ListUserPublicKeys lists a user's public keys.
-func (sm *sshKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User) ([]PublicKey, error) {
+func (sm *sshKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]PublicKey, error) {
 	const op = errors.Op("sshkeys.ListUserPublicKeys")
 
-	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, user.Name)
+	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, user.Name, model)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -93,10 +94,10 @@ func (sm *sshKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.U
 }
 
 // RemoveUserKeyByComment removes a user's public key(s) by the key comment.
-func (sm *sshKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, comment string) error {
+func (sm *sshKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
 	const op = errors.Op("sshkeys.RemoveUserKeyByComment")
 
-	err := sm.store.RemoveSSHKeyByComment(ctx, user.Name, comment)
+	err := sm.store.RemoveSSHKeyByComment(ctx, user.Name, model, comment)
 	if err != nil {
 		return errors.E(op, err)
 	}
@@ -104,10 +105,10 @@ func (sm *sshKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openf
 }
 
 // RemoveUserKeyByFingerprint removes a user's public key by the key fingerprint.
-func (sm *sshKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, fingerprint string) error {
+func (sm *sshKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
 	const op = errors.Op("sshkeys.RemoveUserKeyByFingerprint")
 
-	err := sm.store.RemoveSSHKeyByFingerprint(ctx, user.Name, fingerprint)
+	err := sm.store.RemoveSSHKeyByFingerprint(ctx, user.Name, model, fingerprint)
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/jimm/sshkeys/sshkeys_test.go
+++ b/internal/jimm/sshkeys/sshkeys_test.go
@@ -27,9 +27,11 @@ type sshKeysManagerSuite struct {
 	db         *db.Database
 	ofgaClient *openfga.OFGAClient
 	pubKey     sshkeys.PublicKey
+	modelUUID  string
 }
 
 func (s *sshKeysManagerSuite) Init(c *qt.C) {
+	ctx := context.Background()
 	// Setup DB
 	db := &db.Database{
 		DB: jimmtest.PostgresDB(c, time.Now),
@@ -38,21 +40,19 @@ func (s *sshKeysManagerSuite) Init(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	s.db = db
-
+	user, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 	// Setup OFGA
 	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
 	s.ofgaClient = ofgaClient
 
+	s.modelUUID = model.UUID.String
 	s.manager, err = sshkeys.NewSSHKeyManager(db)
 	c.Assert(err, qt.IsNil)
 
 	// Create test identity
-	i, err := dbmodel.NewIdentity("alice")
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.DB.Create(i).Error, qt.IsNil)
-	s.user = openfga.NewUser(i, ofgaClient)
+	s.user = openfga.NewUser(&user, ofgaClient)
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	c.Assert(err, qt.IsNil)
@@ -60,19 +60,20 @@ func (s *sshKeysManagerSuite) Init(c *qt.C) {
 	pubKey, err := gossh.NewPublicKey(&key.PublicKey)
 	c.Assert(err, qt.IsNil)
 	s.pubKey = sshkeys.PublicKey{PublicKey: pubKey, Comment: "myComment"}
+
 }
 
 func (s *sshKeysManagerSuite) TestAddUserPublicKey(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	err := s.manager.AddUserPublicKey(ctx, s.user, s.pubKey)
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
 	c.Assert(err, qt.IsNil)
 
 	var dbKey dbmodel.SSHKey
 	c.Assert(s.db.DB.First(&dbKey).Error, qt.IsNil)
 	c.Assert(dbKey.ID, qt.Not(qt.Equals), 0)
-	c.Assert(dbKey.IdentityName, qt.Equals, "alice")
+	c.Assert(dbKey.IdentityName, qt.Equals, s.user.Name)
 	c.Assert(dbKey.PublicKey, qt.DeepEquals, s.pubKey.Marshal())
 	c.Assert(dbKey.MD5Fingerprint, qt.Equals, gossh.FingerprintLegacyMD5(s.pubKey))
 	c.Assert(dbKey.KeyComment, qt.Equals, s.pubKey.Comment)
@@ -82,10 +83,10 @@ func (s *sshKeysManagerSuite) TestListUserPublicKeys(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	err := s.manager.AddUserPublicKey(ctx, s.user, s.pubKey)
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
 	c.Assert(err, qt.IsNil)
 
-	keys, err := s.manager.ListUserPublicKeys(ctx, s.user)
+	keys, err := s.manager.ListUserPublicKeys(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID})
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(keys, qt.HasLen, 1)
@@ -97,14 +98,14 @@ func (s *sshKeysManagerSuite) TestVerifyPublicKeys(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	err := s.manager.AddUserPublicKey(ctx, s.user, s.pubKey)
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
 	c.Assert(err, qt.IsNil)
 
 	rawKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	c.Assert(err, qt.IsNil)
 	anotherPubKey, err := gossh.NewPublicKey(&rawKey.PublicKey)
 	c.Assert(err, qt.IsNil)
-	err = s.manager.AddUserPublicKey(ctx, s.user, sshkeys.PublicKey{PublicKey: anotherPubKey, Comment: "myComment"})
+	err = s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, sshkeys.PublicKey{PublicKey: anotherPubKey, Comment: "myComment"})
 	c.Assert(err, qt.IsNil)
 
 	rawKey, err = rsa.GenerateKey(rand.Reader, 2048)
@@ -176,13 +177,13 @@ func (s *sshKeysManagerSuite) TestRemoveUserKeyByComment(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	err := s.manager.AddUserPublicKey(ctx, s.user, s.pubKey)
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
 	c.Assert(err, qt.IsNil)
 
 	var key dbmodel.SSHKey
 	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).First(&key).Error, qt.IsNil)
 
-	err = s.manager.RemoveUserKeyByComment(ctx, s.user, s.pubKey.Comment)
+	err = s.manager.RemoveUserKeyByComment(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey.Comment)
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).Error, qt.Equals, gorm.ErrRecordNotFound)
@@ -192,13 +193,13 @@ func (s *sshKeysManagerSuite) TestRemoveUserKeyByFingerprint(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	err := s.manager.AddUserPublicKey(ctx, s.user, s.pubKey)
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
 	c.Assert(err, qt.IsNil)
 
 	var key dbmodel.SSHKey
 	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).First(&key).Error, qt.IsNil)
 
-	err = s.manager.RemoveUserKeyByFingerprint(ctx, s.user, gossh.FingerprintLegacyMD5(s.pubKey))
+	err = s.manager.RemoveUserKeyByFingerprint(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, gossh.FingerprintLegacyMD5(s.pubKey))
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).Error, qt.Equals, gorm.ErrRecordNotFound)

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -227,6 +227,7 @@ func controllerConnectionFunc(s apiProxier, jwtGenerator *jujuauth.TokenGenerato
 			Conn:           controllerConn,
 			ControllerUUID: m.Controller.UUID,
 			ModelName:      fullModelName,
+			ModelUUID:      uuid,
 		}, nil
 	}
 }

--- a/internal/rpcproxy/keymanager.go
+++ b/internal/rpcproxy/keymanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/v3/ssh"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -27,12 +28,13 @@ var isFingerprintRegexp = regexp.MustCompile("^[0-9a-f]{2}(:[0-9a-f]{2}){15}$")
 type keyManagerFacade struct {
 	keyManager SSHKeyManager
 	user       *openfga.User
+	modelUUID  string
 }
 
 // ListKeys lists the authenticated user's SSH keys
 // in the format defined in args.
 func (s *keyManagerFacade) ListKeys(ctx context.Context, args jujuparams.ListSSHKeys) (jujuparams.StringsResults, error) {
-	keys, err := s.keyManager.ListUserPublicKeys(ctx, s.user)
+	keys, err := s.keyManager.ListUserPublicKeys(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID})
 	if err != nil {
 		return jujuparams.StringsResults{}, err
 	}
@@ -75,7 +77,7 @@ func (s *keyManagerFacade) AddKeys(ctx context.Context, args jujuparams.ModifyUs
 			PublicKey: out,
 			Comment:   comment,
 		}
-		if err := s.keyManager.AddUserPublicKey(ctx, s.user, parsedKey); err != nil {
+		if err := s.keyManager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, parsedKey); err != nil {
 			res = append(res, errF(err, fmt.Sprintf("Failed to add key (comment %s)", comment)))
 		}
 	}
@@ -96,12 +98,12 @@ func (s *keyManagerFacade) DeleteKeys(ctx context.Context, args jujuparams.Modif
 
 	for _, key := range args.Keys {
 		if isFingerprintRegexp.MatchString(key) {
-			err := s.keyManager.RemoveUserKeyByFingerprint(ctx, s.user, key)
+			err := s.keyManager.RemoveUserKeyByFingerprint(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, key)
 			if err != nil {
 				res = append(res, errF(err, fmt.Sprintf("Failed to remove key by fingerprint (%s)", key)))
 			}
 		} else {
-			err := s.keyManager.RemoveUserKeyByComment(ctx, s.user, key)
+			err := s.keyManager.RemoveUserKeyByComment(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, key)
 			if err != nil {
 				res = append(res, errF(err, fmt.Sprintf("Failed to remove key by comment (%s)", key)))
 			}

--- a/internal/rpcproxy/keymanager_test.go
+++ b/internal/rpcproxy/keymanager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/utils/v3/ssh"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/rpcproxy"
@@ -54,18 +55,17 @@ func (k *keyManagerFacadeSuite) Init(c *qt.C) {
 		PublicKey: pubKey2,
 		Comment:   "comment-2",
 	}
-
 	keyManager := mocks.SSHKeyManager{
-		ListUserPublicKeys_: func(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error) {
+		ListUserPublicKeys_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
 			return []sshkeys.PublicKey{k.key1, k.key2}, nil
 		},
-		AddUserPublicKey_: func(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error {
+		AddUserPublicKey_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error {
 			return k.addKeyF(ctx, user, publicKey)
 		},
-		RemoveUserKeyByComment_: func(ctx context.Context, user *openfga.User, comment string) error {
+		RemoveUserKeyByComment_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
 			return k.removeKeyByCommentF(ctx, user, comment)
 		},
-		RemoveUserKeyByFingerprint_: func(ctx context.Context, user *openfga.User, fingerprint string) error {
+		RemoveUserKeyByFingerprint_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
 			return k.removeKeyByFingerprintF(ctx, user, fingerprint)
 		},
 	}

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
@@ -36,13 +37,13 @@ const (
 // SSHKeyManager is an interface for managing SSH keys.
 type SSHKeyManager interface {
 	// AddUserPublicKey saves a user's public key.
-	AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error
+	AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
 	// ListUserPublicKeys lists a user's public keys.
-	ListUserPublicKeys(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error)
+	ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
 	// RemoveUserKeyByComment removes a user's public key(s) by the key comment.
-	RemoveUserKeyByComment(ctx context.Context, user *openfga.User, comment string) error
+	RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error
 	// RemoveUserKeyByFingerprint removes a user's public key(s) by the key fingerprint.
-	RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, fingerprint string) error
+	RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error
 }
 
 // TokenGenerator authenticates a user and generates a JWT token.
@@ -74,6 +75,7 @@ type WebsocketConnectionWithMetadata struct {
 	Conn           WebsocketConnection
 	ControllerUUID string
 	ModelName      string
+	ModelUUID      string
 }
 
 // LoginService represents the LoginService interface used by the proxy.
@@ -269,6 +271,7 @@ type modelProxy struct {
 	sshKeyManager           SSHKeyManager
 	loginService            LoginService
 	modelName               string
+	modelUUID               string
 	conversationId          string
 	authenticatedIdentityID string
 
@@ -444,6 +447,7 @@ func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
 
 		p.msgs.controllerUUID = connWithMetadata.ControllerUUID
 		p.modelName = connWithMetadata.ModelName
+		p.modelUUID = connWithMetadata.ModelUUID
 		p.dst = &writeLockConn{conn: connWithMetadata.Conn}
 		controllerToClient := controllerProxy{
 			modelProxy: modelProxy{
@@ -760,7 +764,7 @@ func (p *clientProxy) handleKeyManagerFacade(ctx context.Context, msg *message) 
 		msg.Response = resp
 		return msg, nil
 	}
-	keyManager := keyManagerFacade{keyManager: p.sshKeyManager, user: p.user}
+	keyManager := keyManagerFacade{keyManager: p.sshKeyManager, user: p.user, modelUUID: p.modelUUID}
 
 	switch msg.Request {
 	case "ListKeys":

--- a/internal/rpcproxy/rpcproxy_test.go
+++ b/internal/rpcproxy/rpcproxy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/utils/v3/ssh"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -313,21 +314,25 @@ func TestProxySocketsSSHKeys(t *testing.T) {
 				email: "alice@canonical.com",
 			},
 			SSHKeyManager: &mocks.SSHKeyManager{
-				AddUserPublicKey_: func(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error {
+				AddUserPublicKey_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error {
 					sshFacadeChan <- "add-keys"
 					return nil
 				},
-				ListUserPublicKeys_: func(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error) {
+				ListUserPublicKeys_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
 					sshFacadeChan <- "list-keys"
 					return nil, nil
 				},
-				RemoveUserKeyByComment_: func(ctx context.Context, user *openfga.User, comment string) error {
+				RemoveUserKeyByComment_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
 					sshFacadeChan <- "remove-keys-comment"
 					return nil
 				},
-				RemoveUserKeyByFingerprint_: func(ctx context.Context, user *openfga.User, fingerprint string) error {
+				RemoveUserKeyByFingerprint_: func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
 					sshFacadeChan <- "remove-keys-fingerprint"
 					return nil
+				},
+				VerifyPublicKey_: func(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
+					sshFacadeChan <- "verify-key"
+					return true, nil
 				},
 			},
 		}

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -1,50 +1,53 @@
-// Copyright 2025 Canonical.
 package mocks
 
 import (
 	"context"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
 type SSHKeyManager struct {
-	AddUserPublicKey_           func(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error
-	ListUserPublicKeys_         func(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error)
-	RemoveUserKeyByComment_     func(ctx context.Context, user *openfga.User, comment string) error
-	RemoveUserKeyByFingerprint_ func(ctx context.Context, user *openfga.User, fingerprint string) error
+	AddUserPublicKey_           func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
+	ListUserPublicKeys_         func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
+	RemoveUserKeyByComment_     func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error
+	RemoveUserKeyByFingerprint_ func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error
 	VerifyPublicKey_            func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, publicKey sshkeys.PublicKey) error {
+func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error {
 	if j.AddUserPublicKey_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.AddUserPublicKey_(ctx, user, publicKey)
+	return j.AddUserPublicKey_(ctx, user, model, publicKey)
 }
-func (j *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User) ([]sshkeys.PublicKey, error) {
+
+func (j *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
 	if j.ListUserPublicKeys_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ListUserPublicKeys_(ctx, user)
+	return j.ListUserPublicKeys_(ctx, user, model)
 }
-func (j *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, comment string) error {
+
+func (j *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
 	if j.RemoveUserKeyByComment_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.RemoveUserKeyByComment_(ctx, user, comment)
+	return j.RemoveUserKeyByComment_(ctx, user, model, comment)
 }
-func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, fingerprint string) error {
+
+func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
 	if j.RemoveUserKeyByFingerprint_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.RemoveUserKeyByFingerprint_(ctx, user, fingerprint)
+	return j.RemoveUserKeyByFingerprint_(ctx, user, model, fingerprint)
 }
 
 func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 	if j.VerifyPublicKey_ == nil {
-		return true, nil
+		return false, errors.E(errors.CodeNotImplemented)
 	}
 	return j.VerifyPublicKey_(ctx, claimUser, publicKey)
 }


### PR DESCRIPTION
## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->
In this PR we add model uuid to ssh key table.
This is to be consistent with juju 3.6 behaviour.

The approach is to add a new struct to ssh keys method, called SSHKeyModel.
It contains two fields:
- ModelUUID: string
- All: boolean

And passing this struct to ssh keys methods to scope the operation on a single model or every models.

This is to facilitate behaviour where we want to query all ssh keys for user, independently of the model.
So, it should be easy to reuse this code for juju 4 as well.


I've QAed locally, and by landing this PR, the failing ssh keys tests in the terraform provider pass.
```
Running tool: /usr/local/go/bin/go test -timeout 120s -run ^TestAcc_ResourceSSHKey$ github.com/juju/terraform-provider-juju/internal/provider

ok  	github.com/juju/terraform-provider-juju/internal/provider	3.897s
```