### PR TITLE
feat(discharge): change discharge endpoint to try to resolve local users to external users

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -580,7 +580,7 @@ func (s *Service) setupDischarger(p Params) (*discharger.MacaroonDischarger, err
 		MacaroonExpiryDuration: p.MacaroonExpiryDuration,
 		ControllerUUID:         p.ControllerUUID,
 	}
-	MacaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, s.jimm.Database, s.jimm.OpenFGAClient)
+	MacaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, s.jimm.Database, s.jimm.OfferAuthorizer())
 	if err != nil {
 		return nil, errors.E(err)
 	}

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package discharger
 
@@ -18,10 +18,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/db"
-	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
-	"github.com/canonical/jimm/v3/internal/openfga"
-	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
+	"github.com/canonical/jimm/v3/internal/jimm"
 )
 
 var defaultDischargeExpiry = 15 * time.Minute
@@ -33,17 +31,22 @@ type MacaroonDischargerConfig struct {
 	ControllerUUID         string
 }
 
-func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, ofgaClient *openfga.OFGAClient) (*MacaroonDischarger, error) {
+// NewMacaroonDischarger creates a new MacaroonDischarger instance with the provided configuration, database, and offer authorizer.
+func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, offerAuthorizer jimm.OfferAuthorizer) (*MacaroonDischarger, error) {
+	op := errors.Op("discharger.NewMacaroonDischarger")
 	var kp bakery.KeyPair
 	if cfg.PublicKey == "" || cfg.PrivateKey == "" {
 		return nil, errors.E("missing bakery private/public key")
 	} else {
 		if err := kp.Private.UnmarshalText([]byte(cfg.PrivateKey)); err != nil {
-			return nil, errors.E(err, "cannot unmarshal private key")
+			return nil, errors.E(op, err, "cannot unmarshal private key")
 		}
 		if err := kp.Public.UnmarshalText([]byte(cfg.PublicKey)); err != nil {
-			return nil, errors.E(err, "cannot unmarshal public key")
+			return nil, errors.E(op, err, "cannot unmarshal public key")
 		}
+	}
+	if offerAuthorizer == nil {
+		return nil, errors.E(op, "userMappingManager cannot be nil")
 	}
 
 	checker := checkers.New(jjmacaroon.MacaroonNamespace)
@@ -62,16 +65,16 @@ func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, ofgaCl
 	)
 
 	return &MacaroonDischarger{
-		ofgaClient: ofgaClient,
-		bakery:     b,
-		kp:         kp,
+		offerAuthorizer: offerAuthorizer,
+		bakery:          b,
+		kp:              kp,
 	}, nil
 }
 
 type MacaroonDischarger struct {
-	ofgaClient *openfga.OFGAClient
-	bakery     *bakery.Bakery
-	kp         bakery.KeyPair
+	bakery          *bakery.Bakery
+	kp              bakery.KeyPair
+	offerAuthorizer jimm.OfferAuthorizer
 }
 
 // GetDischargerMux returns a mux that can handle macaroon bakery requests for the provided discharger.
@@ -98,7 +101,7 @@ func GetDischargerMux(macaroonDischarger *MacaroonDischarger, rootPath string) *
 // a declared caveat declaring offer uuid:
 //
 //	declared offer-uuid <offer uuid>
