### PR TITLE
ignore logs for some paths

### DIFF
--- a/internal/logger/http_logger.go
+++ b/internal/logger/http_logger.go
@@ -1,9 +1,10 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package logger
 
 import (
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -20,6 +21,8 @@ type httpLogEntry struct {
 	request *http.Request
 }
 
+var pathsToIgnore = []string{"/", "/.well-known/jwks.json"}
+
 // Write is called when the request handler has finished.
 func (l *httpLogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
 	fields := make([]zap.Field, 0)
@@ -27,13 +30,19 @@ func (l *httpLogEntry) Write(status, bytes int, header http.Header, elapsed time
 	if status != 0 {
 		fields = append(fields, zap.Int("status", status))
 	}
+	path := l.request.RequestURI
+	// we don't want logs for the health checks or jwks.json
+	if slices.Contains(pathsToIgnore, path) {
+		return
+	}
 	fields = append(fields,
 		zap.String("method", l.request.Method),
-		zap.String("path", l.request.RequestURI),
+		zap.String("path", path),
 		zap.String("elapsed", elapsed.String()),
 	)
 
-	if status != 200 {
+	// we log it to debug if the request is successful
+	if status == 200 {
 		zapctx.Debug(l.request.Context(), "request", fields...)
 	} else {
 		zapctx.Warn(l.request.Context(), "request", fields...)


### PR DESCRIPTION
## Description
In this PR we add a check for path to ignore in our HTTP logger.
Some of logs are really repetitive and annoying.

If you feel like they are somewhat useful feel free to drop this pr.

Example: 10 logs in 10 second
![image](https://github.com/user-attachments/assets/3692e7df-6ab4-419d-ac75-1a7eee08aafc)

Example with the changes:
![image](https://github.com/user-attachments/assets/a5cb4a23-ee1e-4d3c-86aa-2d01f37e2cb8)

> fly-by change the log level for request with 200 status code, because it makes more sense.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
