### PR TITLE
make snap jaas executable

### DIFF
--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -3,8 +3,7 @@ summary: JAAS plugin
 description: Juju plugin for providing JAAS functionality to the Juju CLI.
 version: git
 grade: stable
-base: bare
-build-base: core20
+base: core20
 confinement: strict
 
 slots:
@@ -14,10 +13,20 @@ slots:
     read: 
       - $SNAP/bin
 
-# The app has no plugs as it is intended to be invoked by the Juju CLI Snap.
+plugs:
+  dot-local-share-juju:
+    interface: personal-files
+    read:
+    - $HOME/.local/share/juju
+    write:
+    - $HOME/.local/share/juju
+
 apps:
   jaas:
     command: bin/jaas
+    plugs:
+     - dot-local-share-juju
+     - network
 
 parts:
   jaas:


### PR DESCRIPTION
## Description
`jaas` snap was not executable by itself as it is `jimmctl`, it was just a juju plugin. This pr makes jaas executable by itself.
The reason we need this is to make sure we can use jaas commands by doing `jaas add-service-account` instead `juju add-service-account`, and this is particularly useful when we build juju in devmode and we can't access snap jaas plugin commands via juju.

To accomplish that I've basically c/p jimmctl snapcraft.yaml

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