-func (md *MacaroonDischarger) CheckThirdPartyCaveat(ctx context.Context, req *http.Request, cavInfo *bakery.ThirdPartyCaveatInfo, _ *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
+func (md *MacaroonDischarger) CheckThirdPartyCaveat(ctx context.Context, _ *http.Request, cavInfo *bakery.ThirdPartyCaveatInfo, _ *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
 	caveatTokens := strings.Split(string(cavInfo.Condition), " ")
 	if len(caveatTokens) != 3 {
 		zapctx.Error(ctx, "caveat token length incorrect", zap.Int("length", len(caveatTokens)))
@@ -112,36 +115,24 @@ func (md *MacaroonDischarger) CheckThirdPartyCaveat(ctx context.Context, req *ht
 		zapctx.Error(ctx, "unknown third party caveat", zap.String("condition", relationString))
 		return nil, checkers.ErrCaveatNotRecognized
 	}
-
 	userTag, err := names.ParseUserTag(userTagString)
 	if err != nil {
 		zapctx.Error(ctx, "failed to parse caveat user tag", zap.Error(err))
 		return nil, checkers.ErrCaveatNotRecognized
 	}
-
 	offerTag := names.NewApplicationOfferTag(offerUUID)
 
-	i, err := dbmodel.NewIdentity(userTag.Id())
+	allowed, err := md.offerAuthorizer.IsUserConsumerForOffer(ctx, userTag, offerTag)
 	if err != nil {
-		return nil, err
+		zapctx.Error(ctx, "failed to check if user is consumer for offer", zap.Error(err), zap.String("user", userTagString), zap.String("offer", offerUUID))
+		return nil, checkers.ErrCaveatNotRecognized
 	}
-	user := openfga.NewUser(
-		i,
-		md.ofgaClient,
-	)
-
-	allowed, err := openfga.CheckRelation(ctx, user, offerTag, ofganames.ConsumerRelation)
-	if err != nil {
-		zapctx.Error(ctx, "failed to check request caveat relation", zap.Error(err))
-		return nil, errors.E(err)
-	}
-
 	if allowed {
 		return []checkers.Caveat{
 			checkers.DeclaredCaveat("offer-uuid", offerUUID),
 			checkers.TimeBeforeCaveat(time.Now().Add(defaultDischargeExpiry)),
 		}, nil
 	}
-	zapctx.Debug(ctx, "macaroon dishcharge denied", zap.String("user", user.Name), zap.String("offer", offerUUID))
+	zapctx.Debug(ctx, "macaroon dishcharge denied", zap.String("user", userTagString), zap.String("offer", offerUUID))
 	return nil, httpbakery.ErrPermissionDenied
 }

--- a/internal/discharger/discharger_test.go
+++ b/internal/discharger/discharger_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Canonical.
+
+package discharger_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
+	"github.com/google/uuid"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/discharger"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+type dischargerSuite struct {
+	discharger *discharger.MacaroonDischarger
+
+	validOfferUUID string
+}
+
+var _ = gc.Suite(&dischargerSuite{})
+
+func (s *dischargerSuite) Init(c *qt.C) {
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	err := db.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+	jimmUUID := uuid.NewString()
+	cfg := discharger.MacaroonDischargerConfig{
+		MacaroonExpiryDuration: 1 * time.Hour,
+		ControllerUUID:         jimmUUID,
+		PrivateKey:             "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
+		PublicKey:              "izcYsQy3TePp6bLjqOo3IRPFvkQd2IKtyODGqC6SdFk=",
+	}
+	s.validOfferUUID = uuid.NewString()
+	authorizer := &mocks.OfferAuthorizer{
+		IsUserConsumerForOfferFunc: func(ctx context.Context, userTag names.UserTag, offerTag names.ApplicationOfferTag) (bool, error) {
+			if userTag.IsLocal() {
+				if userTag.Id() == "local-user" && offerTag.Id() == s.validOfferUUID {
+					return true, nil
+				}
+				return false, nil
+			} else if userTag.Id() == "external-user@external.com" && offerTag.Id() == s.validOfferUUID {
+				return true, nil
+			}
+			return false, nil
+		},
+	}
+	s.discharger, err = discharger.NewMacaroonDischarger(cfg, db, authorizer)
+	c.Assert(err, qt.IsNil)
+
+}
+
+func (s *dischargerSuite) TestCheckThirdPartyCaveat(c *qt.C) {
+	tests := []struct {
+		name          string
+		condition     string
+		expectedError error
+	}{
+		{
+			name:          "valid local user and offer",
+			condition:     fmt.Sprintf("is-consumer user-local-user %s", s.validOfferUUID),
+			expectedError: nil,
+		},
+		{
+			name:          "valid external user and offer",
+			condition:     fmt.Sprintf("is-consumer user-external-user@external.com %s", s.validOfferUUID),
+			expectedError: nil,
+		},
+		{
+			name:          "invalid user and offer",
+			condition:     fmt.Sprintf("is-consumer user-invalid-user %s", s.validOfferUUID),
+			expectedError: httpbakery.ErrPermissionDenied,
+		},
+		{
+			name:          "invalid condition format",
+			condition:     "is-consumer local-user",
+			expectedError: checkers.ErrCaveatNotRecognized,
+		},
+		{
+			name:          "unknown relation string",
+			condition:     "unknown-relation user-local-user offer-1",
+			expectedError: checkers.ErrCaveatNotRecognized,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			ctx := context.Background()
+			cavInfo := &bakery.ThirdPartyCaveatInfo{
+				Condition: []byte(test.condition),
+			}
+			_, err := s.discharger.CheckThirdPartyCaveat(ctx, nil, cavInfo, nil)
+			c.Assert(err, qt.Equals, test.expectedError)
+		})
+	}
+}
+
+func TestDischarger(t *testing.T) {
+	qtsuite.Run(qt.New(t), &dischargerSuite{})
+}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -32,6 +32,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/jimm/jujuauth"
 	"github.com/canonical/jimm/v3/internal/jimm/login"
