### PR TITLE
chore: create JWT token for SSH authentication

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -197,12 +197,12 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ControllerInfoFromModelUUID resolves the address of the controller to contact given the model UUID and
-	// a valid JWT To connect to the controller.
-	ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error)
+	// DialInfo resolves the address of the controller to contact given the model UUID and
+	// returns a struct with parameters to connect and authenticate to the controller.
+	DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error)
 
-	// DialControllerSSHServer dials the controller using the provided details.
-	DialControllerSSHServer(ctx context.Context, ctrlInfo ssh.ControllerInfo, user *openfga.User) (*gossh.Client, error)
+	// DialController dials a controller's SSH server using the provided details.
+	DialController(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error)
 }
 
 // JujuManager is the interface to manage all Juju related operations.
@@ -513,8 +513,8 @@ func (j *JIMM) PermissionManager() PermissionManager {
 
 // NewJujuAuthenticator returns a new token generator for authenticating
 // requests to a Juju controller.
-func (j *JIMM) NewJujuAuthenticator() jujuauth.TokenGenerator {
-	return j.jujuAuthFactory.New()
+func (j *JIMM) NewJujuAuthenticator() jujuauth.LoginTokenGenerator {
+	return j.jujuAuthFactory.NewLoginGenerator()
 }
 
 // AuditLogManager returns a manager that handles audit logging.

--- a/internal/jimm/jujuauth/factory.go
+++ b/internal/jimm/jujuauth/factory.go
@@ -2,9 +2,9 @@
 
 package jujuauth
 
-// Factory holds the necessary components for producing new stateful
-// Juju authenticator objects. Because these objects are
-// stateful, it is expected that a new one is used for each connection.
+// Factory holds the necessary components for producing
+// Juju authenticator objects. Currently a login token generator
+// and an SSH token generator are available.
 type Factory struct {
 	db            GeneratorDatabase
 	jwtService    JWTService
@@ -20,7 +20,16 @@ func NewFactory(db GeneratorDatabase, jwtService JWTService, accessChecker Gener
 	}
 }
 
-// New returns a new Juju token generator.
-func (f *Factory) New() TokenGenerator {
-	return newTokenGenerator(f.db, f.accessChecker, f.jwtService)
+// NewLoginGenerator returns a new token generator for Juju RPC login requests.
+// The LoginTokenGenerator is stateful and should be re-used for the lifetime
+// of a single connection, and recreated for each new connection.
+func (f *Factory) NewLoginGenerator() LoginTokenGenerator {
+	return newLoginTokenGenerator(f.db, f.accessChecker, f.jwtService)
+}
+
+// NewSSHGenerator returns a new token generator for Juju SSH connections.
+// The SSHToken generator is not stateful and can be re-used across
+// multiple connections.
+func (f *Factory) NewSSHGenerator() SSHTokenGenerator {
+	return newSSHTokenGenerator(f.jwtService)
 }

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -42,8 +42,10 @@ type JWTService interface {
 	NewJWT(context.Context, jimmjwx.JWTParams) ([]byte, error)
 }
 
-// TokenGenerator provides the necessary state and methods to authorize a user and generate JWT tokens.
-type TokenGenerator struct {
+// LoginTokenGenerator provides the necessary state and
+// methods to authorize a user and generate JWT tokens
+// appropriate when logging in for RPC based communication..
+type LoginTokenGenerator struct {
 	database      GeneratorDatabase
 	accessChecker GeneratorAccessChecker
 	jwtService    JWTService
@@ -56,9 +58,9 @@ type TokenGenerator struct {
 	callCount      int
 }
 
-// newTokenGenerator returns a new TokenGenerator.
-func newTokenGenerator(database GeneratorDatabase, accessChecker GeneratorAccessChecker, jwtService JWTService) TokenGenerator {
-	return TokenGenerator{
+// newLoginTokenGenerator returns a new LoginTokenGenerator.
+func newLoginTokenGenerator(database GeneratorDatabase, accessChecker GeneratorAccessChecker, jwtService JWTService) LoginTokenGenerator {
+	return LoginTokenGenerator{
 		database:      database,
 		accessChecker: accessChecker,
 		jwtService:    jwtService,
@@ -66,13 +68,15 @@ func newTokenGenerator(database GeneratorDatabase, accessChecker GeneratorAccess
 }
 
 // SetTags implements TokenGenerator.
-func (auth *TokenGenerator) SetTags(mt names.ModelTag, ct names.ControllerTag) {
+// It sets the model and controller we are operating on
+// which will be used to set the JWT audience and claims.
+func (auth *LoginTokenGenerator) SetTags(mt names.ModelTag, ct names.ControllerTag) {
 	auth.mt = mt
 	auth.ct = ct
 }
 
 // SetTags implements TokenGenerator.
-func (auth *TokenGenerator) GetUser() names.UserTag {
+func (auth *LoginTokenGenerator) GetUser() names.UserTag {
 	if auth.user != nil {
 		return auth.user.ResourceTag()
 	}
@@ -82,7 +86,7 @@ func (auth *TokenGenerator) GetUser() names.UserTag {
 // MakeLoginToken authorizes the user based on the provided login requests and returns
 // a JWT containing claims about user's access to the controller, model (if applicable)
 // and all clouds that the controller knows about.
-func (auth *TokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.User) ([]byte, error) {
+func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.User) ([]byte, error) {
 	const op = errors.Op("jimm.MakeLoginToken")
 
 	auth.mu.Lock()
@@ -148,7 +152,7 @@ func (auth *TokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.Us
 // MakeToken assumes MakeLoginToken has already been called and checks the permissions
 // specified in the permissionMap. If the logged in user has all those permissions
 // a JWT will be returned with assertions confirming all those permissions.
-func (auth *TokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
+func (auth *LoginTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
 	const op = errors.Op("jimm.MakeToken")
 
 	auth.mu.Lock()

--- a/internal/jimm/jujuauth/logintokens_test.go
+++ b/internal/jimm/jujuauth/logintokens_test.go
@@ -239,7 +239,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 
 	for _, test := range tests {
 		authFactory := jujuauth.NewFactory(test.database, test.jwtService, test.accessChecker)
-		generator := authFactory.New()
+		generator := authFactory.NewLoginGenerator()
 		generator.SetTags(mt, ct)
 
 		i, err := dbmodel.NewIdentity(test.username)
@@ -339,7 +339,7 @@ func TestJWTGeneratorMakeToken(t *testing.T) {
 				permissionCheckErr: test.checkPermissionsError,
 			},
 		)
-		generator := authFactory.New()
+		generator := authFactory.NewLoginGenerator()
 		generator.SetTags(mt, ct)
 
 		i, err := dbmodel.NewIdentity("eve@canonical.com")

--- a/internal/jimm/jujuauth/sshtokens.go
+++ b/internal/jimm/jujuauth/sshtokens.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Canonical.
+
+// Package jujuauth generates JWT tokens to
+// authenticate and authorize messages to Juju controllers.
+// This package is more specialised than a generic
+// JWT token generator as it crafts Juju specific
+// permissions that are added as claims to the JWT
+// and therefore exists in JIMM's business logic layer.
+package jujuauth
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/jimmjwx"
+)
+
+// SSHTokenGenerator provides the ability to generate JWT tokens that
+// authenticate and authorize SSH connections to Juju controllers.
+type SSHTokenGenerator struct {
+	jwtService JWTService
+}
+
+// newSSHTokenGenerator returns a new SSHTokenGenerator.
+func newSSHTokenGenerator(jwtService JWTService) SSHTokenGenerator {
+	return SSHTokenGenerator{
+		jwtService: jwtService,
+	}
+}
+
+// SSHTokenArgs holds the arguments needed to generate a
+// JWT token for SSH authentication with Juju controllers.
+type SSHTokenArgs struct {
+	User           string
+	ControllerUUID string
+	Port           int
+	ModelTag       names.Tag
+	PublicKey      []byte
+}
+
+// NewSSHToken generates a JWT token with the correct claims
+// for SSH authentication with Juju controllers.
+// It is expected that this function is called after
+// user authentication and authorization has taken place.
+func (s *SSHTokenGenerator) NewSSHToken(ctx context.Context, tokenArgs SSHTokenArgs) ([]byte, error) {
+	token, err := s.jwtService.NewJWT(ctx, jimmjwx.JWTParams{
+		Controller: tokenArgs.ControllerUUID,
+		User:       tokenArgs.User,
+		Access: map[string]string{
+			tokenArgs.ModelTag.String(): string(permission.AdminAccess),
+		},
+		ExtraClaims: map[string]any{
+			"ssh_public_key": base64.StdEncoding.EncodeToString(tokenArgs.PublicKey),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}

--- a/internal/jimm/jujuauth/sshtokens.go
+++ b/internal/jimm/jujuauth/sshtokens.go
@@ -18,6 +18,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
 )
 
+const (
+	sshPublicKeyClaim = "ssh_public_key"
+)
+
 // SSHTokenGenerator provides the ability to generate JWT tokens that
 // authenticate and authorize SSH connections to Juju controllers.
 type SSHTokenGenerator struct {
@@ -36,7 +40,6 @@ func newSSHTokenGenerator(jwtService JWTService) SSHTokenGenerator {
 type SSHTokenArgs struct {
 	User           string
 	ControllerUUID string
-	Port           int
 	ModelTag       names.Tag
 	PublicKey      []byte
 }
@@ -53,7 +56,7 @@ func (s *SSHTokenGenerator) NewSSHToken(ctx context.Context, tokenArgs SSHTokenA
 			tokenArgs.ModelTag.String(): string(permission.AdminAccess),
 		},
 		ExtraClaims: map[string]any{
-			"ssh_public_key": base64.StdEncoding.EncodeToString(tokenArgs.PublicKey),
+			sshPublicKeyClaim: base64.StdEncoding.EncodeToString(tokenArgs.PublicKey),
 		},
 	})
 	if err != nil {

--- a/internal/jimm/jujuauth/sshtokens_test.go
+++ b/internal/jimm/jujuauth/sshtokens_test.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Canonical.
+
+package jujuauth_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/jimm/jujuauth"
+)
+
+func TestNewSSHToken(t *testing.T) {
+	c := qt.New(t)
+
+	jwtSvc := testJWTService{}
+	authFactory := jujuauth.NewFactory(nil, &jwtSvc, nil)
+	sshTokenGen := authFactory.NewSSHGenerator()
+
+	params := jujuauth.SSHTokenArgs{
+		User:           "testuser",
+		ControllerUUID: "123",
+		ModelTag:       names.NewModelTag("testmodel"),
+		PublicKey:      []byte("testkey"),
+	}
+	sshToken, err := sshTokenGen.NewSSHToken(context.Background(), params)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sshToken), qt.Equals, "test jwt")
+
+	c.Assert(jwtSvc.params.User, qt.Equals, "testuser")
+	c.Assert(jwtSvc.params.Controller, qt.Equals, "123")
+	c.Assert(jwtSvc.params.ExtraClaims, qt.DeepEquals, map[string]any{
+		"ssh_public_key": "dGVzdGtleQ==", // base64.StdEncoding.EncodeToString([]byte("testkey"))
+	})
+	c.Assert(jwtSvc.params.Access, qt.DeepEquals, map[string]string{
+		"model-testmodel": string(permission.AdminAccess),
+	})
+}

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -4,11 +4,13 @@ package ssh
 
 import (
 	"context"
+	"encoding/base64"
 	goerr "errors"
 	"fmt"
 	"net"
 	"time"
 
+	"github.com/gliderlabs/ssh"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/zaputil/zapctx"
 	gossh "golang.org/x/crypto/ssh"
@@ -20,8 +22,9 @@ import (
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
-// ControllerInfo is the struct holding the infomation to contact a controller
-type ControllerInfo struct {
+// DialInfo is the struct holding the infomation
+// to dial a controller via SSH.
+type DialInfo struct {
 	// addresses to dial the controller
 	Addresses []string
 
@@ -48,18 +51,13 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-// JWTGeneratorFactory provides a means to create a token generator.
-type JWTGeneratorFactory interface {
-	New() jujuauth.TokenGenerator
-}
-
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(identityManager IdentityManager, jujuManager JujuManager, sshKeyManager SSHKeyManager, jwtFactory JWTGeneratorFactory) (*sshManager, error) {
+func NewSSHManager(identityManager IdentityManager, jujuManager JujuManager, sshKeyManager SSHKeyManager, jwtFactory *jujuauth.Factory) (*sshManager, error) {
 	if identityManager == nil {
 		return nil, errors.E("identityManager cannot be nil")
 	}
 	if jujuManager == nil {
-		return nil, errors.E("modelManager cannot be nil")
+		return nil, errors.E("jujuManager cannot be nil")
 	}
 	if sshKeyManager == nil {
 		return nil, errors.E("sshManager cannot be nil")
@@ -80,7 +78,7 @@ type sshManager struct {
 	jujuManager     JujuManager
 	identityManager IdentityManager
 	sshKeyManager   SSHKeyManager
-	jwtFactory      JWTGeneratorFactory
+	jwtFactory      *jujuauth.Factory
 }
 
 // PublicKeyHandler is the method to verify the public key of the user. It first checks for the public key and then fetches the user.
@@ -88,64 +86,89 @@ type sshManager struct {
 func (s *sshManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	zapctx.Info(ctx, "PublicKeyHandler")
 	if ok, err := s.sshKeyManager.VerifyPublicKey(ctx, claimUser, key); !ok || err != nil {
-		return nil, errors.E(err, "cannot verify key for user")
+		return nil, fmt.Errorf("cannot verify key for user %s: %v", claimUser, err)
 	}
 	user, err := s.identityManager.FetchIdentity(ctx, claimUser)
 	if err != nil {
 		zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", claimUser))
-		return nil, errors.E(err, "cannot find user")
+		return nil, fmt.Errorf("cannot find user %s: %v", claimUser, err)
 	}
 	return user, nil
 }
 
-// ControllerInfoFromModelUUID is the method to resolve the address of the controller to contact given the model UUID and
-// a valid JWT To connect to the controller.
-func (s *sshManager) ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ControllerInfo, error) {
-	zapctx.Info(ctx, "ControllerInfoFromModelUUID")
+// DialInfo resolves the address of the controller to contact given the
+// model UUID and returns a struct with parameters to connect and authenticate
+// to the controller. The context should contain the public key the user
+// used to authenticate.
+func (s *sshManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (DialInfo, error) {
+	zapctx.Info(ctx, "SSHDialInfo")
 	model, err := s.jujuManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return ControllerInfo{}, errors.E(err, "cannot find model")
-	}
-	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
-	if len(addrs) == 0 {
-		return ControllerInfo{}, errors.E(err, "cannot find addresses for model's controller")
+		return DialInfo{}, fmt.Errorf("cannot find model: %v", err)
 	}
 
 	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, model.Controller.Name)
 	if err != nil {
-		return ControllerInfo{}, errors.E(err, "cannot get controller config")
+		return DialInfo{}, errors.E(err, "cannot get controller config")
 	}
 
-	jwtGenerator := s.jwtFactory.New()
-	jwtGenerator.SetTags(model.ResourceTag(), model.Controller.ResourceTag())
-	jwt, err := jwtGenerator.MakeLoginToken(ctx, user)
+	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
+	if len(addrs) == 0 {
+		return DialInfo{}, fmt.Errorf("cannot find addresses for model's controller: %v", err)
+	}
+
+	addrsNoPort := make([]string, len(addrs))
+	for i, addr := range addrs {
+		hostNoPort, _, err := net.SplitHostPort(addr)
+		// If there was an error we will assume there is no port since
+		// SplitHostPort doesn't expose const error types for checking.
+		if err != nil {
+			addrsNoPort[i] = addr
+		} else {
+			addrsNoPort[i] = hostNoPort
+		}
+	}
+
+	publicKey, _ := ctx.Value(ssh.ContextKeyPublicKey).(ssh.PublicKey)
+	if publicKey == nil {
+		return DialInfo{}, errors.E("cannot find user's public key")
+	}
+
+	tokenArgs := jujuauth.SSHTokenArgs{
+		User:           user.Name,
+		ControllerUUID: model.Controller.UUID,
+		ModelTag:       model.Tag(),
+		PublicKey:      publicKey.Marshal(),
+	}
+	jwtGenerator := s.jwtFactory.NewSSHGenerator()
+	token, err := jwtGenerator.NewSSHToken(ctx, tokenArgs)
 	if err != nil {
-		return ControllerInfo{}, errors.E(err, "cannot generate jwt")
+		return DialInfo{}, fmt.Errorf("cannot generate jwt: %v", err)
 	}
 
-	return ControllerInfo{
-		Addresses: addrs,
+	return DialInfo{
+		Addresses: addrsNoPort,
 		Port:      controllerConfig.SSHServerPort(),
-		JWT:       string(jwt),
+		JWT:       base64.StdEncoding.EncodeToString(token),
 	}, nil
 }
 
-// DialControllerSSHServer dials the controller and returns
-// an SSH connection.
-func (s *sshManager) DialControllerSSHServer(ctx context.Context, ctrlInfo ControllerInfo, user *openfga.User) (*gossh.Client, error) {
+// DialController dials a controller's SSH
+// server and returns an SSH connection.
+func (s *sshManager) DialController(ctx context.Context, dialInfo DialInfo, user *openfga.User) (*gossh.Client, error) {
 	var client *gossh.Client
 	var err error
 	var errs []error
 
-	for _, addr := range ctrlInfo.Addresses {
-		dest := net.JoinHostPort(addr, fmt.Sprint(ctrlInfo.Port))
+	for _, addr := range dialInfo.Addresses {
+		dest := net.JoinHostPort(addr, fmt.Sprint(dialInfo.Port))
 		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
 			User: "jimm",
 			//nolint:gosec // this will be removed once we handle hostkeys
 			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 			Auth: []gossh.AuthMethod{
 				gossh.PasswordCallback(func() (secret string, err error) {
-					return ctrlInfo.JWT, nil
+					return dialInfo.JWT, nil
 				}),
 			},
 			Timeout: 5 * time.Second,

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -7,11 +7,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"database/sql"
+	"encoding/base64"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
+	gliderssh "github.com/gliderlabs/ssh"
 	jujucontroller "github.com/juju/juju/controller"
 	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/names/v5"
@@ -31,9 +33,9 @@ import (
 )
 
 type sshManagerSuite struct {
-	publicKey             sshkeys.PublicKey
-	allowedModelUUID      string
-	allowedControllerUUID string
+	publicKey        sshkeys.PublicKey
+	allowedModelUUID string
+	database         *db.Database
 
 	sshManager *ssh.SSHManager
 
@@ -57,7 +59,7 @@ controllers:
   uuid: 00000001-0000-0000-0000-000000000001
   cloud: test
   region: test-region
-  public-address: localhost
+  public-address: localhost:1234
 
 models:
 - name: test-1
@@ -81,16 +83,16 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	jimmTag := names.NewControllerTag(uuid)
 	// Setup DB
 
-	database := &db.Database{
+	s.database = &db.Database{
 		DB: jimmtest.PostgresDB(c, time.Now),
 	}
-	err := database.Migrate(context.Background())
+	err := s.database.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)
 	// Setup OFGA
 	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
 	c.Assert(err, qt.IsNil)
 
-	identityManager, err := identity.NewIdentityManager(database, ofgaClient)
+	identityManager, err := identity.NewIdentityManager(s.database, ofgaClient)
 	c.Assert(err, qt.IsNil)
 
 	// this is a mock non-mock model manager, bandaid until we have a real model manager to avoid creating a whole jimm.
@@ -102,7 +104,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 					Valid:  true,
 				},
 			}
-			err := database.GetModel(ctx, &m)
+			err := s.database.GetModel(ctx, &m)
 			return m, err
 		},
 	}
@@ -120,32 +122,31 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 		ModelManager:      modelManager,
 		ControllerService: controllerService,
 	}
-	permissionManager, err := permissions.NewManager(database, ofgaClient, uuid, jimmTag)
+	permissionManager, err := permissions.NewManager(s.database, ofgaClient, uuid, jimmTag)
 	c.Assert(err, qt.IsNil)
-	jwtFactory := jujuauth.NewFactory(database, mocks.JWTService{
+	jwtFactory := jujuauth.NewFactory(s.database, mocks.JWTService{
 		NewJWT_: func(ctx context.Context, j jimmjwx.JWTParams) ([]byte, error) {
 			return []byte("jwt"), nil
 		},
 	}, permissionManager)
 
-	sshKeyManager, err := sshkeys.NewSSHKeyManager(database)
+	sshKeyManager, err := sshkeys.NewSSHKeyManager(s.database)
 	c.Assert(err, qt.IsNil)
 
 	s.sshManager, err = ssh.NewSSHManager(identityManager, &jujuManager, sshKeyManager, jwtFactory)
 	c.Assert(err, qt.IsNil)
 	env := jimmtest.ParseEnvironment(c, testSSHManagerEnv)
-	env.PopulateDB(c, database)
-	env.PopulateDBAndPermissions(c, jimmTag, database, ofgaClient)
+	env.PopulateDB(c, s.database)
+	env.PopulateDBAndPermissions(c, jimmTag, s.database, ofgaClient)
 	// create a user and set permission for one model
 	s.userWithAccess, err = identityManager.FetchIdentity(ctx, env.Users[0].Username)
 	c.Assert(err, qt.IsNil)
 	s.allowedModelUUID = env.Models[0].UUID
-	s.allowedControllerUUID = env.Controllers[0].UUID
 
 	// create a user without access
 	i2, err := dbmodel.NewIdentity("bob")
 	c.Assert(err, qt.IsNil)
-	c.Assert(database.DB.Create(i2).Error, qt.IsNil)
+	c.Assert(s.database.DB.Create(i2).Error, qt.IsNil)
 	s.userWithoutAccess = openfga.NewUser(i2, ofgaClient)
 	// setup public key
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -170,21 +171,35 @@ func (s *sshManagerSuite) TestPublicKeyHandler(c *qt.C) {
 
 	// Test that the PublicKeyHandler returns an error when the public key is invalid.
 	_, err = s.sshManager.PublicKeyHandler(ctx, s.userWithoutAccess.Name, s.publicKey.Marshal())
-	c.Assert(err, qt.ErrorMatches, `cannot verify key for user`)
+	c.Assert(err, qt.ErrorMatches, `cannot verify key for user bob: cannot find a matching key for this user`)
 }
 
-func (s *sshManagerSuite) TestControllerInfoFromModelUUID(c *qt.C) {
+func (s *sshManagerSuite) TestDialInfo(c *qt.C) {
 	ctx := context.Background()
 
-	// Test that the ControllerInfoFromModelUUID returns the correct controller address and user when the model UUID is valid.
-	connInfo, err := s.sshManager.ControllerInfoFromModelUUID(ctx, s.allowedModelUUID, s.userWithAccess)
+	ctrl := dbmodel.Controller{Name: "test"}
+	err := s.database.GetController(ctx, &ctrl)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.PublicAddress, qt.Equals, "localhost:1234")
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	c.Assert(err, qt.IsNil)
+	pubKey, err := gossh.NewPublicKey(&key.PublicKey)
+	c.Assert(err, qt.IsNil)
+	ctx = context.WithValue(ctx, gliderssh.ContextKeyPublicKey, pubKey)
+
+	// Test that the DialInfo returns the correct controller address and user when the model UUID is valid.
+	connInfo, err := s.sshManager.DialInfo(ctx, s.allowedModelUUID, s.userWithAccess)
 	c.Assert(err, qt.IsNil)
 	c.Assert(connInfo.Addresses, qt.HasLen, 1)
+	c.Assert(connInfo.Addresses[0], qt.Equals, "localhost")
 	c.Assert(connInfo.JWT, qt.Not(qt.HasLen), 0)
 	c.Assert(connInfo.Port, qt.Equals, 17023)
+	_, err = base64.StdEncoding.DecodeString(connInfo.JWT)
+	c.Assert(err, qt.IsNil)
 
 	// Test that the ControllerInfoFromModelUUID returns an error when the model UUID is invalid.
-	_, err = s.sshManager.ControllerInfoFromModelUUID(ctx, "not-valid", s.userWithAccess)
+	_, err = s.sshManager.DialInfo(ctx, "not-valid", s.userWithAccess)
 	c.Assert(err, qt.ErrorMatches, ".*cannot find model.*")
 }
 

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -70,7 +70,7 @@ func (sm *sshKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, 
 			return true, nil
 		}
 	}
-	return false, fmt.Errorf("cannot find a matching key for this user.")
+	return false, fmt.Errorf("cannot find a matching key for this user")
 
 }
 

--- a/internal/jimm/sshkeys/sshkeys_test.go
+++ b/internal/jimm/sshkeys/sshkeys_test.go
@@ -142,21 +142,21 @@ func (s *sshKeysManagerSuite) TestVerifyPublicKeys(c *qt.C) {
 			user:          "not-existing",
 			key:           s.pubKey.Marshal(),
 			okExpected:    false,
-			errorExpected: "cannot find a matching key for this user.",
+			errorExpected: "cannot find a matching key for this user",
 		},
 		{
 			name:          "valid user with a not added key",
 			user:          s.user.Name,
 			key:           notAddedPublicKey.Marshal(),
 			okExpected:    false,
-			errorExpected: "cannot find a matching key for this user.",
+			errorExpected: "cannot find a matching key for this user",
 		},
 		{
 			name:          "valid user with a key added on another user",
 			user:          "bob",
 			key:           anotherPubKey.Marshal(),
 			okExpected:    false,
-			errorExpected: "cannot find a matching key for this user.",
+			errorExpected: "cannot find a matching key for this user",
 		},
 	}
 

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmjwx
 
@@ -78,7 +78,11 @@ type JWTParams struct {
 	// User is the "sub" of the JWT
 	User string
 	// Access is a claim of key/values denoting what the user wishes to access
+	// stored in a claim called "access".
 	Access map[string]string
+	// ExtraClaims contain any extra claims that should be added to the JWT.
+	// "access" is a reserved claim and will cause an error if used.
+	ExtraClaims map[string]interface{}
 }
 
 // NewJWTService returns a new JWT service for handling JIMMs JWTs.
@@ -142,14 +146,22 @@ func (j *JWTService) NewJWT(ctx context.Context, params JWTParams) ([]byte, erro
 		return nil, err
 	}
 
-	token, err := jwt.NewBuilder().
+	builder := jwt.NewBuilder().
 		Audience([]string{params.Controller}).
 		Subject(params.User).
 		Issuer(j.Host).
 		JwtID(jti).
 		Claim("access", params.Access).
-		Expiration(time.Now().Add(j.Expiry)).
-		Build()
+		Expiration(time.Now().Add(j.Expiry))
+
+	for k, v := range params.ExtraClaims {
+		if k == "access" {
+			return nil, errors.E("access is a reserved claim")
+		}
+		builder = builder.Claim(k, v)
+	}
+
+	token, err := builder.Build()
 	if err != nil {
 		zapctx.Error(ctx, "failed to create token", zap.Error(err))
 		return nil, err

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -20,6 +20,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm/credentials"
 )
 
+const (
+	accessClaim = "access"
+)
+
 type JWTServiceParams struct {
 	Host   string
 	Store  credentials.CredentialStore
@@ -151,11 +155,11 @@ func (j *JWTService) NewJWT(ctx context.Context, params JWTParams) ([]byte, erro
 		Subject(params.User).
 		Issuer(j.Host).
 		JwtID(jti).
-		Claim("access", params.Access).
+		Claim(accessClaim, params.Access).
 		Expiration(time.Now().Add(j.Expiry))
 
 	for k, v := range params.ExtraClaims {
-		if k == "access" {
+		if k == accessClaim {
 			return nil, errors.E("access is a reserved claim")
 		}
 		builder = builder.Claim(k, v)

--- a/internal/jimmjwx/jwt_test.go
+++ b/internal/jimmjwx/jwt_test.go
@@ -1,9 +1,9 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package jimmjwx_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -45,13 +45,6 @@ func TestNewJWTIsParsableByExponent(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Set env for 'fake' service
-	c.Assert(os.Setenv("JIMM_DNS_NAME", "127.0.0.1:17070"), qt.IsNil)
-	c.Assert(os.Setenv("JIMM_JWT_EXPIRY", "10s"), qt.IsNil)
-	c.Cleanup(func() {
-		os.Clearenv()
-	})
-
 	store := setupCredentialStore(ctx, c)
 
 	// Setup JWKSService
@@ -72,6 +65,9 @@ func TestNewJWTIsParsableByExponent(t *testing.T) {
 		Access: map[string]string{
 			"controller": "superuser",
 			"model":      "administrator",
+		},
+		ExtraClaims: map[string]any{
+			"my-claim": "my-value",
 		},
 	})
 	c.Assert(err, qt.IsNil)
@@ -96,21 +92,15 @@ func TestNewJWTIsParsableByExponent(t *testing.T) {
 		"controller": "superuser",
 		"model":      "administrator",
 	})
+	extraClaim, ok := token.Get("my-claim")
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(extraClaim, qt.Equals, "my-value")
 	c.Assert(token.Issuer(), qt.Equals, "host")
 }
 
-func TestNewJWTExpires(t *testing.T) {
+func TestNewJWTWithReservedClaimErrors(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Set env for 'fake' service
-	c.Assert(os.Setenv("JIMM_DNS_NAME", "127.0.0.1:17070"), qt.IsNil)
-	c.Assert(os.Setenv("JIMM_JWT_EXPIRY", "1ns"), qt.IsNil)
-	c.Cleanup(func() {
-		os.Clearenv()
-	})
 
 	store := setupCredentialStore(ctx, c)
 
@@ -122,7 +112,41 @@ func TestNewJWTExpires(t *testing.T) {
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
 		Host:   "host",
 		Store:  store,
-		Expiry: time.Nanosecond,
+		Expiry: time.Minute,
+	})
+
+	_, err := jwtService.NewJWT(ctx, jimmjwx.JWTParams{
+		Controller: "controller-my-diglett-controller",
+		User:       "diglett@canonical.com",
+		Access: map[string]string{
+			"controller": "superuser",
+			"model":      "administrator",
+		},
+		ExtraClaims: map[string]any{
+			"access": "foo",
+		},
+	})
+	c.Assert(err, qt.ErrorMatches, `access is a reserved claim`)
+}
+
+func TestNewJWTExpires(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	store := setupCredentialStore(ctx, c)
+	expiry := time.Second
+
+	// Setup JWKSService
+	jwksService := jimmjwx.NewJWKSService(store)
+	// Start rotator
+	startAndTestRotator(c, ctx, store, jwksService)
+	// Setup JWTService
+	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
+		Host:   "host",
+		Store:  store,
+		Expiry: expiry,
 	})
 
 	// Mint a new JWT
@@ -140,28 +164,38 @@ func TestNewJWTExpires(t *testing.T) {
 	set, err := jwtService.JWKS.Get(ctx)
 	c.Assert(err, qt.IsNil)
 
-	time.Sleep(time.Nanosecond * 10)
-
 	// Test the token fails to parse
 	_, err = jwt.Parse(
 		tok,
 		jwt.WithKeySet(set),
+		jwt.WithClock(futureClock{expiry: expiry}),
 	)
 	c.Assert(err, qt.ErrorMatches, `"exp" not satisfied`)
+}
+
+type futureClock struct {
+	expiry time.Duration
+}
+
+func (f futureClock) Now() time.Time {
+	return time.Now().Add(f.expiry)
 }
 
 func TestCredentialCache(t *testing.T) {
 	c := qt.New(t)
 	store := newStore(c)
 	ctx := context.Background()
+
 	set, _, err := jimmjwx.GenerateJWK(ctx)
 	c.Assert(err, qt.IsNil)
 	err = store.PutJWKS(ctx, set)
 	c.Assert(err, qt.IsNil)
+
 	vaultCache := jimmjwx.NewCredentialCache(store)
 	gotSet, err := vaultCache.Get(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(gotSet.Len(), qt.Not(qt.Equals), 0)
+
 	expectedKeyPairs := getKeyPairs(ctx, set)
 	wantKeyPairs := getKeyPairs(ctx, gotSet)
 	c.Assert(expectedKeyPairs, qt.DeepEquals, wantKeyPairs)

--- a/internal/jimmjwx/utils_test.go
+++ b/internal/jimmjwx/utils_test.go
@@ -1,4 +1,5 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package jimmjwx_test
 
 import (
@@ -81,16 +82,9 @@ func startAndTestRotator(c *qt.C, ctx context.Context, store credentials.Credent
 	return ks
 }
 
-// setupCredentialStore sets up a credential store with the correct params to connect to vault. It also ensures
-// that vault is wiped each time this is called.
-func setupCredentialStore(ctx context.Context, c *qt.C) credentials.CredentialStore {
-	store := newStore(c)
-	// Ensure store is wiped
-	err := store.CleanupJWKS(ctx)
-	c.Assert(err, qt.IsNil)
-
-	_, _, _, _, ok := jimmtest.VaultClient(c)
-	c.Assert(ok, qt.IsTrue)
+// setupCredentialStore sets up an in-memory credential store for testing.
+func setupCredentialStore(_ context.Context, _ *qt.C) credentials.CredentialStore {
+	store := jimmtest.NewInMemoryCredentialStore()
 
 	return store
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -194,7 +194,7 @@ func (s apiProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
 
 // controllerConnectionFunc returns a function that will be used to
 // connect to a controller when a client makes a request.
-func controllerConnectionFunc(s apiProxier, jwtGenerator *jujuauth.TokenGenerator) func(context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
+func controllerConnectionFunc(s apiProxier, jwtGenerator *jujuauth.LoginTokenGenerator) func(context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
 	return func(ctx context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
 		const op = errors.Op("proxy.controllerConnectionFunc")
 		path := jimmhttp.PathElementFromContext(ctx, "path")

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -33,12 +33,12 @@ type SSHManager interface {
 	// PublicKeyHandler is the method to verify the public key of the user. It returns a user if successful.
 	PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
 
-	// ControllerInfoFromModelUUID uses the given model UUID to return the address of the controller to
-	// contact and a valid JWT To authenticate to the controller.
-	ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ControllerInfo, error)
+	// DialInfo resolves the address of the controller to contact given the model UUID and
+	// returns a struct with parameters to connect and authenticate to the controller.
+	DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.DialInfo, error)
 
-	// DialControllerSSHServer dials the controller using the provided controller info.
-	DialControllerSSHServer(ctx context.Context, ctrlInfo jimmssh.ControllerInfo, user *openfga.User) (*gossh.Client, error)
+	// DialController dials a controller's SSH server using the provided info.
+	DialController(ctx context.Context, dialInfo jimmssh.DialInfo, user *openfga.User) (*gossh.Client, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -153,13 +153,13 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			return
 		}
 
-		connInfo, err := sshManager.ControllerInfoFromModelUUID(ctx, modelTag.Id(), user)
+		dialInfo, err := sshManager.DialInfo(ctx, modelTag.Id(), user)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to get controller connection info", err)
 			return
 		}
 
-		client, err := sshManager.DialControllerSSHServer(ctx, connInfo, user)
+		client, err := sshManager.DialController(ctx, dialInfo, user)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to dial controller", err)
 			return

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -126,13 +126,13 @@ func (s *sshSuite) Init(c *qt.C) {
 				}
 				return userWithoutAccess, nil
 			},
-			ControllerInfoFromModelUUID_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.ControllerInfo, error) {
+			DialInfo_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.DialInfo, error) {
 				if modelUUID != s.virtualHostname.ModelUUID() {
-					return jimmssh.ControllerInfo{}, errors.E("permission denied")
+					return jimmssh.DialInfo{}, errors.E("permission denied")
 				}
-				return jimmssh.ControllerInfo{}, nil
+				return jimmssh.DialInfo{}, nil
 			},
-			DialControllerSSHServer_: func(ctx context.Context, ctrlInfo jimmssh.ControllerInfo, user *openfga.User) (*gossh.Client, error) {
+			DialController_: func(ctx context.Context, ctrlInfo jimmssh.DialInfo, user *openfga.User) (*gossh.Client, error) {
 				conn, err := destinationServerListener.Dial()
 				if err != nil {
 					return nil, err

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -14,9 +14,9 @@ import (
 
 // SSHManager is an implementation of the SshManager interface.
 type SSHManager struct {
-	PublicKeyHandler_            func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-	DialControllerSSHServer_     func(ctx context.Context, ctrlInfo ssh.ControllerInfo, user *openfga.User) (*gossh.Client, error)
-	ControllerInfoFromModelUUID_ func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error)
+	PublicKeyHandler_ func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
+	DialController_   func(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error)
+	DialInfo_         func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error)
 }
 
 func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
@@ -26,16 +26,16 @@ func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key 
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
-func (j SSHManager) DialControllerSSHServer(ctx context.Context, ctrlInfo ssh.ControllerInfo, user *openfga.User) (*gossh.Client, error) {
-	if j.DialControllerSSHServer_ == nil {
+func (j SSHManager) DialController(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error) {
+	if j.DialController_ == nil {
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
-	return j.DialControllerSSHServer_(ctx, ctrlInfo, user)
+	return j.DialController_(ctx, ctrlInfo, user)
 }
 
-func (j SSHManager) ControllerInfoFromModelUUID(ctx context.Context, modelUUID string, user *openfga.User) (ssh.ControllerInfo, error) {
-	if j.ControllerInfoFromModelUUID_ == nil {
-		return ssh.ControllerInfo{}, errors.E(errors.CodeNotImplemented)
+func (j SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error) {
+	if j.DialInfo_ == nil {
+		return ssh.DialInfo{}, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ControllerInfoFromModelUUID_(ctx, modelUUID, user)
+	return j.DialInfo_(ctx, modelUUID, user)
 }

--- a/local/jimm/setup-controller.sh
+++ b/local/jimm/setup-controller.sh
@@ -24,5 +24,5 @@ if [ "${SKIP_BOOTSTRAP:-false}" == true ]; then
 fi
 
 echo "Bootstrapping controller"
-juju bootstrap lxd "${CONTROLLER_NAME}" --config "${CLOUDINIT_FILE}" --config login-token-refresh-url=https://jimm.localhost/.well-known/jwks.json
+JUJU_DEV_FEATURE_FLAGS=ssh-jump juju bootstrap lxd "${CONTROLLER_NAME}" --config "${CLOUDINIT_FILE}" --config login-token-refresh-url=https://jimm.localhost/.well-known/jwks.json
 rm "$CLOUDINIT_FILE"


### PR DESCRIPTION
## Description
This PR fixes how we generate JWTs when JIMM attempts to connect to a Juju controller via SSH. With this and some tweaks to Juju, I was able to successfully SSH into a machine by going through JIMM.

The full changes include:
1. Create separate JWT token generators for RPC login vs SSH login. Their needs are very different and the factory pattern we already have in place makes it easy to create one type of generator over the other.
2. Split the host and port when we fetch the controller's addresses.
3. Change our `setup-controller.sh` script to bootstrap with the `ssh-jump` feature flag.
4. Ensure the user's public key is added to the JWT we send Juju. This was requested by the Juju team, so that we can authenticate the user in Juju as well (even though the Juju database doesn't hold their public key).
5. Some drive-by fixes to naming.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Requires https://github.com/juju/juju/pull/19742 in Juju to land, then:
1. `make qa-lxd`
2. `juju add-model test`
3. `juju deploy ubuntu`
4. `juju show-model` get model UUID.
5. `ssh -J jimm-test@canonical.com@jimm.localhost:17022 ubuntu@0.$model_uuid.juju.local`
