### PR TITLE
chore: parse public DNS name input

### DIFF
--- a/cmd/jimmsrv/service/export_test.go
+++ b/cmd/jimmsrv/service/export_test.go
@@ -1,8 +1,11 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package service
 
-var NewOpenFGAClient = newOpenFGAClient
+var (
+	NewOpenFGAClient           = newOpenFGAClient
+	ParseURLWithOptionalScheme = parseURLWithOptionalScheme
+)
 
 // GetCleanups export `Service.cleanups` field for testing purposes.
 func (s *Service) GetCleanups() []func() error {

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -484,13 +485,17 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	macaroonDischarger, err := s.setupDischarger(p)
 	if err != nil {
-		return nil, errors.E(op, err, "failed to set up discharger")
+		return nil, errors.E(op, fmt.Errorf("failed to set up discharger: %v", err))
 	}
 	s.mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
 
+	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
+	if err != nil {
+		return nil, errors.E(op, fmt.Errorf("failed to parse public DNS name: %v", err))
+	}
 	params := jujuapi.Params{
 		ControllerUUID: p.ControllerUUID,
-		PublicDNSName:  p.PublicDNSName,
+		PublicDNSName:  publicDNS.Host,
 	}
 
 	// Websockets require extra care when cookies are used for authentication
@@ -509,6 +514,23 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	s.isLeader = p.IsLeader
 
 	return s, nil
+}
+
+// parseURLWithOptionalScheme parses an input string
+// that may exclude a scheme, i.e. missing "http://".
+// If no scheme is provided, "https" will be used.
+func parseURLWithOptionalScheme(addr string) (*url.URL, error) {
+	uriScheme := "https"
+	// Add the schema if parsing fails or the host is empty.
+	// This avoids parsing ambiguity in url.Parse.
+	url, err := url.Parse(addr)
+	if err != nil || url.Host == "" {
+		url, err = url.Parse(uriScheme + "://" + addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return url, nil
 }
 
 func (s *Service) StartServices(ctx context.Context, svc *service.Service) {

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package service_test
 
@@ -597,4 +597,47 @@ func TestCORS(t *testing.T) {
 	c.Assert(response.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response.Header.Get("Access-Control-Allow-Credentials"), qt.Equals, "true")
 	c.Assert(response.Header.Get("Access-Control-Allow-Origin"), qt.Equals, allowedOrigin)
+}
+
+func TestParseURLWithOptionalSchem(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		about       string
+		url         string
+		expected    string
+		expectError string
+	}{
+		{
+			about:    "URL with scheme",
+			url:      "https://example.com",
+			expected: "https://example.com",
+		},
+		{
+			about:    "URL without scheme",
+			url:      "example.com",
+			expected: "https://example.com",
+		},
+		{
+			about:    "URL without scheme and with path",
+			url:      "example.com/my-favorite-path",
+			expected: "https://example.com/my-favorite-path",
+		},
+		{
+			about:       "Invalid URL",
+			url:         "foo\bar",
+			expectError: `parse "https://foo\\bar": net/url: invalid control character in URL`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.about, func(c *qt.C) {
+			parsedURL, err := jimmsvc.ParseURLWithOptionalScheme(test.url)
+			if test.expectError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+				return
+			}
+			c.Assert(parsedURL.String(), qt.Equals, test.expected)
+		})
+	}
 }

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package jujuapi implements API endpoints for the juju API.
 package jujuapi
@@ -17,8 +17,8 @@ type Params struct {
 	// ControllerUUID is the UUID of the JIMM controller.
 	ControllerUUID string
 
-	// PublicDNSName is the name to advertise as the public address of
-	// the juju controller.
+	// PublicDNSName is returned to Juju clients on login.
+	// It is the hostname that will be used during TLS verification.
 	PublicDNSName string
 }
 


### PR DESCRIPTION
## Description
This PR validates the `PublicDNSName` variable supplied to JIMM on startup. This value is passed to Juju clients on login and used as part of TLS, see https://github.com/juju/juju/blob/3.6/juju/api.go#L194. The client will verify that the server's certificate contains the specified hostname. Normally when deploying JIMM via charms, the user will set this value manually.

But, when using an ingress charm like Traefik, it is the ingress that defines the URL for the service and JIMM accepts this value from Traefik. In the case of one of our deployments, this value was `https://some-domain.com/some-path` but the only part of that we actually want is the hostname, i.e. `some-domain.com`.

This PR now validates the config value by converting it to a URL, which we can then use to extract the host.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests