### PR TITLE
chore: increase websocket timeout from 90s to 180s

### DIFF
--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -30,7 +30,7 @@ import (
 const (
 	requestTimeout        = 1 * time.Minute
 	maxRequestConcurrency = 10
-	pingTimeout           = 90 * time.Second
+	pingTimeout           = 180 * time.Second
 )
 
 // A root is an rpc.Root enhanced so that it can notify on ping requests.


### PR DESCRIPTION
## Description
This a very simple PR to increase the timeout on our websockets. Currently JIMM handles websockets by closing them if we haven't received a ping in 90s. This timeout value was found to be a bit low when trying to login via OAuth in cases where the infra is being slow and the external login pages are taking a while to load. I've bumped this value up to 180s which should help in these scenarios without being overly long.
