### PR TITLE
fix(ssh-jump): fix key to get hostkey from controller config and get addrs to dial

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,14 +161,6 @@ func start(ctx context.Context, s *service.Service) error {
 
 	logSQL, _ := strconv.ParseBool(os.Getenv("JIMM_LOG_SQL"))
 
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return errors.E("failed to split host and port", zap.Error(err))
-	}
-	portInt, err := strconv.Atoi(port)
-	if err != nil {
-		return errors.E("failed to parse port", zap.Error(err))
-	}
 	sshPort := os.Getenv("JIMM_SSH_PORT")
 	if sshPort == "" {
 		return errors.E("empty ssh port from env variable")
@@ -232,12 +223,10 @@ func start(ctx context.Context, s *service.Service) error {
 		LogLevel:                  logLevel,
 		IsLeader:                  os.Getenv("JIMM_IS_LEADER") != "",
 		ControllerConfig: config.ControllerConfig{
-			ControllerUUID:              jimmUUID,
-			PublicDNSName:               publicDnsName,
-			APIPort:                     portInt,
-			SSHPort:                     sshPortInt,
-			SSHPublicHostKey:            publicHostKey,
-			SSHMaxConcurrentConnections: maxConcurrentConnections,
+			ControllerUUID:   jimmUUID,
+			PublicDNSName:    publicDnsName,
+			SSHPort:          sshPortInt,
+			SSHPublicHostKey: publicHostKey,
 		},
 		CrossModelQueryTimeout: crossModelQueryTimeout,
 	})

--- a/internal/jimm/config/config.go
+++ b/internal/jimm/config/config.go
@@ -20,14 +20,8 @@ type ControllerConfig struct {
 	// It is the hostname that will be used during TLS verification.
 	PublicDNSName string
 
-	// APIPort is the port for API connections.
-	APIPort int
-
 	// SSHPort is the port for SSH connections.
 	SSHPort int
-
-	// SSHMaxConcurrentConnections is the maximum number of concurrent SSH connections.
-	SSHMaxConcurrentConnections int
 
 	// SSHPublicHostKey is the host key for SSH connections.
 	SSHPublicHostKey string

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -230,11 +230,9 @@ func (r *controllerRoot) ControllerConfig(ctx context.Context) (jujuparams.Contr
 	}
 	cfg := make(map[string]interface{})
 	cfg[jujucontroller.ControllerUUIDKey] = config.ControllerUUID
-	cfg[jujucontroller.APIPort] = config.APIPort
 	cfg[jujucontroller.SSHServerPort] = config.SSHPort
 	// TODO: update this to use the key coming from juju when we update the juju dependency.
 	cfg["ssh-host-key"] = config.SSHPublicHostKey
-	cfg[jujucontroller.SSHMaxConcurrentConnections] = config.SSHMaxConcurrentConnections
 	cfg[jujucontroller.PublicDNSAddress] = config.PublicDNSName
 	return jujuparams.ControllerConfigResult{
 		Config: cfg,

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -233,7 +233,7 @@ func (r *controllerRoot) ControllerConfig(ctx context.Context) (jujuparams.Contr
 	cfg[jujucontroller.APIPort] = config.APIPort
 	cfg[jujucontroller.SSHServerPort] = config.SSHPort
 	// TODO: update this to use the key coming from juju when we update the juju dependency.
-	cfg["ssh-server-hostkey"] = config.SSHPublicHostKey
+	cfg["ssh-host-key"] = config.SSHPublicHostKey
 	cfg[jujucontroller.SSHMaxConcurrentConnections] = config.SSHMaxConcurrentConnections
 	cfg[jujucontroller.PublicDNSAddress] = config.PublicDNSName
 	return jujuparams.ControllerConfigResult{

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -166,7 +166,7 @@ func (s *controllerSuite) TestControllerConfig(c *gc.C) {
 
 	c.Assert(config[jujucontroller.ControllerUUIDKey], gc.Equals, s.JIMM.ControllerConfig.ControllerUUID)
 	c.Assert(config[jujucontroller.PublicDNSAddress], gc.Equals, s.JIMM.ControllerConfig.PublicDNSName)
-	c.Assert(config["ssh-server-hostkey"], gc.Equals, s.JIMM.ControllerConfig.SSHPublicHostKey)
+	c.Assert(config["ssh-host-key"], gc.Equals, s.JIMM.ControllerConfig.SSHPublicHostKey)
 	// the reason we need to cast to float64 is because it is a map[string]interface{} and the json marshaller defaults to float64.
 	c.Assert(config[jujucontroller.SSHServerPort], gc.Equals, float64(s.JIMM.ControllerConfig.SSHPort))
 	c.Assert(config[jujucontroller.SSHMaxConcurrentConnections], gc.Equals, float64(s.JIMM.ControllerConfig.SSHMaxConcurrentConnections))

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -169,8 +169,6 @@ func (s *controllerSuite) TestControllerConfig(c *gc.C) {
 	c.Assert(config["ssh-host-key"], gc.Equals, s.JIMM.ControllerConfig.SSHPublicHostKey)
 	// the reason we need to cast to float64 is because it is a map[string]interface{} and the json marshaller defaults to float64.
 	c.Assert(config[jujucontroller.SSHServerPort], gc.Equals, float64(s.JIMM.ControllerConfig.SSHPort))
-	c.Assert(config[jujucontroller.SSHMaxConcurrentConnections], gc.Equals, float64(s.JIMM.ControllerConfig.SSHMaxConcurrentConnections))
-	c.Assert(config[jujucontroller.APIPort], gc.Equals, float64(s.JIMM.ControllerConfig.APIPort))
 }
 
 type watcherSuite struct {

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -68,14 +68,13 @@ func GetAddressesAndTLSConfig(ctx context.Context, ctl *dbmodel.Controller) ([]s
 			MinVersion: tls.VersionTLS12,
 		}
 	}
-
+	var addrs []string
 	if ctl.PublicAddress != "" {
 		// If there is a public-address configured it is almost
 		// certainly the one we want to use.
-		return []string{ctl.PublicAddress}, tlsConfig
+		addrs = append(addrs, ctl.PublicAddress)
 	}
 
-	var addrs []string
 	for _, hps := range ctl.Addresses {
 		for _, hp := range hps {
 			if maybeReachable(hp.Scope) {

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -70,8 +70,6 @@ func GetAddressesAndTLSConfig(ctx context.Context, ctl *dbmodel.Controller) ([]s
 	}
 	var addrs []string
 	if ctl.PublicAddress != "" {
-		// If there is a public-address configured it is almost
-		// certainly the one we want to use.
 		addrs = append(addrs, ctl.PublicAddress)
 	}
 


### PR DESCRIPTION
In this PR two small fixes:
- set the right key to extract the hostkey when calling ControllerConfig with JIMM and JUJU
- gather all available addresses. This is a fix for my setup (and potentially others), in which using the PublicAddress to ssh wasn't working. Isn't just better to always try all addresses and not to stop at the public one?


QA here: https://github.com/juju/juju/pull/19814

