### PR TITLE
chore: copy jimmctl commands to jaas snap

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	"github.com/juju/juju/cloud"
+	jujucmd "github.com/juju/juju/cmd"
+	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
+	jujucmdcommon "github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	_ "github.com/juju/juju/provider/all"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	jimmjujuapi "github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	addCloudToControllerCommandDoc = `
+The add-cloud-to-controller command adds the specified cloud to a specific 
+controller on jimm.
+
+One can specify a cloud definition via a yaml file passed with the --cloud 
+flag. If the flag is missing, the command will assume the cloud definition
+is already known and will error otherwise.
+`
+	addCloudToControllerExample = `
+    jimmctl add-cloud-to-controller mycontroller mycloud
+    jimmctl add-cloud-to-controller mycontroller mycloud --cloud=./cloud-definition.yaml
+`
+)
+
+// NewAddControllerCommand returns a command to add a cloud to a specific
+// controller in JIMM.
+func NewAddCloudToControllerCommand() cmd.Command {
+	cmd := &addCloudToControllerCommand{
+		store:           jujuclient.NewFileClientStore(),
+		cloudByNameFunc: jujucmdcommon.CloudByName,
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addControllerCommand adds a controller.
+type addCloudToControllerCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	// cloudName is the name of the cloud to add.
+	cloudName string
+
+	// cloudDefinitionFile is the name of the cloud file.
+	cloudDefinitionFile string
+
+	// dstControllerName is the name of the controller in JIMM where the cloud
+	// should be added to.
+	dstControllerName string
+
+	// force skips checks that verify whether the cloud that is being added is
+	// compatible with the cloud on which the controller is running.
+	force bool
+
+	cloudByNameFunc func(string) (*cloud.Cloud, error)
+	store           jujuclient.ClientStore
+	dialOpts        *jujuapi.DialOpts
+}
+
+// Info implements Command.Info.
+func (c *addCloudToControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "add-cloud-to-controller",
+		Args:     "<controller_name> <cloud_name>",
+		Purpose:  "Add cloud to specific controller in jimm",
+		Doc:      addCloudToControllerCommandDoc,
+		Examples: addCloudToControllerExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *addCloudToControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+
+	f.BoolVar(&c.force, "force", false, "Forces the cloud to be added to the controller")
+	f.StringVar(&c.cloudDefinitionFile, "cloud", "", "The path to the cloud's definition file.")
+}
+
+// Init implements the cmd.Command interface.
+func (c *addCloudToControllerCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("missing arguments")
+	}
+	if len(args) > 2 {
+		return errors.E("too many arguments")
+	}
+	c.dstControllerName = args[0]
+	if ok := names.IsValidControllerName(c.dstControllerName); !ok {
+		return errors.E("invalid controller name %q", c.dstControllerName)
+	}
+	c.cloudName = args[1]
+	if ok := names.IsValidCloud(c.cloudName); !ok {
+		return errors.E("invalid cloud name %q", c.cloudName)
+	}
+
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
+	var newCloud *cloud.Cloud
+	var err error
+	if c.cloudDefinitionFile != "" {
+		newCloud, err = c.readCloudFromFile(ctxt)
+		if err != nil {
+			return errors.E(err, fmt.Sprintf("error reading cloud from file: %v", err))
+		}
+	} else {
+		// It's possible that the user wants to add an existing cloud to a controller,
+		// so let's see if we can find the cloud.
+		newCloud, err = c.cloudByNameFunc(c.cloudName)
+		if err != nil {
+			return errors.E("could not find existing cloud, please provide a cloud file")
+		}
+	}
+
+	// All clouds must have at least one default region.
+	if len(newCloud.Regions) == 0 {
+		newCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
+	}
+
+	err = c.addCloudToController(ctxt, newCloud)
+	if err != nil {
+		return errors.E(err, fmt.Sprintf("error adding cloud to controller: %v", err))
+	}
+
+	return nil
+}
+
+func (c *addCloudToControllerCommand) addCloudToController(ctxt *cmd.Context, cloud *cloud.Cloud) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine the current controller")
+	}
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+	client := api.NewClient(apiCaller)
+
+	params := &apiparams.AddCloudToControllerRequest{
+		ControllerName: c.dstControllerName,
+		AddCloudArgs: params.AddCloudArgs{
+			Name:  c.cloudName,
+			Cloud: jimmjujuapi.CloudToParams(*cloud),
+			Force: &c.force,
+		},
+	}
+
+	err = client.AddCloudToController(params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	ctxt.Infof("Cloud %q added to controller %q.", c.cloudName, c.dstControllerName)
+	return nil
+}
+
+func (c *addCloudToControllerCommand) readCloudFromFile(ctxt *cmd.Context) (*cloud.Cloud, error) {
+	r := &jujucmdcloud.CloudFileReader{
+		CloudMetadataStore: &cloudToCommandAdapter{},
+		CloudName:          c.cloudName,
+	}
+	newCloud, err := r.ReadCloudFromFile(c.cloudDefinitionFile, ctxt)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+	return newCloud, nil
+}
+
+type cloudToCommandAdapter struct {
+	jujucmdcloud.CloudMetadataStore
+}
+
+// ReadCloudData implements CloudMetadataStore.ReadCloudData.
+func (cloudToCommandAdapter) ReadCloudData(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// ParseOneCloud implements CloudMetadataStore.ParseOneCloud.
+func (cloudToCommandAdapter) ParseOneCloud(data []byte) (cloud.Cloud, error) {
+	return cloud.ParseOneCloud(data)
+}
+
+// PublicCloudMetadata implements CloudMetadataStore.PublicCloudMetadata.
+func (cloudToCommandAdapter) PublicCloudMetadata(searchPaths ...string) (map[string]cloud.Cloud, bool, error) {
+	return cloud.PublicCloudMetadata(searchPaths...)
+}
+
+// PersonalCloudMetadata implements CloudMetadataStore.PersonalCloudMetadata.
+func (cloudToCommandAdapter) PersonalCloudMetadata() (map[string]cloud.Cloud, error) {
+	return cloud.PersonalCloudMetadata()
+}
+
+// WritePersonalCloudMetadata implements CloudMetadataStore.WritePersonalCloudMetadata.
+func (cloudToCommandAdapter) WritePersonalCloudMetadata(cloudsMap map[string]cloud.Cloud) error {
+	return cloud.WritePersonalCloudMetadata(cloudsMap)
+}

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type addCloudToControllerSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&addCloudToControllerSuite{})
+
+func (s *addCloudToControllerSuite) SetUpTest(c *gc.C) {
+	s.JimmCmdSuite.SetUpTest(c)
+
+	// We add user bob, who is a JIMM administrator.
+	i, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, gc.IsNil)
+	err = s.JIMM.Database.UpdateIdentity(context.Background(), i)
+	c.Assert(err, gc.IsNil)
+
+	// We add a test-cloud cloud.
+	info := s.APIInfo(c)
+	err = s.JIMM.Database.AddCloud(context.Background(), &dbmodel.Cloud{
+		Name:    "test-cloud",
+		Type:    "kubernetes",
+		Regions: []dbmodel.CloudRegion{{Name: "default", CloudName: "test-cloud"}},
+	})
+	c.Assert(err, gc.IsNil)
+	region, err := s.JIMM.Database.FindRegionByCloudType(context.Background(), "kubernetes", "default")
+	c.Assert(err, gc.IsNil)
+
+	// We grant user bob administrator access to JIMM and the added
+	// test-cloud.
+	i, err = dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, gc.IsNil)
+	bob := openfga.NewUser(
+		i,
+		s.JIMM.OpenFGAClient,
+	)
+	err = bob.SetControllerAccess(context.Background(), s.JIMM.ResourceTag(), ofganames.AdministratorRelation)
+	c.Assert(err, gc.IsNil)
+	err = bob.SetCloudAccess(context.Background(), names.NewCloudTag("test-cloud"), ofganames.AdministratorRelation)
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.Database.AddController(context.Background(), &dbmodel.Controller{
+		Name:          "controller-1",
+		CACertificate: info.CACert,
+		UUID:          info.ControllerUUID,
+		PublicAddress: info.Addrs[0],
+		CloudName:     "test-cloud",
+		CloudRegion:   "default",
+		CloudRegions: []dbmodel.CloudRegionControllerPriority{{
+			CloudRegion: *region,
+			Priority:    1,
+		}},
+	})
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.OpenFGAClient.AddController(context.Background(), s.JIMM.ResourceTag(), names.NewControllerTag(info.ControllerUUID))
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *addCloudToControllerSuite) TestAddCloudToController(c *gc.C) {
+	tests := []struct {
+		about             string
+		cloudInfo         string
+		force             bool
+		cloudByNameFunc   func(cloudName string) (*cloud.Cloud, error)
+		expectedCloudName string
+		expectedIndex     int
+		expectedError     string
+	}{
+		{
+			about: "Add Kubernetes Cloud",
+			cloudInfo: `
+clouds:
+  test-hosted-cloud:
+    type: kubernetes
+    auth-types: [certificate]
+    host-cloud-region: kubernetes/default`,
+			force:             false,
+			expectedCloudName: "test-hosted-cloud",
+			expectedIndex:     1,
+			expectedError:     "",
+		}, {
+			about: "Add MAAS Cloud",
+			cloudInfo: `
+clouds:
+  test-maas-cloud:
+    type: maas
+    auth-types: [oauth1]
+    regions:
+      default: {}`,
+			force:             true,
+			expectedCloudName: "test-maas-cloud",
+			expectedIndex:     2,
+			expectedError:     "",
+		}, {
+			about: "Add cloud with unknown provider",
+			cloudInfo: `
+clouds:
+  test-unknown-cloud:
+    type: unknown
+    auth-types: [oauth1]
+    regions:
+      default: {}`,
+			force:             false,
+			expectedCloudName: "test-unknown-cloud",
+			expectedError:     ".*no registered provider.*",
+		}, {
+			about: "Add cloud to controller with wrong name",
+			cloudInfo: `
+clouds:
+  test-hosted-cloud-2:
+    type: kubernetes
+    auth-types: [certificate]
+    host-cloud-region: kubernetes/default`,
+			force:             false,
+			expectedCloudName: "test-cloud",
+			expectedError:     ".* cloud .* not found in file .*",
+		}, {
+			about: "Add existing cloud to controller",
+			cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
+				return &cloud.Cloud{
+					Name:            "test-hosted-cloud-2",
+					Type:            "kubernetes",
+					AuthTypes:       []cloud.AuthType{"certificate"},
+					HostCloudRegion: "kubernetes/default",
+				}, nil
+			},
+			force:             false,
+			expectedCloudName: "test-hosted-cloud-2",
+			expectedIndex:     3,
+			expectedError:     "",
+		}, {
+			about: "Add existing cloud to controller where existing cloud is not found",
+			cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
+				return nil, errors.E("not found")
+			},
+			force:             false,
+			expectedCloudName: "test-cloud",
+			expectedError:     "could not find existing cloud, please provide a cloud file",
+		},
+	}
+
+	for _, test := range tests {
+		c.Log(test.about)
+		tmpfile, cleanupFunc := writeTempFile(c, test.cloudInfo)
+
+		bClient := s.SetupCLIAccess(c, "bob@canonical.com")
+		// Running the command succeeds
+		newCmd := cmd.NewAddCloudToControllerCommandForTesting(s.ClientStore(), bClient, test.cloudByNameFunc)
+		var err error
+		if test.cloudInfo != "" {
+			_, err = cmdtesting.RunCommand(c, newCmd, "controller-1", test.expectedCloudName, "--cloud="+tmpfile, "--force="+strconv.FormatBool(test.force))
+		} else {
+			_, err = cmdtesting.RunCommand(c, newCmd, "controller-1", test.expectedCloudName, "--force="+strconv.FormatBool(test.force))
+		}
+
+		if test.expectedError != "" {
+			c.Assert(err, gc.NotNil)
+			errWithoutBreaks := strings.ReplaceAll(err.Error(), "\n", "")
+			c.Assert(errWithoutBreaks, gc.Matches, test.expectedError)
+		} else {
+			c.Assert(err, gc.IsNil)
+			cloud := dbmodel.Cloud{Name: test.expectedCloudName}
+			err = s.JIMM.Database.GetCloud(context.Background(), &cloud)
+			c.Assert(err, gc.IsNil)
+			controller := dbmodel.Controller{Name: "controller-1"}
+			err = s.JIMM.Database.GetController(context.Background(), &controller)
+			c.Assert(err, gc.IsNil)
+			c.Assert(controller.CloudRegions[test.expectedIndex].CloudRegion.CloudName, gc.Equals, test.expectedCloudName)
+		}
+		cleanupFunc()
+		// Needed for JIMM CLI table tests
+		s.RefreshControllerAddress(c)
+	}
+}
+
+func writeTempFile(c *gc.C, content string) (string, func()) {
+	dir, err := os.MkdirTemp("", "add-cloud-to-controller-test")
+	c.Assert(err, gc.Equals, nil)
+
+	tmpfn := filepath.Join(dir, "tmp.yaml")
+
+	err = os.WriteFile(tmpfn, []byte(content), 0600)
+	c.Assert(err, gc.Equals, nil)
+	return tmpfn, func() {
+		os.RemoveAll(dir)
+	}
+}

--- a/cmd/jaas/cmd/addcontroller.go
+++ b/cmd/jaas/cmd/addcontroller.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"sigs.k8s.io/yaml"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+var (
+	// stdinMarkers contains file names that are taken to be stdin.
+	stdinMarkers = []string{"-"}
+
+	addControllerCommandDoc = `
+The add-controller command adds a controller to jimm.
+`
+	addControllerCommandExample = `
+    jimmctl add-controller ./controller-info 
+    jimmctl add-controller ./controller-info.yaml --format json
+`
+)
+
+// NewAddControllerCommand returns a command to add a controller.
+func NewAddControllerCommand() cmd.Command {
+	cmd := &addControllerCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addControllerCommand adds a controller.
+type addControllerCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	file     cmd.FileVar
+}
+
+func (c *addControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "add-controller",
+		Purpose:  "Add controller to jimm",
+		Args:     "<filepath>",
+		Doc:      addControllerCommandDoc,
+		Examples: addControllerCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *addControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	c.file.StdinMarkers = stdinMarkers
+}
+
+// Init implements the cmd.Command interface.
+func (c *addControllerCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("filename not specified")
+	}
+	c.file.Path = args[0]
+	if len(args) > 1 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *addControllerCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	var params apiparams.AddControllerRequest
+	if err = unmarshalYAMLFile(ctxt, &params, c.file); err != nil {
+		return errors.E(err)
+	}
+
+	client := api.NewClient(apiCaller)
+	info, err := client.AddController(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, info)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+func unmarshalYAMLFile(ctxt *cmd.Context, v interface{}, fv cmd.FileVar) error {
+	buf, err := fv.Read(ctxt)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = yaml.Unmarshal(buf, &v)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/addcontroller_test.go
+++ b/cmd/jaas/cmd/addcontroller_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+type addControllerSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&addControllerSuite{})
+
+func (s *addControllerSuite) TestAddControllerSuperuser(c *gc.C) {
+	info := s.APIInfo(c)
+	params := apiparams.AddControllerRequest{
+		UUID:          info.ControllerUUID,
+		Name:          "controller-1",
+		CACertificate: info.CACert,
+		APIAddresses:  info.Addrs,
+		Username:      info.Tag.Id(),
+		Password:      info.Password,
+	}
+	tmpdir, tmpfile := writeYAMLTempFile(c, params)
+	defer os.RemoveAll(tmpdir)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewAddControllerCommandForTesting(s.ClientStore(), bClient), tmpfile)
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `name: controller-1
+uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+publicaddress: \"\"
+apiaddresses:
+- localhost:.*
+cacertificate: |
+  -----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----
+cloudtag: cloud-`+jimmtest.TestCloudName+`
+cloudregion: `+jimmtest.TestCloudRegionName+`
+username: admin
+agentversion: .*
+status:
+  status: available
+  info: ""
+  data: .*
+  since: null
+`)
+
+	username, password, err := s.JIMM.CredentialStore.GetControllerCredentials(context.Background(), "controller-1")
+	c.Assert(err, gc.IsNil)
+	c.Assert(username, gc.Equals, info.Tag.Id())
+	c.Assert(password, gc.Equals, info.Password)
+}
+
+func (s *addControllerSuite) TestAddController(c *gc.C) {
+	info := s.APIInfo(c)
+	params := apiparams.AddControllerRequest{
+		Name:          "controller-1",
+		CACertificate: info.CACert,
+		APIAddresses:  info.Addrs,
+		Username:      info.Tag.Id(),
+		Password:      info.Password,
+	}
+	tmpdir, tmpfile := writeYAMLTempFile(c, params)
+	defer os.RemoveAll(tmpdir)
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddControllerCommandForTesting(s.ClientStore(), bClient), tmpfile)
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func writeYAMLTempFile(c *gc.C, payload interface{}) (string, string) {
+	data, err := yaml.Marshal(payload)
+	c.Assert(err, gc.Equals, nil)
+
+	dir, err := os.MkdirTemp("", "add-controller-test")
+	c.Assert(err, gc.Equals, nil)
+
+	tmpfn := filepath.Join(dir, "tmp.yaml")
+	err = os.WriteFile(tmpfn, data, 0600)
+	c.Assert(err, gc.Equals, nil)
+	return dir, tmpfn
+}

--- a/cmd/jaas/cmd/auth.go
+++ b/cmd/jaas/cmd/auth.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	jujucmd "github.com/juju/cmd/v3"
+)
+
+const authDoc = `
+The auth command enables user access management.
+`
+
+func NewAuthCommand() *jujucmd.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(jujucmd.SuperCommandParams{
+		Name:        "auth",
+		UsagePrefix: "jimmctl",
+		Doc:         authDoc,
+		Purpose:     "Authorisation model management.",
+	})
+	cmd.Register(NewGroupCommand())
+	cmd.Register(NewRelationCommand())
+	cmd.Register(NewRoleCommand())
+
+	return cmd
+}

--- a/cmd/jaas/cmd/controllerinfo.go
+++ b/cmd/jaas/cmd/controllerinfo.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"sigs.k8s.io/yaml"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	controllerInfoCommandDoc = `
+The controller-info command writes controller information contained
+in the juju client store to a yaml file.
+
+If a public address is specified, the output controller information
+will contain the public address provided and omit a CA cert, this assumes
+that the server is secured with a public certificate.
+
+Use the --local flag if the server is not configured with a public address.
+`
+	controllerInfoCommandExample = `
+    jimmctl controller-info mycontroller ./destination/file.yaml mycontroller.example.com 
+    jimmctl controller-info mycontroller ./destination/file.yaml --local
+`
+)
+
+// NewControllerInfoCommand returns a command that writes
+// controller information to a yaml file.
+func NewControllerInfoCommand() cmd.Command {
+	cmd := &controllerInfoCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// controllerInfoCommand writes controller information
+// to a yaml file.
+type controllerInfoCommand struct {
+	modelcmd.ControllerCommandBase
+
+	store          jujuclient.ClientStore
+	controllerName string
+	publicAddress  string
+	file           cmd.FileVar
+	local          bool
+	tlsHostname    string
+}
+
+func (c *controllerInfoCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "controller-info",
+		Args:     "<name> <filepath> [<public address>]",
+		Purpose:  "Stores controller info to a yaml file",
+		Doc:      controllerInfoCommandDoc,
+		Examples: controllerInfoCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *controllerInfoCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.BoolVar(&c.local, "local", false, "If local flag is specified, then the local API address and CA cert of the controller will be used.")
+	f.StringVar(&c.tlsHostname, "tls-hostname", "", "Specify the hostname for TLS verification.")
+}
+
+// Init implements the cmd.Command interface.
+func (c *controllerInfoCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.New("controller name or filename not specified")
+	}
+	c.controllerName, c.file.Path = args[0], args[1]
+	if len(args) == 3 {
+		c.publicAddress = args[2]
+	}
+	if len(args) > 3 {
+		return errors.New("too many args")
+	}
+	if c.local && len(c.publicAddress) > 0 {
+		return errors.New("cannot set both public address and local flag")
+	}
+	if !c.local && len(c.publicAddress) == 0 {
+		return errors.New("provide either a public address or use --local")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *controllerInfoCommand) Run(ctxt *cmd.Context) error {
+	controller, err := c.store.ControllerByName(c.controllerName)
+	if err != nil {
+		return errors.Mask(err)
+	}
+
+	accountDetails, err := c.store.AccountDetails(c.controllerName)
+	if err != nil {
+		return errors.Mask(err)
+	}
+
+	info := apiparams.AddControllerRequest{
+		UUID:         controller.ControllerUUID,
+		Name:         c.controllerName,
+		APIAddresses: controller.APIEndpoints,
+		Username:     accountDetails.User,
+		Password:     accountDetails.Password,
+	}
+
+	info.TLSHostname = c.tlsHostname
+	info.PublicAddress = c.publicAddress
+	if c.local {
+		info.CACertificate = controller.CACert
+	}
+	data, err := yaml.Marshal(info)
+	if err != nil {
+		return errors.Mask(err)
+	}
+	err = os.WriteFile(c.file.Path, data, 0600)
+	if err != nil {
+		return errors.Mask(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/controllerinfo_test.go
+++ b/cmd/jaas/cmd/controllerinfo_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"os"
+	"path"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/juju/jujuclient"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type controllerInfoSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&controllerInfoSuite{})
+
+func (s *controllerInfoSuite) TestControllerInfo(c *gc.C) {
+	store := s.ClientStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+	dir, err := os.MkdirTemp("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(store), "controller-1", fname, "controller1.example.com")
+	c.Assert(err, gc.IsNil)
+
+	data, err := os.ReadFile(fname)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Matches, `api-addresses:
+- 127.0.0.1:17070
+name: controller-1
+password: super-secret-password
+public-address: controller1.example.com
+username: test-user
+uuid: 982b16d9-a945-4762-b684-fd4fd885aa11
+`)
+}
+
+func (s *controllerInfoSuite) TestControllerInfoWithLocalFlag(c *gc.C) {
+	store := s.ClientStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+	dir, err := os.MkdirTemp("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(store), "controller-1", fname, "--local")
+	c.Assert(err, gc.IsNil)
+
+	data, err := os.ReadFile(fname)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Matches, `api-addresses:
+- 127.0.0.1:17070
+ca-certificate: |-
+  -----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----
+name: controller-1
+password: super-secret-password
+public-address: 127.0.0.1:17070
+username: test-user
+uuid: 982b16d9-a945-4762-b684-fd4fd885aa11
+`)
+}
+
+func (s *controllerInfoSuite) TestControllerInfoMissingPublicAddressAndNoLocalFlag(c *gc.C) {
+	store := s.ClientStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+	dir, err := os.MkdirTemp("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(store), "controller-1", fname)
+	c.Assert(err, gc.ErrorMatches, "provide either a public address or use --local")
+}
+
+func (s *controllerInfoSuite) TestControllerInfoCannotProvideAddrAndLocalFlag(c *gc.C) {
+	store := s.ClientStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+	dir, err := os.MkdirTemp("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(store), "controller-1", fname, "myaddress", "--local")
+	c.Assert(err, gc.ErrorMatches, "cannot set both public address and local flag")
+}
+
+func (s *controllerInfoSuite) TestControllerInfoWithTlsFlag(c *gc.C) {
+	store := s.ClientStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert: `-----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+	dir, err := os.MkdirTemp("", "controller-info-test")
+	c.Assert(err, gc.Equals, nil)
+	defer os.RemoveAll(dir)
+
+	fname := path.Join(dir, "test.yaml")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewControllerInfoCommandForTesting(store), "controller-1", fname, "myaddress", "--tls-hostname", "foo")
+	c.Assert(err, gc.IsNil)
+
+	data, err := os.ReadFile(fname)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Matches, `api-addresses:
+- 127.0.0.1:17070
+name: controller-1
+password: super-secret-password
+public-address: myaddress
+tls-hostname: foo
+username: test-user
+uuid: 982b16d9-a945-4762-b684-fd4fd885aa11
+`)
+}

--- a/cmd/jaas/cmd/crossmodelquery.go
+++ b/cmd/jaas/cmd/crossmodelquery.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	// stdinMarkers contains file names that are taken to be stdin.
+	crossModelQueryDoc = `
+The query-models command queries all models available to the current user
+performing the query against each model status individually, returning
+the collated query responses for each model.
+
+The query runs against the output of "juju status --format json",
+as such you can format your query against an output like this.
+
+The queries expect a JQ query string.
+`
+	crossModelQueryExample = `
+    jimmctl query-models '.applications | with_entries(select(.key=="nginx-ingress-integrator"))'
+`
+)
+
+// crossModelQueryCommand queries all models available to the current
+// user.
+type crossModelQueryCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+	// query holds the query the user wishes to run against their models.
+	query string
+	// queryType holds the type of query the user wishes to use.
+	queryType string
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	file     cmd.FileVar
+}
+
+// NewCrossModelQueryCommand returns a command to query all of the models
+// available to the current user.
+func NewCrossModelQueryCommand() cmd.Command {
+	cmd := &crossModelQueryCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// Init implements modelcmd.Command.
+func (c *crossModelQueryCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("no query specified")
+	}
+	c.query = args[0]
+	c.queryType = "jq"
+	return nil
+}
+
+// SetFlags implements modelcmd.Command.
+func (c *crossModelQueryCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "json", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	c.file.StdinMarkers = stdinMarkers
+}
+
+// Info implements modelcmd.Command.
+func (c *crossModelQueryCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "query-models",
+		Args:     "<query>",
+		Purpose:  "Query model statuses",
+		Doc:      crossModelQueryDoc,
+		Examples: crossModelQueryExample,
+	})
+}
+
+// Run implements modelcmd.Command.
+func (c *crossModelQueryCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.Annotate(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	req := apiparams.CrossModelQueryRequest{
+		Type:  c.queryType,
+		Query: c.query,
+	}
+
+	client := api.NewClient(apiCaller)
+	resp, err := client.CrossModelQuery(&req)
+	if err != nil {
+		return errors.Mask(err)
+	}
+
+	err = c.out.Write(ctxt, resp)
+	if err != nil {
+		return errors.Mask(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/crossmodelquery_test.go
+++ b/cmd/jaas/cmd/crossmodelquery_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"encoding/json"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type crossModelQuerySuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&crossModelQuerySuite{})
+
+func (s *crossModelQuerySuite) TestCrossModelQueryCommand(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	s.AddController(c, "controller-2", s.APIInfo(c))
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/alice@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	mt := s.AddModel(c, names.NewUserTag("alice@canonical.com"), "stg-o11y", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	state, _ := s.StatePool.Get(mt.Id())
+	f := factory.NewFactory(state.State, s.StatePool)
+	app := f.MakeApplication(c, &factory.ApplicationParams{
+		Name: "test-app",
+		Charm: f.MakeCharm(c, &factory.CharmParams{
+			Name: "wordpress",
+		}),
+	})
+	f.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+	})
+
+	// Test.
+	cmdCtx, err := cmdtesting.RunCommand(c, cmd.NewCrossModelQueryCommandForTesting(s.ClientStore(), bClient), ".")
+	c.Assert(err, gc.IsNil)
+
+	topLevel := make(map[string]any)
+	c.Assert(json.Unmarshal([]byte(cmdtesting.Stdout(cmdCtx)), &topLevel), gc.IsNil)
+
+	// Check for no errors.
+	c.Assert(topLevel["errors"].(map[string]any), gc.DeepEquals, make(map[string]any))
+
+	// There's only 1 model and 1 "result", so we just loop to check it's as
+	// we expect.
+	for _, v := range topLevel["results"].(map[string]any) {
+		modelStatus := v.([]any)[0].(map[string]any)
+		// We test simply for fields to be present in our "test-app".
+		testApp := modelStatus["applications"].(map[string]any)["test-app"].(map[string]any)
+		c.Assert(len(testApp), gc.Equals, 10)
+
+		testModel := modelStatus["model"].(map[string]any)
+		c.Assert(len(testModel), gc.Equals, 8)
+	}
+}

--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -1,15 +1,26 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package cmd
 
 import (
 	"github.com/juju/cmd/v3"
 	jujuapi "github.com/juju/juju/api"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
 	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
 )
+
+var (
+	AccessMessage          = accessMessageFormat
+	AccessResultAllowed    = accessResultAllowed
+	AccessResultDenied     = accessResultDenied
+	DefaultPageSize        = defaultPageSize
+	FormatRelationsTabular = formatRelationsTabular
+)
+
+type AccessResult = accessResult
 
 func NewAddServiceAccountCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addServiceAccountCommand{
@@ -40,6 +51,273 @@ func NewUpdateCredentialsCommandForTesting(store jujuclient.ClientStore, lp juju
 
 func NewGrantCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &grantCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewListControllersCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &listControllersCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewModelStatusCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &modelStatusCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewGrantAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &grantAuditLogAccessCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRevokeAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &revokeAuditLogAccessCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewListAuditEventsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &listAuditEventsCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewAddCloudToControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider, cloudByNameFunc func(string) (*cloud.Cloud, error)) cmd.Command {
+	cmd := &addCloudToControllerCommand{
+		store:           store,
+		cloudByNameFunc: cloudByNameFunc,
+		dialOpts:        cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+type RemoveCloudFromControllerAPI = removeCloudFromControllerAPI
+
+func NewRemoveCloudFromControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider, removeCloudFromControllerAPIFunc func() (RemoveCloudFromControllerAPI, error)) cmd.Command {
+	cmd := &removeCloudFromControllerCommand{
+		store:                            store,
+		dialOpts:                         cmdtest.TestDialOpts(lp),
+		removeCloudFromControllerAPIFunc: removeCloudFromControllerAPIFunc,
+	}
+	if removeCloudFromControllerAPIFunc == nil {
+		cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewAddControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &addControllerCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRemoveControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &removeControllerCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewControllerInfoCommandForTesting(store jujuclient.ClientStore) cmd.Command {
+	cmd := &controllerInfoCommand{
+		store: store,
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &setControllerDeprecatedCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewImportModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &importModelCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewUpdateMigratedModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &updateMigratedModelCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewImportCloudCredentialsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &importCloudCredentialsCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewAddRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &addRoleCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRenameRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &renameRoleCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRemoveRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &removeRoleCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewListRolesCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &listRolesCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewAddGroupCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &addGroupCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRenameGroupCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &renameGroupCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRemoveGroupCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &removeGroupCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewListGroupsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &listGroupsCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewAddRelationCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &addRelationCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewRemoveRelationCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &removeRelationCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewListRelationsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &listRelationsCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewCheckRelationCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &checkRelationCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewCrossModelQueryCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &crossModelQueryCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewPurgeLogsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &purgeLogsCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+func NewMigrateModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
+	cmd := &migrateModelCommand{
 		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	grantAuditLogAccessDoc = `
+Grants a user access to read audit logs.
+`
+
+	grantAuditLogAccessExamples = `
+    jimmctl grant-audit-log-access <username> 
+`
+)
+
+// NewGrantAuditLogAccessCommand returns a command used to grant
+// users access to audit logs.
+func NewGrantAuditLogAccessCommand() cmd.Command {
+	cmd := &grantAuditLogAccessCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// grantAuditLogAccessCommand displays full
+// model status.
+type grantAuditLogAccessCommand struct {
+	modelcmd.ControllerCommandBase
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	username string
+}
+
+func (c *grantAuditLogAccessCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "grant-audit-log-access",
+		Args:     "<username>",
+		Purpose:  "Grants access to audit logs.",
+		Doc:      grantAuditLogAccessDoc,
+		Examples: grantAuditLogAccessExamples,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *grantAuditLogAccessCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+}
+
+// Init implements the cmd.Command interface.
+func (c *grantAuditLogAccessCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.E("missing username")
+	}
+	c.username, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("unknown arguments")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	userTag := names.NewUserTag(c.username)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{
+		UserTag: userTag.String(),
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type grantAuditLogAccessSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&grantAuditLogAccessSuite{})
+
+func (s *grantAuditLogAccessSuite) TestGrantAuditLogAccessSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err := cmdtesting.RunCommand(c, cmd.NewGrantAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *grantAuditLogAccessSuite) TestGrantAuditLogAccess(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewGrantAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/group.go
+++ b/cmd/jaas/cmd/group.go
@@ -1,0 +1,390 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	jujucmdv3 "github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	groupDoc = `
+The group command enables group management for jimm
+`
+
+	addGroupDoc = `
+The add command adds group to jimm.
+`
+	addGroupExample = `
+    jimmctl auth group add mygroup
+`
+	renameGroupDoc = `
+The rename command renames a group in jimm.
+`
+	renameGroupExample = `
+    jimmctl auth group rename mygroup newgroup
+`
+	removeGroupDoc = `
+The remove command removes a group in jimm.
+`
+
+	removeGroupExample = `
+    jimmctl auth group remove mygroup
+`
+
+	listGroupsDoc = `
+The list command lists all groups in jimm.
+`
+	listGroupsExample = `
+    jimmctl auth group list
+`
+)
+
+// NewGroupCommand returns a command for group management.
+func NewGroupCommand() *jujucmdv3.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(jujucmdv3.SuperCommandParams{
+		Name:        "group",
+		UsagePrefix: "auth",
+		Doc:         groupDoc,
+		Purpose:     "Group management.",
+	})
+	cmd.Register(newAddGroupCommand())
+	cmd.Register(newRenameGroupCommand())
+	cmd.Register(newRemoveGroupCommand())
+	cmd.Register(newListGroupsCommand())
+
+	return cmd
+}
+
+// newAddGroupCommand returns a command to add a group.
+func newAddGroupCommand() cmd.Command {
+	cmd := &addGroupCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addGroupCommand adds a group.
+type addGroupCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name string
+}
+
+// Info implements the cmd.Command interface.
+func (c *addGroupCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "add",
+		Args:     "<name>",
+		Purpose:  "Add group to jimm.",
+		Doc:      addGroupDoc,
+		Examples: addGroupExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *addGroupCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *addGroupCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("group name not specified")
+	}
+	c.name, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *addGroupCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	resp, err := client.AddGroup(&apiparams.AddGroupRequest{
+		Name: c.name,
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, resp)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+// newRenameGroupCommand returns a command to rename a group.
+func newRenameGroupCommand() cmd.Command {
+	cmd := &renameGroupCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// renameGroupCommand renames a group.
+type renameGroupCommand struct {
+	modelcmd.ControllerCommandBase
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name    string
+	newName string
+}
+
+// Info implements the cmd.Command interface.
+func (c *renameGroupCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "rename",
+		Args:     "<name> <new name>",
+		Purpose:  "Rename a group.",
+		Doc:      renameGroupDoc,
+		Examples: renameGroupExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *renameGroupCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("group name not specified")
+	}
+	c.name, c.newName, args = args[0], args[1], args[2:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *renameGroupCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	params := apiparams.RenameGroupRequest{
+		Name:    c.name,
+		NewName: c.newName,
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RenameGroup(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// newRemoveGroupCommand returns a command to Remove a group.
+func newRemoveGroupCommand() cmd.Command {
+	cmd := &removeGroupCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// removeGroupCommand Removes a group.
+type removeGroupCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name  string
+	force bool
+}
+
+// Info implements the cmd.Command interface.
+func (c *removeGroupCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "remove",
+		Args:     "<name>",
+		Purpose:  "Remove a group.",
+		Doc:      removeGroupDoc,
+		Examples: removeGroupExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *removeGroupCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("group name not specified")
+	}
+	c.name, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *removeGroupCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "smart", map[string]cmd.Formatter{
+		"smart": cmd.FormatSmart,
+	})
+	f.BoolVar(&c.force, "y", false, "delete group without prompt")
+}
+
+// Run implements Command.Run.
+func (c *removeGroupCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	if !c.force {
+		reader := bufio.NewReader(ctxt.Stdin)
+		// Using Fprintf over c.out.write to avoid printing a new line.
+		_, err := fmt.Fprintf(ctxt.Stdout, "This will also delele all associated relations.\nConfirm you would like to delete group %q (y/N): ", c.name)
+		if err != nil {
+			return err
+		}
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.E(err, "Failed to read from input.")
+		}
+		text = strings.ReplaceAll(text, "\n", "")
+		if !(text == "y" || text == "Y") {
+			return nil
+		}
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	params := apiparams.RemoveGroupRequest{
+		Name: c.name,
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RemoveGroup(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// newListGroupsCommand returns a command to list all groups.
+func newListGroupsCommand() cmd.Command {
+	cmd := &listGroupsCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// listGroupsCommand Lists all groups.
+type listGroupsCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	limit  int
+	offset int
+}
+
+// Info implements the cmd.Command interface.
+func (c *listGroupsCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "list",
+		Purpose:  "List all groups.",
+		Doc:      listGroupsDoc,
+		Examples: listGroupsExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *listGroupsCommand) Init(args []string) error {
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listGroupsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.IntVar(&c.limit, "limit", 0, "The maximum number of groups to return")
+	f.IntVar(&c.offset, "offset", 0, "The offset to use when requesting groups")
+}
+
+// Run implements Command.Run.
+func (c *listGroupsCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	req := apiparams.ListGroupsRequest{Limit: c.limit, Offset: c.offset}
+	groups, err := client.ListGroups(&req)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, groups)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}

--- a/cmd/jaas/cmd/group_test.go
+++ b/cmd/jaas/cmd/group_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+type groupSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&groupSuite{})
+
+func (s *groupSuite) TestAddGroupSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), "test-group")
+	c.Assert(err, gc.IsNil)
+
+	group := &dbmodel.GroupEntry{Name: "test-group"}
+	err = s.JimmCmdSuite.JIMM.Database.GetGroup(context.TODO(), group)
+	c.Assert(err, gc.IsNil)
+	c.Assert(group.ID, gc.Equals, uint(1))
+	c.Assert(group.Name, gc.Equals, "test-group")
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, fmt.Sprintf(`(?s).*uuid: %s\n.*`, group.UUID))
+}
+
+func (s *groupSuite) TestAddGroup(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), "test-group")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *groupSuite) TestRenameGroupSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	groupEntry, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.TODO(), "test-group")
+	c.Assert(err, gc.IsNil)
+	c.Assert(groupEntry.UUID, gc.Not(gc.Equals), "")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewRenameGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "renamed-group")
+	c.Assert(err, gc.IsNil)
+
+	group := &dbmodel.GroupEntry{Name: "renamed-group"}
+	err = s.JimmCmdSuite.JIMM.Database.GetGroup(context.TODO(), group)
+	c.Assert(err, gc.IsNil)
+	c.Assert(group.ID, gc.Equals, uint(1))
+	c.Assert(group.Name, gc.Equals, "renamed-group")
+}
+
+func (s *groupSuite) TestRenameGroup(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRenameGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "renamed-group")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *groupSuite) TestRemoveGroupSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.TODO(), "test-group")
+	c.Assert(err, gc.IsNil)
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewRemoveGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "-y")
+	c.Assert(err, gc.IsNil)
+
+	group := &dbmodel.GroupEntry{Name: "test-group"}
+	err = s.JimmCmdSuite.JIMM.Database.GetGroup(context.TODO(), group)
+	c.Assert(err, gc.ErrorMatches, "record not found")
+}
+
+func (s *groupSuite) TestRemoveGroupWithoutFlag(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveGroupCommandForTesting(s.ClientStore(), bClient), "test-group")
+	c.Assert(err.Error(), gc.Matches, "Failed to read from input.")
+}
+
+func (s *groupSuite) TestRemoveGroup(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "-y")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *groupSuite) TestListGroupsSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.TODO(), fmt.Sprint("test-group", i))
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewListGroupsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	output := cmdtesting.Stdout(ctx)
+	groups := []params.Group{}
+	err = yaml.Unmarshal([]byte(output), &groups)
+	c.Assert(err, gc.IsNil)
+	c.Log(groups)
+	c.Assert(strings.Contains(output, "test-group0"), gc.Equals, true)
+	c.Assert(strings.Contains(output, "test-group1"), gc.Equals, true)
+	c.Assert(strings.Contains(output, "test-group2"), gc.Equals, true)
+}
+
+func (s *groupSuite) TestListGroupsLimitSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.TODO(), fmt.Sprint("test-group", i))
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewListGroupsCommandForTesting(s.ClientStore(), bClient), "--limit", "1", "--offset", "1")
+	c.Assert(err, gc.IsNil)
+	output := cmdtesting.Stdout(ctx)
+	groups := []params.Group{}
+	err = yaml.Unmarshal([]byte(output), &groups)
+	c.Assert(err, gc.IsNil)
+	c.Assert(groups, gc.HasLen, 1)
+	c.Assert(groups[0].Name, gc.Equals, "test-group1")
+	c.Assert(groups[0].UUID, gc.Not(gc.Equals), "")
+}
+
+func (s *groupSuite) TestListGroups(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewListGroupsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/importcloudcredentials.go
+++ b/cmd/jaas/cmd/importcloudcredentials.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/juju/cmd/v3"
+	jujuapi "github.com/juju/juju/api"
+	"github.com/juju/juju/api/client/cloud"
+	jujucloud "github.com/juju/juju/cloud"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+const (
+	//nolint:gosec // Thinks a credential is exposed.
+	importCloudCredentialsDoc = `
+The import-cloud-credentials imports a set of cloud credentials
+loaded from a file containing a series of JSON objects. The JSON
+objects specifying the credentials should be of the form:
+
+{
+	"_id": <cloud-credential-id>,
+	"type": <credential-type>,
+	"attributes": {
+		<key1>: <value1>,
+		...
+	}
+}
+`
+	//nolint:gosec // Thinks a credential is exposed.
+	importCloudCredentialsExample = `
+    jimmctl import-cloud-credentials ./path/creds.json
+`
+)
+
+// NewImportCloudCredentialsCommand returns a command to import cloud
+// credentials.
+func NewImportCloudCredentialsCommand() cmd.Command {
+	cmd := &importCloudCredentialsCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	cmd.file.StdinMarkers = stdinMarkers
+	return modelcmd.WrapBase(cmd)
+}
+
+// importCloudCredentialsCommand imports a set of cloud credentials.
+type importCloudCredentialsCommand struct {
+	modelcmd.ControllerCommandBase
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	file cmd.FileVar
+}
+
+// Info implements cmd.Command interface.
+func (c *importCloudCredentialsCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "import-cloud-credentials",
+		Args:     "<filepath>",
+		Purpose:  "Import cloud credentials to jimm",
+		Doc:      importCloudCredentialsDoc,
+		Examples: importCloudCredentialsExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *importCloudCredentialsCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("filename not specified")
+	}
+	c.file.Path = args[0]
+	if len(args) > 1 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements the cmd.Command interface.
+func (c *importCloudCredentialsCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := cloud.NewClient(apiCaller)
+
+	rc, err := c.file.Open(ctxt)
+	if err != nil {
+		return errors.E(err)
+	}
+	defer rc.Close()
+
+	d := json.NewDecoder(rc)
+	for d.More() {
+		var cred credential
+		if err := d.Decode(&cred); err != nil {
+			return errors.E(err)
+		}
+		ctxt.Verbosef("importing %s", cred.Tag().Id())
+		resp, err := client.AddCloudsCredentials(map[string]jujucloud.Credential{
+			cred.Tag().String(): cred.Credential(),
+		})
+		if err == nil && resp[0].Error != nil {
+			err = resp[0].Error
+		}
+		if err != nil {
+			ctxt.Warningf("failed adding credential %s: %s", cred.Tag().Id(), err)
+		}
+	}
+	return nil
+}
+
+type credential struct {
+	ID         string            `json:"_id"`
+	Type       string            `json:"type"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+// Tag returns the names.Tag for the credential.
+func (c credential) Tag() names.Tag {
+	tag := names.NewCloudCredentialTag(c.ID)
+	if tag.Owner().IsLocal() {
+		id := tag.Cloud().Id() + "/" + tag.Owner().WithDomain("external").Id() + "/" + tag.Name()
+		tag = names.NewCloudCredentialTag(id)
+	}
+	return tag
+}
+
+// Credential returns the jujucloud.Credential for this credential.
+func (c credential) Credential() jujucloud.Credential {
+	return jujucloud.NewCredential(jujucloud.AuthType(c.Type), c.Attributes)
+}

--- a/cmd/jaas/cmd/importcloudcredentials_test.go
+++ b/cmd/jaas/cmd/importcloudcredentials_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type importCloudCredentialsSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&importCloudCredentialsSuite{})
+
+//nolint:gosec // Thinks hardcoded creds.
+const creds = `{
+	"_id": "aws/alice@canonical.com/test1",
+	"type": "access-key",
+	"attributes": {
+		"access-key": "key-id",
+		"secret-key": "shhhh"
+	}
+}
+{
+	"_id": "aws/bob@canonical.com/test1",
+	"type": "access-key",
+	"attributes": {
+		"access-key": "key-id2",
+		"secret-key": "shhhh"
+	}
+}
+{
+	"_id": "gce/charlie@canonical.com/test1",
+	"type": "empty",
+	"attributes": {}
+}`
+
+func (s *importCloudCredentialsSuite) TestImportCloudCredentials(c *gc.C) {
+	err := s.JIMM.Database.AddCloud(context.Background(), &dbmodel.Cloud{
+		Name:    "aws",
+		Type:    "kubernetes",
+		Regions: []dbmodel.CloudRegion{{Name: "default", CloudName: "test-cloud"}},
+	})
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.Database.AddCloud(context.Background(), &dbmodel.Cloud{
+		Name:    "gce",
+		Type:    "kubernetes",
+		Regions: []dbmodel.CloudRegion{{Name: "default", CloudName: "test-cloud"}},
+	})
+	c.Assert(err, gc.IsNil)
+
+	tmpfile := filepath.Join(c.MkDir(), "test.json")
+	err = os.WriteFile(tmpfile, []byte(creds), 0600)
+	c.Assert(err, gc.IsNil)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err = cmdtesting.RunCommand(c, cmd.NewImportCloudCredentialsCommandForTesting(s.ClientStore(), bClient), tmpfile)
+	c.Assert(err, gc.IsNil)
+
+	cred1 := dbmodel.CloudCredential{
+		CloudName:         "aws",
+		OwnerIdentityName: "alice@canonical.com",
+		Name:              "test1",
+	}
+	err = s.JIMM.Database.GetCloudCredential(context.Background(), &cred1)
+	c.Assert(err, gc.IsNil)
+	c.Check(cred1.AuthType, gc.Equals, "access-key")
+
+	cred2 := dbmodel.CloudCredential{
+		CloudName:         "aws",
+		OwnerIdentityName: "bob@canonical.com",
+		Name:              "test1",
+	}
+	err = s.JIMM.Database.GetCloudCredential(context.Background(), &cred2)
+	c.Assert(err, gc.IsNil)
+	c.Check(cred2.AuthType, gc.Equals, "access-key")
+
+	cred3 := dbmodel.CloudCredential{
+		CloudName:         "gce",
+		OwnerIdentityName: "charlie@canonical.com",
+		Name:              "test1",
+	}
+	err = s.JIMM.Database.GetCloudCredential(context.Background(), &cred3)
+	c.Assert(err, gc.IsNil)
+	c.Check(cred3.AuthType, gc.Equals, "empty")
+}

--- a/cmd/jaas/cmd/importmodel.go
+++ b/cmd/jaas/cmd/importmodel.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	importModelCommandDoc = `
+The import-model imports a model running on a controller to jimm.
+
+When importing, it is necessary for JIMM to contain a set of cloud credentials
+that represent a user's access to the incoming model's cloud. 
+
+The --owner command is necessary when importing a model created by a 
+local user and it will switch the model owner to the desired external user.
+`
+	importModelCommandExample = `
+    jimmctl import-model mycontroller ac30d6ae-0bed-4398-bba7-75d49e39f189
+    jimmctl import-model mycontroller ac30d6ae-0bed-4398-bba7-75d49e39f189 --owner user@canonical.com
+`
+)
+
+// NewImportModelCommand returns a command to import a model.
+func NewImportModelCommand() cmd.Command {
+	cmd := &importModelCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// importModelCommand imports a model.
+type importModelCommand struct {
+	modelcmd.ControllerCommandBase
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	req apiparams.ImportModelRequest
+}
+
+// Info implements the cmd.Command interface.
+func (c *importModelCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "import-model",
+		Args:     "<controller name> <model uuid>",
+		Purpose:  "Import a model to jimm",
+		Doc:      importModelCommandDoc,
+		Examples: importModelCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *importModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.req.Owner, "owner", "", "switch the model owner to the desired user")
+}
+
+// Init implements the cmd.Command interface.
+func (c *importModelCommand) Init(args []string) error {
+	switch len(args) {
+	default:
+		return errors.E("too many args")
+	case 0:
+		return errors.E("controller not specified")
+	case 1:
+		return errors.E("model uuid not specified")
+	case 2:
+	}
+
+	c.req.Controller = args[0]
+	if !names.IsValidModel(args[1]) {
+		return errors.E("invalid model uuid")
+	}
+	c.req.ModelTag = names.NewModelTag(args[1]).String()
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *importModelCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	if err := client.ImportModel(&c.req); err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/importmodel_test.go
+++ b/cmd/jaas/cmd/importmodel_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	jjcloud "github.com/juju/juju/cloud"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/testing/factory"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type importModelSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&importModelSuite{})
+
+func (s *importModelSuite) TestImportModelSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty", Attributes: map[string]string{"key": "value"}})
+
+	err := s.BackingState.UpdateCloudCredential(cct, jjcloud.NewCredential(jjcloud.EmptyAuthType, map[string]string{"key": "value"}))
+	c.Assert(err, gc.Equals, nil)
+
+	m := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            "model-2",
+		Owner:           names.NewUserTag("charlie@canonical.com"),
+		CloudName:       jimmtest.TestCloudName,
+		CloudRegion:     jimmtest.TestCloudRegionName,
+		CloudCredential: cct,
+	})
+	defer m.Close()
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err = cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-1", m.ModelUUID())
+	c.Assert(err, gc.IsNil)
+
+	var model2 dbmodel.Model
+	model2.SetTag(names.NewModelTag(m.ModelUUID()))
+	err = s.JIMM.Database.GetModel(context.Background(), &model2)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(model2.OwnerIdentityName, gc.Equals, "charlie@canonical.com")
+}
+
+func (s *importModelSuite) TestImportModelFromLocalUser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	// Add credentials for Alice on the test cloud, they are needed for the Alice user to become the new model owner
+	cctAlice := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/alice@canonical.com/cred")
+	s.UpdateCloudCredential(c, cctAlice, jujuparams.CloudCredential{AuthType: "empty"})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	var model dbmodel.Model
+	model.SetTag(mt)
+	err := s.JIMM.Database.GetModel(context.Background(), &model)
+	c.Assert(err, gc.Equals, nil)
+	err = s.JIMM.OpenFGAClient.RemoveControllerModel(context.Background(), model.Controller.ResourceTag(), model.ResourceTag())
+	c.Assert(err, gc.Equals, nil)
+	err = s.JIMM.Database.DeleteModel(context.Background(), &model)
+	c.Assert(err, gc.Equals, nil)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err = cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-1", mt.Id(), "--owner", "alice@canonical.com")
+	c.Assert(err, gc.IsNil)
+
+	var model2 dbmodel.Model
+	model2.SetTag(mt)
+	err = s.JIMM.Database.GetModel(context.Background(), &model2)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(model2.CreatedAt.After(model.CreatedAt), gc.Equals, true)
+	c.Check(model2.OwnerIdentityName, gc.Equals, "alice@canonical.com")
+}
+
+func (s *importModelSuite) TestImportModelUnauthorized(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+
+	err := s.BackingState.UpdateCloudCredential(cct, jjcloud.NewCredential(jjcloud.EmptyAuthType, map[string]string{"key": "value"}))
+	c.Assert(err, gc.Equals, nil)
+
+	m := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name:            "model-2",
+		Owner:           names.NewUserTag("charlie@canonical.com"),
+		CloudName:       jimmtest.TestCloudName,
+		CloudRegion:     jimmtest.TestCloudRegionName,
+		CloudCredential: cct,
+	})
+	defer m.Close()
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err = cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-1", m.ModelUUID())
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *importModelSuite) TestImportModelNoController(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.ErrorMatches, `controller not specified`)
+}
+
+func (s *importModelSuite) TestImportModelNoModelUUID(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-id")
+	c.Assert(err, gc.ErrorMatches, `model uuid not specified`)
+}
+
+func (s *importModelSuite) TestImportModelInvalidModelUUID(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid")
+	c.Assert(err, gc.ErrorMatches, `invalid model uuid`)
+}
+
+func (s *importModelSuite) TestImportModelTooManyArgs(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewImportModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid", "spare-argument")
+	c.Assert(err, gc.ErrorMatches, `too many args`)
+}

