### PR TITLE
fix(soft-delete): remove soft-delete from cloud_credentials

### DIFF
--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -286,3 +286,55 @@ func (s *dbSuite) TestForEachCloudCredential(c *qt.C) {
 		})
 	}
 }
+
+func (s *dbSuite) TestDeleteCloudCredential(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	u, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+		Type: "test-provider",
+		Regions: []dbmodel.CloudRegion{{
+			Name: "test-region",
+		}},
+	}
+	c.Assert(s.Database.DB.Create(&cloud).Error, qt.IsNil)
+
+	cred := dbmodel.CloudCredential{
+		Name:              "test-cred",
+		CloudName:         cloud.Name,
+		OwnerIdentityName: u.Name,
+		AuthType:          "empty",
+	}
+	cred.Cloud.Regions = nil
+	err = s.Database.SetCloudCredential(context.Background(), &cred)
+	c.Assert(err, qt.Equals, nil)
+
+	cred.Cloud = cloud
+	cred.Cloud.Regions = nil
+
+	dbCred := dbmodel.CloudCredential{
+		CloudName:         cloud.Name,
+		OwnerIdentityName: u.Name,
+		Name:              cred.Name,
+	}
+	err = s.Database.GetCloudCredential(context.Background(), &dbCred)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(dbCred, jimmtest.DBObjectEquals, cred)
+
+	err = s.Database.DeleteCloudCredential(context.Background(), &cred)
+	c.Assert(err, qt.Equals, nil)
+
+	dbCred = dbmodel.CloudCredential{
+		CloudName:         cloud.Name,
+		OwnerIdentityName: u.Name,
+		Name:              cred.Name,
+	}
+	err = s.Database.GetCloudCredential(context.Background(), &dbCred)
+	c.Assert(err, qt.ErrorMatches, `cloudcredential \S+ not found`)
+
+}

--- a/internal/dbmodel/cloudcredential.go
+++ b/internal/dbmodel/cloudcredential.go
@@ -5,14 +5,17 @@ package dbmodel
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/juju/names/v5"
-	"gorm.io/gorm"
 )
 
 // A CloudCredential is a credential that is used to access a cloud.
 type CloudCredential struct {
-	gorm.Model
+	// Note that we do not use gorm.Model to avoid the use of soft-deletes.
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
 
 	// Name is the name of the credential.
 	Name string

--- a/internal/dbmodel/identity_test.go
+++ b/internal/dbmodel/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel_test
 
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
 func TestIdentity(t *testing.T) {
@@ -101,14 +102,12 @@ func TestIdentityCloudCredentials(t *testing.T) {
 	var creds []dbmodel.CloudCredential
 	err = db.Model(u).Association("CloudCredentials").Find(&creds)
 	c.Assert(err, qt.IsNil)
-	c.Check(creds, qt.DeepEquals, []dbmodel.CloudCredential{{
-		Model:             cred1.Model,
+	c.Assert(creds, jimmtest.DBObjectEquals, []dbmodel.CloudCredential{{
 		Name:              cred1.Name,
 		CloudName:         cred1.CloudName,
 		OwnerIdentityName: cred1.OwnerIdentityName,
 		AuthType:          cred1.AuthType,
 	}, {
-		Model:             cred2.Model,
 		Name:              cred2.Name,
 		CloudName:         cred2.CloudName,
 		OwnerIdentityName: cred2.OwnerIdentityName,

--- a/internal/dbmodel/sql/postgres/025_remove_credentials_soft_delete.up.sql
+++ b/internal/dbmodel/sql/postgres/025_remove_credentials_soft_delete.up.sql
@@ -1,0 +1,5 @@
+-- deletes soft-deleted cloud_credentials and drops the
+-- deleted_at column from the cloud_credentials table.
+
+DELETE FROM cloud_credentials WHERE deleted_at IS NOT null;
+ALTER TABLE cloud_credentials DROP COLUMN deleted_at;

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -259,7 +259,7 @@ type JujuManager interface {
 	Offer(ctx context.Context, user *openfga.User, offer juju.AddApplicationOfferParams) error
 	RemoveCloud(ctx context.Context, u *openfga.User, ct names.CloudTag) error
 	RemoveCloudFromController(ctx context.Context, u *openfga.User, controllerName string, ct names.CloudTag) error
-	RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag, force bool) error
+	RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error
 	RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -47,7 +47,7 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 
 // RevokeCloudCredential checks that the credential with the given path
 // can be revoked  and revokes the credential.
-func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag, force bool) error {
+func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
 	const op = errors.Op("jimm.RevokeCloudCredential")
 
 	if user.Name != tag.Owner().Id() {
@@ -75,8 +75,10 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 	if err != nil {
 		return errors.E(op, err)
 	}
-	// if the cloud credential is still used by any model we return an error
-	if len(models) > 0 && !force {
+	// Before we accepted the force flag to remove the credential regardless of the references count.
+	// Now we want to ensure that the credential is not used by any models before removing it to maintain
+	// referential integrity.
+	if len(models) > 0 {
 		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("cloud credential still used by %d model(s)", len(models)))
 	}
 

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1225,7 +1225,7 @@ func TestRevokeCloudCredential(t *testing.T) {
 			user, tag, expectedError := test.createEnv(c, j, j.OpenFGAClient)
 
 			ctx := context.Background()
-			err := j.RevokeCloudCredential(ctx, user, tag, false)
+			err := j.RevokeCloudCredential(ctx, user, tag)
 			if expectedError == "" {
 				c.Assert(err, qt.Equals, nil)
 

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -59,19 +59,6 @@ func init() {
 	}
 }
 
-// RevokeCredentials implements the RevokeCredentials method used in
-// version 1 & 2 of the Cloud facade.
-func (r *controllerRoot) RevokeCredentials(ctx context.Context, args jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	creds := make([]jujuparams.RevokeCredentialArg, len(args.Entities))
-	for i, e := range args.Entities {
-		creds[i].Tag = e.Tag
-		creds[i].Force = true
-	}
-	return r.RevokeCredentialsCheckModels(ctx, jujuparams.RevokeCredentialArgs{
-		Credentials: creds,
-	})
-}
-
 // DefaultCloud implements the DefaultCloud method of the Cloud facade.
 // It returns a default cloud if there is only one cloud available.
 func (r *controllerRoot) DefaultCloud(ctx context.Context) (jujuparams.StringResult, error) {
@@ -164,14 +151,14 @@ func (r *controllerRoot) RevokeCredentialsCheckModels(ctx context.Context, args 
 }
 
 // RevokeCredentials revokes a set of cloud credentials.
-func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, force bool) error {
+func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, _ bool) error {
 	const op = errors.Op("jujuapi.RevokeCredentialsCheckModels")
 
 	ct, err := names.ParseCloudCredentialTag(tag)
 	if err != nil {
 		return errors.E(op, err, errors.CodeBadRequest)
 	}
-	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct, force); err != nil {
+	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct); err != nil {
 		return errors.E(op, err)
 	}
 	return nil

--- a/internal/jujuapi/cloud_test.go
+++ b/internal/jujuapi/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi_test
 
@@ -511,7 +511,7 @@ func (s *cloudSuite) TestRevokeCredentialsCheckModels(c *gc.C) {
 	}})
 
 	mmclient := modelmanager.NewClient(conn)
-	_, err = mmclient.CreateModel("test", "test@canonical.com", jimmtest.TestCloudName, jimmtest.TestCloudRegionName, credTag, nil)
+	modelInfo, err := mmclient.CreateModel("test", "test@canonical.com", jimmtest.TestCloudName, jimmtest.TestCloudRegionName, credTag, nil)
 	c.Assert(err, gc.Equals, nil)
 
 	var resp jujuparams.ErrorResults
@@ -525,10 +525,23 @@ func (s *cloudSuite) TestRevokeCredentialsCheckModels(c *gc.C) {
 	c.Assert(resp.Results[0].Error, gc.ErrorMatches, `cloud credential still used by 1 model\(s\)`)
 
 	resp.Results = nil
+	// we don't support the force flag, so the test should fail again.
 	err = conn.APICall("Cloud", 7, "", "RevokeCredentialsCheckModels", jujuparams.RevokeCredentialArgs{
 		Credentials: []jujuparams.RevokeCredentialArg{{
 			Tag:   credTag.String(),
 			Force: true,
+		}},
+	}, &resp)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(resp.Results[0].Error, gc.ErrorMatches, `cloud credential still used by 1 model\(s\)`)
+
+	s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(modelInfo.UUID))
+
+	resp.Results = nil
+	err = conn.APICall("Cloud", 7, "", "RevokeCredentialsCheckModels", jujuparams.RevokeCredentialArgs{
+		Credentials: []jujuparams.RevokeCredentialArg{{
+			Tag:   credTag.String(),
+			Force: false,
 		}},
 	}, &resp)
 	c.Assert(err, gc.Equals, nil)

--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/testutils/jimmtest/cmp.go
+++ b/internal/testutils/jimmtest/cmp.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmtest
 
@@ -42,7 +42,7 @@ var DBObjectEquals = qt.CmpEquals(
 	cmpopts.EquateEmpty(),
 	cmpopts.IgnoreTypes(gorm.Model{}),
 	cmpopts.IgnoreFields(dbmodel.Cloud{}, "ID", "CreatedAt", "UpdatedAt"),
-	cmpopts.IgnoreFields(dbmodel.CloudCredential{}, "CloudName", "OwnerIdentityName"),
+	cmpopts.IgnoreFields(dbmodel.CloudCredential{}, "CloudName", "OwnerIdentityName", "ID", "CreatedAt", "UpdatedAt"),
 	cmpopts.IgnoreFields(dbmodel.CloudRegion{}, "CloudName"),
 	cmpopts.IgnoreFields(dbmodel.CloudRegionControllerPriority{}, "CloudRegionID", "ControllerID"),
 	cmpopts.IgnoreFields(dbmodel.Controller{}, "ID", "UpdatedAt", "CreatedAt"),

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -49,7 +49,7 @@ type JujuManager struct {
 	PurgeLogs_                         func(ctx context.Context, user *openfga.User, before time.Time) (int64, error)
 	RemoveCloud_                       func(ctx context.Context, u *openfga.User, ct names.CloudTag) error
 	RemoveCloudFromController_         func(ctx context.Context, u *openfga.User, controllerName string, ct names.CloudTag) error
-	RevokeCloudCredential_             func(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag, force bool) error
+	RevokeCloudCredential_             func(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error
 	UpdateApplicationOffer_            func(ctx context.Context, controller *dbmodel.Controller, offerUUID string, removed bool) error
 	UpdateCloud_                       func(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujuparams.Cloud) error
 	UpdateCloudCredential_             func(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
@@ -210,11 +210,11 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, u *openfga.
 	}
 	return j.RemoveCloudFromController_(ctx, u, controllerName, ct)
 }
-func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag, force bool) error {
+func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
 	if j.RevokeCloudCredential_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.RevokeCloudCredential_(ctx, user, tag, force)
+	return j.RevokeCloudCredential_(ctx, user, tag)
 }
 func (j *JujuManager) UpdateApplicationOffer(ctx context.Context, controller *dbmodel.Controller, offerUUID string, removed bool) error {
 	if j.UpdateApplicationOffer_ == nil {

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -4,6 +4,7 @@ package jimmtest
 
 import (
 	"context"
+	"database/sql"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -342,6 +343,29 @@ func (s *JIMMSuite) AddModel(c *gc.C, owner names.UserTag, name string, cloud na
 	c.Assert(err, gc.Equals, nil)
 
 	return names.NewModelTag(mi.UUID)
+}
+
+func (s *JIMMSuite) DestroyModelAndDeleteFromDatabase(c *gc.C, modelTag names.ModelTag) {
+	ctx := context.Background()
+
+	// Call Juju DestroyModel API and set the model to dying state.
+	err := s.JIMM.JujuManager().DestroyModel(ctx, s.AdminUser, modelTag, nil, nil, nil, nil)
+	c.Assert(err, gc.Equals, nil)
+
+	// Remove the dying model from the database.
+	// This is required because the model will be deleted in JIMM's state only when it's finally
+	// removed from the backing controller and the cleanup routine runs.
+	// Sometimes we don't want to wait for that in tests.
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelTag.Id(),
+			Valid:  true,
+		},
+	}
+	err = s.JIMM.Database.GetModel(context.Background(), model)
+	c.Assert(err, gc.Equals, nil)
+	err = s.JIMM.Database.DeleteModel(context.Background(), model)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *JIMMSuite) AddGroup(c *gc.C, groupName string) dbmodel.GroupEntry {


### PR DESCRIPTION
Before: we were soft-deleting credentials. This is an issue because when you delete and re-add a credential it isn't re-added but can't be used because it is soft-deleted.
So this PR remove the soft-delete.

By removing the soft-delete we can't `RevokeCredentials` with `force` anymore, because models hold a reference to credentials and if we delete a cloud credential with a model still referencing it, postgresql returns an error and it isn't good to break our state to allow `force`.
