### PR TITLE
feat: add user mapping and model migrations tables

### DIFF
--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Canonical.
+
+package db
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// AddModelMigration stores information about an incoming model migration.
+//   - returns an error with code errors.CodeAlreadyExists if
+//     a migration row with the same model UUID already exists.
+func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+	const op = errors.Op("db.AddModelMigration")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	if err := db.Create(modelMigration).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// GetModelMigration returns model migration information based on the model UUID.
+func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+	const op = errors.Op("db.GetModelMigration")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	switch {
+	case modelMigration.ModelUUID.Valid:
+		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
+	default:
+		return errors.E(op, "missing uuid", errors.CodeBadRequest)
+	}
+
+	if err := db.First(&modelMigration).Error; err != nil {
+		err = dbError(err)
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.E(op, err, "model migration not found")
+		}
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// DeleteModelMigration removes a model migration entry from the database.
+func (d *Database) DeleteModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+	const op = errors.Op("db.DeleteModelMigration")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Delete(modelMigration).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -13,7 +13,7 @@ import (
 // AddModelMigration stores information about an incoming model migration.
 //   - returns an error with code errors.CodeAlreadyExists if
 //     a migration row with the same model UUID already exists.
-func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.AddModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -32,7 +32,7 @@ func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmode
 }
 
 // GetModelMigration returns model migration information based on the model UUID.
-func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.GetModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -61,7 +61,7 @@ func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmode
 }
 
 // DeleteModelMigration removes a model migration entry from the database.
-func (d *Database) DeleteModelMigration(ctx context.Context, modelMigration *dbmodel.ModelMigration) (err error) {
+func (d *Database) DeleteModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.DeleteModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -5,22 +5,12 @@ package db_test
 import (
 	"context"
 	"database/sql"
-	"testing"
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 )
-
-func TestAddModelMigrationUnconfiguredDatabase(t *testing.T) {
-	c := qt.New(t)
-	var d db.Database
-	err := d.AddModelMigration(context.Background(), &dbmodel.ModelMigration{})
-	c.Check(err, qt.ErrorMatches, `database not configured`)
-	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
-}
 
 func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	err := s.Database.Migrate(context.Background())

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Canonical.
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+func TestAddModelMigrationUnconfiguredDatabase(t *testing.T) {
+	c := qt.New(t)
+	var d db.Database
+	err := d.AddModelMigration(context.Background(), &dbmodel.ModelMigration{})
+	c.Check(err, qt.ErrorMatches, `database not configured`)
+	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
+}
+
+func (s *dbSuite) TestAddModelMigration(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		CloudName: cloud.Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+
+	migration := dbmodel.ModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+	}
+	err = s.Database.AddModelMigration(context.Background(), &migration)
+	c.Assert(err, qt.Equals, nil)
+
+	var dbMigration dbmodel.ModelMigration
+	result := s.Database.DB.Where("model_uuid = ?", migration.ModelUUID).First(&dbMigration)
+	c.Assert(result.Error, qt.Equals, nil)
+	c.Assert(dbMigration.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+	c.Assert(dbMigration.TargetControllerID, qt.Equals, controller.ID)
+	c.Assert(dbMigration.UserMapping, qt.DeepEquals, migration.UserMapping)
+}
+
+func (s *dbSuite) TestAddModelMigrationAlreadyExists(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		CloudName: cloud.Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+
+	migration := dbmodel.ModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+	}
+	err = s.Database.AddModelMigration(context.Background(), &migration)
+	c.Assert(err, qt.Equals, nil)
+
+	migration2 := migration
+	err = s.Database.AddModelMigration(context.Background(), &migration2)
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func (s *dbSuite) TestGetModelMigration(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		CloudName: cloud.Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+
+	migration := dbmodel.ModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+	}
+	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
+
+	lookup := dbmodel.ModelMigration{ModelUUID: migration.ModelUUID}
+	err = s.Database.GetModelMigration(context.Background(), &lookup)
+	c.Assert(err, qt.Equals, nil)
+
+	// Not found
+	lookup = dbmodel.ModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}
+	err = s.Database.GetModelMigration(context.Background(), &lookup)
+	c.Assert(err, qt.Not(qt.IsNil))
+	eError, ok := err.(*errors.Error)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+}
+
+func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		CloudName: cloud.Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+
+	migration := dbmodel.ModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+	}
+	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
+
+	err = s.Database.DeleteModelMigration(context.Background(), &migration)
+	c.Assert(err, qt.Equals, nil)
+
+	var dbMigration dbmodel.ModelMigration
+	result := s.Database.DB.Where("model_uuid = ?", migration.ModelUUID).First(&dbMigration)
+	c.Assert(result.Error, qt.Not(qt.IsNil))
+}

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -53,35 +53,9 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	c.Assert(dbMigration.ModelUUID, qt.DeepEquals, migration.ModelUUID)
 	c.Assert(dbMigration.TargetControllerID, qt.Equals, controller.ID)
 	c.Assert(dbMigration.UserMapping, qt.DeepEquals, migration.UserMapping)
-}
 
-func (s *dbSuite) TestAddModelMigrationAlreadyExists(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	cloud := dbmodel.Cloud{
-		Name: "test-cloud",
-	}
-	err = s.Database.AddCloud(context.Background(), &cloud)
-	c.Assert(err, qt.IsNil)
-
-	controller := dbmodel.Controller{
-		Name:      "test-controller",
-		UUID:      "00000000-0000-0000-0000-000000000001",
-		CloudName: cloud.Name,
-	}
-	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
-
-	migration := dbmodel.ModelMigration{
-		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
-		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
-	}
+	migration.ID = 0 // Reset ID to ensure it is not reused
 	err = s.Database.AddModelMigration(context.Background(), &migration)
-	c.Assert(err, qt.Equals, nil)
-
-	migration2 := migration
-	err = s.Database.AddModelMigration(context.Background(), &migration2)
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -29,7 +29,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	}
 	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
 
-	migration := dbmodel.ModelMigration{
+	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
 		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
@@ -37,7 +37,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	err = s.Database.AddModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
-	var dbMigration dbmodel.ModelMigration
+	var dbMigration dbmodel.IncomingModelMigration
 	result := s.Database.DB.Where("model_uuid = ?", migration.ModelUUID).First(&dbMigration)
 	c.Assert(result.Error, qt.Equals, nil)
 	c.Assert(dbMigration.ModelUUID, qt.DeepEquals, migration.ModelUUID)
@@ -66,19 +66,19 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	}
 	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
 
-	migration := dbmodel.ModelMigration{
+	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
 		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
-	lookup := dbmodel.ModelMigration{ModelUUID: migration.ModelUUID}
+	lookup := dbmodel.IncomingModelMigration{ModelUUID: migration.ModelUUID}
 	err = s.Database.GetModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Equals, nil)
 
 	// Not found
-	lookup = dbmodel.ModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}
+	lookup = dbmodel.IncomingModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}
 	err = s.Database.GetModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Not(qt.IsNil))
 	eError, ok := err.(*errors.Error)
@@ -103,7 +103,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	}
 	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
 
