### PR TITLE
chore: improve doc publishing and jaas tool detection

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -36,10 +36,10 @@ jobs:
       # We do this because the original doc doesn't have a top level heading.: 
     - name: Create final doc with title
       run: |
-        echo "\`\`jaas\`\` Reference" > jaas-reference.rst
-        echo "##################" >> jaas-reference.rst
-        echo "" >> jaas-reference.rst
-        cat documentation.rst >> jaas-reference.rst
+        echo "\`\`jaas\`\` plugin" > jaas-plugin.rst
+        echo "###############" >> jaas-plugin.rst
+        echo "" >> jaas-plugin.rst
+        cat documentation.rst >> jaas-plugin.rst
     
     - name: Checkout docs
       uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   
     - name: Update Docs
       working-directory: ./jaas-documentation
-      run: cp ../jaas-reference.rst ./reference/jaas.rst
+      run: cp ../jaas-plugin.rst ./reference/jaas-plugin.rst
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6

--- a/cmd/jaas/cmd/listauditevents.go
+++ b/cmd/jaas/cmd/listauditevents.go
@@ -26,7 +26,7 @@ Returns audit log events.
 `
 	listAuditEventsCommandExample = `
     juju list-audit-events --after 2020-01-01T15:00:00 --before 2020-01-01T15:00:00 --user-tag user@canonical.com --limit 50
-	juju list-audit-events --method CreateModel
+    juju list-audit-events --method CreateModel
     juju audit-events --after 2020-01-01T15:00:00 --format yaml
 `
 )

--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -58,38 +58,38 @@ E.g. "user-Alice" or "controller-MyController"
 Certain constraints apply when creating/removing permissions, namely:
 Object may be one of:
 
-	user tag                = "user-<name>"
-	group tag               = "group-<name>"
-	controller tag          = "controller-<name>"
-	model tag               = "model-<name>"
-	application offer tag   = "offer-<name>"
+    user tag                = "user-<name>"
+    group tag               = "group-<name>"
+    controller tag          = "controller-<name>"
+    model tag               = "model-<name>"
+    application offer tag   = "offer-<name>"
 
 If target_object is a group, the relation can only be:
 
-	member
+    member
 
 If target_object is a controller, the relation can be one of:
 
-	loginer
-	administrator
+    loginer
+    administrator
 
 If target_object is a model, the relation can be one of:
 
-	reader
-	writer
-	administrator
+    reader
+    writer
+    administrator
 
 If target_object is an application offer, the relation can be one of:
 
-	reader
-	consumer
-	administrator
+    reader
+    consumer
+    administrator
 
 
 Additionally, if the object is a group, a userset can be applied by adding #member as follows.
 This will grant/revoke access to all users within TeamA:
 
-	group-TeamA#member administrator controller-MyController
+    group-TeamA#member administrator controller-MyController
 `
 
 	addPermissionDoc = `
@@ -99,7 +99,7 @@ Grants access to a resource.
 	addRelationExample = `
     juju add-permission user-alice@canonical.com member group-mygroup
     juju add-permission group-MyTeam#member admin model-mymodel
-	juju add-permission -f /path/to/file.yaml
+    juju add-permission -f /path/to/file.yaml
 `
 
 	removePermissionDoc = `
@@ -109,7 +109,7 @@ Revokes access to a resource.
 	removePermissionExample = `
     juju remove-permission user-alice@canonical.com member group-mygroup
     juju remove-permission group-MyTeam#member admin model-mymodel
-	juju remove-permission -f /path/to/file.yaml
+    juju remove-permission -f /path/to/file.yaml
 `
 
 	checkPermissionDoc = `
@@ -128,14 +128,14 @@ only those permissions matching the filter will be returned.
 List all permissions
 
     juju list-permissions
-	
+
 List permissions where the target object match
 
     juju list-permissions --target model-mymodel
 
 List permissions where the target object and relation match
 
-	juju list-permissions --target model-mymodel  --relation admin
+    juju list-permissions --target model-mymodel  --relation admin
 `
 )
 

--- a/local/jimm/detect-jaas.sh
+++ b/local/jimm/detect-jaas.sh
@@ -28,7 +28,7 @@ else
         JAAS="juju jaas"
     else
         echo "juju cli snap not detected, running jaas binary directly"
-        JAAS=$(command -v jaas)
+        JAAS="/snap/jaas/current/bin/jaas"
     fi
 fi
 


### PR DESCRIPTION
## Description
This PR contains 3 fixes/improvements to the JAAS plugin.

1. When using the JAAS tool standalone, we should directly reference the binary, using the file at /snap/bin/jaas references the snapcraft runner which intentionally doesn't work as the jaas snap is intended to be run via the Juju CLI as a plugin. 
2. Changes the documentation generation to put the docs into the correct file. 
3. Update some commands where tabs and spaces were mixed. Spaces seem to be the correct and more widely used option.