### PR TITLE
chore: fix security scan after kev changes

### DIFF
--- a/.github/workflows/security-scan-weekly.yaml
+++ b/.github/workflows/security-scan-weekly.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Fetch KEV list from CISA
         shell: bash
         run: |
-          curl -s -o ./kev.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+          curl --fail --retry 3 -s -o ./kev.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
 
       - name: Compare Trivy results with KEV list
         run: ./scripts/compare_kev_vulnerabilities.sh 2>&1 | tee kev-trivy-fs-scan.txt
@@ -78,7 +78,7 @@ jobs:
       - name: Upload KEV Trivy scan results as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: govuln-security-scan-results
+          name: kev-trivy-fs-scan-results
           path: 'kev-trivy-fs-scan.txt'
 
       - name: Compare govuln results with KEV list
@@ -91,13 +91,16 @@ jobs:
       - name: Upload KEV Govuln scan results as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: govuln-security-scan-results
+          name: kev-govuln-scan-results
           path: 'kev-govuln-scan.txt'
 
   container-security-scan:
     runs-on: [ubuntu-latest]
     name: Container Security Scan
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run Trivy container scanner for the latest JIMM image
         uses: aquasecurity/trivy-action@0.29.0
         with:
@@ -121,7 +124,7 @@ jobs:
       - name: Fetch KEV list from CISA
         shell: bash
         run: |
-          curl -s -o ./kev.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+          curl --fail --retry 3 -s -o ./kev.json https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
 
       - name: Compare Trivy container scan results with KEV list
         run: ./scripts/compare_kev_vulnerabilities.sh 2>&1 | tee kev-trivy-container-scan.txt
@@ -133,5 +136,5 @@ jobs:
       - name: Upload KEV Trivy Container scan results as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: govuln-security-scan-results
-          path: 'kev-govuln-scan.txt'
+          name: kev-trivy-container-scan-results
+          path: 'kev-trivy-container-scan.txt'


### PR DESCRIPTION
## Description
Fixes (hopefully) the security scan workflow after #1588. I used the new copilot button to generate the rest of this PR description with some tweaks of my own, let me know what you think.

This pull request includes several updates to the `security-scan-weekly.yaml` workflow to improve the reliability of fetching the KEV list and to standardize the naming of scan result artifacts.

Improvements to reliability and artifact naming:

* [`.github/workflows/security-scan-weekly.yaml`](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L69-R69): Added `--fail` and `--retry 3` options to the `curl` command to improve reliability when fetching the KEV list from CISA. [[1]](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L69-R69) [[2]](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L124-R127)
* [`.github/workflows/security-scan-weekly.yaml`](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L81-R81): Updated artifact names for Trivy and Govuln scan results to be more descriptive and consistent. [[1]](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L81-R81) [[2]](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L94-R103) [[3]](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L136-R140)
* [`.github/workflows/security-scan-weekly.yaml`](diffhunk://#diff-cc7f6f628349b3000113c906869ed827d20bb21749482b192ee68f7e53ec0293L94-R103): Added a step to check out the repository before running the Trivy container scanner, needed to run the kev scan script.
