### PR TITLE
Prevent controller removals

### DIFF
--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -342,3 +342,47 @@ func (s *dbSuite) TestForEachControllerModel(c *qt.C) {
 		"00000002-0000-0000-0000-000000000004",
 	})
 }
+
+func (s *dbSuite) TestDeleteController_MigrationActive(c *qt.C) {
+	ctx := c.Context()
+
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(ctx, &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-0000-0000000000001",
+		CloudName: "test-cloud",
+	}
+	err = s.Database.AddController(ctx, &controller)
+	c.Assert(err, qt.Equals, nil)
+
+	dbController := dbmodel.Controller{
+		UUID: controller.UUID,
+	}
+	err = s.Database.GetController(ctx, &dbController)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(dbController, qt.CmpEquals(cmpopts.EquateEmpty()), controller)
+
+	// Now we set a migration to active, and attempt to delete the controller expecting it to fail.
+	dbController.MigrationActive = true
+	c.Assert(s.Database.UpdateController(ctx, &dbController), qt.IsNil)
+
+	// Now we expect an error.
+	err = s.Database.DeleteController(ctx, &controller)
+	c.Assert(err, qt.ErrorMatches, ".*migration is in progress.*")
+
+	// Next unset the migration active.
+	dbController.MigrationActive = false
+	c.Assert(s.Database.UpdateController(ctx, &dbController), qt.IsNil)
+
+	// Now we expect no error.
+	err = s.Database.DeleteController(ctx, &controller)
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -14,7 +14,7 @@ import (
 //   - returns an error with code errors.CodeAlreadyExists if
 //     a migration row with the same model UUID already exists.
 func (d *Database) AddIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.AddModelMigration")
+	const op = errors.Op("db.AddIncomingModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
 	}
@@ -33,7 +33,7 @@ func (d *Database) AddIncomingModelMigration(ctx context.Context, modelMigration
 
 // GetIncomingModelMigration returns model migration information based on the model UUID.
 func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.GetModelMigration")
+	const op = errors.Op("db.GetIncomingModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
 	}
@@ -62,7 +62,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 
 // DeleteIncomingModelMigration removes a model migration entry from the database.
 func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.DeleteModelMigration")
+	const op = errors.Op("db.DeleteIncomingModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -50,7 +50,7 @@ func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmode
 		return errors.E(op, "missing uuid", errors.CodeBadRequest)
 	}
 
-	if err := db.First(&modelMigration).Error; err != nil {
+	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(op, err, "model migration not found")

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -10,10 +10,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
-// AddModelMigration stores information about an incoming model migration.
+// AddIncomingModelMigration stores information about an incoming model migration.
 //   - returns an error with code errors.CodeAlreadyExists if
 //     a migration row with the same model UUID already exists.
-func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
+func (d *Database) AddIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.AddModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -31,8 +31,8 @@ func (d *Database) AddModelMigration(ctx context.Context, modelMigration *dbmode
 	return nil
 }
 
-// GetModelMigration returns model migration information based on the model UUID.
-func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
+// GetIncomingModelMigration returns model migration information based on the model UUID.
+func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.GetModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -60,8 +60,8 @@ func (d *Database) GetModelMigration(ctx context.Context, modelMigration *dbmode
 	return nil
 }
 
-// DeleteModelMigration removes a model migration entry from the database.
-func (d *Database) DeleteModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
+// DeleteIncomingModelMigration removes a model migration entry from the database.
+func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.DeleteModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -34,7 +34,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 		TargetControllerID: controller.ID,
 		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
-	err = s.Database.AddModelMigration(context.Background(), &migration)
+	err = s.Database.AddIncomingModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
 	var dbMigration dbmodel.IncomingModelMigration
@@ -45,7 +45,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	c.Assert(dbMigration.UserMapping, qt.DeepEquals, migration.UserMapping)
 
 	migration.ID = 0 // Reset ID to ensure it is not reused
-	err = s.Database.AddModelMigration(context.Background(), &migration)
+	err = s.Database.AddIncomingModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 
@@ -74,12 +74,12 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
 	lookup := dbmodel.IncomingModelMigration{ModelUUID: migration.ModelUUID}
-	err = s.Database.GetModelMigration(context.Background(), &lookup)
+	err = s.Database.GetIncomingModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Equals, nil)
 
 	// Not found
 	lookup = dbmodel.IncomingModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}
-	err = s.Database.GetModelMigration(context.Background(), &lookup)
+	err = s.Database.GetIncomingModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Not(qt.IsNil))
 	eError, ok := err.(*errors.Error)
 	c.Assert(ok, qt.IsTrue)
@@ -110,7 +110,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
-	err = s.Database.DeleteModelMigration(context.Background(), &migration)
+	err = s.Database.DeleteIncomingModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
 	var dbMigration dbmodel.IncomingModelMigration

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -32,7 +32,7 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	err = s.Database.AddModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
@@ -69,7 +69,7 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
@@ -106,7 +106,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local":"external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -23,6 +23,22 @@ type Controller struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
+	/**
+	* JIMM Specific fields, these are fields about controllers but are specific to JIMM,
+	* I.e., if a migration is active.
+	 */
+	// Deprecated records whether this controller is deprecated, and
+	// therefore no new models or clouds will be added to the controller.
+	Deprecated bool `gorm:"not null;default:FALSE"`
+
+	// MigrationActive determines if a migration is active. If a migration is active, then this controller
+	// cannot be deleted (handled by a trigger in the DB).
+	MigrationActive bool `gorm:"not null;default:FALSE"`
+
+	/**
+	* Juju fields, these are fields which Juju holds about controllers too.
+	 */
+
 	// Name is the name given to this controller.
 	Name string `gorm:"not null;uniqueIndex"`
 
@@ -53,10 +69,6 @@ type Controller struct {
 	// CloudRegion is the name of the cloud region which is hosting
 	// this controller.
 	CloudRegion string
-
-	// Deprecated records whether this controller is deprecated, and
-	// therefore no new models or clouds will be added to the controller.
-	Deprecated bool `gorm:"not null;default:FALSE"`
 
 	// AgentVersion holds the string representation of the controller's
 	// agent version.

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -24,5 +24,5 @@ type IncomingModelMigration struct {
 	TargetController   Controller
 
 	// UserMapping holds a mapping of local users to external users.
-	UserMapping JSON
+	UserMapping StringMap
 }

--- a/internal/dbmodel/modelmigration_test.go
+++ b/internal/dbmodel/modelmigration_test.go
@@ -24,7 +24,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 			Valid:  true,
 		},
 		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"local": "external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)
 
@@ -34,7 +34,7 @@ func TestModelMigration_UniqueModelUUIDConstraint(t *testing.T) {
 			Valid:  true,
 		},
 		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.JSON([]byte(`{"new-local": "new-external"}`)),
+		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
 	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"incoming_model_migrations_model_uuid_key\".*")
 }

