### PR TITLE
fix: ssh dial multiple addresses

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -429,7 +429,14 @@ func New(p Parameters) (*JIMM, error) {
 	}
 	j.sshKeyManager = sshKeyManager
 
-	sshManager, err := ssh.NewSSHManager(j.identityManager, j.jujuManager, j.sshKeyManager, j.jujuAuthFactory)
+	sshParams := ssh.SSHManagerParams{
+		IdentityManager: j.identityManager,
+		JujuManager:     j.jujuManager,
+		SSHKeyManager:   j.sshKeyManager,
+		JWTFactory:      j.jujuAuthFactory,
+		Dialer:          &ssh.BasicDialer{},
+	}
+	sshManager, err := ssh.NewSSHManager(sshParams)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -64,6 +64,8 @@ func (d *BasicDialer) Dial(network string, addr string, config *gossh.ClientConf
 	return gossh.Dial(network, addr, config)
 }
 
+// SSHManagerParams contains the dependencies
+// needed to create the SSHManager service.
 type SSHManagerParams struct {
 	IdentityManager IdentityManager
 	JujuManager     JujuManager
@@ -72,22 +74,29 @@ type SSHManagerParams struct {
 	Dialer          SSHDialer
 }
 
-// NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(p SSHManagerParams) (*sshManager, error) {
+func (p *SSHManagerParams) validate() error {
 	if p.IdentityManager == nil {
-		return nil, errors.E("identityManager cannot be nil")
+		return errors.E("identityManager cannot be nil")
 	}
 	if p.JujuManager == nil {
-		return nil, errors.E("jujuManager cannot be nil")
+		return errors.E("jujuManager cannot be nil")
 	}
 	if p.SSHKeyManager == nil {
-		return nil, errors.E("sshManager cannot be nil")
+		return errors.E("sshManager cannot be nil")
 	}
 	if p.JWTFactory == nil {
-		return nil, errors.E("jwtFactory cannot be nil")
+		return errors.E("jwtFactory cannot be nil")
 	}
 	if p.Dialer == nil {
-		return nil, errors.E("dialer cannot be nil")
+		return errors.E("dialer cannot be nil")
+	}
+	return nil
+}
+
+// NewSSHManager returns a new SSHManager that offers domain functionality to the SSHJumpServer.
+func NewSSHManager(p SSHManagerParams) (*sshManager, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
 	}
 	return &sshManager{
 		jujuManager:     p.JujuManager,

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -51,25 +51,50 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
+// SSHDialer provides a means to establish an SSH connection.
+type SSHDialer interface {
+	Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error)
+}
+
+// BasicDialer is a wrapper around the default Go x/crypto/ssh
+// dialer for cases where no changes are needed.
+type BasicDialer struct{}
+
+func (d *BasicDialer) Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error) {
+	return gossh.Dial(network, addr, config)
+}
+
+type SSHManagerParams struct {
+	IdentityManager IdentityManager
+	JujuManager     JujuManager
+	SSHKeyManager   SSHKeyManager
+	JWTFactory      *jujuauth.Factory
+	Dialer          SSHDialer
+}
+
 // NewSSHManager returns a new SSHManager that offers jimm functionality to the SSHJumpServer.
-func NewSSHManager(identityManager IdentityManager, jujuManager JujuManager, sshKeyManager SSHKeyManager, jwtFactory *jujuauth.Factory) (*sshManager, error) {
-	if identityManager == nil {
+func NewSSHManager(p SSHManagerParams) (*sshManager, error) {
+	if p.IdentityManager == nil {
 		return nil, errors.E("identityManager cannot be nil")
 	}
-	if jujuManager == nil {
+	if p.JujuManager == nil {
 		return nil, errors.E("jujuManager cannot be nil")
 	}
-	if sshKeyManager == nil {
+	if p.SSHKeyManager == nil {
 		return nil, errors.E("sshManager cannot be nil")
 	}
-	if jwtFactory == nil {
+	if p.JWTFactory == nil {
 		return nil, errors.E("jwtFactory cannot be nil")
 	}
+	if p.Dialer == nil {
+		return nil, errors.E("dialer cannot be nil")
+	}
 	return &sshManager{
-		jujuManager:     jujuManager,
-		identityManager: identityManager,
-		sshKeyManager:   sshKeyManager,
-		jwtFactory:      jwtFactory,
+		jujuManager:     p.JujuManager,
+		identityManager: p.IdentityManager,
+		sshKeyManager:   p.SSHKeyManager,
+		jwtFactory:      p.JWTFactory,
+		dialer:          p.Dialer,
 	}, nil
 }
 
@@ -79,6 +104,7 @@ type sshManager struct {
 	identityManager IdentityManager
 	sshKeyManager   SSHKeyManager
 	jwtFactory      *jujuauth.Factory
+	dialer          SSHDialer
 }
 
 // PublicKeyHandler is the method to verify the public key of the user. It first checks for the public key and then fetches the user.
@@ -162,7 +188,7 @@ func (s *sshManager) DialController(ctx context.Context, dialInfo DialInfo, user
 
 	for _, addr := range dialInfo.Addresses {
 		dest := net.JoinHostPort(addr, fmt.Sprint(dialInfo.Port))
-		client, err = gossh.Dial("tcp", dest, &gossh.ClientConfig{
+		client, err = s.dialer.Dial("tcp", dest, &gossh.ClientConfig{
 			User: "jimm",
 			//nolint:gosec // this will be removed once we handle hostkeys
 			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
@@ -175,11 +201,13 @@ func (s *sshManager) DialController(ctx context.Context, dialInfo DialInfo, user
 		})
 		if err != nil {
 			errs = append(errs, err)
+		} else {
+			break
 		}
 	}
 
 	if client == nil {
-		return nil, errors.E(goerr.Join(errs...), "cannot dial controller")
+		return nil, fmt.Errorf("failed to dial controller: %v", goerr.Join(errs...))
 	}
 	return client, nil
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"database/sql"
 	"encoding/base64"
+	"errors"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ type sshManagerSuite struct {
 	publicKey        sshkeys.PublicKey
 	allowedModelUUID string
 	database         *db.Database
+	mockDialer       *mockDialer
 
 	sshManager *ssh.SSHManager
 
@@ -133,7 +135,16 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	sshKeyManager, err := sshkeys.NewSSHKeyManager(s.database)
 	c.Assert(err, qt.IsNil)
 
-	s.sshManager, err = ssh.NewSSHManager(identityManager, &jujuManager, sshKeyManager, jwtFactory)
+	s.mockDialer = &mockDialer{}
+
+	params := ssh.SSHManagerParams{
+		IdentityManager: identityManager,
+		JujuManager:     &jujuManager,
+		SSHKeyManager:   sshKeyManager,
+		JWTFactory:      jwtFactory,
+		Dialer:          s.mockDialer,
+	}
+	s.sshManager, err = ssh.NewSSHManager(params)
 	c.Assert(err, qt.IsNil)
 	env := jimmtest.ParseEnvironment(c, testSSHManagerEnv)
 	env.PopulateDB(c, s.database)
@@ -201,6 +212,39 @@ func (s *sshManagerSuite) TestDialInfo(c *qt.C) {
 	// Test that the ControllerInfoFromModelUUID returns an error when the model UUID is invalid.
 	_, err = s.sshManager.DialInfo(ctx, "not-valid", s.userWithAccess)
 	c.Assert(err, qt.ErrorMatches, ".*cannot find model.*")
+}
+
+type mockDialer struct {
+	validAddress string
+	callCount    int
+}
+
+func (d *mockDialer) Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error) {
+	d.callCount++
+	if addr == d.validAddress {
+		return &gossh.Client{}, nil
+	}
+	return nil, errors.New("dial error")
+}
+
+func (s *sshManagerSuite) TestDialAllAddresses(c *qt.C) {
+	ctx := context.Background()
+
+	dialInfo := ssh.DialInfo{
+		Addresses: []string{"10.1.2.3", "10.1.2.4"},
+		Port:      1234,
+		JWT:       "fake-jwt",
+	}
+
+	_, err := s.sshManager.DialController(ctx, dialInfo, s.userWithAccess)
+	c.Assert(err, qt.ErrorMatches, "failed to dial controller: dial error\ndial error")
+	c.Assert(s.mockDialer.callCount, qt.Equals, 2)
+
+	s.mockDialer.validAddress = "10.1.2.4:1234"
+	// Test that DialController works when there are multiple addresses.
+	_, err = s.sshManager.DialController(ctx, dialInfo, s.userWithAccess)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.mockDialer.callCount, qt.Equals, 4)
 }
 
 func TestSSHManager(t *testing.T) {


### PR DESCRIPTION
## Description
This PR fixes the `DialController` method in the SSH manager, which did not correctly break out of the loop if a dial succeeded. I've also added a test for the functionality.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests