### PR TITLE
fix(max-concurrent-connections): fix max concurrent connections by closing the connection

### DIFF
--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -67,7 +67,6 @@ type Server struct {
 // NewJumpServer creates the jump server struct.
 func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (Server, error) {
 	zapctx.Info(ctx, "NewJumpServer")
-
 	if sshManager == nil {
 		return Server{}, fmt.Errorf("Cannot create JumpSSHServer with a nil ssh manager.")
 	}
@@ -239,8 +238,10 @@ func ConnCallback(maxConcurrentConnections int) ssh.ConnCallback {
 			if err != nil {
 				zapctx.Error(ctx, "failed to write to connection", zap.Error(err))
 			}
-			// if ConnCallback returns a nil net.Conn, the connection is closed.
-			return nil
+			// The connection is close before returning, otherwise
+			// the context is not cancelled and the counter is not decremented.
+			conn.Close()
+			return conn
 		}
 		return conn
 	}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -39,8 +39,9 @@ type sshSuite struct {
 	privateKey         gossh.Signer
 	hostKey            gossh.Signer
 
-	received         chan bool
-	allowedModelUUID string
+	received                 chan bool
+	allowedModelUUID         string
+	maxConcurrentConnections int
 }
 
 func (s *sshSuite) Init(c *qt.C) {
@@ -109,11 +110,12 @@ func (s *sshSuite) Init(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	s.jumpServerListener = bufconn.Listen(1 * 1024)
+	s.maxConcurrentConnections = 10
 	jumpServer, err := ssh.NewJumpServer(context.Background(),
 		ssh.Config{
 			Port:                     "22",
 			HostKey:                  hostKey,
-			MaxConcurrentConnections: 10,
+			MaxConcurrentConnections: s.maxConcurrentConnections,
 		},
 		mocks.SSHManager{
 			PublicKeyHandler_: func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -274,30 +276,35 @@ func (s *sshSuite) TestSSHFinalDestinationDialFail(c *qt.C) {
 }
 
 func (s *sshSuite) TestSSHServerMaxConnections(c *qt.C) {
-	clients := make([]*gossh.Client, 0, 10)
-	config := &gossh.ClientConfig{
-		HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
-		Auth: []gossh.AuthMethod{
-			gossh.PublicKeys(s.privateKey),
-		},
-		User: "alice",
-	}
-	for range 10 {
+	// the reason we repeat this test 2 times is to make sure that closing the connections on
+	// the first iteration completely resets the counter on the ssh server side.
+	for range 2 {
+		clients := make([]*gossh.Client, 0, s.maxConcurrentConnections)
+		config := &gossh.ClientConfig{
+			HostKeyCallback: gossh.FixedHostKey(s.hostKey.PublicKey()),
+			Auth: []gossh.AuthMethod{
+				gossh.PublicKeys(s.privateKey),
+			},
+			User: "alice",
+		}
+		for range s.maxConcurrentConnections {
+			client := inMemoryDial(c, s.jumpServerListener, config)
+			clients = append(clients, client)
+		}
+		jumpServerConn, err := s.jumpServerListener.Dial()
+		c.Assert(err, qt.IsNil)
+
+		_, _, _, err = gossh.NewClientConn(jumpServerConn, "", config)
+		c.Assert(err, qt.ErrorMatches, ".*handshake failed: EOF.*")
+
+		// close the connections
+		for _, client := range clients {
+			client.Close()
+		}
+		// check the next connection is accepted
 		client := inMemoryDial(c, s.jumpServerListener, config)
-		clients = append(clients, client)
-	}
-	jumpServerConn, err := s.jumpServerListener.Dial()
-	c.Assert(err, qt.IsNil)
-
-	_, _, _, err = gossh.NewClientConn(jumpServerConn, "", config)
-	c.Assert(err, qt.ErrorMatches, ".*handshake failed: EOF.*")
-
-	// close the connections
-	for _, client := range clients {
 		client.Close()
 	}
-	// check the next connection is accepted
-	inMemoryDial(c, s.jumpServerListener, config)
 }
 
 func TestIdentityManager(t *testing.T) {


### PR DESCRIPTION
By returning `nil` we were closing the connection, but the context was not canceled. 
Making the context.Done stuck, now we close the connection before returning so the context is cancelled.

To test this, we repeat the dial test two times, so we are sure we have reset the counter in the ssh server back to 0.
