### PR TITLE
add option to bootstrap controller via charmed k8s action

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -23,6 +23,13 @@ inputs:
     description: 'Dump JIMM container logs at the end of the action.'
     required: false
     default: "false"
+  use-charmed-k8s-action:
+    description: |
+      If set to true the action will use the charmed-kubernetes/actions-operator to bootstrap a Juju controller via Juju snap.
+      If set to false the workflow calling this action needs to provide the Juju binary in the PATH, that the action will use 
+      to bootstrap a controller.
+    required: false
+    default: 'true'
 
 outputs:
   url:
@@ -87,7 +94,9 @@ runs:
         sudo lxd init --auto && \
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket && \
         lxc network set lxdbr0 ipv6.address none && \
-        sudo usermod -a -G lxd $USER
+        sudo usermod -a -G lxd $USER && \
+        sudo iptables -F FORWARD && \
+        sudo iptables -P FORWARD ACCEPT
       shell: bash
 
     - name: Setup cloud-init script for bootstraping Juju controllers
@@ -95,7 +104,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}/../../..
       env:
-        SKIP_BOOTSTRAP: true
+        # skip bootstrap in case we use the charmed k8s action
+        SKIP_BOOTSTRAP: ${{ inputs.use-charmed-k8s-action == 'true'}} 
         CLOUDINIT_FILE: "cloudinit.temp.yaml"
 
     # See: https://github.com/charmed-kubernetes/actions-operator/issues/82
@@ -105,6 +115,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Setup Juju Controller
+      if: ${{ inputs.use-charmed-k8s-action == 'true' }}
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: "lxd"

--- a/local/jimm/setup-service-account.sh
+++ b/local/jimm/setup-service-account.sh
@@ -10,6 +10,8 @@ SERVICE_ACCOUNT_ID="${SERVICE_ACCOUNT_ID:-test-client-id}"
 CLOUD="${CLOUD:-localhost}"
 CREDENTIAL_NAME="${CREDENTIAL_NAME:-localhost}"
 
-juju add-service-account "$SERVICE_ACCOUNT_ID"
-juju update-service-account-credential "$SERVICE_ACCOUNT_ID" "$CLOUD" "$CREDENTIAL_NAME"
+# the reason we use `/snap/jaas/current/bin/jaas` instead of `juju` is because we can't access jaas commands when we build juju
+# instead of using the snap. 
+/snap/jaas/current/bin/jaas add-service-account "$SERVICE_ACCOUNT_ID"
+/snap/jaas/current/bin/jaas update-service-account-credential "$SERVICE_ACCOUNT_ID" "$CLOUD" "$CREDENTIAL_NAME"
 jimmctl auth relation add user-"$SERVICE_ACCOUNT_ID"@serviceaccount administrator controller-jimm


### PR DESCRIPTION
## Description
Add an option to bootstrap the controller via charmed action or not.
The idea is to set this option to false in juju action where we build juju manually and we can then bootstrap the controller with that build.

By making this changes, we are able to add smoke test to juju with a running jaas and a dev-built bootstrapped juju controller.

You can check it here: https://github.com/juju/juju/actions/runs/13655481588/job/38173523588?pr=19051



## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
