### PR TITLE
fix: missing check for cloud-credential owner

### DIFF
--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -472,7 +472,7 @@ clouds:
     access: add-model
 cloud-credentials:
 - name: test-credential-1
-  owner: alice@canonical.com
+  owner: bob@canonical.com
   cloud: test-cloud
   auth-type: empty
 controllers:
@@ -518,7 +518,7 @@ users:
 `[1:]),
 	username:     "alice@canonical.com",
 	jimmAdmin:    true,
-	cloudCredTag: names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential-1"),
+	cloudCredTag: names.NewCloudCredentialTag("test-cloud/bob@canonical.com/test-credential-1"),
 	args: jujuparams.ModelCreateArgs{
 		Name:        "test-model",
 		OwnerTag:    names.NewUserTag("bob@canonical.com").String(),
@@ -1224,6 +1224,49 @@ users:
 		CloudRegion: "test-region-1",
 	},
 	expectError: "unsupported cloud region test-cloud/test-region-1",
+}, {
+	name: "CreateModelWithAnotherUsersCredential",
+	env: `
+clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region-1
+  users:
+  - user: alice@canonical.com
+    access: add-model
+cloud-credentials:
+- name: test-credential-1
+  owner: bob@canonical.com
+  cloud: test-cloud
+  auth-type: empty
+controllers:
+- name: controller-1
+  uuid: 00000000-0000-0000-0000-0000-0000000000001
+  cloud: test-cloud
+  region: test-region-1
+  cloud-regions:
+  - cloud: test-cloud
+    region: test-region-1
+    priority: 0
+`[1:],
+	updateCredential: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
+		return nil, nil
+	},
+	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
+		return nil
+	},
+	createModel:  nil,
+	username:     "alice@canonical.com",
+	jimmAdmin:    true,
+	cloudCredTag: names.NewCloudCredentialTag("test-cloud/bob@canonical.com/test-credential-1"),
+	args: jujuparams.ModelCreateArgs{
+		Name:        "test-model",
+		OwnerTag:    names.NewUserTag("alice@canonical.com").String(),
+		CloudTag:    names.NewCloudTag("test-cloud").String(),
+		CloudRegion: "test-region-1",
+	},
+	expectError: "invalid owner for cloud credential",
 }}
 
 func TestAddModel(t *testing.T) {

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1266,7 +1266,7 @@ controllers:
 		CloudTag:    names.NewCloudTag("test-cloud").String(),
 		CloudRegion: "test-region-1",
 	},
-	expectError: "invalid owner for cloud credential",
+	expectError: "model owner doesn't match cloud-credential owner",
 }}
 
 func TestAddModel(t *testing.T) {

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -230,7 +230,7 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 
 	// Verify ownership of cloud credential
 	if b.owner == nil || b.owner.Name != credentialTag.Owner().Id() {
-		b.err = errors.E("invalid owner for cloud credential", errors.CodeUnauthorized)
+		b.err = errors.E("model owner doesn't match cloud-credential owner", errors.CodeUnauthorized)
 		return b
 	}
 

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -227,6 +227,13 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 	if b.err != nil {
 		return b
 	}
+
+	// Verify ownership of cloud credential
+	if b.owner == nil || b.owner.Name != credentialTag.Owner().Id() {
+		b.err = errors.E("invalid owner for cloud credential", errors.CodeUnauthorized)
+		return b
+	}
+
 	credential := dbmodel.CloudCredential{
 		Name:              credentialTag.Name(),
 		CloudName:         credentialTag.Cloud().Id(),


### PR DESCRIPTION
## Description
This PR fixes a vulnerability identified in JIMM where a user can deploy a model using another user's cloud-credentials.
During model creation, the arguments include 3 key pieces of information:
1. The user making the request
2. The model owner
3. The cloud-credential to use
 
We check that the user making the request is either the same as the model owner or a JIMM superuser, who is allowed to create models on another user's behalf. But, importantly, we were not validating that the model owner had access to the cloud-credential.

Because JIMM doesn't model access to cloud-credentials, the only thing we can do is check that the owner of the cloud-credential matches the model owner.

This also means that if a JIMM admin is attempting to create a model on behalf of another user, say `Alice` is trying to create a model for `Bob`. Alice must specify the name of Bob's credential rather than her own. This behaviour was already possible but is now limited to JIMM superusers and while it doesn't seem particularly desirable, can be improved in a follow-up.

A note on the tests:
- I've added a test to cover the vulnerability.
- There was a test that verified a superuser could create models owned by other users, but this started failing after the fix. The test created a model for user `Bob` created by `Alice`, using `Alice's` credential. I've updated the test so that it uses a credential owned by `Bob`.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
