### PR TITLE
fix(ssh-keys): remove '\n'  from ssh key to be consistent with juju facade

### DIFF
--- a/internal/rpcproxy/keymanager.go
+++ b/internal/rpcproxy/keymanager.go
@@ -126,7 +126,6 @@ func marshalAuthorizedKeyWithComment(key sshkeys.PublicKey) string {
 	e.Close()
 	b.WriteByte(' ')
 	b.WriteString(key.Comment)
-	b.WriteByte('\n')
 	return b.String()
 }
 

--- a/internal/rpcproxy/keymanager_test.go
+++ b/internal/rpcproxy/keymanager_test.go
@@ -96,8 +96,8 @@ func (k *keyManagerFacadeSuite) TestListKeysFull(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(res.Results[0].Result, qt.HasLen, 2)
-	c.Assert(res.Results[0].Result[0], qt.Matches, `ssh-rsa .+ comment-1\n`)
-	c.Assert(res.Results[0].Result[1], qt.Matches, `ssh-rsa .+ comment-2\n`)
+	c.Assert(res.Results[0].Result[0], qt.Matches, `ssh-rsa .+ comment-1`)
+	c.Assert(res.Results[0].Result[1], qt.Matches, `ssh-rsa .+ comment-2`)
 }
 
 func (k *keyManagerFacadeSuite) TestAddKeys(c *qt.C) {


### PR DESCRIPTION
## Description
In this PR we remove the new line from the formatter because it was messing with terraform provider tests.
That's because juju formats keys without a new line:
https://github.com/juju/juju/blob/b6efd0cc0128716f62d8f508a0101ef2fb2650ac/apiserver/facades/client/keymanager/keymanager.go#L109-L131
