### PR TITLE
chore: update rockcraft.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,6 @@ run:
   tests: true
   allow-parallel-runners: false
   allow-serial-runners: false
-  # go: "1.23"
 
 issues:
   exclude-use-default: true

--- a/rocks/jimm.yaml
+++ b/rocks/jimm.yaml
@@ -21,7 +21,7 @@ parts:
         source: .
         source-type: local
         build-snaps:
-          - go/1.23/stable
+          - go/1.24/stable
         build-packages:
           - git
           - make 


### PR DESCRIPTION
## Description
The release for the JIMM rock failed because I neglected to update the Go channel used in the rockcraft.yaml file.