### PR TITLE
fix(applicationoffer): forwards call to grant/revoke offer access to controller.

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -252,6 +252,7 @@ type JujuManager interface {
 	GetCloud(ctx context.Context, u *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error)
 	GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
+	GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)
 	ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
@@ -260,6 +261,7 @@ type JujuManager interface {
 	RemoveCloud(ctx context.Context, u *openfga.User, ct names.CloudTag) error
 	RemoveCloudFromController(ctx context.Context, u *openfga.User, controllerName string, ct names.CloudTag) error
 	RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag, force bool) error
+	RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
 

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -600,3 +600,17 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 	}
 	return nil
 }
+
+// GrantOfferAccessOnController dials the controller in charge of the application offer and grants the user identified by `ut` the specified level of access to the offer.
+func (j *JujuManager) GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
+	return j.doApplicationOfferAdmin(ctx, user, offerURL, func(offer *dbmodel.ApplicationOffer, api API) error {
+		return api.GrantApplicationOfferAccess(ctx, offerURL, ut, access)
+	})
+}
+
+// RevokeOfferAccessOnController dials the controller in charge of the application offer and revokes the user identified by `ut` the specified level of access to the offer.
+func (j *JujuManager) RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
+	return j.doApplicationOfferAdmin(ctx, user, offerURL, func(offer *dbmodel.ApplicationOffer, api API) error {
+		return api.RevokeApplicationOfferAccess(ctx, offerURL, ut, access)
+	})
+}

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -2003,3 +2003,151 @@ func TestListApplicationOffers(t *testing.T) {
 		}},
 	}})
 }
+
+func TestGrantOfferAccessOnController(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			UUID: "00000000-0000-0000-0000-0000-0000000000001",
+			API: &jimmtest.API{
+				GrantApplicationOfferAccess_: func(ctx context.Context, s string, ut names.UserTag, oap jujuparams.OfferAccessPermission) error {
+					if s != "test-offer-url" {
+						return errors.E(errors.CodeNotFound)
+					}
+					return nil
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, listApplicationsTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	offer := env.ApplicationOffers[0]
+
+	u, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	u1, err := dbmodel.NewIdentity("eve@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	u2, err := dbmodel.NewIdentity("adam@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	tuples := []openfga.Tuple{{
+		Object:   ofganames.ConvertTag(u.ResourceTag()),
+		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}, {
+		Object:   ofganames.ConvertTag(u1.ResourceTag()),
+		Relation: ofganames.ConsumerRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}, {
+		Object:   ofganames.ConvertTag(u2.ResourceTag()),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}}
+	err = j.OpenFGAClient.AddRelation(context.Background(), tuples...)
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		about         string
+		user          *openfga.User
+		expectedError string
+	}{{
+		about: "admin is allowed",
+		user:  openfga.NewUser(u, j.OpenFGAClient),
+	}, {
+		about:         "consumer is not allowed",
+		user:          openfga.NewUser(u1, j.OpenFGAClient),
+		expectedError: "unauthorized",
+	}, {
+		about:         "reader is not allowed",
+		user:          openfga.NewUser(u2, j.OpenFGAClient),
+		expectedError: "unauthorized",
+	}}
+
+	for _, test := range tests {
+		err = j.GrantOfferAccessOnController(ctx, test.user, names.NewUserTag("bob@canonical.com"), offer.URL, "consume")
+		if test.expectedError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, qt.IsNil)
+		}
+	}
+}
+
+func TestRevokeOfferAccessOnController(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			UUID: "00000000-0000-0000-0000-0000-0000000000001",
+			API: &jimmtest.API{
+				RevokeApplicationOfferAccess_: func(ctx context.Context, s string, ut names.UserTag, oap jujuparams.OfferAccessPermission) error {
+					if s != "test-offer-url" {
+						return errors.E(errors.CodeNotFound)
+					}
+					return nil
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, listApplicationsTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	offer := env.ApplicationOffers[0]
+
+	u, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	u1, err := dbmodel.NewIdentity("eve@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	u2, err := dbmodel.NewIdentity("adam@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	tuples := []openfga.Tuple{{
+		Object:   ofganames.ConvertTag(u.ResourceTag()),
+		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}, {
+		Object:   ofganames.ConvertTag(u1.ResourceTag()),
+		Relation: ofganames.ConsumerRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}, {
+		Object:   ofganames.ConvertTag(u2.ResourceTag()),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(offer.DBObject(c, j.Database).ResourceTag()),
+	}}
+	err = j.OpenFGAClient.AddRelation(context.Background(), tuples...)
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		about         string
+		user          *openfga.User
+		expectedError string
+	}{{
+		about: "admin is allowed",
+		user:  openfga.NewUser(u, j.OpenFGAClient),
+	}, {
+		about:         "consumer is not allowed",
+		user:          openfga.NewUser(u1, j.OpenFGAClient),
+		expectedError: "unauthorized",
+	}, {
+		about:         "reader is not allowed",
+		user:          openfga.NewUser(u2, j.OpenFGAClient),
+		expectedError: "unauthorized",
+	}}
+
+	for _, test := range tests {
+		err = j.RevokeOfferAccessOnController(ctx, test.user, names.NewUserTag("bob@canonical.com"), offer.URL, "consume")
+		if test.expectedError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, qt.IsNil)
+		}
+	}
+}

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -5,6 +5,7 @@ package jujuapi
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/juju/core/crossmodel"
@@ -175,12 +176,23 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 	}
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
+		// We grant access on the controller because pre 3.6.6 controllers are consulting their database to check if
+		// user has access to the offer when getting consume details. This is a bug and will be fixed in the following
+		// releases of Juju.
+		if err := r.jimm.JujuManager().GrantOfferAccessOnController(ctx, r.user, ut, change.OfferURL, change.Access); err != nil {
+			if !strings.Contains(err.Error(), "user already has") {
+				return errors.E(op, err)
+			}
+		}
 		if err := r.jimm.PermissionManager().GrantOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
 			return errors.E(op, err)
 		}
 		return nil
 	case jujuparams.RevokeOfferAccess:
 		if err := r.jimm.PermissionManager().RevokeOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