-	migration := dbmodel.ModelMigration{
+	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
 		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
@@ -113,7 +113,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	err = s.Database.DeleteModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
-	var dbMigration dbmodel.ModelMigration
+	var dbMigration dbmodel.IncomingModelMigration
 	result := s.Database.DB.Where("model_uuid = ?", migration.ModelUUID).First(&dbMigration)
 	c.Assert(result.Error, qt.Not(qt.IsNil))
 }

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -44,8 +44,12 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 	switch {
 	case userMapping.ModelUUID.Valid && userMapping.LocalUser != "":
 		db = db.Where("model_uuid = ? AND local_user = ?", userMapping.ModelUUID.String, userMapping.LocalUser)
+	case !userMapping.ModelUUID.Valid:
+		return errors.E(op, "missing model UUID", errors.CodeBadRequest)
+	case userMapping.LocalUser == "":
+		return errors.E(op, "missing local user", errors.CodeBadRequest)
 	default:
-		return errors.E(op, "missing model uuid and/or local user", errors.CodeBadRequest)
+		return errors.E(op, "invalid parameters", errors.CodeBadRequest)
 	}
 
 	if err := db.First(&userMapping).Error; err != nil {

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Canonical.
+
+package db
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// AddUserMapping stores information mapping a local user to an external user.
+func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
+	const op = errors.Op("db.AddUserMapping")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	if err := db.Create(userMapping).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// GetUserMapping returns user mapping info based on the model UUID and local user.
+func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
+	const op = errors.Op("db.GetUserMapping")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	switch {
+	case userMapping.ModelUUID.Valid && userMapping.LocalUser != "":
+		db = db.Where("model_uuid = ? AND local_user = ?", userMapping.ModelUUID.String, userMapping.LocalUser)
+	default:
+		return errors.E(op, "missing model uuid and/or local user", errors.CodeBadRequest)
+	}
+
+	if err := db.First(&userMapping).Error; err != nil {
+		err = dbError(err)
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.E(op, err, "user mapping not found")
+		}
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// DeleteUserMapping removes a user mapping from the database.
+func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
+	const op = errors.Op("db.DeleteUserMapping")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Delete(userMapping).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/usermapping_test.go
+++ b/internal/db/usermapping_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Canonical.
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+func (s *dbSuite) TestAddUserMapping(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	localUser := "localuser1"
+	identityName := "bob@canonical.com"
+
+	u, err := dbmodel.NewIdentity(identityName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+
+	userMapping := &dbmodel.UserMapping{
+		ModelUUID:        modelUUID,
+		LocalUser:        localUser,
+		ExternalUserName: identityName,
+	}
+
+	err = s.Database.AddUserMapping(ctx, userMapping)
+	c.Assert(err, qt.IsNil)
+	c.Assert(userMapping.ID, qt.Not(qt.Equals), 0)
+}
+
+func (s *dbSuite) TestGetUserMapping(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	localUser := "localuser1"
+	identityName := "bob@canonical.com"
+
+	u, err := dbmodel.NewIdentity(identityName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+
+	// Insert mapping first
+	userMapping := &dbmodel.UserMapping{
+		ModelUUID:        modelUUID,
+		LocalUser:        localUser,
+		ExternalUserName: identityName,
+	}
+	c.Assert(s.Database.AddUserMapping(ctx, userMapping), qt.IsNil)
+
+	lookup := &dbmodel.UserMapping{
+		ModelUUID: modelUUID,
+		LocalUser: localUser,
+	}
+	err = s.Database.GetUserMapping(ctx, lookup)
+	c.Assert(err, qt.IsNil)
+	c.Assert(lookup.ExternalUserName, qt.Equals, identityName)
+	c.Assert(lookup.ModelUUID.String, qt.Equals, modelUUID.String)
+	c.Assert(lookup.LocalUser, qt.Equals, localUser)
+
+	// Not found
+	missing := &dbmodel.UserMapping{
+		ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true},
+		LocalUser: "nouser",
+	}
+	err = s.Database.GetUserMapping(ctx, missing)
+	c.Assert(err, qt.ErrorMatches, ".*user mapping not found.*")
+}
+
+func (s *dbSuite) TestDeleteUserMapping(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	localUser := "localuser1"
+	identityName := "externaluser@canonical.com"
+
+	u, err := dbmodel.NewIdentity(identityName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+
+	userMapping := &dbmodel.UserMapping{
+		ModelUUID:        modelUUID,
+		LocalUser:        localUser,
+		ExternalUserName: identityName,
+	}
+	c.Assert(s.Database.AddUserMapping(ctx, userMapping), qt.IsNil)
+
+	// Delete
+	err = s.Database.DeleteUserMapping(ctx, userMapping)
+	c.Assert(err, qt.IsNil)
+
+	// Read after delete
+	err = s.Database.GetUserMapping(ctx, userMapping)
+	c.Assert(err, qt.ErrorMatches, ".*user mapping not found.*")
+}

--- a/internal/db/usermapping_test.go
+++ b/internal/db/usermapping_test.go
@@ -33,6 +33,10 @@ func (s *dbSuite) TestAddUserMapping(c *qt.C) {
 	err = s.Database.AddUserMapping(ctx, userMapping)
 	c.Assert(err, qt.IsNil)
 	c.Assert(userMapping.ID, qt.Not(qt.Equals), 0)
+
+	userMapping.ID = 0 // Reset ID to ensure it is not reused
+	err = s.Database.AddUserMapping(ctx, userMapping)
+	c.Assert(err, qt.Not(qt.IsNil))
 }
 
 func (s *dbSuite) TestGetUserMapping(c *qt.C) {

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -8,6 +8,9 @@ import (
 )
 
 // ModelMigration holds the information for a pending model migration.
+// It includes the model UUID, the target controller for the migration,
+// and a mapping of local users to external users that will be persisted
+// separately in the UserMapping table if the migration is successful.
 type ModelMigration struct {
 	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
 	ID        uint `gorm:"primarykey"`
@@ -16,7 +19,7 @@ type ModelMigration struct {
 	// ModelUUID is the UUID of the incoming model.
 	ModelUUID sql.NullString
 
-	// TargetControllerID is the target controller for the model undegroing migration.
+	// TargetControllerID is the target controller for the model undergoing migration.
 	TargetControllerID uint
 	TargetController   Controller
 

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Canonical.
+
+package dbmodel
+
+import (
+	"database/sql"
+	"time"
+)
+
+// ModelMigration holds the information for a pending model migration.
+type ModelMigration struct {
+	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+
+	// ModelUUID is the UUID of the incoming model.
+	ModelUUID sql.NullString
+
+	// TargetControllerID is the target controller for the model undegroing migration.
+	TargetControllerID uint
+	TargetController   Controller
+
+	// UserMapping holds a mapping of local users to external users.
+	UserMapping JSON
+}

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -7,11 +7,11 @@ import (
 	"time"
 )
 
-// ModelMigration holds the information for a pending model migration.
+// IncomingModelMigration holds the information for a model migrating into JIMM.
 // It includes the model UUID, the target controller for the migration,
 // and a mapping of local users to external users that will be persisted
 // separately in the UserMapping table if the migration is successful.
-type ModelMigration struct {
+type IncomingModelMigration struct {
 	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
 	ID        uint `gorm:"primarykey"`
 	CreatedAt time.Time

--- a/internal/dbmodel/modelmigration_test.go
+++ b/internal/dbmodel/modelmigration_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Canonical.
+
+package dbmodel_test
+
+import (
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+// TestModelMigration_UniqueModelUUIDConstraint tests that the unique constraint
+// on ModelMigration is enforced correctly, ensuring that two rows with the same
+// ModelUUID cannot be created.
+func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+	_, _, ctl, _ := initModelEnv(c, db)
+	m := dbmodel.ModelMigration{
+		ModelUUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		TargetControllerID: ctl.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+	}
+	c.Assert(db.Create(&m).Error, qt.IsNil)
+
+	m2 := dbmodel.ModelMigration{
+		ModelUUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		TargetControllerID: ctl.ID,
+		UserMapping:        dbmodel.JSON([]byte(`{"new-local": "new-external"}`)),
+	}
+	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"model_migrations_model_uuid_key\".*")
+}

--- a/internal/dbmodel/modelmigration_test.go
+++ b/internal/dbmodel/modelmigration_test.go
@@ -18,7 +18,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 	c := qt.New(t)
 	db := gormDB(c)
 	_, _, ctl, _ := initModelEnv(c, db)
-	m := dbmodel.ModelMigration{
+	m := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
 			String: "00000001-0000-0000-0000-000000000001",
 			Valid:  true,
@@ -28,7 +28,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)
 
-	m2 := dbmodel.ModelMigration{
+	m2 := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
 			String: "00000001-0000-0000-0000-000000000001",
 			Valid:  true,
@@ -36,5 +36,5 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 		TargetControllerID: ctl.ID,
 		UserMapping:        dbmodel.JSON([]byte(`{"new-local": "new-external"}`)),
 	}
-	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"model_migrations_model_uuid_key\".*")
+	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"incoming_model_migrations_model_uuid_key\".*")
 }

--- a/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
+++ b/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
@@ -1,0 +1,27 @@
+-- Add tables to handle model migrations
+-- The model_migration table contains information
+-- about ongoing migrations and their target controller.
+-- The UserMapping table is used to map local users
+-- from migrated models to their external counterparts.
+
+CREATE TABLE model_migrations (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    model_uuid TEXT NOT NULL UNIQUE,
+    target_controller_id INTEGER REFERENCES controllers (id),
+    user_mapping JSONB NOT NULL
+);
+
+CREATE INDEX idx_model_migrations_model_uuid ON model_migrations (model_uuid);
+
+CREATE TABLE user_mappings (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE,
+    model_uuid TEXT NOT NULL,
+    local_user TEXT NOT NULL,
+    external_user TEXT NOT NULL REFERENCES identities(name),
+    CONSTRAINT unique_user_mappings_key UNIQUE(model_uuid, local_user)
+);
+
+CREATE INDEX idx_model_user_mappings_local_user ON user_mappings (model_uuid, local_user);

--- a/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
+++ b/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
@@ -22,4 +22,4 @@ CREATE TABLE user_mappings (
     CONSTRAINT unique_user_mappings_key UNIQUE(model_uuid, local_user)
 );
 
-CREATE INDEX idx_model_user_mappings_local_user ON user_mappings (model_uuid, local_user);
+CREATE INDEX idx_model_user_mappings_model_uuid ON user_mappings (model_uuid);

--- a/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
+++ b/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
@@ -1,10 +1,10 @@
 -- Add tables to handle model migrations
--- The model_migration table contains information
--- about ongoing migrations and their target controller.
+-- The incoming_model_migration table contains information
+-- about models migrating into JIMM and their target controller.
 -- The UserMapping table is used to map local users
 -- from migrated models to their external counterparts.
 
-CREATE TABLE model_migrations (
+CREATE TABLE incoming_model_migrations (
     id SERIAL PRIMARY KEY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     model_uuid TEXT NOT NULL UNIQUE,

--- a/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
+++ b/internal/dbmodel/sql/postgres/024_add_model_migration_tables.up.sql
@@ -12,8 +12,6 @@ CREATE TABLE model_migrations (
     user_mapping JSONB NOT NULL
 );
 
-CREATE INDEX idx_model_migrations_model_uuid ON model_migrations (model_uuid);
-
 CREATE TABLE user_mappings (
     id SERIAL PRIMARY KEY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/internal/dbmodel/usermapping.go
+++ b/internal/dbmodel/usermapping.go
@@ -21,7 +21,7 @@ type UserMapping struct {
 	// LocalUser is the local user that this mapping applies to.
 	LocalUser string
 
-	// ExtneralUserName is the external user that this local user maps to.
+	// ExternalUserName is the external user that this local user maps to.
 	ExternalUserName string   `gorm:"column:external_user"`
 	ExternalUser     Identity `gorm:"foreignkey:ExternalUserName;references:Name"`
 }

--- a/internal/dbmodel/usermapping.go
+++ b/internal/dbmodel/usermapping.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Canonical.
+
+package dbmodel
+
+import (
+	"database/sql"
+	"time"
+)
+
+// UserMapping holds information per model on
+// mapping local users to external users.
+type UserMapping struct {
+	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// ModelUUID is the UUID of the model the mapping applies to.
+	ModelUUID sql.NullString
+
+	// LocalUser is the local user that this mapping applies to.
+	LocalUser string
+
+	// ExtneralUserName is the external user that this local user maps to.
+	ExternalUserName string   `gorm:"column:external_user"`
+	ExternalUser     Identity `gorm:"foreignkey:ExternalUserName;references:Name"`
+}

--- a/internal/dbmodel/usermapping_test.go
+++ b/internal/dbmodel/usermapping_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
 
-// TestUserMapping_UniqueConstraint tests that the unique constraint on
+// TestUserMappingUniqueConstraint tests that the unique constraint on
 // UserMapping is enforced correctly ensuring two rows with the same
 // ModelUUID and LocalUser cannot be created.
-func TestUserMapping_UniqueConstraint(t *testing.T) {
+func TestUserMappingUniqueConstraint(t *testing.T) {
 	c := qt.New(t)
 	db := gormDB(c)
 

--- a/internal/dbmodel/usermapping_test.go
+++ b/internal/dbmodel/usermapping_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Canonical.
+
+package dbmodel_test
+
+import (
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+// TestUserMapping_UniqueConstraint tests that the unique constraint on
+// UserMapping is enforced correctly ensuring two rows with the same
+// ModelUUID and LocalUser cannot be created.
+func TestUserMapping_UniqueConstraint(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+
+	u, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Create(&u).Error, qt.IsNil)
+
+	m := dbmodel.UserMapping{
+		ModelUUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		LocalUser:        "bob",
+		ExternalUserName: u.Name,
+	}
+	c.Assert(db.Create(&m).Error, qt.IsNil)
+
+	m2 := dbmodel.UserMapping{
+		ModelUUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		LocalUser:        "bob",
+		ExternalUserName: u.Name,
+	}
+	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"unique_user_mappings_key\".*")
+}


### PR DESCRIPTION
## Description
This PR adds 2 new tables called `model_migrations` and `user_mappings` which will be used when migrating models to JIMM. In full this PR adds,
- 1 new SQL schema migration.
- The Go representations for the new structs in `internal/dbmodel`
- CRUD methods in `internal/db`, not all CRUD methods have been added, only those that make sense.

Fixes [JUJU-7950](https://warthogs.atlassian.net/browse/JUJU-7950)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->


[JUJU-7950]: https://warthogs.atlassian.net/browse/JUJU-7950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