+	"github.com/canonical/jimm/v3/internal/jimm/offer"
 	"github.com/canonical/jimm/v3/internal/jimm/permissions"
 	"github.com/canonical/jimm/v3/internal/jimm/role"
 	"github.com/canonical/jimm/v3/internal/jimm/ssh"
@@ -202,6 +203,12 @@ type SSHManager interface {
 type ConfigManager interface {
 	// GetConfig returns the configuration for the JIMM controller.
 	GetConfig() (config.ControllerConfig, error)
+}
+
+// OfferAuthorizer provides methods to check if a user is a consumer of an application offer.
+type OfferAuthorizer interface {
+	// IsUserConsumerForOffer checks if a user is a consumer of an application offer.
+	IsUserConsumerForOffer(ctx context.Context, userTag names.UserTag, offerTag names.ApplicationOfferTag) (bool, error)
 }
 
 // JujuManager is the interface to manage all Juju related operations.
@@ -467,6 +474,12 @@ func New(p Parameters) (*JIMM, error) {
 	}
 	j.configManager = configManager
 
+	offerAuthorizer, err := offer.NewOfferAuthorizer(j.Database, j.OpenFGAClient)
+	if err != nil {
+		return nil, err
+	}
+	j.offerAuthorizer = offerAuthorizer
+
 	return j, nil
 }
 
@@ -507,6 +520,9 @@ type JIMM struct {
 
 	// jujuManager provides a means to manage Juju resources within JIMM.
 	jujuManager JujuManager
+
+	// offerAuthorizer provides a means to check if a user is a consumer of an application offer.
+	offerAuthorizer OfferAuthorizer
 }
 
 // ResourceTag returns JIMM's controller tag stating its UUID.
