### PR TITLE
fix: timeout jq-queries

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -185,7 +185,7 @@ func start(ctx context.Context, s *service.Service) error {
 	if crossModelQueryTimeoutRaw != "" {
 		expiry, err := time.ParseDuration(crossModelQueryTimeoutRaw)
 		if err != nil {
-			zapctx.Error(ctx, "failed to parse cross model query timeout duration", zap.Error(err))
+			return errors.E("cannot parse cross model query timeout into duration")
 		} else {
 			crossModelQueryTimeout = expiry
 		}

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -180,6 +180,17 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 	jimmUUID := os.Getenv("JIMM_UUID")
 	publicDnsName := os.Getenv("JIMM_DNS_NAME")
+	crossModelQueryTimeout := 5 * time.Second
+	crossModelQueryTimeoutRaw := os.Getenv("JIMM_CROSS_MODEL_QUERY_TIMEOUT")
+	if crossModelQueryTimeoutRaw != "" {
+		expiry, err := time.ParseDuration(crossModelQueryTimeoutRaw)
+		if err != nil {
+			zapctx.Error(ctx, "failed to parse cross model query timeout duration", zap.Error(err))
+		} else {
+			crossModelQueryTimeout = expiry
+		}
+	}
+
 	jimmsvc, err := jimmsvc.NewService(ctx, jimmsvc.Params{
 		ControllerUUID:      jimmUUID,
 		DSN:                 os.Getenv("JIMM_DSN"),
@@ -228,6 +239,7 @@ func start(ctx context.Context, s *service.Service) error {
 			SSHPublicHostKey:            publicHostKey,
 			SSHMaxConcurrentConnections: maxConcurrentConnections,
 		},
+		CrossModelQueryTimeout: crossModelQueryTimeout,
 	})
 	if err != nil {
 		return err
@@ -240,8 +252,6 @@ func start(ctx context.Context, s *service.Service) error {
 		Handler:           jimmsvc,
 		ReadHeaderTimeout: time.Second * 5,
 	}
-
-	// intentionally ignore the error because invalid values are handled by the jump server.
 
 	sshServer, err := ssh.NewJumpServer(ctx, ssh.Config{
 		Port:                     sshPort,

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -204,6 +204,9 @@ type Params struct {
 	// ControllerConfig is the configuration to expose when the ControllerConfig
 	// facade is called.
 	ControllerConfig config.ControllerConfig
+
+	// CrossModelQueryTimeout is the timeout for cross model queries.
+	CrossModelQueryTimeout time.Duration
 }
 
 // A Service is the implementation of a JIMM server.
@@ -318,9 +321,10 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	s := new(Service)
 
 	jimmParameters := jimm.Parameters{
-		UUID:             p.ControllerUUID,
-		Pubsub:           &pubsub.Hub{MaxConcurrency: 50},
-		ControllerConfig: p.ControllerConfig,
+		UUID:                   p.ControllerUUID,
+		Pubsub:                 &pubsub.Hub{MaxConcurrency: 50},
+		ControllerConfig:       p.ControllerConfig,
+		CrossModelQueryTimeout: p.CrossModelQueryTimeout,
 	}
 	// Setup all dependency services
 	if jimmParameters.UUID == "" {
@@ -426,14 +430,12 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 		return nil, errors.E(op, err, "failed to parse final redirect url for the dashboard")
 	}
 
-	// instantiate jimm
 	s.jimm, err = jimm.New(jimmParameters)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
 
 	s.mux = chi.NewRouter()
-
 	s.mux.Use(chimiddleware.RequestLogger(&logger.HTTPLogFormatter{}))
 	s.mux.Use(middleware.MeasureHTTPResponseTime)
 

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -56,6 +56,7 @@ func newTestServiceParameters(t jimmtest.Tester) jimmsvc.Params {
 			JWTSessionKey:       jimmtest.JWTTestSecret,
 		},
 		DashboardFinalRedirectURL: "dashboard-url",
+		CrossModelQueryTimeout:    time.Second * 5,
 	}
 }
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -325,6 +325,9 @@ type Parameters struct {
 	// ControllerConfig is the configuration which will be exposed when
 	// the ControllerConfig facade is called.
 	ControllerConfig config.ControllerConfig
+
+	// CrossModelQueryTimeout is the timeout for cross model queries.
+	CrossModelQueryTimeout time.Duration
 }
 
 func (p *Parameters) Validate() error {
@@ -358,6 +361,10 @@ func (p *Parameters) Validate() error {
 
 	if p.OAuthAuthenticator == nil {
 		return errors.E("missing oauth authenticator")
+	}
+
+	if p.CrossModelQueryTimeout <= 0 {
+		return errors.E("missing cross model query timeout")
 	}
 
 	return nil
@@ -413,10 +420,16 @@ func New(p Parameters) (*JIMM, error) {
 
 	j.jujuAuthFactory = jujuauth.NewFactory(j.Database, j.JWTService, permissionManager)
 
-	jujuManager, err := juju.NewJujuManager(j.Database, j.OpenFGAClient,
-		j.CredentialStore, j.permissionManager,
-		jimmResourceTag, p.ReservedCloudNames,
-		j.Dialer)
+	jujuManager, err := juju.NewJujuManager(
+		j.Database,
+		j.OpenFGAClient,
+		j.CredentialStore,
+		j.permissionManager,
+		jimmResourceTag,
+		p.ReservedCloudNames,
+		j.Dialer,
+		p.CrossModelQueryTimeout,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimm/juju/export_test.go
+++ b/internal/jimm/juju/export_test.go
@@ -17,7 +17,6 @@ var (
 	NewControllerClient = &newControllerClient
 	FillMigrationTarget = fillMigrationTarget
 	InitiateMigration   = &initiateMigration
-	JqQueryDeadline     = &jqQueryDeadline
 )
 
 func NewWatcherWithControllerUnavailableChan(db *db.Database, dialer Dialer, pubsub Publisher, testChannel chan error) *Watcher {

--- a/internal/jimm/juju/export_test.go
+++ b/internal/jimm/juju/export_test.go
@@ -17,6 +17,7 @@ var (
 	NewControllerClient = &newControllerClient
 	FillMigrationTarget = fillMigrationTarget
 	InitiateMigration   = &initiateMigration
+	JqQueryDeadline     = &jqQueryDeadline
 )
 
 func NewWatcherWithControllerUnavailableChan(db *db.Database, dialer Dialer, pubsub Publisher, testChannel chan error) *Watcher {

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -4,6 +4,7 @@ package juju
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/names/v5"
 
@@ -16,21 +17,28 @@ import (
 
 // JujuManager handles all business logic with Juju resources.
 type JujuManager struct {
-	Database           *db.Database
-	OpenFGAClient      *openfga.OFGAClient
-	CredentialStore    credentials.CredentialStore
-	permissionManager  PermissionChecker
-	resourceTag        names.ControllerTag
-	ReservedCloudNames []string
-	Dialer             Dialer
+	Database               *db.Database
+	OpenFGAClient          *openfga.OFGAClient
+	CredentialStore        credentials.CredentialStore
+	permissionManager      PermissionChecker
+	resourceTag            names.ControllerTag
+	ReservedCloudNames     []string
+	Dialer                 Dialer
+	CrossModelQueryTimeout time.Duration
 }
 
 // NewJujuManager returns a new JIMM struct that manages business logic associated
 // with Juju resources.
-func NewJujuManager(store *db.Database, authSvc *openfga.OFGAClient,
-	credentialStore credentials.CredentialStore, permissionManager PermissionChecker,
-	resourceTag names.ControllerTag, reservedCloudNames []string,
-	dialer Dialer) (*JujuManager, error) {
+func NewJujuManager(
+	store *db.Database,
+	authSvc *openfga.OFGAClient,
+	credentialStore credentials.CredentialStore,
+	permissionManager PermissionChecker,
+	resourceTag names.ControllerTag,
+	reservedCloudNames []string,
+	dialer Dialer,
+	crossModelQueryTimeout time.Duration,
+) (*JujuManager, error) {
 	if store == nil {
 		return nil, errors.E("role store cannot be nil")
 	}
@@ -46,14 +54,18 @@ func NewJujuManager(store *db.Database, authSvc *openfga.OFGAClient,
 	if resourceTag.Id() == "" {
 		return nil, errors.E("invalid jimm controller tag")
 	}
+	if crossModelQueryTimeout <= 0 {
+		return nil, errors.E("cross model query timeout must be greater than 0")
+	}
 	return &JujuManager{
-		Database:           store,
-		OpenFGAClient:      authSvc,
-		CredentialStore:    credentialStore,
-		permissionManager:  permissionManager,
-		resourceTag:        resourceTag,
-		ReservedCloudNames: reservedCloudNames,
-		Dialer:             dialer,
+		Database:               store,
+		OpenFGAClient:          authSvc,
+		CredentialStore:        credentialStore,
+		permissionManager:      permissionManager,
+		resourceTag:            resourceTag,
+		ReservedCloudNames:     reservedCloudNames,
+		Dialer:                 dialer,
+		CrossModelQueryTimeout: crossModelQueryTimeout,
 	}, nil
 }
 

--- a/internal/jimm/juju/juju_test.go
+++ b/internal/jimm/juju/juju_test.go
@@ -18,13 +18,18 @@ import (
 )
 
 type parameters struct {
-	Dialer          juju.Dialer
-	CredentialStore credentials.CredentialStore
+	Dialer                 juju.Dialer
+	CredentialStore        credentials.CredentialStore
+	CrossModelQueryTimeout time.Duration
 }
 
 func newTestJujuManager(c *qt.C, p *parameters) *juju.JujuManager {
 	if p == nil {
 		p = &parameters{}
+	}
+
+	if p.CrossModelQueryTimeout <= 0 {
+		p.CrossModelQueryTimeout = time.Second * 5
 	}
 	db := &db.Database{
 		DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
@@ -53,7 +58,7 @@ func newTestJujuManager(c *qt.C, p *parameters) *juju.JujuManager {
 	jujuManager, err := juju.NewJujuManager(db, ofgaClient,
 		p.CredentialStore, permissionManager,
 		jimmResourceTag, []string{},
-		p.Dialer)
+		p.Dialer, p.CrossModelQueryTimeout)
 	c.Assert(err, qt.IsNil)
 
 	return jujuManager

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -96,7 +96,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			// query. As such, we simply append all to the errors field and continue to collect
 			// both erreoneous and valid query results.
 			if err, ok := v.(error); ok {
-				if stderrors.Is(v.(error), context.DeadlineExceeded) {
+				if stderrors.Is(err, context.DeadlineExceeded) {
 					return results, errors.E(op, fmt.Sprintf("jq query timed out after %.2f seconds", j.CrossModelQueryTimeout.Seconds()), err)
 				}
 				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
-	"time"
 
 	"github.com/itchyny/gojq"
 	jujucmd "github.com/juju/cmd/v3"
@@ -21,10 +20,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api/params"
-)
-
-var (
-	jqQueryDeadline = time.Second * 5
 )
 
 // QueryModels queries every specified model in modelUUIDs.
@@ -87,7 +82,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			return results, errors.E(op, err)
 		}
 
-		queryCtx, cancel := context.WithTimeout(ctx, jqQueryDeadline)
+		queryCtx, cancel := context.WithTimeout(ctx, j.CrossModelQueryTimeout)
 		defer cancel()
 		queryIter := query.RunWithContext(queryCtx, tempMap)
 
@@ -102,7 +97,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			// both erreoneous and valid query results.
 			if err, ok := v.(error); ok {
 				if stderrors.Is(v.(error), context.DeadlineExceeded) {
-					return results, errors.E(op, fmt.Sprintf("jq query timed out after %.2f seconds", jqQueryDeadline.Seconds()), err)
+					return results, errors.E(op, fmt.Sprintf("jq query timed out after %.2f seconds", j.CrossModelQueryTimeout.Seconds()), err)
 				}
 				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())
 				continue

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -5,6 +5,9 @@ package juju
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"time"
 
 	"github.com/itchyny/gojq"
 	jujucmd "github.com/juju/cmd/v3"
@@ -18,6 +21,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+var (
+	jqQueryDeadline = time.Second * 5
 )
 
 // QueryModels queries every specified model in modelUUIDs.
@@ -68,7 +75,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 		}
 		// We could use output.NewFormatter() from 3.0+ juju/juju, but ultimately
 		// we just want some JSON output, regardless of user formatting. As such json.Marshal
-		// *should* be OK. But TODO: make sure this is fine.
+		// *should* be OK.
 		fb, err := json.Marshal(formattedStatus)
 		if err != nil {
 			zapctx.Error(ctx, "failed to marshal formatted status", zap.String("model-uuid", modelUUID))
@@ -79,7 +86,10 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 		if err := json.Unmarshal(fb, &tempMap); err != nil {
 			return results, errors.E(op, err)
 		}
-		queryIter := query.RunWithContext(ctx, tempMap)
+
+		queryCtx, cancel := context.WithTimeout(ctx, jqQueryDeadline)
+		defer cancel()
+		queryIter := query.RunWithContext(queryCtx, tempMap)
 
 		for {
 			v, ok := queryIter.Next()
@@ -91,6 +101,9 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			// query. As such, we simply append all to the errors field and continue to collect
 			// both erreoneous and valid query results.
 			if err, ok := v.(error); ok {
+				if stderrors.Is(v.(error), context.DeadlineExceeded) {
+					return results, errors.E(op, fmt.Sprintf("jq query timed out after %.2f seconds", jqQueryDeadline.Seconds()), err)
+				}
 				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())
 				continue
 			}

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -771,35 +771,7 @@ func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
 						return &model1, nil
 					},
 					ListFilesystems_: func(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
-						return []jujuparams.FilesystemDetailsListResult{
-							{
-								Result: []jujuparams.FilesystemDetails{
-									{
-										FilesystemTag: "filesystem-myapp-0-0",
-										VolumeTag:     "volume-myapp-0-0",
-										Info: jujuparams.FilesystemInfo{
-											Size:         4096,
-											Pool:         "pool-1",
-											FilesystemId: "da64ec3c-0cf7-42f2-9951-35a5a3eaadc1",
-										},
-										Life: life.Alive,
-										Status: jujuparams.EntityStatus{
-											Status: status.Active,
-											Since:  &now,
-										},
-										UnitAttachments: map[string]jujuparams.FilesystemAttachmentDetails{
-											"filesystem-myapp-0-1": {
-												FilesystemAttachmentInfo: jujuparams.FilesystemAttachmentInfo{
-													MountPoint: "/home/ubuntu/myapp/.data",
-													ReadOnly:   false,
-												},
-												Life: life.Value(state.Alive.String()),
-											},
-										},
-									},
-								},
-							},
-						}, nil
+						return []jujuparams.FilesystemDetailsListResult{}, nil
 					},
 					ListVolumes_: func(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
 						return []jujuparams.VolumeDetailsListResult{}, nil

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/state"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
@@ -756,4 +757,70 @@ func TestQueryModelsJq(t *testing.T) {
 		}
 	}
 	`, qt.JSONEquals, res)
+}
+
+func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	c.Patch(juju.JqQueryDeadline, time.Millisecond*1)
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: jimmtest.ModelDialerMap{
+			"10000000-0000-0000-0000-000000000000": &jimmtest.Dialer{
+				API: &jimmtest.API{
+					Status_: func(_ context.Context, _ []string) (*jujuparams.FullStatus, error) {
+						return &model1, nil
+					},
+					ListFilesystems_: func(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
+						return []jujuparams.FilesystemDetailsListResult{
+							{
+								Result: []jujuparams.FilesystemDetails{
+									{
+										FilesystemTag: "filesystem-myapp-0-0",
+										VolumeTag:     "volume-myapp-0-0",
+										Info: jujuparams.FilesystemInfo{
+											Size:         4096,
+											Pool:         "pool-1",
+											FilesystemId: "da64ec3c-0cf7-42f2-9951-35a5a3eaadc1",
+										},
+										Life: life.Alive,
+										Status: jujuparams.EntityStatus{
+											Status: status.Active,
+											Since:  &now,
+										},
+										UnitAttachments: map[string]jujuparams.FilesystemAttachmentDetails{
+											"filesystem-myapp-0-1": {
+												FilesystemAttachmentInfo: jujuparams.FilesystemAttachmentInfo{
+													MountPoint: "/home/ubuntu/myapp/.data",
+													ReadOnly:   false,
+												},
+												Life: life.Value(state.Alive.String()),
+											},
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					ListVolumes_: func(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
+						return []jujuparams.VolumeDetailsListResult{}, nil
+					},
+					ListStorageDetails_: func(ctx context.Context) ([]jujuparams.StorageDetails, error) {
+						return []jujuparams.StorageDetails{}, nil
+					},
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, crossModelQueryEnv)
+	env.PopulateDB(c, j.Database)
+
+	modelUUIDs := []string{
+		"10000000-0000-0000-0000-000000000000",
+	}
+
+	_, err := j.QueryModelsJq(ctx, modelUUIDs, "range(infinite)")
+	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds")
 }

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/state"
 
 	"github.com/canonical/jimm/v3/internal/errors"
-	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
@@ -763,9 +762,8 @@ func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	c.Patch(juju.JqQueryDeadline, time.Millisecond*1)
-
 	j := newTestJujuManager(c, &parameters{
+		CrossModelQueryTimeout: time.Millisecond * 1,
 		Dialer: jimmtest.ModelDialerMap{
 			"10000000-0000-0000-0000-000000000000": &jimmtest.Dialer{
 				API: &jimmtest.API{

--- a/internal/testutils/cmdtest/jimmsuite.go
+++ b/internal/testutils/cmdtest/jimmsuite.go
@@ -80,6 +80,7 @@ func (s *JimmCmdSuite) SetUpTest(c *gc.C) {
 			JWTSessionKey:       jimmtest.JWTTestSecret,
 		},
 		DashboardFinalRedirectURL: "dashboard-url",
+		CrossModelQueryTimeout:    time.Second * 5,
 	}
 	dsn, err := url.Parse(s.Params.DSN)
 	c.Assert(err, gc.Equals, nil)

--- a/internal/testutils/jimmtest/jimm.go
+++ b/internal/testutils/jimmtest/jimm.go
@@ -57,6 +57,9 @@ func NewJIMM(t Tester, additionalParameters *jimm.Parameters, options ...Option)
 		if additionalParameters.OAuthAuthenticator != nil {
 			p.OAuthAuthenticator = additionalParameters.OAuthAuthenticator
 		}
+		if additionalParameters.CrossModelQueryTimeout > 0 {
+			p.CrossModelQueryTimeout = additionalParameters.CrossModelQueryTimeout
+		}
 	}
 
 	if p.Database == nil {

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -171,6 +171,8 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 		OAuthAuthenticator: authenticator,
 
 		JWTService: jwtService,
+
+		CrossModelQueryTimeout: time.Second * 5,
 	})
 
 	err = s.AdminUser.SetControllerAccess(ctx, s.JIMM.ResourceTag(), ofganames.AdministratorRelation)


### PR DESCRIPTION
This PR adds a simple timeout to the jq queries so that long running queries end after 5 seconds

## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