--- a/cmd/jaas/cmd/listauditevents.go
+++ b/cmd/jaas/cmd/listauditevents.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gosuri/uitable"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	listAuditEventsCommandDoc = `
+The list-audit-events command displays matching audit events.
+`
+	listAuditEventsCommandExample = `
+    jimmctl list-audit-events --after 2020-01-01T15:00:00 --before 2020-01-01T15:00:00 --user-tag user@canonical.com --limit 50
+	jimmctl list-audit-events --method CreateModel
+    jimmctl audit-events --after 2020-01-01T15:00:00 --format yaml
+`
+)
+
+// NewListAuditEventsCommand returns a command to list audit events matching
+// specified criteria.
+func NewListAuditEventsCommand() cmd.Command {
+	cmd := &listAuditEventsCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// listAuditEventsCommand displays full
+// model status.
+type listAuditEventsCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	args     apiparams.FindAuditEventsRequest
+}
+
+func (c *listAuditEventsCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "list-audit-events",
+		Purpose:  "Displays audit events",
+		Doc:      listAuditEventsCommandDoc,
+		Examples: listAuditEventsCommandExample,
+		Aliases:  []string{"audit-events"},
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listAuditEventsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatTabular,
+	})
+	f.StringVar(&c.args.After, "after", "", "display events that happened after a specified time, formatted as RFC3339")
+	f.StringVar(&c.args.Before, "before", "", "display events that happened before specified time, formatted as RFC3339")
+	f.StringVar(&c.args.UserTag, "user-tag", "", "display events performed by authenticated user")
+	f.StringVar(&c.args.Method, "method", "", "display events for a specific method call")
+	f.StringVar(&c.args.Model, "model", "", "display events for a specific model (model name is controller/model)")
+	f.IntVar(&c.args.Offset, "offset", 0, "offset the set of returned audit events")
+	f.IntVar(&c.args.Limit, "limit", 0, "limit the maximum number of returned audit events")
+	f.BoolVar(&c.args.SortTime, "reverse", false, "reverse the order of logs, showing the most recent first")
+
+}
+
+// Init implements the cmd.Command interface.
+func (c *listAuditEventsCommand) Init(args []string) error {
+	if len(args) > 0 {
+		return errors.E("unknown arguments")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *listAuditEventsCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	events, err := client.FindAuditEvents(&c.args)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, events)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+func formatTabular(writer io.Writer, value interface{}) error {
+	e, ok := value.(apiparams.AuditEvents)
+	if !ok {
+		return errors.E(fmt.Sprintf("expected value of type %T, got %T", e, value))
+	}
+
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.Wrap = true
+
+	table.AddRow("Time", "User", "Model", "ConversationId", "MessageId", "Method", "IsResponse", "Params", "Errors")
+	for _, event := range e.Events {
+		errorJSON, err := json.Marshal(event.Errors)
+		if err != nil {
+			return errors.E(err)
+		}
+		paramsJSON, err := json.Marshal(event.Params)
+		if err != nil {
+			return errors.E(err)
+		}
+		table.AddRow(event.Time, event.UserTag, event.Model, event.ConversationId, event.MessageId, event.FacadeMethod, event.IsResponse, string(paramsJSON), string(errorJSON))
+	}
+	fmt.Fprint(writer, table)
+	return nil
+}

--- a/cmd/jaas/cmd/listauditevents_test.go
+++ b/cmd/jaas/cmd/listauditevents_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type listAuditEventsSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&listAuditEventsSuite{})
+
+func (s *listAuditEventsSuite) TestListAuditEventsSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(c, cmd.NewListAuditEventsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches,
+		`events:
+- time: .*
+  conversation-id: .*
+  message-id: 1
+  facade-name: Admin
+  facade-method: LoginWithSessionToken
+  facade-version: \d
+  user-tag: user-
+  is-response: false
+  params:
+    params: redacted
+- time: .*
+  conversation-id: .*
+  message-id: 1
+  facade-name: Admin
+  facade-method: LoginWithSessionToken
+  facade-version: \d
+  user-tag: user-alice@canonical.com
+  is-response: true
+  errors:
+    results:
+    - error:
+        code: ""
+        message: ""
+[\s\S]*`)
+}
+
+func (s *listAuditEventsSuite) TestListAuditEventsStatus(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewListAuditEventsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/listcontrollers.go
+++ b/cmd/jaas/cmd/listcontrollers.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+)
+
+const (
+	listControllersCommandDoc = `
+The list-controllers command displays controller information
+for all controllers known to JIMM.
+`
+	listControllersCommandExample = `
+    jimmctl controllers 
+    jimmctl controllers --format json
+`
+)
+
+// NewListControllersCommand returns a command to list controller information.
+func NewListControllersCommand() cmd.Command {
+	cmd := &listControllersCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// listControllersCommand shows controller information
+// for all controllers known to JIMM.
+type listControllersCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+}
+
+func (c *listControllersCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "controllers",
+		Purpose:  "Lists all controllers known to JIMM.",
+		Doc:      listControllersCommandDoc,
+		Examples: listControllersCommandExample,
+		Aliases:  []string{"list-controllers"},
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listControllersCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Run implements Command.Run.
+func (c *listControllersCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	controllers, err := client.ListControllers()
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, controllers)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+var (
+	expectedSuperuserOutput = `- name: controller-1
+  uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  publicaddress: ""
+  apiaddresses:
+  - localhost:.*
+  cacertificate: |
+    -----BEGIN CERTIFICATE-----
+    .*
+    -----END CERTIFICATE-----
+  cloudtag: cloud-` + jimmtest.TestCloudName + `
+  cloudregion: ` + jimmtest.TestCloudRegionName + `
+  agentversion: .*
+  status:
+    status: available
+    info: ""
+    data: {}
+    since: null
+- name: controller-1
+  uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+  publicaddress: ""
+  apiaddresses:
+  - localhost:46539
+  cacertificate: |
+    -----BEGIN CERTIFICATE-----
+    .*
+    -----END CERTIFICATE-----
+  cloudtag: cloud-` + jimmtest.TestCloudName + `
+  cloudregion: ` + jimmtest.TestCloudRegionName + `
+  agentversion: .*
+  status:
+    status: available
+    info: ""
+    data: {}
+    since: null
+`
+
+	expectedOutput = `- name: jaas
+  uuid: 6acf4fd8-32d6-49ea-b4eb-dcb9d1590c11
+  publicaddress: ""
+  apiaddresses: \[\]
+  cacertificate: ""
+  cloudtag: ""
+  cloudregion: ""
+  agentversion: .*
+  status:
+    status: available
+    info: ""
+    data: {}
+    since: null
+`
+)
+
+type listControllersSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&listControllersSuite{})
+
+func (s *listControllersSuite) TestListControllersSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(c, cmd.NewListControllersCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expectedSuperuserOutput)
+}
+
+func (s *listControllersSuite) TestListControllers(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	context, err := cmdtesting.RunCommand(c, cmd.NewListControllersCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expectedOutput)
+}

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	migrateModelCommandDoc = `
+The migrate commands migrates a model, or many models between two controllers
+registered within JIMM. 
+
+You may specify a model name (of the form owner/name) or model UUID.
+
+`
+	migrateModelCommandExample = `
+    jimmctl migrate mycontroller 2cb433a6-04eb-4ec4-9567-90426d20a004 fd469983-27c2-423b-bebf-84f616fb036b ...
+    jimmctl migrate mycontroller user@domain.com/model-a user@domain.com/model-b ...
+    jimmctl migrate mycontroller user@domain.com/model-a fd469983-27c2-423b-bebf-84f616fb036b ...
+
+`
+)
+
+// NewMigrateModelCommand returns a command to migrate models.
+func NewMigrateModelCommand() cmd.Command {
+	cmd := &migrateModelCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// migrateModelCommand migrates a model.
+type migrateModelCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store            jujuclient.ClientStore
+	dialOpts         *jujuapi.DialOpts
+	targetController string
+	modelTargets     []string
+}
+
+func (c *migrateModelCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "migrate",
+		Args:     "<controller name> <model uuid> [<model uuid>...]",
+		Purpose:  "Migrate models to the target controller",
+		Doc:      migrateModelCommandDoc,
+		Examples: migrateModelCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *migrateModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *migrateModelCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("Missing controller name and model target arguments")
+	}
+	for i, arg := range args {
+		if i == 0 {
+			c.targetController = arg
+			continue
+		}
+		c.modelTargets = append(c.modelTargets, arg)
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	specs := []apiparams.MigrateModelInfo{}
+	for _, model := range c.modelTargets {
+		specs = append(specs, apiparams.MigrateModelInfo{TargetModelNameOrUUID: model, TargetController: c.targetController})
+	}
+	req := apiparams.MigrateModelRequest{Specs: specs}
+	events, err := client.MigrateModel(&req)
+	if err != nil {
+		return err
+	}
+
+	err = c.out.Write(ctxt, events)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/migratemodel_test.go
+++ b/cmd/jaas/cmd/migratemodel_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type migrateModelSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&migrateModelSuite{})
+
+// TestMigrateModelCommandSuperuser tests that a migration request makes it through to the Juju controller.
+// Because our test suite only spins up 1 controller the furthest we can go is reaching Juju pre-checks which
+// detect that a model with the same UUID already exists on the target controller.
+// This functionality is already tested in jujuapi and ideally this test would only test the CLI functionality
+// but our CLI tests are currently integration based.
+func (s *migrateModelSuite) TestMigrateModelCommandSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-1", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	mt2 := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(
+		c, cmd.NewMigrateModelCommandForTesting(s.ClientStore(), bClient),
+		"controller-1",
+		mt.Id(),
+		"charlie@canonical.com/model-2",
+	)
+	c.Assert(err, gc.IsNil)
+
+	res := &jujuparams.InitiateMigrationResults{}
+	out := cmdtesting.Stdout(context)
+	err = yaml.Unmarshal([]byte(out), res)
+	c.Assert(err, gc.IsNil)
+
+	expected := "target prechecks failed: model with same UUID already exists (%s)"
+	c.Assert(res.Results[0].Error.Message, gc.Equals, fmt.Sprintf(expected, mt.Id()))
+	c.Assert(res.Results[1].Error.Message, gc.Equals, fmt.Sprintf(expected, mt2.Id()))
+}
+
+func (s *migrateModelSuite) TestMigrateModelCommandFailsWithMissingArgs(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err := cmdtesting.RunCommand(c, cmd.NewMigrateModelCommandForTesting(s.ClientStore(), bClient), "myController")
+	c.Assert(err, gc.ErrorMatches, "Missing controller name and model target arguments")
+}

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	modelStatusCommandDoc = `
+The model-status command displays full model status.
+`
+	modelStatusCommandExample = `
+    jimmctl model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    jimmctl model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 --format yaml
+`
+)
+
+// NewModelStatusCommand returns a command to display full model status.
+func NewModelStatusCommand() cmd.Command {
+	cmd := &modelStatusCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// modelStatusCommand displays full
+// model status.
+type modelStatusCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store     jujuclient.ClientStore
+	dialOpts  *jujuapi.DialOpts
+	modelUUID string
+}
+
+func (c *modelStatusCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "model-status",
+		Args:     "<model uuid>",
+		Purpose:  "Displays full model status",
+		Doc:      modelStatusCommandDoc,
+		Examples: modelStatusCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *modelStatusCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *modelStatusCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("missing model uuid")
+	}
+	c.modelUUID, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("unknown arguments")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *modelStatusCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	modelTag := names.NewModelTag(c.modelUUID)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	status, err := client.FullModelStatus(&apiparams.FullModelStatusRequest{
+		ModelTag: modelTag.String(),
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, status)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/modelstatus_test.go
+++ b/cmd/jaas/cmd/modelstatus_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+var (
+	expectedModelStatusOutput = `model:
+  name: model-2
+  type: iaas
+  cloudtag: cloud-` + jimmtest.TestCloudName + `
+  cloudregion: ` + jimmtest.TestCloudRegionName + `
+  version: .*
+  availableversion: ""
+  modelstatus:
+    status: available
+    info: ""
+    data: {}
+    since: .*
+    kind: ""
+    version: ""
+    life: ""
+    err: null
+  meterstatus:
+    color: ""
+    message: ""
+  sla: unsupported
+machines: {}
+applications: {}
+remoteapplications: {}
+offers: {}
+relations: \[\]
+controllertimestamp: .*
+branches: {}
+storage: \[\]
+filesystems: \[\]
+volumes: \[\]
+`
+)
+
+type modelStatusSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&modelStatusSuite{})
+
+func (s *modelStatusSuite) TestModelStatusSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty", Attributes: map[string]string{"key": "value"}})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(c, cmd.NewModelStatusCommandForTesting(s.ClientStore(), bClient), mt.Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, expectedModelStatusOutput)
+}
+
+func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty", Attributes: map[string]string{"key": "value"}})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewModelStatusCommandForTesting(s.ClientStore(), bClient), mt.Id())
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/purge_logs.go
+++ b/cmd/jaas/cmd/purge_logs.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	purgeLogsDoc = `
+The purge-audit-logs purges logs from the database before the given date.
+
+The provided date must be formatted as an ISO8601 date string.
+`
+	purgeLogsExample = `
+    jimmctl purge-audit-logs 2021-02-03
+    jimmctl purge-audit-logs 2021-02-03T00
+    jimmctl purge-audit-logs 2021-02-03T15:04:05Z	
+`
+)
+
+// NewPurgeLogsCommand returns a command to purge logs.
+func NewPurgeLogsCommand() cmd.Command {
+	cmd := &purgeLogsCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	return modelcmd.WrapBase(cmd)
+}
+
+// purgeLogsCommand purges logs.
+type purgeLogsCommand struct {
+	modelcmd.ControllerCommandBase
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	out      cmd.Output
+
+	date time.Time
+}
+
+// Info implements Command.Info. It returns the command information.
+func (c *purgeLogsCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "purge-audit-logs",
+		Args:     "<date>",
+		Purpose:  "purge audit logs from the database before the given date",
+		Doc:      purgeLogsDoc,
+		Examples: purgeLogsExample,
+	})
+}
+
+// Init implements Command.Init. It checks the number of arguments and validates
+// the date.
+func (c *purgeLogsCommand) Init(args []string) error {
+	if len(args) != 1 {
+		return errors.E("expected one argument (ISO8601 date)")
+	}
+	// validate date
+	var err error
+	c.date, err = parseDate(args[0])
+	if err != nil {
+		return errors.E("invalid date. Expected ISO8601 date")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *purgeLogsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Run implements Command.Run. It purges logs from the database before the given
+// date.
+func (c *purgeLogsCommand) Run(ctx *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	response, err := client.PurgeLogs(&apiparams.PurgeLogsRequest{
+		Date: c.date,
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+	err = c.out.Write(ctx, response)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+// parseDate validates the date string is in ISO8601 format. If it is, it
+// sets the date field in the command.
+func parseDate(date string) (time.Time, error) {
+	// Define the possible ISO8601 date layouts
+	layouts := []string{
+		"2006-01-02T15:04:05-0700",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04Z",
+		"2006-01-02",
+	}
+
+	// Try to parse the date string using the defined layouts
+	for _, layout := range layouts {
+		date_time, err := time.Parse(layout, date)
+		if err == nil {
+			// If parsing was successful, the date is valid
+			// You can use the parsed time t if needed
+			return date_time, nil
+		}
+	}
+
+	// If none of the layouts match, the date is not in the correct format
+	return time.Time{}, errors.E("invalid date. Expected ISO8601 date")
+}

--- a/cmd/jaas/cmd/purge_logs_test.go
+++ b/cmd/jaas/cmd/purge_logs_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Canonical.
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type purgeLogsSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&purgeLogsSuite{})
+
+func (s *purgeLogsSuite) TestPurgeLogsSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	datastring := "2021-01-01T00:00:00Z"
+	cmdCtx, err := cmdtesting.RunCommand(c, cmd.NewPurgeLogsCommandForTesting(s.ClientStore(), bClient), datastring)
+	c.Assert(err, gc.IsNil)
+	expected := "deleted-count: 0\n"
+	actual := cmdCtx.Stdout.(*bytes.Buffer).String()
+	c.Assert(actual, gc.Equals, expected)
+}
+
+func (s *purgeLogsSuite) TestInvalidISO8601Date(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	datastring := "13/01/2021"
+	_, err := cmdtesting.RunCommand(c, cmd.NewPurgeLogsCommandForTesting(s.ClientStore(), bClient), datastring)
+	c.Assert(err, gc.ErrorMatches, `invalid date. Expected ISO8601 date`)
+
+}
+
+func (s *purgeLogsSuite) TestPurgeLogs(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewPurgeLogsCommandForTesting(s.ClientStore(), bClient), "2021-01-01T00:00:00Z")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *purgeLogsSuite) TestPurgeLogsFromDb(c *gc.C) {
+	// create logs
+	layouts := []string{
+		"2006-01-02T15:04:05-0700",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04Z",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+
+		ctx := context.Background()
+		relativeNow := time.Now().AddDate(-1, 0, 0)
+		ale := dbmodel.AuditLogEntry{
+			Time:        relativeNow.UTC().Round(time.Millisecond),
+			IdentityTag: names.NewUserTag("alice@canonical.com").String(),
+		}
+		ale_past := dbmodel.AuditLogEntry{
+			Time:        relativeNow.AddDate(0, 0, -1).UTC().Round(time.Millisecond),
+			IdentityTag: names.NewUserTag("alice@canonical.com").String(),
+		}
+		ale_future := dbmodel.AuditLogEntry{
+			Time:        relativeNow.AddDate(0, 0, 5).UTC().Round(time.Millisecond),
+			IdentityTag: names.NewUserTag("alice@canonical.com").String(),
+		}
+
+		err := s.JIMM.Database.Migrate(context.Background())
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.Database.AddAuditLogEntry(ctx, &ale)
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.Database.AddAuditLogEntry(ctx, &ale_past)
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.Database.AddAuditLogEntry(ctx, &ale_future)
+		c.Assert(err, gc.IsNil)
+
+		tomorrow := relativeNow.AddDate(0, 0, 1).Format(layout)
+		// alice is superuser
+		bClient := s.SetupCLIAccess(c, "alice")
+		cmdCtx, err := cmdtesting.RunCommand(c, cmd.NewPurgeLogsCommandForTesting(s.ClientStore(), bClient), tomorrow)
+		c.Assert(err, gc.IsNil)
+		// check that logs have been deleted
+		expectedOutput := "deleted-count: 2\n"
+		actual := cmdCtx.Stdout.(*bytes.Buffer).String()
+		c.Assert(actual, gc.Equals, expectedOutput)
+	}
+}

--- a/cmd/jaas/cmd/relation.go
+++ b/cmd/jaas/cmd/relation.go
@@ -1,0 +1,612 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gosuri/uitable"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	// accessMessageFormat is an informative message sent back to the user denoting the access for a particular resource.
+	// The final format string holds either an AccessResultAllowed or AccessResultDenied.
+	accessMessageFormat = "access check for %s on resource %s with role %s is %s"
+	accessResultAllowed = "allowed"
+	accessResultDenied  = "not allowed"
+	defaultPageSize     = 50
+)
+
+const (
+	relationDoc = `
+relation command enables relation management for jimm
+`
+	genericConstraintsDoc = `
+The object and target object must be of the form <tag>-<objectname> or <tag>-<object-uuid>
+E.g. "user-Alice" or "controller-MyController"
+
+-f    Read from a file where filename is the location of a JSON encoded file of the form:
+    [
+        {
+            "object":"user-mike",
+            "relation":"member",
+            "target_object":"group-yellow"
+        },
+        {
+            "object":"user-alice",
+            "relation":"member",
+            "target_object":"group-yellow"
+        }
+    ]
+
+Certain constraints apply when creating/removing a relation, namely:
+Object may be one of:
+
+	user tag                = "user-<name>"
+	group tag               = "group-<name>"
+	controller tag          = "controller-<name>"
+	model tag               = "model-<name>"
+	application offer tag   = "offer-<name>"
+
+If target_object is a group, the relation can only be:
+
+	member
+
+If target_object is a controller, the relation can be one of:
+
+	loginer
+	administrator
+
+If target_object is a model, the relation can be one of:
+
+	reader
+	writer
+	administrator
+
+If target_object is an application offer, the relation can be one of:
+
+	reader
+	consumer
+	administrator
+
+
+Additionally, if the object is a group, a userset can be applied by adding #member as follows.
+This will grant/revoke the relation to all users within TeamA:
+
+	group-TeamA#member administrator controller-MyController
+`
+
+	addRelationDoc = `
+The add command adds relation to jimm.
+` + genericConstraintsDoc
+
+	addRelationExample = `
+    jimmctl auth relation add user-alice@canonical.com member group-mygroup
+    jimmctl auth relation add group-MyTeam#member admin model-mymodel
+	jimmctl auth relation add -f /path/to/file.yaml
+`
+
+	removeRelationDoc = `
+The remove command removes a relation from jimm.
+` + genericConstraintsDoc
+
+	removeRelationExample = `
+    jimmctl auth relation remove user-alice@canonical.com member group-mygroup
+    jimmctl auth relation remove group-MyTeam#member admin model-mymodel
+	jimmctl auth relation remove -f /path/to/file.yaml
+`
+
+	checkRelationDoc = `
+Verifies the access between resources.
+`
+	checkRelationExample = `
+    jimmctl auth relation check user-alice@canonical.com administrator controller-aws-controller-1
+`
+
+	listRelationsDoc = `
+List relations known to jimm. Using the "target", "relation" and "object" flags, 
+only those relations matching the filter will be returned.
+`
+
+	listRelationsExample = `
+List all relations
+
+    jimmctl auth relation list
+	
+List relations where the target object match
+
+    jimmctl auth relation list --target model-mymodel
+
+List relations where the target object and relation match
+
+	jimmctl auth relation list --target model-mymodel  --relation admin
+`
+)
+
+// NewRelationCommand returns a command for relation management.
+func NewRelationCommand() *cmd.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name:        "relation",
+		UsagePrefix: "auth",
+		Doc:         relationDoc,
+		Purpose:     "Relation management.",
+	})
+	cmd.Register(newAddRelationCommand())
+	cmd.Register(newRemoveRelationCommand())
+	cmd.Register(newCheckRelationCommand())
+	cmd.Register(newListRelationsCommand())
+
+	return cmd
+}
+
+// newAddRelationCommand returns a command to add a relation.
+func newAddRelationCommand() cmd.Command {
+	cmd := &addRelationCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addRelationCommand adds a relation.
+type addRelationCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	object       string
+	relation     string
+	targetObject string
+
+	filename string // optional
+}
+
+// Info implements the cmd.Command interface.
+func (c *addRelationCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "add",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Add relation to jimm.",
+		Doc:      addRelationDoc,
+		Examples: addRelationExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *addRelationCommand) Init(args []string) error {
+	if c.filename != "" {
+		return nil
+	}
+	err := verifyTupleArguments(args)
+	if err != nil {
+		return errors.E(err)
+	}
+	c.object, c.relation, c.targetObject = args[0], args[1], args[2]
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *addRelationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.StringVar(&c.filename, "f", "", "file location of JSON encoded tuples")
+}
+
+// Run implements Command.Run.
+func (c *addRelationCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	var params apiparams.AddRelationRequest
+	if c.filename == "" {
+		params.Tuples = append(params.Tuples, apiparams.RelationshipTuple{
+			Object:       c.object,
+			Relation:     c.relation,
+			TargetObject: c.targetObject,
+		})
+	} else {
+		params.Tuples, err = readTupleFile(c.filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.AddRelation(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// newRemoveRelationCommand returns a command to remove a relation.
+func newRemoveRelationCommand() cmd.Command {
+	cmd := &removeRelationCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// removeRelationCommand removes a relation.
+type removeRelationCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	object       string
+	relation     string
+	targetObject string
+
+	filename string // optional
+}
+
+// Info implements the cmd.Command interface.
+func (c *removeRelationCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "remove",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Remove relation from jimm.",
+		Doc:      removeRelationDoc,
+		Examples: removeRelationExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *removeRelationCommand) Init(args []string) error {
+	if c.filename != "" {
+		return nil
+	}
+	err := verifyTupleArguments(args)
+	if err != nil {
+		return errors.E(err)
+	}
+	c.object, c.relation, c.targetObject = args[0], args[1], args[2]
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *removeRelationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.StringVar(&c.filename, "f", "", "file location of JSON encoded tuples")
+}
+
+// Run implements Command.Run.
+func (c *removeRelationCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	var params apiparams.RemoveRelationRequest
+	if c.filename == "" {
+		params.Tuples = append(params.Tuples, apiparams.RelationshipTuple{
+			Object:       c.object,
+			Relation:     c.relation,
+			TargetObject: c.targetObject,
+		})
+	} else {
+		params.Tuples, err = readTupleFile(c.filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RemoveRelation(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// checkRelationCommand holds the fields required to check a relation.
+type checkRelationCommand struct {
+	modelcmd.ControllerCommandBase
+	out      cmd.Output
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	tuple apiparams.RelationshipTuple
+}
+
+// accessResult holds the accessCheck result to be passed to a formatter
+type accessResult struct {
+	Msg     string                      `yaml:"result" json:"result"`
+	Tuple   apiparams.RelationshipTuple `yaml:"tuple" json:"tuple"`
+	Allowed bool                        `yaml:"allowed" json:"allowed"`
+}
+
+func (ar *accessResult) setMessage() *accessResult {
+	t := ar.Tuple
+
+	accessMsg := accessResultDenied
+	if ar.Allowed {
+		accessMsg = accessResultAllowed
+	}
+	ar.Msg = fmt.Sprintf(accessMessageFormat, t.Object, t.TargetObject, t.Relation, accessMsg)
+	return ar
+}
+
+// newCheckRelationCommand
+func newCheckRelationCommand() cmd.Command {
+	cmd := &checkRelationCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// Info implements the cmd.Command interface.
+func (c *checkRelationCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "check",
+		Args:     "<object> <relation> <target_object>",
+		Purpose:  "Check access to a resource.",
+		Doc:      checkRelationDoc,
+		Examples: checkRelationExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *checkRelationCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "smart", map[string]cmd.Formatter{
+		"smart": formatCheckRelationString,
+		"json":  cmd.FormatJson,
+		"yaml":  cmd.FormatYaml,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *checkRelationCommand) Init(args []string) error {
+	err := verifyTupleArguments(args)
+	if err != nil {
+		return errors.E(err)
+	}
+	c.tuple = apiparams.RelationshipTuple{
+		Object:       args[0],
+		Relation:     args[1],
+		TargetObject: args[2],
+	}
+	return nil
+}
+
+func formatCheckRelationString(writer io.Writer, value interface{}) error {
+	accessResult, ok := value.(accessResult)
+	if !ok {
+		return errors.E("failed to parse access result")
+	}
+	_, err := writer.Write([]byte((&accessResult).setMessage().Msg))
+	if err != nil {
+		return errors.E("failed to write access result", err)
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *checkRelationCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+	client := api.NewClient(apiCaller)
+
+	resp, err := client.CheckRelation(&apiparams.CheckRelationRequest{
+		Tuple: c.tuple,
+	})
+	if err != nil {
+		return err
+	}
+	err = c.out.Write(ctxt, *(&accessResult{
+		Tuple:   c.tuple,
+		Allowed: resp.Allowed,
+	}).setMessage())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// readTupleFile reads a file with filename as provided by the user and attempts to
+// unmarshal the JSON into a list of relationship tuples.
+func readTupleFile(filename string) ([]apiparams.RelationshipTuple, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []apiparams.RelationshipTuple
+	err = json.Unmarshal(content, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// verifyTupleArguments is used across relation commands to verify the number of arguments.
+func verifyTupleArguments(args []string) error {
+	switch len(args) {
+	default:
+		return errors.E("too many args")
+	case 0:
+		return errors.E("object not specified")
+	case 1:
+		return errors.E("relation not specified")
+	case 2:
+		return errors.E("target object not specified")
+	case 3:
+	}
+	return nil
+}
+
+// newListRelationsCommand returns a command to list relations.
+func newListRelationsCommand() cmd.Command {
+	cmd := &listRelationsCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// listRelationsCommand adds a relation.
+type listRelationsCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	tuple        apiparams.RelationshipTuple
+	resolveUUIDs bool
+}
+
+// Info implements the cmd.Command interface.
+func (c *listRelationsCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "list",
+		Purpose:  "List relations.",
+		Doc:      listRelationsDoc,
+		Examples: listRelationsExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *listRelationsCommand) Init(args []string) error {
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listRelationsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": formatRelationsTabular,
+	})
+	f.StringVar(&c.tuple.Object, "object", "", "relation object")
+	f.StringVar(&c.tuple.Relation, "relation", "", "relation name")
+	f.StringVar(&c.tuple.TargetObject, "target", "", "relation target object")
+	f.BoolVar(&c.resolveUUIDs, "resolve", true, "resolves UUIDs to human readable tags")
+}
+
+// Run implements Command.Run.
+func (c *listRelationsCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	params := apiparams.ListRelationshipTuplesRequest{
+		Tuple:        c.tuple,
+		PageSize:     defaultPageSize,
+		ResolveUUIDs: c.resolveUUIDs,
+	}
+	result, err := fetchRelations(client, params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	// Ensure continutation token is empty so that we don't print it.
+	result.ContinuationToken = ""
+	err = c.out.Write(ctxt, result)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+func fetchRelations(client *api.Client, params apiparams.ListRelationshipTuplesRequest) (*apiparams.ListRelationshipTuplesResponse, error) {
+	tuples := make([]apiparams.RelationshipTuple, 0)
+	for {
+		response, err := client.ListRelationshipTuples(&params)
+		if err != nil {
+			return nil, errors.E(fmt.Sprintf("failed to fetch list of relationship tuples: %s", err.Error()))
+		}
+		tuples = append(tuples, response.Tuples...)
+
+		if response.ContinuationToken == "" {
+			return &apiparams.ListRelationshipTuplesResponse{Tuples: tuples, Errors: response.Errors}, nil
+		}
+		params.ContinuationToken = response.ContinuationToken
+	}
+}
+
+func formatRelationsTabular(writer io.Writer, value interface{}) error {
+	resp, ok := value.(*apiparams.ListRelationshipTuplesResponse)
+	if !ok {
+		return errors.E(fmt.Sprintf("expected value of type %T, got %T", resp, value))
+	}
+
+	table := uitable.New()
+	table.MaxColWidth = 80
+	table.Wrap = true
+
+	table.AddRow("Object", "Relation", "Target Object")
+	for _, tuple := range resp.Tuples {
+		table.AddRow(tuple.Object, tuple.Relation, tuple.TargetObject)
+	}
+	fmt.Fprint(writer, table)
+
+	if len(resp.Errors) != 0 {
+		fmt.Fprintf(writer, "\n\n")
+		fmt.Fprintln(writer, "Errors")
+		for _, msg := range resp.Errors {
+			fmt.Fprintln(writer, msg)
+		}
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/relation_test.go
+++ b/cmd/jaas/cmd/relation_test.go
@@ -1,0 +1,663 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/google/uuid"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+	yamlv2 "gopkg.in/yaml.v2"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
+)
+
+type relationSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&relationSuite{})
+
+func (s *relationSuite) TestAddRelationSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	group1 := "testGroup1"
+	group2 := "testGroup2"
+	type tuple struct {
+		user     string
+		relation string
+		target   string
+	}
+	tests := []struct {
+		testName string
+		input    tuple
+		err      bool
+		message  string
+	}{
+		{
+			testName: "Add Group",
+			input: tuple{
+				user:     "group-" + group1 + "#member",
+				relation: "member",
+				target:   "group-" + group2,
+			},
+			err: false,
+		},
+		{
+			testName: "Add admin relation to controller-jimm",
+			input: tuple{
+				user:     "group-" + group1 + "#member",
+				relation: "administrator",
+				target:   "controller-jimm",
+			},
+			err: false,
+		},
+		{
+			testName: "Invalid Relation",
+			input: tuple{
+				user:     "group-" + group1 + "#member",
+				relation: "admin",
+				target:   "group-" + group2,
+			},
+			err:     true,
+			message: "unknown relation",
+		},
+	}
+
+	_, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.Background(), group1)
+	c.Assert(err, gc.IsNil)
+	_, err = s.JimmCmdSuite.JIMM.Database.AddGroup(context.Background(), group2)
+	c.Assert(err, gc.IsNil)
+
+	for i, tc := range tests {
+		_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), tc.input.user, tc.input.relation, tc.input.target)
+		c.Log("Test: " + tc.testName)
+		if tc.err {
+			c.Logf("error message: %s", err.Error())
+			c.Assert(strings.Contains(err.Error(), tc.message), gc.Equals, true)
+		} else {
+			c.Assert(err, gc.IsNil)
+			tuples, ct, err := s.JimmCmdSuite.JIMM.OpenFGAClient.ReadRelatedObjects(context.Background(), openfga.Tuple{}, 50, "")
+			c.Assert(err, gc.IsNil)
+			c.Assert(ct, gc.Equals, "")
+			// NOTE: this is a bad test because it relies on the number of related objects. So all the
+			// non-failing test cases must be executed before any of the failing tests - failing tests
+			// do not add any tuples therefore the following assertion fails.
+			c.Assert(len(tuples), gc.Equals, i+3)
+		}
+	}
+
+}
+
+func (s *relationSuite) TestMissingParamsAddRelationSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "foo", "bar")
+	c.Assert(err, gc.ErrorMatches, "target object not specified")
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "foo")
+	c.Assert(err, gc.ErrorMatches, "relation not specified")
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.ErrorMatches, "object not specified")
+
+}
+
+func (s *relationSuite) TestAddRelationViaFileSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	group1 := "testGroup1"
+	group2 := "testGroup2"
+	group3 := "testGroup3"
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group1)
+	c.Assert(err, gc.IsNil)
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group2)
+	c.Assert(err, gc.IsNil)
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group3)
+	c.Assert(err, gc.IsNil)
+
+	file, err := os.CreateTemp(".", "relations.json")
+	c.Assert(err, gc.IsNil)
+	defer os.Remove(file.Name())
+	testRelations := `[{"object":"user-alice","relation":"member","target_object":"group-` + group3 + `"},{"object":"group-` + group2 + `#member","relation":"member","target_object":"group-` + group3 + `"}]`
+	_, err = file.Write([]byte(testRelations))
+	c.Assert(err, gc.IsNil)
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "-f", file.Name())
+	c.Assert(err, gc.IsNil)
+
+	tuples, ct, err := s.JimmCmdSuite.JIMM.OpenFGAClient.ReadRelatedObjects(context.Background(), openfga.Tuple{}, 50, "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(ct, gc.Equals, "")
+	c.Assert(len(tuples), gc.Equals, 4)
+}
+
+func (s *relationSuite) TestAddRelationRejectsUnauthorisedUsers(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "test-group1", "member", "test-group2")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *relationSuite) TestRemoveRelationSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	group1 := "testGroup1"
+	group2 := "testGroup2"
+	type tuple struct {
+		user     string
+		relation string
+		target   string
+	}
+	tests := []struct {
+		testName string
+		input    tuple
+		err      bool
+		message  string
+	}{
+		{testName: "Remove Group Relation", input: tuple{user: "group-" + group1 + "#member", relation: "member", target: "group-" + group2}, err: false},
+	}
+
+	// Create groups and relation
+	_, err := s.JimmCmdSuite.JIMM.Database.AddGroup(context.Background(), group1)
+	c.Assert(err, gc.IsNil)
+	_, err = s.JimmCmdSuite.JIMM.Database.AddGroup(context.Background(), group2)
+	c.Assert(err, gc.IsNil)
+	totalKeys := 2
+	for _, tc := range tests {
+		_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), tc.input.user, tc.input.relation, tc.input.target)
+		c.Assert(err, gc.IsNil)
+		totalKeys++
+	}
+
+	for _, tc := range tests {
+		_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRelationCommandForTesting(s.ClientStore(), bClient), tc.input.user, tc.input.relation, tc.input.target)
+		c.Log("Test: " + tc.testName)
+		if tc.err {
+			c.Assert(err, gc.ErrorMatches, tc.message)
+		} else {
+			c.Assert(err, gc.IsNil)
+			tuples, ct, err := s.JimmCmdSuite.JIMM.OpenFGAClient.ReadRelatedObjects(context.Background(), openfga.Tuple{}, 50, "")
+			c.Assert(err, gc.IsNil)
+			c.Assert(ct, gc.Equals, "")
+			totalKeys--
+			c.Assert(len(tuples), gc.Equals, totalKeys)
+		}
+	}
+}
+
+func (s *relationSuite) TestRemoveRelationViaFileSuperuser(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice")
+	group1 := "testGroup1"
+	group2 := "testGroup2"
+	group3 := "testGroup3"
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group1)
+	c.Assert(err, gc.IsNil)
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group2)
+	c.Assert(err, gc.IsNil)
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), group3)
+	c.Assert(err, gc.IsNil)
+
+	file, err := os.CreateTemp(".", "relations.json")
+	c.Assert(err, gc.IsNil)
+	defer os.Remove(file.Name())
+	testRelations := `[{"object":"group-` + group1 + `#member","relation":"member","target_object":"group-` + group3 + `"},{"object":"group-` + group2 + `#member","relation":"member","target_object":"group-` + group3 + `"}]`
+	_, err = file.Write([]byte(testRelations))
+	c.Assert(err, gc.IsNil)
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "-f", file.Name())
+	c.Assert(err, gc.IsNil)
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewRemoveRelationCommandForTesting(s.ClientStore(), bClient), "-f", file.Name())
+	c.Assert(err, gc.IsNil)
+
+	tuples, ct, err := s.JimmCmdSuite.JIMM.OpenFGAClient.ReadRelatedObjects(context.Background(), openfga.Tuple{}, 50, "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(ct, gc.Equals, "")
+	c.Logf("existing relations %v", tuples)
+	// Only two relations exist.
+	sort.Slice(tuples, func(i, j int) bool {
+		return tuples[i].Object.ID < tuples[j].Object.ID
+	})
+	c.Assert(tuples, gc.DeepEquals, []openfga.Tuple{{
+		Object:   ofganames.ConvertTag(names.NewUserTag("admin")),
+		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(names.NewControllerTag(s.Params.ControllerUUID)),
+	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
+		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(names.NewControllerTag(s.Params.ControllerUUID)),
+	}})
+}
+
+func (s *relationSuite) TestRemoveRelation(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRelationCommandForTesting(s.ClientStore(), bClient), "group-testGroup1#member", "member", "group-testGroup2")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+type environment struct {
+	users             []dbmodel.Identity
+	clouds            []dbmodel.Cloud
+	credentials       []dbmodel.CloudCredential
+	controllers       []dbmodel.Controller
+	models            []dbmodel.Model
+	applicationOffers []dbmodel.ApplicationOffer
+}
+
+func initializeEnvironment(c *gc.C, ctx context.Context, db *db.Database, u dbmodel.Identity) *environment {
+	env := environment{}
+
+	u1, err := dbmodel.NewIdentity("eve@canonical.com")
+	c.Assert(err, gc.IsNil)
+	c.Assert(db.DB.Create(u1).Error, gc.IsNil)
+
+	env.users = []dbmodel.Identity{u, *u1}
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+		Type: "test-provider",
+		Regions: []dbmodel.CloudRegion{{
+			Name: "test-region-1",
+		}},
+	}
+	c.Assert(db.DB.Create(&cloud).Error, gc.IsNil)
+	env.clouds = []dbmodel.Cloud{cloud}
+
+	controller := dbmodel.Controller{
+		Name:          "test-controller-1",
+		UUID:          "1fffa2ed-8fd9-49f4-94c0-149288891dd6",
+		PublicAddress: "test-public-address",
+		CACertificate: "test-ca-cert",
+		CloudName:     cloud.Name,
+		CloudRegion:   cloud.Regions[0].Name,
+		CloudRegions: []dbmodel.CloudRegionControllerPriority{{
+			Priority:      0,
+			CloudRegionID: cloud.Regions[0].ID,
+		}},
+	}
+	err = db.AddController(ctx, &controller)
+	c.Assert(err, gc.Equals, nil)
+	env.controllers = []dbmodel.Controller{controller}
+
+	cred := dbmodel.CloudCredential{
+		Name:              "test-credential-1",
+		CloudName:         cloud.Name,
+		OwnerIdentityName: u.Name,
+		AuthType:          "empty",
+	}
+	err = db.SetCloudCredential(ctx, &cred)
+	c.Assert(err, gc.Equals, nil)
+	env.credentials = []dbmodel.CloudCredential{cred}
+
+	model := dbmodel.Model{
+		Name: "test-model-1",
+		UUID: sql.NullString{
+			String: "acdbf3e5-67e1-42a2-a2dc-64505265c030",
+			Valid:  true,
+		},
+		OwnerIdentityName: u.Name,
+		ControllerID:      controller.ID,
+		CloudRegionID:     cloud.Regions[0].ID,
+		CloudCredentialID: cred.ID,
+	}
+	err = db.AddModel(ctx, &model)
+	c.Assert(err, gc.IsNil)
+	env.models = []dbmodel.Model{model}
+
+	offer := dbmodel.ApplicationOffer{
+		ID:      1,
+		UUID:    "436b2264-d8f8-4e24-b16f-dd43c4116528",
+		URL:     env.controllers[0].Name + ":" + env.models[0].OwnerIdentityName + "/" + env.models[0].Name + ".testoffer1",
+		Name:    "testoffer1",
+		ModelID: model.ID,
+		Model:   model,
+	}
+	err = db.AddApplicationOffer(ctx, &offer)
+	c.Assert(err, gc.IsNil)
+	env.applicationOffers = []dbmodel.ApplicationOffer{offer}
+
+	return &env
+}
+
+func (s *relationSuite) TestListRelations(c *gc.C) {
+	env := initializeEnvironment(c, context.Background(), s.JIMM.Database, *s.AdminUser)
+	bClient := s.SetupCLIAccess(c, "alice") // alice is superuser
+
+	relations := []apiparams.RelationshipTuple{{
+		Object:       "user-" + env.users[0].Name,
+		Relation:     "member",
+		TargetObject: "group-group-1",
+	}, {
+		Object:       "group-group-2#member",
+		Relation:     "member",
+		TargetObject: "group-group-3",
+	}, {
+		Object:       "group-group-3#member",
+		Relation:     "administrator",
+		TargetObject: "controller-" + env.controllers[0].Name,
+	}, {
+		Object:       "group-group-1#member",
+		Relation:     "administrator",
+		TargetObject: "model-" + env.models[0].OwnerIdentityName + "/" + env.models[0].Name,
+	}, {
+		Object:       "user-" + env.users[1].Name,
+		Relation:     "administrator",
+		TargetObject: "applicationoffer-" + env.applicationOffers[0].URL,
+	}, {
+		Object:       "user-" + env.users[0].Name,
+		Relation:     "administrator",
+		TargetObject: "serviceaccount-test@serviceaccount",
+	}}
+
+	for i := 0; i < cmd.DefaultPageSize+1; i++ {
+		groupName := fmt.Sprintf("group-%d", i)
+		_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), groupName)
+		c.Assert(err, gc.IsNil)
+
+		relations = append(relations, apiparams.RelationshipTuple{
+			Object:       "user-" + env.users[1].Name,
+			Relation:     "member",
+			TargetObject: "group-" + groupName,
+		})
+	}
+
+	for _, relation := range relations {
+		_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), relation.Object, relation.Relation, relation.TargetObject)
+		c.Assert(err, gc.IsNil)
+	}
+
+	expectedData := apiparams.ListRelationshipTuplesResponse{Tuples: append(
+		[]apiparams.RelationshipTuple{{
+			Object:       "user-admin",
+			Relation:     "administrator",
+			TargetObject: "controller-jimm",
+		}, {
+			Object:       "user-alice@canonical.com",
+			Relation:     "administrator",
+			TargetObject: "controller-jimm",
+		}},
+		relations...,
+	)}
+
+	context, err := cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient), "--format", "tabular")
+	c.Assert(err, gc.IsNil)
+	var builder strings.Builder
+	err = cmd.FormatRelationsTabular(&builder, &expectedData)
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, builder.String())
+
+	expectedJSONData, err := json.Marshal(expectedData)
+	c.Assert(err, gc.IsNil)
+	context, err = cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient), "--format", "json")
+	c.Assert(err, gc.IsNil)
+	c.Assert(strings.TrimRight(cmdtesting.Stdout(context), "\n"), gc.Equals, string(expectedJSONData))
+
+	// Necessary to use yamlv2 to match what Juju does.
+	expectedYAMLData, err := yamlv2.Marshal(expectedData)
+	c.Assert(err, gc.IsNil)
+	context, err = cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, string(expectedYAMLData))
+}
+
+func (s *relationSuite) TestListRelationsWithError(c *gc.C) {
+	env := initializeEnvironment(c, context.Background(), s.JIMM.Database, *s.AdminUser)
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), "group-1")
+	c.Assert(err, gc.IsNil)
+
+	relation := apiparams.RelationshipTuple{
+		Object:       "user-" + env.users[0].Name,
+		Relation:     "member",
+		TargetObject: "group-group-1",
+	}
+	_, err = cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), relation.Object, relation.Relation, relation.TargetObject)
+	c.Assert(err, gc.IsNil)
+
+	ctx := context.Background()
+	group := &dbmodel.GroupEntry{Name: "group-1"}
+	err = s.JIMM.Database.GetGroup(ctx, group)
+	c.Assert(err, gc.IsNil)
+	err = s.JIMM.Database.RemoveGroup(ctx, group)
+	c.Assert(err, gc.IsNil)
+
+	expectedData := apiparams.ListRelationshipTuplesResponse{
+		Tuples: []apiparams.RelationshipTuple{{
+			Object:       "user-admin",
+			Relation:     "administrator",
+			TargetObject: "controller-jimm",
+		}, {
+			Object:       "user-alice@canonical.com",
+			Relation:     "administrator",
+			TargetObject: "controller-jimm",
+		}, {
+			Object:       "user-" + env.users[0].Name,
+			Relation:     "member",
+			TargetObject: "group:" + group.UUID,
+		}},
+		Errors: []string{
+			"failed to parse target: failed to fetch group information: " + group.UUID,
+		},
+	}
+	expectedJSONData, err := json.Marshal(expectedData)
+	c.Assert(err, gc.IsNil)
+	// Necessary to use yamlv2 to match what Juju does.
+	expectedYAMLData, err := yamlv2.Marshal(expectedData)
+	c.Assert(err, gc.IsNil)
+
+	context, err := cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient), "--format", "json")
+	c.Assert(err, gc.IsNil)
+	c.Assert(strings.TrimRight(cmdtesting.Stdout(context), "\n"), gc.Equals, string(expectedJSONData))
+
+	context, err = cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, string(expectedYAMLData))
+
+	context, err = cmdtesting.RunCommand(c, cmd.NewListRelationsCommandForTesting(s.ClientStore(), bClient), "--format", "tabular")
+	c.Assert(err, gc.IsNil)
+	var builder strings.Builder
+	err = cmd.FormatRelationsTabular(&builder, &expectedData)
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Equals, builder.String())
+}
+
+// TODO: remove boilerplate of env setup and use initialiseEnvironment
+func (s *relationSuite) TestCheckRelationViaSuperuser(c *gc.C) {
+	ctx := context.TODO()
+	bClient := s.SetupCLIAccess(c, "alice")
+	ofgaClient := s.JIMM.OpenFGAClient
+
+	// Add some resources to check against
+	db := s.JIMM.Database
+	_, err := db.AddGroup(ctx, "test-group")
+	c.Assert(err, gc.IsNil)
+	group := dbmodel.GroupEntry{Name: "test-group"}
+	err = db.GetGroup(ctx, &group)
+	c.Assert(err, gc.IsNil)
+
+	u, err := dbmodel.NewIdentity(petname.Generate(2, "-") + "@canonical.com")
+	c.Assert(err, gc.IsNil)
+	c.Assert(db.DB.Create(u).Error, gc.IsNil)
+
+	cloud := dbmodel.Cloud{
+		Name: petname.Generate(2, "-"),
+		Type: "aws",
+		Regions: []dbmodel.CloudRegion{{
+			Name: petname.Generate(2, "-"),
+		}},
+	}
+	c.Assert(db.DB.Create(&cloud).Error, gc.IsNil)
+	id, _ := uuid.NewRandom()
+	controller := dbmodel.Controller{
+		Name:        petname.Generate(2, "-"),
+		UUID:        id.String(),
+		CloudName:   cloud.Name,
+		CloudRegion: cloud.Regions[0].Name,
+		CloudRegions: []dbmodel.CloudRegionControllerPriority{{
+			Priority:      0,
+			CloudRegionID: cloud.Regions[0].ID,
+		}},
+	}
+	err = db.AddController(ctx, &controller)
+	c.Assert(err, gc.IsNil)
+
+	cred := dbmodel.CloudCredential{
+		Name:              petname.Generate(2, "-"),
+		CloudName:         cloud.Name,
+		OwnerIdentityName: u.Name,
+		AuthType:          "empty",
+	}
+	err = db.SetCloudCredential(ctx, &cred)
+	c.Assert(err, gc.IsNil)
+
+	model := dbmodel.Model{
+		Name: petname.Generate(2, "-"),
+		UUID: sql.NullString{
+			String: id.String(),
+			Valid:  true,
+		},
+		OwnerIdentityName: u.Name,
+		ControllerID:      controller.ID,
+		CloudRegionID:     cloud.Regions[0].ID,
+		CloudCredentialID: cred.ID,
+		Life:              "alive",
+	}
+
+	err = db.AddModel(ctx, &model)
+	c.Assert(err, gc.IsNil)
+
+	err = ofgaClient.AddRelation(ctx,
+		openfga.Tuple{
+			Object:   ofganames.ConvertTag(u.ResourceTag()),
+			Relation: "member",
+			Target:   ofganames.ConvertTag(group.Tag().(jimmnames.GroupTag)),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(group.Tag().(jimmnames.GroupTag), ofganames.MemberRelation),
+			Relation: "reader",
+			Target:   ofganames.ConvertTag(model.ResourceTag()),
+		},
+	)
+	c.Assert(err, gc.IsNil)
+
+	// Test reader is OK
+	userToCheck := "user-" + u.Name
+	modelToCheck := "model-" + u.Name + "/" + model.Name
+	cmdCtx, err := cmdtesting.RunCommand(
+		c,
+		cmd.NewCheckRelationCommandForTesting(s.ClientStore(), bClient),
+		userToCheck,
+		"reader",
+		modelToCheck,
+	)
+
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(
+		strings.TrimRight(cmdtesting.Stdout(cmdCtx), "\n"),
+		gc.Equals,
+		fmt.Sprintf(cmd.AccessMessage, userToCheck, modelToCheck, "reader", cmd.AccessResultAllowed),
+	)
+
+	// Test writer is NOT OK
+	cmdCtx, err = cmdtesting.RunCommand(
+		c,
+		cmd.NewCheckRelationCommandForTesting(s.ClientStore(), bClient),
+		userToCheck,
+		"writer",
+		modelToCheck,
+	)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(
+		strings.TrimRight(cmdtesting.Stdout(cmdCtx), "\n"),
+		gc.Equals,
+		fmt.Sprintf(cmd.AccessMessage, userToCheck, modelToCheck, "writer", cmd.AccessResultDenied),
+	)
+
+	// Test format JSON
+	cmdCtx, err = cmdtesting.RunCommand(
+		c,
+		cmd.NewCheckRelationCommandForTesting(s.ClientStore(), bClient),
+		userToCheck,
+		"reader",
+		modelToCheck,
+		"--format",
+		"json",
+	)
+	c.Assert(err, gc.IsNil)
+
+	res := cmdtesting.Stdout(cmdCtx)
+	ar := cmd.AccessResult{}
+	err = json.Unmarshal([]byte(res), &ar)
+	c.Assert(err, gc.IsNil)
+	b, err := json.Marshal(ar)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(
+		strings.TrimRight(cmdtesting.Stdout(cmdCtx), "\n"),
+		gc.Equals,
+		string(b),
+	)
+
+	// Test format YAML
+	cmdCtx, err = cmdtesting.RunCommand(
+		c,
+		cmd.NewCheckRelationCommandForTesting(s.ClientStore(), bClient),
+		userToCheck,
+		"reader",
+		modelToCheck,
+		"--format",
+		"yaml",
+	)
+	c.Assert(err, gc.IsNil)
+
+	// Create identical test output as we expect the CLI to return
+	// via marshalling and umarshalling.
+	res = cmdtesting.Stdout(cmdCtx)
+	ar = cmd.AccessResult{}
+	err = yamlv2.Unmarshal([]byte(res), &ar)
+	c.Assert(err, gc.IsNil)
+	b, err = yamlv2.Marshal(ar)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(
+		cmdtesting.Stdout(cmdCtx),
+		gc.Equals,
+		string(b),
+	)
+
+}
+
+func (s *relationSuite) TestCheckRelation(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(
+		c,
+		cmd.NewCheckRelationCommandForTesting(s.ClientStore(), bClient),
+		"user-diglett",
+		"reader",
+		"controller-jimm",
+	)
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/removecloudfromcontroller.go
+++ b/cmd/jaas/cmd/removecloudfromcontroller.go
@@ -1,0 +1,145 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	removeCloudFromControllerCommandDoc = `
+The remove-cloud-from-controller command removes the specified cloud from the 
+specified controller in jimm.
+`
+
+	removeCloudFromControllerCommandExample = `
+    jimmctl remove-cloud-from-controller mycontroller mycloud
+`
+)
+
+// NewAddControllerCommand returns a command to add a cloud to a specific
+// controller in JIMM.
+func NewRemoveCloudFromControllerCommand() cmd.Command {
+	cmd := &removeCloudFromControllerCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addControllerCommand adds a controller.
+type removeCloudFromControllerCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	// cloudName is the name of the cloud to remove.
+	cloudName string
+
+	// targetControllerName is the name of the controller in JIMM where the cloud
+	// should be removed from.
+	targetControllerName string
+
+	removeCloudFromControllerAPIFunc func() (removeCloudFromControllerAPI, error)
+	store                            jujuclient.ClientStore
+	dialOpts                         *jujuapi.DialOpts
+}
+
+type removeCloudFromControllerAPI interface {
+	RemoveCloudFromController(params *apiparams.RemoveCloudFromControllerRequest) error
+}
+
+// Info implements Command.Info.
+func (c *removeCloudFromControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "remove-cloud-from-controller",
+		Args:     "<controller_name> <cloud_name>",
+		Purpose:  "Remove cloud from specific controller in jimm",
+		Doc:      removeCloudFromControllerCommandDoc,
+		Examples: removeCloudFromControllerCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *removeCloudFromControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *removeCloudFromControllerCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("missing arguments")
+	}
+	if len(args) > 2 {
+		return errors.E("too many arguments")
+	}
+	c.targetControllerName = args[0]
+	if ok := names.IsValidControllerName(c.targetControllerName); !ok {
+		return errors.E("invalid controller name %q", c.targetControllerName)
+	}
+	c.cloudName = args[1]
+	if ok := names.IsValidCloud(c.cloudName); !ok {
+		return errors.E("invalid cloud name %q", c.cloudName)
+	}
+
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *removeCloudFromControllerCommand) Run(ctxt *cmd.Context) error {
+	err := c.removeCloudFromController(ctxt)
+	if err != nil {
+		return errors.E(err, fmt.Sprintf("error removing cloud from controller: %v", err))
+	}
+
+	return nil
+}
+
+func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.Context) error {
+	client, err := c.removeCloudFromControllerAPIFunc()
+	if err != nil {
+		return errors.E(err)
+	}
+
+	params := &apiparams.RemoveCloudFromControllerRequest{
+		CloudTag:       "cloud-" + c.cloudName,
+		ControllerName: c.targetControllerName,
+	}
+
+	err = client.RemoveCloudFromController(params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	ctxt.Infof("Cloud %q removed from controller %q.", c.cloudName, c.targetControllerName)
+	return nil
+}
+
+func (c *removeCloudFromControllerCommand) cloudAPI() (removeCloudFromControllerAPI, error) {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return nil, errors.E(err, "could not determine the current controller")
+	}
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
+}

--- a/cmd/jaas/cmd/removecloudfromcontroller_test.go
+++ b/cmd/jaas/cmd/removecloudfromcontroller_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+type removeCloudFromControllerSuite struct {
+	cmdtest.JimmCmdSuite
+
+	api *fakeRemoveCloudFromControllerAPI
+}
+
+var _ = gc.Suite(&removeCloudFromControllerSuite{})
+
+func (s *removeCloudFromControllerSuite) SetUpTest(c *gc.C) {
+	s.JimmCmdSuite.SetUpTest(c)
+	s.api = &fakeRemoveCloudFromControllerAPI{}
+}
+
+func (s *removeCloudFromControllerSuite) TestRemoveCloudFromController(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
+
+	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
+		s.ClientStore(),
+		bClient,
+		func() (cmd.RemoveCloudFromControllerAPI, error) {
+			return s.api, nil
+		})
+	ctx, err := cmdtesting.RunCommand(c, command, "controller-1", "test-cloud")
+	c.Assert(err, gc.IsNil)
+	s.api.CheckCallNames(c, "RemoveCloudFromController")
+	s.api.CheckCalls(c, []jujutesting.StubCall{{
+		FuncName: "RemoveCloudFromController",
+		Args: []interface{}{&apiparams.RemoveCloudFromControllerRequest{
+			ControllerName: "controller-1",
+			CloudTag:       "cloud-test-cloud",
+		}},
+	}})
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"test-cloud\" removed from controller \"controller-1\".\n")
+}
+
+func (s *removeCloudFromControllerSuite) TestRemoveCloudFromControllerWrongArguments(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
+
+	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
+		s.ClientStore(),
+		bClient,
+		func() (cmd.RemoveCloudFromControllerAPI, error) {
+			return s.api, nil
+		})
+	_, err := cmdtesting.RunCommand(c, command, "controller-1")
+	c.Assert(err, gc.ErrorMatches, "missing arguments")
+	_, err = cmdtesting.RunCommand(c, command, "controller-1", "cloud", "fake-arg")
+	c.Assert(err, gc.ErrorMatches, "too many arguments")
+}
+
+func (s *removeCloudFromControllerSuite) TestRemoveCloudFromControllerCloudNotFound(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
+
+	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
+		s.ClientStore(),
+		bClient,
+		nil)
+	_, err := cmdtesting.RunCommand(c, command, "controller-1", "test-cloud")
+	c.Assert(err, gc.ErrorMatches, ".*cloud \"test-cloud\" not found.*")
+}
+
+type fakeRemoveCloudFromControllerAPI struct {
+	jujutesting.Stub
+}
+
+func (api *fakeRemoveCloudFromControllerAPI) Close() error {
+	api.AddCall("Close", nil)
+	return api.NextErr()
+}
+
+func (api *fakeRemoveCloudFromControllerAPI) RemoveCloudFromController(params *apiparams.RemoveCloudFromControllerRequest) error {
+	api.AddCall("RemoveCloudFromController", params)
+	return api.NextErr()
+}

--- a/cmd/jaas/cmd/removecontroller.go
+++ b/cmd/jaas/cmd/removecontroller.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	removeControllerCommandDoc = `
+The remove-controller command removes a controller from jimm.
+`
+
+	removeControllerCommandExample = `
+    jimmctl remove-controller mycontroller 
+    jimmctl remove-controller mycontroller --force
+`
+)
+
+// NewRemoveControllerCommand returns a command to remove a controller.
+func NewRemoveControllerCommand() cmd.Command {
+	cmd := &removeControllerCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// removeControllerCommand remove a controller.
+type removeControllerCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	params   apiparams.RemoveControllerRequest
+}
+
+func (c *removeControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "remove-controller",
+		Args:     "<name>",
+		Purpose:  "Remove controller from jimm",
+		Doc:      removeControllerCommandDoc,
+		Examples: removeControllerCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *removeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.BoolVar(&c.params.Force, "force", false, "force remove a controller")
+}
+
+// Init implements the cmd.Command interface.
+func (c *removeControllerCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("controller name not specified")
+	}
+	c.params.Name = args[0]
+	if len(args) > 1 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *removeControllerCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+	client := api.NewClient(apiCaller)
+	info, err := client.RemoveController(&c.params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, info)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/removecontroller_test.go
+++ b/cmd/jaas/cmd/removecontroller_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type removeControllerSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&removeControllerSuite{})
+
+func (s *removeControllerSuite) TestRemoveControllerSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(c, cmd.NewRemoveControllerCommandForTesting(s.ClientStore(), bClient), "controller-1", "--force")
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, `name: controller-1
+uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+publicaddress: \"\"
+apiaddresses:
+- localhost:.*
+cacertificate: |
+  -----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----
+cloudtag: cloud-`+jimmtest.TestCloudName+`
+cloudregion: `+jimmtest.TestCloudRegionName+`
+username: admin
+agentversion: .*
+status:
+  status: available
+  info: ""
+  data: .*
+  since: null
+`)
+}
+
+func (s *removeControllerSuite) TestRemoveController(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveControllerCommandForTesting(s.ClientStore(), bClient), "controller-1", "--force")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/revokeauditlogaccess.go
+++ b/cmd/jaas/cmd/revokeauditlogaccess.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	revokeAuditLogAccessDoc = `
+The revoke-audit-log-access revokes user access to audit logs.
+`
+	revokeAuditLogAccessExample = `
+    jimmctl revoke-audit-log-access user@canonical.com
+`
+)
+
+// NewrevokeAuditLogAccess returns a command used to revoke
+// users access to audit logs.
+func NewRevokeAuditLogAccessCommand() cmd.Command {
+	cmd := &revokeAuditLogAccessCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// revokeAuditLogAccess displays full
+// model status.
+type revokeAuditLogAccessCommand struct {
+	modelcmd.ControllerCommandBase
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+	username string
+}
+
+func (c *revokeAuditLogAccessCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "revoke-audit-log-access",
+		Args:     "<user>",
+		Purpose:  "revokes access to audit logs.",
+		Doc:      revokeAuditLogAccessDoc,
+		Examples: revokeAuditLogAccessExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *revokeAuditLogAccessCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+}
+
+// Init implements the cmd.Command interface.
+func (c *revokeAuditLogAccessCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.E("missing username")
+	}
+	c.username, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("unknown arguments")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *revokeAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	userTag := names.NewUserTag(c.username)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RevokeAuditLogAccess(&apiparams.AuditLogAccessRequest{
+		UserTag: userTag.String(),
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}

--- a/cmd/jaas/cmd/revokeauditlogaccess_test.go
+++ b/cmd/jaas/cmd/revokeauditlogaccess_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+)
+
+type revokeAuditLogAccessSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&revokeAuditLogAccessSuite{})
+
+func (s *revokeAuditLogAccessSuite) TestRevokeAuditLogAccessSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRevokeAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *revokeAuditLogAccessSuite) TestRevokeAuditLogAccess(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRevokeAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/role.go
+++ b/cmd/jaas/cmd/role.go
@@ -1,0 +1,392 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	jujucmdv3 "github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	roleDoc = `
+The role command enables role management for jimm
+`
+
+	addRoleDoc = `
+The add command adds role to jimm.
+`
+
+	addRoleExample = `
+    jimmctl auth role add myrole 
+`
+
+	renameRoleDoc = `
+The rename command renames a role in jimm.
+`
+	renameRoleExample = `
+    jimmctl auth role rename myrole newrolename
+`
+
+	removeRoleDoc = `
+The remove command removes a role in jimm.
+`
+
+	removeRoleExample = `
+    jimmctl auth role remove myrole
+`
+
+	listRolesDoc = `
+The list command lists all roles in jimm.
+`
+	listRolesExample = `
+    jimmctl auth role list
+`
+)
+
+// NewRoleCommand returns a command for role management.
+func NewRoleCommand() *jujucmdv3.SuperCommand {
+	cmd := jujucmd.NewSuperCommand(jujucmdv3.SuperCommandParams{
+		Name:    "role",
+		Doc:     roleDoc,
+		Purpose: "Role management.",
+	})
+	cmd.Register(newAddRoleCommand())
+	cmd.Register(newRenameRoleCommand())
+	cmd.Register(newRemoveRoleCommand())
+	cmd.Register(newListRolesCommand())
+
+	return cmd
+}
+
+// newAddRoleCommand returns a command to add a role.
+func newAddRoleCommand() cmd.Command {
+	cmd := &addRoleCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// addRoleCommand adds a role.
+type addRoleCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name string
+}
+
+// Info implements the cmd.Command interface.
+func (c *addRoleCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "add",
+		Args:     "<role name>",
+		Purpose:  "Add role to jimm.",
+		Doc:      addRoleDoc,
+		Examples: addRoleExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *addRoleCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *addRoleCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("role name not specified")
+	}
+	c.name, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *addRoleCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	resp, err := client.AddRole(&apiparams.AddRoleRequest{
+		Name: c.name,
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, resp)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+// newRenameRoleCommand returns a command to rename a role.
+func newRenameRoleCommand() cmd.Command {
+	cmd := &renameRoleCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// renameRoleCommand renames a role.
+type renameRoleCommand struct {
+	modelcmd.ControllerCommandBase
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name    string
+	newName string
+}
+
+// Info implements the cmd.Command interface.
+func (c *renameRoleCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "rename",
+		Args:     "<role name> <new role name>",
+		Purpose:  "Rename a role.",
+		Doc:      renameRoleDoc,
+		Examples: renameRoleExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *renameRoleCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("role name not specified")
+	}
+	c.name, c.newName, args = args[0], args[1], args[2:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *renameRoleCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	params := apiparams.RenameRoleRequest{
+		Name:    c.name,
+		NewName: c.newName,
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RenameRole(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// newRemoveRoleCommand returns a command to Remove a role.
+func newRemoveRoleCommand() cmd.Command {
+	cmd := &removeRoleCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// removeRoleCommand Removes a role.
+type removeRoleCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	name  string
+	force bool
+}
+
+// Info implements the cmd.Command interface.
+func (c *removeRoleCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "remove",
+		Args:     "<role name>",
+		Purpose:  "Remove a role.",
+		Doc:      removeRoleDoc,
+		Examples: removeRoleExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *removeRoleCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.E("role name not specified")
+	}
+	c.name, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *removeRoleCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "smart", map[string]cmd.Formatter{
+		"smart": cmd.FormatSmart,
+	})
+	f.BoolVar(&c.force, "y", false, "delete role without prompt")
+}
+
+// Run implements Command.Run.
+func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	if !c.force {
+		reader := bufio.NewReader(ctxt.Stdin)
+		// Using Fprintf over c.out.write to avoid printing a new line.
+		_, err := fmt.Fprintf(ctxt.Stdout, "This will also delete all associated relations.\nConfirm you would like to delete role %q (y/N): ", c.name)
+		if err != nil {
+			return err
+		}
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.E(err, "Failed to read from input.")
+		}
+		text = strings.ReplaceAll(text, "\n", "")
+		if !(text == "y" || text == "Y") {
+			return nil
+		}
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	params := apiparams.RemoveRoleRequest{
+		Name: c.name,
+	}
+
+	client := api.NewClient(apiCaller)
+	err = client.RemoveRole(&params)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
+// newListRolesCommand returns a command to list all roles.
+func newListRolesCommand() cmd.Command {
+	cmd := &listRolesCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// listRolesCommand Lists all roles.
+type listRolesCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	limit  int
+	offset int
+}
+
+// Info implements the cmd.Command interface.
+func (c *listRolesCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "list",
+		Purpose:  "List all roles.",
+		Doc:      listRolesDoc,
+		Examples: listRolesExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *listRolesCommand) Init(args []string) error {
+	if len(args) > 1 {
+		return errors.E("too many args")
+	}
+	return nil
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *listRolesCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.IntVar(&c.limit, "limit", 0, "The maximum number of roles to return")
+	f.IntVar(&c.offset, "offset", 0, "The offset to use when requesting roles")
+}
+
+// Run implements Command.Run.
+func (c *listRolesCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	req := apiparams.ListRolesRequest{Limit: c.limit, Offset: c.offset}
+	roles, err := client.ListRoles(&req)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, roles)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}

--- a/cmd/jaas/cmd/role_test.go
+++ b/cmd/jaas/cmd/role_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+type roleSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&roleSuite{})
+
+func (s *roleSuite) TestAddRoleSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewAddRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
+	c.Assert(err, gc.IsNil)
+
+	role := &dbmodel.RoleEntry{Name: "test-role"}
+	err = s.JimmCmdSuite.JIMM.Database.GetRole(context.Background(), role)
+	c.Assert(err, gc.IsNil)
+	c.Assert(role.ID, gc.Equals, uint(1))
+	c.Assert(role.Name, gc.Equals, "test-role")
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, fmt.Sprintf(`(?s).*uuid: %s\n.*`, role.UUID))
+}
+
+func (s *roleSuite) TestAddRole(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewAddRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *roleSuite) TestRenameRoleSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	roleEntry, err := s.JimmCmdSuite.JIMM.Database.AddRole(context.TODO(), "test-role")
+	c.Assert(err, gc.IsNil)
+	c.Assert(roleEntry.UUID, gc.Not(gc.Equals), "")
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewRenameRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "renamed-role")
+	c.Assert(err, gc.IsNil)
+
+	role := &dbmodel.RoleEntry{Name: "renamed-role"}
+	err = s.JimmCmdSuite.JIMM.Database.GetRole(context.TODO(), role)
+	c.Assert(err, gc.IsNil)
+	c.Assert(role.ID, gc.Equals, uint(1))
+	c.Assert(role.Name, gc.Equals, "renamed-role")
+}
+
+func (s *roleSuite) TestRenameRole(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRenameRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "renamed-role")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *roleSuite) TestRemoveRoleSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := s.JimmCmdSuite.JIMM.Database.AddRole(context.TODO(), "test-role")
+	c.Assert(err, gc.IsNil)
+
+	_, err = cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "-y")
+	c.Assert(err, gc.IsNil)
+
+	role := &dbmodel.RoleEntry{Name: "test-role"}
+	err = s.JimmCmdSuite.JIMM.Database.GetRole(context.TODO(), role)
+	c.Assert(err, gc.ErrorMatches, "record not found")
+}
+
+func (s *roleSuite) TestRemoveRoleWithoutFlag(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
+	c.Assert(err.Error(), gc.Matches, "Failed to read from input.")
+}
+
+func (s *roleSuite) TestRemoveRole(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "-y")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *roleSuite) TestListRolesSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := s.JimmCmdSuite.JIMM.Database.AddRole(context.TODO(), fmt.Sprint("test-role", i))
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role")
+	c.Assert(err, gc.IsNil)
+	output := cmdtesting.Stdout(ctx)
+	c.Assert(strings.Contains(output, "test-role0"), gc.Equals, true)
+	c.Assert(strings.Contains(output, "test-role1"), gc.Equals, true)
+	c.Assert(strings.Contains(output, "test-role2"), gc.Equals, true)
+}
+
+func (s *roleSuite) TestListRolesLimitSuperuser(c *gc.C) {
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := s.JimmCmdSuite.JIMM.Database.AddRole(context.TODO(), fmt.Sprint("test-role", i))
+		c.Assert(err, gc.IsNil)
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role", "--limit", "1", "--offset", "1")
+	c.Assert(err, gc.IsNil)
+	output := cmdtesting.Stdout(ctx)
+	roles := []params.Role{}
+	err = yaml.Unmarshal([]byte(output), &roles)
+	c.Assert(err, gc.IsNil)
+	c.Assert(roles, gc.HasLen, 1)
+	c.Assert(roles[0].Name, gc.Equals, "test-role1")
+	c.Assert(roles[0].UUID, gc.Not(gc.Equals), "")
+}
+
+func (s *roleSuite) TestListRoles(c *gc.C) {
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/setcontrollerdeprecated.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	setControllerDeprecatedDoc = `
+The set-controller-deprecated sets the deprecated status of a controller.
+`
+	setControllerDeprecatedExample = `
+    jimmctl set-controller-deprecated mycontroller
+`
+)
+
+// NewSetControllerDeprecatedCommand returns a command used to grant
+// users access to audit logs.
+func NewSetControllerDeprecatedCommand() cmd.Command {
+	cmd := &setControllerDeprecatedCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// setControllerDeprecatedCommand displays full
+// model status.
+type setControllerDeprecatedCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	controllerName string
+}
+
+func (c *setControllerDeprecatedCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "set-controller-deprecated",
+		Args:     "<controller name>",
+		Purpose:  "Sets controller deprecated status.",
+		Doc:      setControllerDeprecatedDoc,
+		Examples: setControllerDeprecatedExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *setControllerDeprecatedCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *setControllerDeprecatedCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.E("missing controller name")
+	}
+	c.controllerName, args = args[0], args[1:]
+	if len(args) > 0 {
+		return errors.E("unknown arguments")
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *setControllerDeprecatedCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+
+	info, err := client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
+		Name:       c.controllerName,
+		Deprecated: true,
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, info)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/setcontrollerdeprecated_test.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type setControllerDeprecatedSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&setControllerDeprecatedSuite{})
+
+func (s *setControllerDeprecatedSuite) TestSetControllerDeprecatedSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	context, err := cmdtesting.RunCommand(c, cmd.NewSetControllerDeprecatedCommandForTesting(s.ClientStore(), bClient), "controller-1")
+	c.Assert(err, gc.IsNil)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, `name: controller-1
+uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+publicaddress: ""
+apiaddresses:
+- .*
+cacertificate: |
+  -----BEGIN CERTIFICATE-----
+  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+  LQRNNlaY2ajLt0paowf/Xxb8
+  -----END CERTIFICATE-----
+cloudtag: cloud-`+jimmtest.TestCloudName+`
+cloudregion: `+jimmtest.TestCloudRegionName+`
+username: admin
+agentversion: .*
+status:
+  status: deprecated
+  info: ""
+  data: {}
+  since: null
+`)
+}
+
+func (s *setControllerDeprecatedSuite) TestSetControllerDeprecated(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewSetControllerDeprecatedCommandForTesting(s.ClientStore(), bClient), "controller-1")
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}

--- a/cmd/jaas/cmd/updatemigratedmodel.go
+++ b/cmd/jaas/cmd/updatemigratedmodel.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	updateMigratedModelCommandDoc = `
+The update-migrated-model updates a model known to JIMM that has
+been migrated externally to a different JAAS controller.
+`
+	updateMigratedModelCommandExample = `
+    jimmctl update-migrated-model mycontroller e0bf3abf-7029-4e48-9c26-68a7b6e02947
+`
+)
+
+// NewUpdateMigratedModelCommand returns a command to update the controller
+// running a model.
+func NewUpdateMigratedModelCommand() cmd.Command {
+	cmd := &updateMigratedModelCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// updateMigratedModelCommand updates the controller running a model.
+type updateMigratedModelCommand struct {
+	modelcmd.ControllerCommandBase
+	store    jujuclient.ClientStore
+	dialOpts *jujuapi.DialOpts
+
+	req apiparams.UpdateMigratedModelRequest
+}
+
+// Info implements the cmd.Command interface.
+func (c *updateMigratedModelCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "update-migrated-model",
+		Args:     "<controller name> <model uuid>",
+		Purpose:  "Update the controller running a model.",
+		Doc:      updateMigratedModelCommandDoc,
+		Examples: updateMigratedModelCommandExample,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *updateMigratedModelCommand) Init(args []string) error {
+	switch len(args) {
+	default:
+		return errors.E("too many args")
+	case 0:
+		return errors.E("controller not specified")
+	case 1:
+		return errors.E("model uuid not specified")
+	case 2:
+	}
+
+	c.req.TargetController = args[0]
+	if !names.IsValidModel(args[1]) {
+		return errors.E("invalid model uuid")
+	}
+	c.req.ModelTag = names.NewModelTag(args[1]).String()
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *updateMigratedModelCommand) Run(ctxt *cmd.Context) error {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return err
+	}
+
+	client := api.NewClient(apiCaller)
+	if err := client.UpdateMigratedModel(&c.req); err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/updatemigratedmodel_test.go
+++ b/cmd/jaas/cmd/updatemigratedmodel_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Canonical.
+
+package cmd_test
+
+import (
+	"context"
+
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type updateMigratedModelSuite struct {
+	cmdtest.JimmCmdSuite
+}
+
+var _ = gc.Suite(&updateMigratedModelSuite{})
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelSuperuser(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	var model dbmodel.Model
+	model.SetTag(mt)
+	err := s.JIMM.Database.GetModel(context.Background(), &model)
+	c.Assert(err, gc.Equals, nil)
+	s.AddController(c, "controller-2", s.APIInfo(c))
+
+	// alice is superuser
+	bClient := s.SetupCLIAccess(c, "alice")
+	_, err = cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-2", mt.Id())
+	c.Assert(err, gc.IsNil)
+
+	// Check the model has moved controller.
+	var model2 dbmodel.Model
+	model2.SetTag(mt)
+	err = s.JIMM.Database.GetModel(context.Background(), &model2)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(model2.ControllerID, gc.Not(gc.Equals), model.ControllerID)
+}
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelUnauthorized(c *gc.C) {
+	s.AddController(c, "controller-1", s.APIInfo(c))
+
+	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
+	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+
+	// bob is not superuser
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-1", mt.Id())
+	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+}
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelNoController(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient))
+	c.Assert(err, gc.ErrorMatches, `controller not specified`)
+}
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelNoModelUUID(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id")
+	c.Assert(err, gc.ErrorMatches, `model uuid not specified`)
+}
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelInvalidModelUUID(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid")
+	c.Assert(err, gc.ErrorMatches, `invalid model uuid`)
+}
+
+func (s *updateMigratedModelSuite) TestUpdateMigratedModelTooManyArgs(c *gc.C) {
+	bClient := s.SetupCLIAccess(c, "bob")
+	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid", "spare-argument")
+	c.Assert(err, gc.ErrorMatches, `too many args`)
+}


### PR DESCRIPTION
## Description
This PR is the start of the jimmctl migration to the jaas plugin. Here, I've copied all the commands verbatim to the jaas snap folder without wiring them up so that,
1. We maintain the existing functionality of the jimmctl snap
2. We can make follow-up PRs to shape the jaas plugin into it's new shape.

Unfortunately since this is a copy and not a move, I'm unsure how to preserve the history or whether its worth the effort.