### PR TITLE
chore: build air in jimm dev image

### DIFF
--- a/local/jimm/Dockerfile
+++ b/local/jimm/Dockerfile
@@ -1,7 +1,9 @@
-# Installing delve in the image to avoid running go install in running containers
-FROM cosmtrek/air:latest AS dev
+# Installing delve in the image to avoid running go install in running containers.
+# Installing air to avoid breakages when we update our Go version before a new air image is available.
+FROM golang:1.24 AS dev
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/air-verse/air@latest
 
 ENTRYPOINT [ "air" ]
 


### PR DESCRIPTION
## Description
This PR is a small change to our JIMM dev container to build our code hot-reload tool `air` so that we don't run into breakages when we update our Go version before they've released a new version of the air image.