### PR TITLE
chore: ensure graceful server shutdown

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -30,7 +30,7 @@ func main() {
 	})
 	err := s.Wait()
 
-	zapctx.Error(context.Background(), "shutdown", zap.Error(err))
+	zapctx.Error(context.Background(), "jimm shutdown complete", zap.Error(err))
 	if _, ok := err.(*service.SignalError); !ok {
 		os.Exit(1)
 	}
@@ -207,19 +207,8 @@ func start(ctx context.Context, s *service.Service) error {
 		Handler:           jimmsvc,
 		ReadHeaderTimeout: time.Second * 5,
 	}
-	s.OnShutdown(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
 
-		zapctx.Warn(ctx, "server shutdown triggered")
-		err = httpsrv.Shutdown(ctx)
-		if err != nil {
-			zapctx.Error(ctx, "failed to shutdown server gracefully", zap.Error(err))
-		}
-		jimmsvc.Cleanup()
-	})
-	s.Go(httpsrv.ListenAndServe)
-	zapctx.Info(ctx, "Successfully started JIMM server")
+	// intentionally ignore the error because invalid values are handled by the jump server.
 	maxConccurentConncetions, _ := strconv.Atoi(os.Getenv("JIMM_SSH_MAX_CONCURRENT_CONNECTIONS"))
 
 	sshServer, err := ssh.NewJumpServer(ctx, ssh.Config{
@@ -227,10 +216,28 @@ func start(ctx context.Context, s *service.Service) error {
 		HostKey:                  []byte(hostKeyRaw),
 		MaxConcurrentConnections: maxConccurentConncetions,
 	}, jimmsvc.JIMM().SSHManager())
-	if err != nil {
-		return err
-	}
+
+	s.OnShutdown(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		zapctx.Warn(ctx, "HTTP server shutdown triggered")
+		err = httpsrv.Shutdown(ctx)
+		if err != nil {
+			zapctx.Error(ctx, "failed to shutdown HTTP server gracefully", zap.Error(err))
+		}
+
+		zapctx.Warn(ctx, "SSH server shutdown triggered")
+		err = sshServer.Shutdown(ctx)
+		if err != nil {
+			zapctx.Error(ctx, "failed to shutdown SSH server gracefully", zap.Error(err))
+		}
+
+		jimmsvc.Cleanup()
+	})
+	s.Go(httpsrv.ListenAndServe)
+	zapctx.Info(ctx, "Started JIMM HTTP server")
 	s.Go(sshServer.ListenAndServe)
-	zapctx.Info(ctx, "Successfully started JIMM ssh server")
+	zapctx.Info(ctx, "Started JIMM SSH server")
 	return nil
 }

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -247,6 +247,7 @@ func (s *Service) MonitorResources(ctx context.Context) {
 		case <-ticker.C:
 			s.jimm.JujuManager().UpdateMetrics(ctx)
 		case <-ctx.Done():
+			zapctx.Info(ctx, "exiting resource monitor polling")
 			return
 		}
 	}
@@ -263,6 +264,7 @@ func (s *Service) OpenFGACleanup(ctx context.Context, trigger <-chan time.Time) 
 				continue
 			}
 		case <-ctx.Done():
+			zapctx.Info(ctx, "exiting OpenFGA cleanup polling")
 			return nil
 		}
 	}
@@ -279,6 +281,7 @@ func (s *Service) CleanupDyingModels(ctx context.Context, trigger <-chan time.Ti
 				continue
 			}
 		case <-ctx.Done():
+			zapctx.Info(ctx, "exiting dying model cleanup polling")
 			return nil
 		}
 	}

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -78,6 +78,7 @@ func (w *Watcher) WatchAllModelSummaries(ctx context.Context, interval time.Dura
 		}
 		select {
 		case <-ctx.Done():
+			zapctx.Info(ctx, "exiting model summary watcher polling")
 			return ctx.Err()
 		case <-ticker.C:
 		}

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmjwx
 
@@ -124,7 +124,7 @@ func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequir
 					zapctx.Error(ctx, "security failure", zap.Any("op", op), zap.NamedError("jwks-error", err))
 				}
 			case <-ctx.Done():
-				zapctx.Debug(ctx, "Shutdown for JWKS rotator complete.")
+				zapctx.Debug(ctx, "shutdown for JWKS rotator complete.")
 				return
 			}
 		}

--- a/internal/logger/default_logger.go
+++ b/internal/logger/default_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package logger
 
@@ -35,6 +35,7 @@ func SetupLogger(ctx context.Context, logLevel string, devMode bool) {
 	} else {
 		prodConfig := zap.NewProductionConfig()
 		prodConfig.Level = zap.NewAtomicLevelAt(pLogLevel)
+		prodConfig.DisableStacktrace = true       // Disable stacktraces in prod as they are overly verbose and clutter the logs.
 		proLogger := zap.Must(prodConfig.Build()) // this panics if an error is encountered during Build
 		zapctx.Default = proLogger
 	}


### PR DESCRIPTION
## Description
This PR fixes an issue where the JIMM server was not shutting down properly when receiving a SIGTERM signal. This was because all routines started by service.Go() need to end before service.Wait() will return. The SSH server was not being shutdown and blocking return. This is affecting our dev environment deployment where the service manager Pebble is waiting forever for JIMM to exit.

I've also made a change to avoid printing stacktraces in our production logger. These were present in our production logs and were a big clutter and making it very hard to read the logs. These weren't always turned on but I think this behaviour changed when we reworked our logger.

## Test instructions
I'll add a test for this in a follow-up but I've confirmed the issue by doing the following,
1. `docker compose logs -f jimm`

In a separate terminal 
1. `docker compose --profile dev up -d --wait`
3. `docker exec -it jimm bash`
4. `ps aux` (note that JIMM won't be PID 1 because of `air`)
5. `kill <jimm-pid>`
6. See that without these changes JIMM logs hang and with the change the server properly shuts down.