### PR TITLE
chore: use better type for storing usermapping

### DIFF
--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -32,7 +32,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	err = s.Database.AddModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
@@ -69,7 +69,7 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
@@ -106,7 +106,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -24,5 +24,5 @@ type IncomingModelMigration struct {
 	TargetController   Controller
 
 	// UserMapping holds a mapping of local users to external users.
-	UserMapping JSON
+	UserMapping StringMap
 }

--- a/internal/dbmodel/modelmigration_test.go
+++ b/internal/dbmodel/modelmigration_test.go
@@ -24,7 +24,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 			Valid:  true,
 		},
 		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)
 
@@ -34,7 +34,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 			Valid:  true,
 		},
 		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"new-local": "new-external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"incoming_model_migrations_model_uuid_key\".*")
 }


### PR DESCRIPTION
## Description
Use a stronger type than plain JSON for storing the user mapping in the `IncomingModelMigration` table. Instead of `JSON` I've switched it to our `StringMap` type which is a map of `string` to `string`.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests