### PR TITLE
chore: fix set-cli-auth script

### DIFF
--- a/local/jimm/setup-cli-auth.sh
+++ b/local/jimm/setup-cli-auth.sh
@@ -7,4 +7,4 @@ set -eux
 
 # Note that we are working around the fact that yq is a snap and doesn't have permission to hidden folders due to snap confinement.
 cat ~/.local/share/juju/accounts.yaml | yq '.controllers += {"jimm":{"type": "oauth2-device", "user": "jimm-test@canonical.com", "access-token": strenv(JWT)}}' | cat > temp-accounts.yaml && mv temp-accounts.yaml ~/.local/share/juju/accounts.yaml
-cat ~/.local/share/juju/controllers.yaml | yq '.controllers += {"jimm":{"uuid": "3217dbc9-8ea9-4381-9e97-01eab0b3f6bb", "api-endpoints": ["jimm.localhost:443"]}}' | cat > temp-controllers.yaml && mv temp-controllers.yaml ~/.local/share/juju/controllers.yaml
+cat ~/.local/share/juju/controllers.yaml | yq '.controllers += {"jimm":{"oidc-login": true, "uuid": "3217dbc9-8ea9-4381-9e97-01eab0b3f6bb", "api-endpoints": ["jimm.localhost:443"]}}' | cat > temp-controllers.yaml && mv temp-controllers.yaml ~/.local/share/juju/controllers.yaml


### PR DESCRIPTION
## Description
After the changes in https://github.com/juju/juju/pull/19079, the way the client decides when to use OIDC login has changed slightly. We need to set the `oidc-login` field on controllers.yaml. The `type` field on accounts.yaml has also been removed but until that change starts to show up in Juju's `3.6/edge` snap channel, we will keep this field to avoid our CI breaking.
