### PR TITLE
chore: test graceful server shutdown

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -78,6 +78,8 @@ runs:
       working-directory: ${{ github.action_path }}/../../..
       run: make dev-env
       shell: bash
+      env: 
+        JIMM_TARGET: smoke
 
     - name: Retrieve server CA cert.
       id: fetch-cert

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -56,3 +56,19 @@ jobs:
         run: |
           # TODO(simonedutto): improve this test when juju ssh controller is implemented.
           nc -zv localhost 17022
+
+      - name: Stop the application container
+        run: docker stop jimm
+  
+      - name: Check logs for shutdown message
+        run: |
+          APP_CONTAINER=jimm
+          LOGS=$(docker logs "$APP_CONTAINER" -n 20)
+          echo "$LOGS"
+          
+          if echo "$LOGS" | grep -q "jimm shutdown complete"; then
+            echo "Graceful shutdown confirmed."
+          else
+            echo "Graceful shutdown message not found!"
+            exit 1
+          fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,9 +42,12 @@ services:
     extends:
       file: docker-compose.common.yaml
       service: jimm-base
+    # In order to switch the target image you need to run compose with --build
+    # Changing target is mainly useful in CI, so local environments can just rely on the default.
     build:
-      context: .
-      dockerfile: ./local/Dockerfile
+      context: ./local/jimm/
+      dockerfile: Dockerfile
+      target: ${JIMM_TARGET:-dev}
     profiles: ["dev"]
     # working_dir value has to be the same of mapped volume
     hostname: jimm.localhost

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,6 +1,0 @@
-# Installing delve in the image to avoid running go install in running containers
-FROM cosmtrek/air:latest
-
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-
-ENTRYPOINT [ "air" ]

--- a/local/jimm/Dockerfile
+++ b/local/jimm/Dockerfile
@@ -1,0 +1,13 @@
+# Installing delve in the image to avoid running go install in running containers
+FROM cosmtrek/air:latest AS dev
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+ENTRYPOINT [ "air" ]
+
+# Create a target without air that we use in smoke tests.
+FROM golang:1.24-bookworm as smoke
+
+COPY entrypoint.sh     /entry/entrypoint.sh
+
+CMD [ "/entry/entrypoint.sh" ]

--- a/local/jimm/entrypoint.sh
+++ b/local/jimm/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# This container expects the source code to be mounted at /jimm
+cd /jimm
+go build -buildvcs=false -o jimmsrv ./cmd/jimmsrv
+# Exec ensures jimm is PID 1 for testing shutdown.
+exec ./jimmsrv


### PR DESCRIPTION
## Description
This PR is a follow up to #1569 that tests that JIMM gracefully shuts down when it receives a SIGTERM signal.
In order to test shutdown we need to issue the signal to the JIMM process, this is most simply done when JIMM is PID 1 in a container and then we can do something like `docker stop jimm`.

This PR aims to do just that by modifying JIMM's Dockerfile so that we have one target which runs `air` and another target which just compiles and runs JIMM. I've labelled them `no-hot-reload` and `hot-reload` to indicate the purpose of air but I'm open to other naming suggestions.

In our Docker compose, we choose the target by suppling an environment variable, defaulting to the target with `air`. Our integration testing now uses the target without `air` where JIMM is PID 1 so that we can test shutdown.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests