### PR TITLE
chore: add public address flag to register controller command

### DIFF
--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -70,6 +70,7 @@ type registerControllerCommand struct {
 	local          bool
 	tlsHostname    string
 	controllerName string
+	publicAddress  string
 	dryRun         bool
 }
 
@@ -95,6 +96,7 @@ func (c *registerControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.dryRun, "dry-run", false, "Dry-run enabled will only print the controller details.")
 	f.StringVar(&c.tlsHostname, "tls-hostname", "", "Specify the hostname for TLS verification.")
 	f.StringVar(&c.file.Path, "file", "", "Specify a file-path for controller details, use '-' to read from stdin.")
+	f.StringVar(&c.publicAddress, "public-address", "", "Specify a custom public address to use for dialing the controller.")
 }
 
 // Init implements the cmd.Command interface.
@@ -186,6 +188,11 @@ func (c *registerControllerCommand) getControllerDetails(ctxt *cmd.Context) ([]b
 		info.PublicAddress = ""
 		info.CACertificate = controller.CACert
 	}
+
+	if c.publicAddress != "" {
+		info.PublicAddress = c.publicAddress
+	}
+
 	data, err := yaml.Marshal(info)
 	if err != nil {
 		return nil, errors.Mask(err)

--- a/cmd/jaas/cmd/registercontroller_test.go
+++ b/cmd/jaas/cmd/registercontroller_test.go
@@ -114,6 +114,36 @@ password: super-secret-password
 `)
 }
 
+func (s *registerControllerDryRunSuite) TestControllerInfoWithCustomPublicAddress(c *gc.C) {
+	store := jjclient.NewMemStore()
+	store.Controllers["controller-1"] = jujuclient.ControllerDetails{
+		ControllerUUID: "982b16d9-a945-4762-b684-fd4fd885aa11",
+		APIEndpoints:   []string{"127.0.0.1:17070"},
+		PublicDNSName:  "controller1.example.com",
+		CACert:         `foo`,
+	}
+	store.Accounts["controller-1"] = jujuclient.AccountDetails{
+		User:     "test-user",
+		Password: "super-secret-password",
+	}
+
+	ctx, err := cmdtesting.RunCommand(c, cmd.NewRegisterControllerCommandForTesting(store, nil), "controller-1", "--dry-run", "--public-address", "my-address.com:1234")
+	c.Assert(err, gc.IsNil)
+
+	data := cmdtesting.Stdout(ctx)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Matches, `uuid: 982b16d9-a945-4762-b684-fd4fd885aa11
+name: controller-1
+publicaddress: my-address.com:1234
+tlshostname: ""
+apiaddresses:
+- 127.0.0.1:17070
+cacertificate: ""
+username: test-user
+password: super-secret-password
+`)
+}
+
 type registerControllerSuite struct {
 	cmdtest.JimmCmdSuite
 }


### PR DESCRIPTION
## Description
This PR adds a flag to the `jaas register-controller` command to allow for setting a custom public-address when registering the controller with JIMM. The default value for the public address comes from the value in your controller.yaml file. But a custom one is useful for simplifying some of our existing scripts when adding a controller in K8s to JIMM.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests