### PR TITLE
fix(model-cleanup): cleanup from JIMM all the models returning NotFound from their controllers

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -279,12 +279,12 @@ func (s *Service) OpenFGACleanup(ctx context.Context, trigger <-chan time.Time) 
 	}
 }
 
-// CleanupDyingModels triggers every `trigger` time and calls the jimm methods to cleanup dying models.
-func (s *Service) CleanupDyingModels(ctx context.Context, trigger <-chan time.Time) error {
+// CleanupNotFoundModels triggers every `trigger` time and calls the jimm methods to cleanup dying models.
+func (s *Service) CleanupNotFoundModels(ctx context.Context, trigger <-chan time.Time) error {
 	for {
 		select {
 		case <-trigger:
-			err := s.jimm.JujuManager().CleanupDyingModels(ctx)
+			err := s.jimm.JujuManager().CleanupNotFoundModels(ctx)
 			if err != nil {
 				zapctx.Error(ctx, "dying models cleanup", zap.Error(err))
 				continue
@@ -564,9 +564,9 @@ func (s *Service) StartServices(ctx context.Context, svc *service.Service) {
 			return s.OpenFGACleanup(ctx, time.NewTicker(6*time.Hour).C)
 		})
 
-		// CleanupDyingModels cleanup - cleans up all dying models
+		// CleanupNotFoundModels cleanup - cleans up all models not found on the respective controller.
 		svc.Go(func() error {
-			return s.CleanupDyingModels(ctx, time.NewTicker(time.Minute).C)
+			return s.CleanupNotFoundModels(ctx, time.NewTicker(time.Minute).C)
 		})
 	}
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -276,7 +276,7 @@ type JujuManager interface {
 
 	// These are methods on the Juju manager that don't need to be mocked and can be removed from this interface later.
 	UpdateMetrics(ctx context.Context)
-	CleanupDyingModels(ctx context.Context) error
+	CleanupNotFoundModels(ctx context.Context) error
 }
 
 // Parameters holds the services and static fields passed to the jimm.New() constructor.

--- a/internal/jimm/juju/model_cleanup.go
+++ b/internal/jimm/juju/model_cleanup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -15,20 +14,16 @@ import (
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
-// CleanupDyingModels loops over dying models, contacting the respective controller.
+// CleanupNotFoundModels loops over models, contacting the respective controller.
 // And deleting the model from our database if the error is `NotFound` which means the model was successfully deleted.
-func (j *JujuManager) CleanupDyingModels(ctx context.Context) (err error) {
-	const op = errors.Op("jimm.CleanupDyingModels")
+// Before we were cleaning up models in a dying state, but this is not enough if people delete models directly from the controller.
+func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) (err error) {
+	const op = errors.Op("jimm.CleanupNotFoundModels")
 	zapctx.Info(ctx, string(op))
 	durationObserver := servermon.DurationObserver(servermon.JimmMethodsDurationHistogram, string(op))
 	defer durationObserver()
 
 	err = j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
-		if m.Life != state.Dying.String() {
-			return nil
-		}
-		// if the model is dying and not found by querying the controller we can assume it is dead.
-		// And safely delete the reference from our db.
 		api, err := j.dialController(ctx, &m.Controller)
 		if err != nil {
 			zapctx.Error(ctx, fmt.Sprintf("cannot dial controller %s: %s\n", m.Controller.UUID, err))

--- a/internal/jimm/juju/model_cleanup_test.go
+++ b/internal/jimm/juju/model_cleanup_test.go
@@ -119,11 +119,9 @@ func (s *modelCleanupSuite) TestPollModelsDying(c *qt.C) {
 			},
 		},
 	}
-	err := s.jujuManager.DestroyModel(ctx, s.jimmAdmin, names.NewModelTag(s.env.Models[0].UUID), nil, nil, nil, nil)
-	c.Assert(err, qt.IsNil)
 
 	// test
-	err = s.jujuManager.CleanupDyingModels(ctx)
+	err := s.jujuManager.CleanupNotFoundModels(ctx)
 	c.Assert(err, qt.IsNil)
 
 	model := dbmodel.Model{
@@ -158,11 +156,9 @@ func (s *modelCleanupSuite) TestPollModelsDyingControllerErrors(c *qt.C) {
 			},
 		},
 	}
-	err := s.jujuManager.DestroyModel(ctx, s.jimmAdmin, names.NewModelTag(s.env.Models[0].UUID), nil, nil, nil, nil)
-	c.Assert(err, qt.IsNil)
 
 	// test
-	err = s.jujuManager.CleanupDyingModels(ctx)
+	err := s.jujuManager.CleanupNotFoundModels(ctx)
 	c.Assert(err, qt.IsNil)
 
 	model := dbmodel.Model{
@@ -173,7 +169,7 @@ func (s *modelCleanupSuite) TestPollModelsDyingControllerErrors(c *qt.C) {
 	}
 	err = s.jujuManager.Database.GetModel(ctx, &model)
 	c.Assert(err, qt.IsNil)
-	c.Assert(model.Life, qt.Equals, state.Dying.String())
+	c.Assert(model.Life, qt.Equals, state.Alive.String())
 }
 
 func TestDyingModelsCleanup(t *testing.T) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -58,8 +58,8 @@ type JujuManager struct {
 	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 
 	// These mocks can be removed soon once the jujuManager interface is updated.
-	UpdateMetrics_      func(ctx context.Context)
-	CleanupDyingModels_ func(ctx context.Context) error
+	UpdateMetrics_         func(ctx context.Context)
+	CleanupNotFoundModels_ func(ctx context.Context) error
 }
 
 func (j *JujuManager) AddAuditLogEntry(ale *dbmodel.AuditLogEntry) {
@@ -246,11 +246,11 @@ func (j *JujuManager) UpdateMetrics(ctx context.Context) {
 	}
 	j.UpdateMetrics_(ctx)
 }
-func (j *JujuManager) CleanupDyingModels(ctx context.Context) error {
-	if j.CleanupDyingModels_ == nil {
+func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) error {
+	if j.CleanupNotFoundModels_ == nil {
 		return nil
 	}
-	return j.CleanupDyingModels_(ctx)
+	return j.CleanupNotFoundModels_(ctx)
 }
 
 func (j *JujuManager) GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {


### PR DESCRIPTION
Before we were cleaning up model set in a dying state. But this isn't enough in the case people are deleting the model from the controller. Now we scan for every model returing NotFound from the respective controller and we clean it up from JIMM as well.