--- a/internal/dbmodel/sql/postgres/025_migration_trigger.up.sql
+++ b/internal/dbmodel/sql/postgres/025_migration_trigger.up.sql
@@ -1,0 +1,18 @@
+-- Creates a trigger to prevent the controller being unregistered/deleted if a migration is active.
+-- It checks for a "migration_active" bool, and if it's true, prevents deletes.
+ALTER TABLE controllers ADD COLUMN migration_active boolean DEFAULT false;
+
+CREATE OR REPLACE FUNCTION prevent_unregister_if_migration_active()
+RETURNS trigger AS $$
+BEGIN
+  IF OLD.migration_active THEN
+    RAISE EXCEPTION 'migration is in progress';
+  END IF;
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_unregister_if_migration_active
+BEFORE DELETE ON controllers
+FOR EACH ROW
+EXECUTE FUNCTION prevent_unregister_if_migration_active();

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -263,7 +263,7 @@ type JujuManager interface {
 	RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
-	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error
+	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 
 	// These are methods on the Juju manager that don't need to be mocked and can be removed from this interface later.
 	UpdateMetrics(ctx context.Context)

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -263,6 +263,7 @@ type JujuManager interface {
 	RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
+	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error
 
 	// These are methods on the Juju manager that don't need to be mocked and can be removed from this interface later.
 	UpdateMetrics(ctx context.Context)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -277,7 +277,7 @@ func (j *JujuManager) PrepareModelMigration(
 	user *openfga.User,
 	modelUUID string,
 	targetControllerName string,
-	userMapping []byte,
+	userMapping map[string]string,
 ) error {
 	const op = errors.Op("jujumanager.PrepareModelMigration")
 
@@ -294,7 +294,7 @@ func (j *JujuManager) PrepareModelMigration(
 	if err := j.Database.AddIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
 		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.JSON(userMapping),
+		UserMapping:        dbmodel.StringMap(userMapping),
 	}); err != nil {
 		zapctx.Error(ctx, "failed to add incoming model migration details", zap.Error(err))
 		return errors.E(op, err)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/canonical/jimm/v3/internal/db"
@@ -266,4 +268,37 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 		return result, errors.E(op, err)
 	}
 	return result, nil
+}
+
+// PrepareModelMigration takes the model ID from the migrating controller and stores a record
+// in the IncomingModelMigation table to prepare it for migration against the target controller's name.
+func (j *JujuManager) PrepareModelMigration(
+	ctx context.Context,
+	user *openfga.User,
+	modelUUID string,
+	targetControllerName string,
+	userMapping []byte,
+) error {
+	const op = errors.Op("jujumanager.PrepareModelMigration")
+
+	// TODO(ale8k): Use transaction here, to get ctl & then add the model migration
+	// Problem is our DB methods don't take a db object and instead use the instance on
+	// the db struct. Perhaps create two new methods with "TX" in the name...?
+	// Will do this in a follow up.
+	ctl, err := j.getControllerByName(ctx, targetControllerName)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get controller", zap.Error(err))
+		return errors.E(op, err)
+	}
+
+	if err := j.Database.AddIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
+		TargetControllerID: ctl.ID,
+		UserMapping:        dbmodel.JSON(userMapping),
+	}); err != nil {
+		zapctx.Error(ctx, "failed to add incoming model migration details", zap.Error(err))
+		return errors.E(op, err)
+	}
+
+	return nil
 }

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -281,21 +281,23 @@ func (j *JujuManager) PrepareModelMigration(
 ) error {
 	const op = errors.Op("jujumanager.PrepareModelMigration")
 
-	// TODO(ale8k): Use transaction here, to get ctl & then add the model migration
-	// Problem is our DB methods don't take a db object and instead use the instance on
-	// the db struct. Perhaps create two new methods with "TX" in the name...?
-	// Will do this in a follow up.
-	ctl, err := j.getControllerByName(ctx, targetControllerName)
-	if err != nil {
-		zapctx.Error(ctx, "failed to get controller", zap.Error(err))
-		return errors.E(op, err)
-	}
+	err := j.Database.Transaction(func(d *db.Database) error {
+		ctl := dbmodel.Controller{Name: targetControllerName}
+		if err := j.Database.GetController(ctx, &ctl); err != nil {
+			return err
+		}
 
-	if err := j.Database.AddIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
-		ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
-		TargetControllerID: ctl.ID,
-		UserMapping:        dbmodel.StringMap(userMapping),
-	}); err != nil {
+		if err := j.Database.AddIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
+			ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
+			TargetControllerID: ctl.ID,
+			UserMapping:        dbmodel.StringMap(userMapping),
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
 		zapctx.Error(ctx, "failed to add incoming model migration details", zap.Error(err))
 		return errors.E(op, err)
 	}

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -763,7 +763,7 @@ func TestPrepareModelMigration_ControllerDoesNotExist(t *testing.T) {
 
 	user.JimmAdmin = true
 
-	userMapping := []byte(`{"alice":"alice@canonical.com"}`)
+	userMapping := map[string]string{"alice": "alice@canonical.com"}
 
 	err := j.PrepareModelMigration(
 		ctx,
@@ -791,7 +791,7 @@ func TestPrepareModelMigration_Success(t *testing.T) {
 	user.JimmAdmin = true
 
 	modelUUID := env.Models[0].DBObject(c, j.Database).UUID.String
-	userMapping := []byte(`{"alice": "alice@canonical.com"}`)
+	userMapping := map[string]string{"alice": "alice@canonical.com"}
 	targetController := env.Controllers[1].DBObject(c, j.Database)
 
 	err := j.PrepareModelMigration(
@@ -812,5 +812,5 @@ func TestPrepareModelMigration_Success(t *testing.T) {
 
 	c.Assert(incomingMigration.ModelUUID.String, qt.Equals, modelUUID)
 	c.Assert(incomingMigration.TargetController.UUID, qt.Equals, targetController.UUID)
-	c.Assert(incomingMigration.UserMapping, qt.DeepEquals, dbmodel.JSON(userMapping))
+	c.Assert(incomingMigration.UserMapping, qt.DeepEquals, dbmodel.StringMap(userMapping))
 }

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -694,7 +694,6 @@ func TestInitiateInternalMigration(t *testing.T) {
 
 			dbUser := env.User(test.user).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, nil)
-			c.Assert(err, qt.IsNil)
 
 			res, err := j.InitiateInternalMigration(
 				ctx,
@@ -710,4 +709,108 @@ func TestInitiateInternalMigration(t *testing.T) {
 			}
 		})
 	}
+}
+
+const PrepareModelMigrationTestEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+  - owner: alice@canonical.com
+    name: cred-1
+    cloud: test-cloud
+controllers:
+- name: myController
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+- name: myController2
+  uuid: 00000002-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+  - name: model-1
+    uuid: 00000002-0000-0000-0000-000000000001
+    controller: myController
+    cloud: test-cloud
+    region: test-cloud-region
+    cloud-credential: cred-1
+    owner: alice@canonical.com
+    life: alive
+users:
+  - username: alice@canonical.com
+    controller-access: superuser
+`
+
+func TestPrepareModelMigration_ControllerDoesNotExist(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	store := jimmtest.NewInMemoryCredentialStore()
+	j := newTestJujuManager(c, &parameters{
+		CredentialStore: store,
+	})
+
+	env := jimmtest.ParseEnvironment(c, PrepareModelMigrationTestEnv)
+	// We delete the controller from the env, and check for this UUID
+	targetControllerName := env.Controllers[1].Name
+	env.Controllers = env.Controllers[:1]
+	env.PopulateDB(c, j.Database)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	user.JimmAdmin = true
+
+	userMapping := []byte(`{"alice":"alice@canonical.com"}`)
+
+	err := j.PrepareModelMigration(
+		ctx,
+		user,
+		env.Models[0].DBObject(c, j.Database).UUID.String,
+		targetControllerName,
+		userMapping,
+	)
+	c.Assert(err, qt.ErrorMatches, "controller not found")
+}
+
+func TestPrepareModelMigration_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	store := jimmtest.NewInMemoryCredentialStore()
+	j := newTestJujuManager(c, &parameters{
+		CredentialStore: store,
+	})
+
+	env := jimmtest.ParseEnvironment(c, PrepareModelMigrationTestEnv)
+	env.PopulateDB(c, j.Database)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+	user.JimmAdmin = true
+
+	modelUUID := env.Models[0].DBObject(c, j.Database).UUID.String
+	userMapping := []byte(`{"alice": "alice@canonical.com"}`)
+	targetController := env.Controllers[1].DBObject(c, j.Database)
+
+	err := j.PrepareModelMigration(
+		ctx,
+		user,
+		modelUUID,
+		targetController.Name,
+		userMapping,
+	)
+	c.Assert(err, qt.IsNil)
+
+	incomingMigration := &dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
+		TargetControllerID: targetController.ID,
+	}
+	err = j.Database.GetIncomingModelMigration(ctx, incomingMigration)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(incomingMigration.ModelUUID.String, qt.Equals, modelUUID)
+	c.Assert(incomingMigration.TargetController.UUID, qt.Equals, targetController.UUID)
+	c.Assert(incomingMigration.UserMapping, qt.DeepEquals, dbmodel.JSON(userMapping))
 }

--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -4,7 +4,6 @@ package jujuapi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -550,12 +549,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 		}
 	}
 
-	b, err := json.Marshal(args.UserMapping)
-	if err != nil {
-		return errors.E(op, "failed to marshal user mapping")
-	}
-
-	if err := r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.TargetControllerName, b); err != nil {
+	if err := r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.TargetControllerName, args.UserMapping); err != nil {
 		return errors.E(op, err)
 	}
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -4,6 +4,7 @@ package jujuapi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -60,6 +61,7 @@ func init() {
 		purgeLogsMethod := rpc.Method(r.PurgeLogs)
 		migrateModel := rpc.Method(r.MigrateModel)
 		version := rpc.Method(r.Version)
+		prepareModelMigration := rpc.Method(r.PrepareModelMigration)
 
 		// JIMM Generic RPC
 		r.AddMethod("JIMM", 4, "AddController", addControllerMethod)
@@ -96,6 +98,8 @@ func init() {
 		// JIMM Cross-model queries
 		r.AddMethod("JIMM", 4, "CrossModelQuery", crossModelQueryMethod)
 		r.AddMethod("JIMM", 4, "Version", version)
+		// JIMM Model Migrations
+		r.AddMethod("JIMM", 4, "PrepareModelMigration", prepareModelMigration)
 
 		return []int{4}
 	}
@@ -516,4 +520,43 @@ func (r *controllerRoot) Version(ctx context.Context) (apiparams.VersionResponse
 		Commit:  version.VersionInfo.GitCommit,
 	}
 	return versionInfo, nil
+}
+
+// PrepareModelMigration prepares JIMM for an incoming migration.
+func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apiparams.PrepareModelMigrationRequest) error {
+	const op = errors.Op("jujuapi.PrepareModelMigration")
+
+	if !r.user.JimmAdmin {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	mt, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.E(op, "invalid model tag", err)
+	}
+
+	if !names.IsValidControllerName(args.TargetControllerName) {
+		return errors.E(op, "invalid controller name")
+	}
+	userMap := map[string]string{}
+	if err := json.Unmarshal([]byte(args.UserMapping), &userMap); err != nil {
+		return errors.E(op, "invalid user map, unable to unmarshal")
+	}
+
+	// Check each key is a valid local user and each value is a valid user and has a domain
+	for local, external := range userMap {
+		if !names.IsValidUserName(local) {
+			return errors.E(op, fmt.Sprintf("%s is not a valid local user name", local))
+		}
+
+		if !names.IsValidUser(external) || !strings.Contains(external, "@") {
+			return errors.E(op, fmt.Sprintf("%s is not a valid external user name", external))
+		}
+	}
+
+	if err := r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.TargetControllerName, []byte(args.UserMapping)); err != nil {
+		return errors.E(op, err)
+	}
+
+	return nil
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -538,13 +538,9 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	if !names.IsValidControllerName(args.TargetControllerName) {
 		return errors.E(op, "invalid controller name")
 	}
-	userMap := map[string]string{}
-	if err := json.Unmarshal([]byte(args.UserMapping), &userMap); err != nil {
-		return errors.E(op, "invalid user map, unable to unmarshal")
-	}
 
 	// Check each key is a valid local user and each value is a valid user and has a domain
-	for local, external := range userMap {
+	for local, external := range args.UserMapping {
 		if !names.IsValidUserName(local) {
 			return errors.E(op, fmt.Sprintf("%s is not a valid local user name", local))
 		}
@@ -554,7 +550,12 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 		}
 	}
 
-	if err := r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.TargetControllerName, []byte(args.UserMapping)); err != nil {
+	b, err := json.Marshal(args.UserMapping)
+	if err != nil {
+		return errors.E(op, "failed to marshal user mapping")
+	}
+
+	if err := r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.TargetControllerName, b); err != nil {
 		return errors.E(op, err)
 	}
 

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -907,3 +907,92 @@ func (s *jimmSuite) TestVersion(c *gc.C) {
 	c.Assert(versionInfo.Version, gc.Not(gc.Equals), "")
 	c.Assert(versionInfo.Commit, gc.Not(gc.Equals), "")
 }
+
+func (s *jimmSuite) TestPrepareModelMigration_UnauthorizedUser(c *gc.C) {
+	conn := s.open(c, nil, "bob")
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{})
+
+	c.Assert(err, gc.ErrorMatches, "unauthorized \\(unauthorized access\\)")
+}
+
+func (s *jimmSuite) TestPrepareModelMigration_InvalidModelTag(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag: "blah",
+	})
+
+	c.Assert(err, gc.ErrorMatches, "invalid model tag")
+}
+
+func (s *jimmSuite) TestPrepareModelMigration_InvalidControllerName(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: "---bad wolf---",
+	})
+
+	c.Assert(err, gc.ErrorMatches, "invalid controller name")
+}
+
+func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: "controller",
+		UserMapping:          "[]",
+	})
+
+	c.Assert(err, gc.ErrorMatches, "invalid user map, unable to unmarshal")
+
+	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: "controller",
+		UserMapping:          `{"--bad local--": "alice@canonical.com"}`,
+	})
+
+	c.Assert(err, gc.ErrorMatches, `--bad local-- is not a valid local user name`)
+
+	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: "controller",
+		UserMapping:          `{"alice": "alice"}`,
+	})
+
+	c.Assert(err, gc.ErrorMatches, `alice is not a valid external user name`)
+
+	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: "controller",
+		UserMapping:          `{"alice": "--badwolf--@canonical.com"}`,
+	})
+
+	c.Assert(err, gc.ErrorMatches, `--badwolf--@canonical.com is not a valid external user name`)
+}
+
+func (s *jimmSuite) TestPrepareModelMigration_Success(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	ctlName := "prepare-model-migration-controller"
+	s.AddController(c, ctlName, s.APIInfo(c))
+
+	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		TargetControllerName: ctlName,
+		UserMapping:          `{"alice": "alice@canonical.com"}`,
+	})
+	c.Assert(err, gc.IsNil)
+}

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -951,15 +951,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
 		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
 		TargetControllerName: "controller",
-		UserMapping:          "[]",
-	})
-
-	c.Assert(err, gc.ErrorMatches, "invalid user map, unable to unmarshal")
-
-	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
-		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
-		TargetControllerName: "controller",
-		UserMapping:          `{"--bad local--": "alice@canonical.com"}`,
+		UserMapping:          map[string]string{"--bad local--": "alice@canonical.com"},
 	})
 
 	c.Assert(err, gc.ErrorMatches, `--bad local-- is not a valid local user name`)
@@ -967,7 +959,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
 		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
 		TargetControllerName: "controller",
-		UserMapping:          `{"alice": "alice"}`,
+		UserMapping:          map[string]string{"alice": "alice"},
 	})
 
 	c.Assert(err, gc.ErrorMatches, `alice is not a valid external user name`)
@@ -975,7 +967,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	err = client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
 		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
 		TargetControllerName: "controller",
-		UserMapping:          `{"alice": "--badwolf--@canonical.com"}`,
+		UserMapping:          map[string]string{"alice": "--badwolf--@canonical.com"},
 	})
 
 	c.Assert(err, gc.ErrorMatches, `--badwolf--@canonical.com is not a valid external user name`)
@@ -992,7 +984,7 @@ func (s *jimmSuite) TestPrepareModelMigration_Success(c *gc.C) {
 	err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
 		ModelTag:             names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
 		TargetControllerName: ctlName,
-		UserMapping:          `{"alice": "alice@canonical.com"}`,
+		UserMapping:          map[string]string{"alice": "alice@canonical.com"}, // `{"alice": "alice@canonical.com"}`,
 	})
 	c.Assert(err, gc.IsNil)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -56,7 +56,7 @@ type JujuManager struct {
 	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
 	GrantOfferAccessOnController_      func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
-
+	PrepareModelMigration_             func(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error
 	// These mocks can be removed soon once the jujuManager interface is updated.
 	UpdateMetrics_         func(ctx context.Context)
 	CleanupNotFoundModels_ func(ctx context.Context) error
@@ -265,4 +265,11 @@ func (j *JujuManager) RevokeOfferAccessOnController(ctx context.Context, user *o
 		return nil
 	}
 	return j.RevokeOfferAccessOnController_(ctx, user, ut, offerURL, access)
+}
+
+func (j *JujuManager) PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error {
+	if j.PrepareModelMigration_ == nil {
+		return nil
+	}
+	return j.PrepareModelMigration_(ctx, user, modelUUID, targetControllerName, userMapping)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -56,7 +56,7 @@ type JujuManager struct {
 	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
 	GrantOfferAccessOnController_      func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
-	PrepareModelMigration_             func(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error
+	PrepareModelMigration_             func(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	// These mocks can be removed soon once the jujuManager interface is updated.
 	UpdateMetrics_         func(ctx context.Context)
 	CleanupNotFoundModels_ func(ctx context.Context) error
@@ -267,7 +267,7 @@ func (j *JujuManager) RevokeOfferAccessOnController(ctx context.Context, user *o
 	return j.RevokeOfferAccessOnController_(ctx, user, ut, offerURL, access)
 }
 
-func (j *JujuManager) PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping []byte) error {
+func (j *JujuManager) PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error {
 	if j.PrepareModelMigration_ == nil {
 		return nil
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -246,3 +246,9 @@ func (c *Client) Version() (params.VersionResponse, error) {
 	err := c.caller.APICall("JIMM", 4, "", "Version", nil, &response)
 	return response, err
 }
+
+// PrepareModelMigration prepares JIMM for an incoming ModelMigration.
+func (c *Client) PrepareModelMigration(req *params.PrepareModelMigrationRequest) error {
+	err := c.caller.APICall("JIMM", 4, "", "PrepareModelMigration", req, nil)
+	return err
+}

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -545,3 +545,11 @@ type VersionResponse struct {
 	Version string `json:"version" yaml:"version"`
 	Commit  string `json:"commit" yaml:"commit"`
 }
+
+// PrepareModelMigrationRequest holds the details to prepare JIMM
+// for a model migration.
+type PrepareModelMigrationRequest struct {
+	ModelTag             string `json:"model-tag" yaml:"model-tag"`
+	TargetControllerName string `json:"target-controller-name" yaml:"target-controller-name"`
+	UserMapping          string `json:"user-mapping" yaml:"user-mapping"`
+}

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -549,7 +549,7 @@ type VersionResponse struct {
 // PrepareModelMigrationRequest holds the details to prepare JIMM
 // for a model migration.
 type PrepareModelMigrationRequest struct {
-	ModelTag             string `json:"model-tag" yaml:"model-tag"`
-	TargetControllerName string `json:"target-controller-name" yaml:"target-controller-name"`
-	UserMapping          string `json:"user-mapping" yaml:"user-mapping"`
+	ModelTag             string            `json:"model-tag" yaml:"model-tag"`
+	TargetControllerName string            `json:"target-controller-name" yaml:"target-controller-name"`
+	UserMapping          map[string]string `json:"user-mapping" yaml:"user-mapping"`
 }


### PR DESCRIPTION
## Description
    feat: prevent controller deletions during migrations
    
    A controller could be deleted mid migration, this would leave us in a poor spot. This prevents the
    controller being unregistered if a migration is active. It is to be plugged into the prepare call
    (to set the migration active) and to be unset on the final Active call during a migration.

I've built this on top of #1612 accidentally, just review after that has merged.
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