@@ -578,4 +594,9 @@ func (j *JIMM) JujuManager() JujuManager {
 // This is used to expose the config via the ControllerConfig facade.
 func (j *JIMM) ConfigManager() ConfigManager {
 	return j.configManager
+}
+
+// OfferAuthorizer returns an authorizer that enables checking if a user is a consumer of an application offer.
+func (j *JIMM) OfferAuthorizer() OfferAuthorizer {
+	return j.offerAuthorizer
 }

--- a/internal/jimm/offer/authorizer.go
+++ b/internal/jimm/offer/authorizer.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Canonical.
+
+package offer
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+type offerAuthorizer struct {
+	store   *db.Database
+	authSvc *openfga.OFGAClient
+}
+
+// NewOfferAuthorizer returns a new OfferAuthorizer that provides methods to
+// check if a user is a consumer of an application offer.
+func NewOfferAuthorizer(store *db.Database, authSvc *openfga.OFGAClient) (*offerAuthorizer, error) {
+	if store == nil {
+		return nil, errors.E("group store cannot be nil")
+	}
+	if authSvc == nil {
+		return nil, errors.E("group authorisation service cannot be nil")
+	}
+	return &offerAuthorizer{store, authSvc}, nil
+}
+
+// IsUserConsumerForOffer checks if a user is a consumer of an application offer.
+// If the user is local, it is mapped to its corresponding external user
+// based on the model migration user mapping.
+func (offerAuth *offerAuthorizer) IsUserConsumerForOffer(ctx context.Context, userTag names.UserTag, offerTag names.ApplicationOfferTag) (bool, error) {
+	var userIdentifier string
+	var err error
+	if userTag.IsLocal() {
+		userIdentifier, err = offerAuth.resolveLocalUserToExternalUser(ctx, userTag.Id(), offerTag)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		userIdentifier = userTag.Id()
+	}
+	identity, err := dbmodel.NewIdentity(userIdentifier)
+	if err != nil {
+		return false, err
+	}
+	user := openfga.NewUser(
+		identity,
+		offerAuth.authSvc,
+	)
+	return user.IsApplicationOfferConsumer(ctx, offerTag)
+}
+
+func (offerAuth *offerAuthorizer) resolveLocalUserToExternalUser(ctx context.Context, localUsername string, offerTag names.ApplicationOfferTag) (string, error) {
+	offer := dbmodel.ApplicationOffer{
+		UUID: offerTag.Id(),
+	}
+	err := offerAuth.store.GetApplicationOffer(ctx, &offer)
+	if err != nil {
+		return "", err
+	}
+	userMapping := dbmodel.UserMapping{
+		ModelUUID: sql.NullString{
+			String: offer.Model.UUID.String,
+			Valid:  true,
+		},
+		LocalUser: localUsername,
+	}
+	err = offerAuth.store.GetUserMapping(ctx, &userMapping)
+	if err != nil {
+		return "", err
+	}
+	return userMapping.ExternalUserName, nil
+}

--- a/internal/jimm/offer/authorizer_test.go
+++ b/internal/jimm/offer/authorizer_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Canonical.
+
+package offer_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"github.com/google/uuid"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/offer"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type offerAuthorizerSuite struct {
+	offerAuthorizer *offer.OfferAuthorizer
+
+	offerUUID string
+}
+
+const offerAuthEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region-1
+cloud-credentials:
+- owner: alice@canonical.com
+  name: test-credential-1
+  cloud: test-cloud
+controllers:
+- name: test-controller-1
+  uuid: 00000000-0000-0000-0000-0000-0000000000001
+  cloud: test-cloud
+  region: test-region-1
+models:
+- name: test-model
+  uuid: 00000000-0000-0000-0000-0000-0000000000003
+  controller: test-controller-1
+  cloud: test-cloud
+  region: test-region-1
+  cloud-credential: test-credential-1
+  owner: alice@canonical.com
+  life: alive
+application-offers:
+- name: test-offer
+  url: test-offer-url
+  uuid: 00000000-0000-0000-0000-0000-0000000000011
+  model-name: test-model
+  model-owner: alice@canonical.com
+  application-name: application-1
+  application-description: app description 1
+  users:
+  - user: eve@canonical.com
+    access: admin
+  - user: bob@canonical.com
+    access: consume
+`
+
+var _ = gc.Suite(&offerAuthorizerSuite{})
+
+func (s *offerAuthorizerSuite) Init(c *qt.C) {
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	err := db.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
+	if err != nil {
+		c.Fatalf("setting up openfga client: %v", err)
+	}
+	env := jimmtest.ParseEnvironment(c, offerAuthEnv)
+	uuid := uuid.New()
+	env.PopulateDBAndPermissions(c, names.NewControllerTag(uuid.String()), db, ofgaClient)
+	ctrl := dbmodel.Controller{
+		UUID: env.Controllers[0].UUID,
+	}
+	err = db.GetController(c.Context(), &ctrl)
+	c.Assert(err, qt.IsNil)
+	migration := dbmodel.UserMapping{
+		ModelUUID:        sql.NullString{String: env.Models[0].UUID, Valid: true},
+		LocalUser:        "bob",
+		ExternalUserName: "bob@canonical.com",
+	}
+	err = db.AddUserMapping(c.Context(), &migration)
+	c.Assert(err, qt.IsNil)
+
+	s.offerAuthorizer, err = offer.NewOfferAuthorizer(db, ofgaClient)
+	c.Assert(err, qt.IsNil)
+
+	s.offerUUID = env.ApplicationOffers[0].UUID
+}
+
+func (s *offerAuthorizerSuite) TestIsUserConsumerForOffer(c *qt.C) {
+	tests := []struct {
+		name                string
+		userTag             names.UserTag
+		applicationOfferTag names.ApplicationOfferTag
+		allowed             bool
+		expectedError       string
+	}{
+		{
+			name:                "allowed external user",
+			userTag:             names.NewUserTag("eve@canonical.com"),
+			applicationOfferTag: names.NewApplicationOfferTag(s.offerUUID),
+			allowed:             true,
+		},
+		{
+			name:                "not allowed external user",
+			userTag:             names.NewUserTag("eve-not-allowed@canonical.com"),
+			applicationOfferTag: names.NewApplicationOfferTag(s.offerUUID),
+			allowed:             false,
+		},
+		{
+			name:                "not-existing application offer",
+			userTag:             names.NewUserTag("eve@canonical.com"),
+			applicationOfferTag: names.NewApplicationOfferTag("deeadbeef-dead-beef-dead-beefdeadbeef"),
+			allowed:             false,
+		},
+		{
+			name:                "allowed local user",
+			userTag:             names.NewLocalUserTag("bob"),
+			applicationOfferTag: names.NewApplicationOfferTag(s.offerUUID),
+			allowed:             true,
+		},
+		{
+			name:                "not allowed local user",
+			userTag:             names.NewLocalUserTag("alice"),
+			applicationOfferTag: names.NewApplicationOfferTag(s.offerUUID),
+			allowed:             false,
+			expectedError:       "user mapping not found",
+		},
+		{
+			name:                "not-existing application offer local user",
+			userTag:             names.NewUserTag("eve"),
+			applicationOfferTag: names.NewApplicationOfferTag("deeadbeef-dead-beef-dead-beefdeadbeef"),
+			allowed:             false,
+			expectedError:       "^application offer not found.*",
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("Running test: %s", test.name)
+		allowed, err := s.offerAuthorizer.IsUserConsumerForOffer(c.Context(), test.userTag, test.applicationOfferTag)
+		c.Assert(allowed, qt.Equals, test.allowed)
+		if test.expectedError != "" {
+			c.Assert(err, qt.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, qt.IsNil)
+		}
+	}
+}
+
+func TestOfferAuthorizerSuite(t *testing.T) {
+	qtsuite.Run(qt.New(t), &offerAuthorizerSuite{})
+}

--- a/internal/jimm/offer/export_test.go
+++ b/internal/jimm/offer/export_test.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Canonical.
+
+package offer
+
+type OfferAuthorizer = offerAuthorizer

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -25,6 +25,7 @@ type JIMM struct {
 	PubSubHub_         func() *pubsub.Hub
 	ResourceTag_       func() names.ControllerTag
 	ConfigManager_     func() jimm.ConfigManager
+	OfferAuthorizer_   func() jimm.OfferAuthorizer
 }
 
 func (j *JIMM) RoleManager() jimm.RoleManager {
@@ -95,4 +96,11 @@ func (j *JIMM) ConfigManager() jimm.ConfigManager {
 		return nil
 	}
 	return j.ConfigManager_()
+}
+
+func (j *JIMM) OfferAuthorizer() jimm.OfferAuthorizer {
+	if j.OfferAuthorizer_ == nil {
+		return nil
+	}
+	return j.OfferAuthorizer_()
 }

--- a/internal/testutils/jimmtest/mocks/jimm_offerauthorizer_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_offerauthorizer_mock.go
@@ -1,0 +1,23 @@
+// Copyright 2025 Canonical.
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/juju/names/v5"
+)
+
+// OfferAuthorizer is a mock implementation of the OfferAuthorizer interface.
+type OfferAuthorizer struct {
+	// IsUserConsumerForOfferFunc is the mock function for IsUserConsumerForOffer.
+	IsUserConsumerForOfferFunc func(ctx context.Context, userTag names.UserTag, offerTag names.ApplicationOfferTag) (bool, error)
+}
+
+// IsUserConsumerForOffer mocks the IsUserConsumerForOffer method.
+func (m *OfferAuthorizer) IsUserConsumerForOffer(ctx context.Context, userTag names.UserTag, offerTag names.ApplicationOfferTag) (bool, error) {
+	if m.IsUserConsumerForOfferFunc == nil {
+		return false, nil
+	}
+	return m.IsUserConsumerForOfferFunc(ctx, userTag, offerTag)
+}

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -141,20 +140,13 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 		"/.well-known",
 		jimmhttp.NewWellKnownHandler(credentialStore),
 	)
-	macaroonDischarger := setupMacaroonDischarger(c, ControllerUUID, database, s.OFGAClient)
-	localDischargePath := "/macaroons"
-	mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
-
-	s.Server = httptest.NewServer(mux)
-
-	u, _ := url.Parse(s.Server.URL)
 
 	jwksService := jimmjwx.NewJWKSService(credentialStore)
 	err = jwksService.StartJWKSRotator(ctx, time.NewTicker(time.Hour).C, time.Now().UTC().AddDate(0, 3, 0))
 	c.Assert(err, gc.Equals, nil)
 
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   u.Host,
+		Host:   "127.0.0.1",
 		Store:  credentialStore,
 		Expiry: time.Minute,
 	})
@@ -175,6 +167,10 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 
 		CrossModelQueryTimeout: time.Second * 5,
 	})
+	macaroonDischarger := setupMacaroonDischarger(c, ControllerUUID, database, s.JIMM.OfferAuthorizer())
+	localDischargePath := "/macaroons"
+	mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
+	s.Server = httptest.NewServer(mux)
 
 	err = s.AdminUser.SetControllerAccess(ctx, s.JIMM.ResourceTag(), ofganames.AdministratorRelation)
 	c.Assert(err, gc.Equals, nil)
@@ -240,14 +236,14 @@ func (s *JIMMSuite) realAuthenticationService(c *gc.C, db *db.Database) *auth.Au
 	return authSvc
 }
 
-func setupMacaroonDischarger(c *gc.C, uuid string, db *db.Database, ofgaClient *openfga.OFGAClient) *discharger.MacaroonDischarger {
+func setupMacaroonDischarger(c *gc.C, uuid string, db *db.Database, offerAuthorizer jimm.OfferAuthorizer) *discharger.MacaroonDischarger {
 	cfg := discharger.MacaroonDischargerConfig{
 		MacaroonExpiryDuration: 1 * time.Hour,
 		ControllerUUID:         uuid,
 		PrivateKey:             "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
 		PublicKey:              "izcYsQy3TePp6bLjqOo3IRPFvkQd2IKtyODGqC6SdFk=",
 	}
-	macaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, db, ofgaClient)
+	macaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, db, offerAuthorizer)
 	c.Assert(err, gc.IsNil)
 	return macaroonDischarger
 }


### PR DESCRIPTION
The new behaviour in the CheckThirdPartyCaveat method is to call the
OfferAuthorizer to check permissions. The OfferAuthorizer will then be
in charge of trying to resolve the local user to an external user by
consulting the user mapping in incoming migrations.