+			return errors.E(op, err)
+		}
+		if err := r.jimm.JujuManager().RevokeOfferAccessOnController(ctx, r.user, ut, change.OfferURL, change.Access); err != nil {
 			return errors.E(op, err)
 		}
 		return nil

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -1,4 +1,5 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package jujuapi_test
 
 import (
@@ -209,6 +210,76 @@ func (s *applicationOffersSuite) TestGetConsumeDetails(c *gc.C) {
 	})
 }
 
+func (s *applicationOffersSuite) TestGetConsumeDetailsWithConsumeAccess(c *gc.C) {
+	conn := s.open(c, nil, "bob@canonical.com")
+	defer conn.Close()
+	client := applicationoffers.NewClient(conn)
+
+	results, err := client.Offer(s.Model.UUID.String, "test-app", []string{s.endpoint.Name}, "bob@canonical.com", "test-offer", "test offer description")
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Error, gc.Equals, (*jujuparams.Error)(nil))
+
+	ourl := &crossmodel.OfferURL{
+		User:            "bob@canonical.com",
+		ModelName:       "model-1",
+		ApplicationName: "test-offer",
+	}
+
+	user := "regular.joe@canonical.com"
+	err = client.GrantOffer(user, string(jujuparams.OfferConsumeAccess), ourl.String())
+	c.Assert(err, gc.Equals, nil)
+
+	info := s.APIInfo(c)
+	caCert, _ := s.ControllerConfig.CACert()
+
+	conn1 := s.open(c, nil, user)
+	defer conn.Close()
+	client1 := applicationoffers.NewClient(conn1)
+
+	details, err := client1.GetConsumeDetails(ourl.String())
+	c.Assert(err, gc.Equals, nil)
+	c.Check(details.Macaroon, gc.Not(gc.IsNil))
+	details.Macaroon = nil
+	c.Check(details.Offer.OfferUUID, gc.Matches, `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	details.Offer.OfferUUID = ""
+	sort.Slice(details.Offer.Users, func(j, k int) bool {
+		return details.Offer.Users[j].UserName < details.Offer.Users[k].UserName
+	})
+	c.Check(details, gc.DeepEquals, jujuparams.ConsumeOfferDetails{
+		Offer: &jujuparams.ApplicationOfferDetailsV5{
+			SourceModelTag:         s.Model.Tag().String(),
+			OfferURL:               ourl.Path(),
+			OfferName:              "test-offer",
+			ApplicationDescription: "test offer description",
+			Endpoints: []jujuparams.RemoteEndpoint{{
+				Name:      "url",
+				Role:      "provider",
+				Interface: "http",
+			}},
+			Users: []jujuparams.OfferUserDetails{{
+				UserName: ofganames.EveryoneUser,
+				Access:   "read",
+			}, {
+				UserName: user,
+				Access:   "consume",
+			}},
+		},
+		ControllerInfo: &jujuparams.ExternalControllerInfo{
+			ControllerTag: s.Model.Controller.Tag().String(),
+			Addrs:         info.Addrs,
+			Alias:         "controller-1",
+			CACert:        caCert,
+		},
+	})
+
+	err = client.RevokeOffer(user, string(jujuparams.OfferConsumeAccess), ourl.String())
+	c.Assert(err, gc.Equals, nil)
+
+	_, err = client1.GetConsumeDetails(ourl.String())
+	c.Assert(err, gc.ErrorMatches, "unauthorized")
+}
+
 func (s *applicationOffersSuite) TestListApplicationOffers(c *gc.C) {
 	conn := s.open(c, nil, "bob@canonical.com")
 	defer conn.Close()
@@ -311,6 +382,9 @@ func (s *applicationOffersSuite) TestModifyOfferAccess(c *gc.C) {
 	err = client.GrantOffer("test.user@canonical.com", "admin", offerURL)
 	c.Assert(err, jc.ErrorIsNil)
 
+	err = client.GrantOffer("test.user@canonical.com", "admin", offerURL)
+	c.Assert(err, jc.ErrorIsNil)
+
 	testUser := openfga.NewUser(
 		&dbmodel.Identity{
 			Name: "test.user@canonical.com",
@@ -339,6 +413,12 @@ func (s *applicationOffersSuite) TestModifyOfferAccess(c *gc.C) {
 
 	err = client3.RevokeOffer("test.user@canonical.com", "read", offerURL)
 	c.Assert(err, gc.ErrorMatches, "unauthorized")
+
+	err = client.GrantOffer("test.user@canonical.com", "admin", offerURL)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = client.GrantOffer("test.user@canonical.com", "admin", offerURL)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *applicationOffersSuite) TestDestroyOffers(c *gc.C) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -54,6 +54,8 @@ type JujuManager struct {
 	UpdateCloud_                       func(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential_             func(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
 	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
+	GrantOfferAccessOnController_      func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
+	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 
 	// These mocks can be removed soon once the jujuManager interface is updated.
 	UpdateMetrics_      func(ctx context.Context)
@@ -249,4 +251,18 @@ func (j *JujuManager) CleanupDyingModels(ctx context.Context) error {
 		return nil
 	}
 	return j.CleanupDyingModels_(ctx)
+}
+
+func (j *JujuManager) GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
+	if j.GrantOfferAccessOnController_ == nil {
+		return nil
+	}
+	return j.GrantOfferAccessOnController_(ctx, user, ut, offerURL, access)
+}
+
+func (j *JujuManager) RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
+	if j.RevokeOfferAccessOnController_ == nil {
+		return nil
+	}
+	return j.RevokeOfferAccessOnController_(ctx, user, ut, offerURL, access)
 }


### PR DESCRIPTION

## Description

Forwards the call to grant or revoke offer access to the controller in charge of the offer. This should fix the problem with application offers to some extent, but will NOT fix the terraform provider - that still only adds relations in OpenFGA.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

