### PR TITLE
chore: implement Prechecks on the MigrationTarget facade

### DIFF
--- a/internal/dbmodel/cloud_test.go
+++ b/internal/dbmodel/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel_test
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/api/base"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version"
@@ -236,6 +237,9 @@ type JujuManager interface {
 	UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
+
+	// Migration related methods
+	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 
 	// Other methods
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -239,6 +239,9 @@ type JujuManager interface {
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 
 	// Migration related methods
+	// The migration methods below are sorted roughly
+	// in the order they are expected to be called.
+	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 
 	// Other methods
@@ -268,7 +271,6 @@ type JujuManager interface {
 	RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujucloud.Cloud) error
 	UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
-	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 
 	// These are methods on the Juju manager that don't need to be mocked and can be removed from this interface later.
 	UpdateMetrics(ctx context.Context)

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api/base"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 
@@ -129,6 +130,9 @@ type API interface {
 
 	// Ping tests the connection is working.
 	Ping(context.Context) error
+
+	// PreChecks runs pre-checks for a model migration.
+	Prechecks(model migration.ModelInfo) error
 
 	// RemoveCloud removes a cloud.
 	RemoveCloud(names.CloudTag) error

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -16,6 +16,9 @@ import (
 )
 
 // Prechecks checks that the model can be migrated to the target controller.
+// It does this by calling the method of the same name on the target Juju controller.
+// As part of all model migrations passing through JIMM, it modifies the model description
+// to replace any local user references with their external mapping.
 func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
 	const op = errors.Op("jimm.Prechecks")
 
@@ -51,7 +54,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 // modifyMigrationInfo modifies the description of the model migration
 // to replace any local user references with their external mapping.
 func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMapping dbmodel.StringMap) error {
-	if model.Owner.Domain() != "" && model.Owner.Domain() != names.LocalUserDomain {
+	if !model.Owner.IsLocal() {
 		// If the owner is not a local user, we do not modify it.
 		// This is useful when migrating a model from one JIMM
 		// controller to another, where the owner is already an external user.

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Canonical.
+
+package juju
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+// Prechecks checks that the model can be migrated to the target controller.
+func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
+	const op = errors.Op("jimm.Prechecks")
+
+	modelMigration := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: model.UUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
+	}
+
+	err = j.modifyMigrationInfo(&model, modelMigration.UserMapping)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to modify migration info: %w", err))
+	}
+
+	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	err = api.Prechecks(model)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to run pre-checks for migration: %w", err))
+	}
+	return nil
+}
+
+// modifyMigrationInfo modifies the description of the model migration
+// to replace any local user references with their external mapping.
+func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMapping dbmodel.StringMap) error {
+	if model.Owner.Domain() != "" && model.Owner.Domain() != names.LocalUserDomain {
+		// If the owner is not a local user, we do not modify it.
+		// This is useful when migrating a model from one JIMM
+		// controller to another, where the owner is already an external user.
+		return nil
+	}
+	newOwnerFound := false
+	for originalUser, newUser := range userMapping {
+		if originalUser == model.Owner.Id() {
+			if !names.IsValidUser(newUser) {
+				return errors.E(fmt.Errorf("invalid external user name %q", newUser))
+			}
+			model.Owner = names.NewUserTag(newUser)
+			newOwnerFound = true
+		}
+	}
+	if !newOwnerFound {
+		// If the owner is not found in the user mappings, we return an error.
+		// This is to ensure that the migration does not proceed with an invalid owner.
+		return errors.E(fmt.Errorf("no external user mapping found for local user %q", model.Owner.Id()))
+	}
+	// TODO: Replace fields on the model description including the model owner and users.
+
+	return nil
+}

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -22,23 +22,23 @@ import (
 func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
 	const op = errors.Op("jimm.Prechecks")
 
-	modelMigration := dbmodel.IncomingModelMigration{
+	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
 			String: model.UUID,
 			Valid:  true,
 		},
 	}
-	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
 	}
 
-	err = j.modifyMigrationInfo(&model, modelMigration.UserMapping)
+	err = j.modifyMigrationInfo(&model, incomingModel.UserMapping)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to modify migration info: %w", err))
 	}
 
-	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	api, err := j.dialController(ctx, &incomingModel.TargetController)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -60,21 +60,13 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 		// controller to another, where the owner is already an external user.
 		return nil
 	}
-	newOwnerFound := false
-	for originalUser, newUser := range userMapping {
-		if originalUser == model.Owner.Id() {
-			if !names.IsValidUser(newUser) {
-				return errors.E(fmt.Errorf("invalid external user name %q", newUser))
-			}
-			model.Owner = names.NewUserTag(newUser)
-			newOwnerFound = true
-		}
-	}
-	if !newOwnerFound {
+	newOwner, ok := userMapping[model.Owner.Id()]
+	if !ok {
 		// If the owner is not found in the user mappings, we return an error.
 		// This is to ensure that the migration does not proceed with an invalid owner.
 		return errors.E(fmt.Errorf("no external user mapping found for local user %q", model.Owner.Id()))
 	}
+	model.Owner = names.NewUserTag(newOwner)
 	// TODO: Replace fields on the model description including the model owner and users.
 
 	return nil

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Canonical.
+
+package juju_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/description/v8"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+const testMigrationEnv = `clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+controllers:
+- name: test1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region-1
+  agent-version: 3.2.1
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+`
+
+func TestPrechecks_ModifiesModelDescription(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Validate that the API request to Juju is made with a modified version
+	// of the model description, where the owner is replaced with an external user.
+	api := &jimmtest.API{
+		Prechecks_: func(mi migration.ModelInfo) error {
+			c.Check(mi.UUID, qt.Equals, "00000001-0000-0000-0000-000000000001")
+			c.Check(mi.Owner.Id(), qt.Equals, "alice@canonical.com")
+			// TODO: Check the description has been modified to use the external user mapping.
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo("bob")
+	err = j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestPrechecks_ControllerUnreachable(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	api := &jimmtest.API{
+		Prechecks_: func(mi migration.ModelInfo) error {
+			return errors.New("controller unreachable")
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo("bob")
+	err = j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.ErrorMatches, `.*controller unreachable`)
+}
+
+func TestPrechecks_MissingUserMapping(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"random-user": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo("bob")
+	err = j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.ErrorMatches, `.*no external user mapping found for local user "bob"`)
+}
+
+func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo("bob")
+	err := j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+}
+
+func newIncomingMigration(userMap map[string]string, ctl dbmodel.Controller) dbmodel.IncomingModelMigration {
+	return dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		TargetControllerID: ctl.ID,
+		UserMapping:        userMap,
+	}
+}
+
+func newMigrationInfo(owner string) migration.ModelInfo {
+	descriptionArgs := description.ModelArgs{
+		AgentVersion: "3.2.1",
+		Owner:        names.NewUserTag(owner),
+		Type:         description.IAAS,
+		Cloud:        "test",
+	}
+	modelDescription := description.NewModel(descriptionArgs)
+	userArgs := description.UserArgs{
+		Name:        names.NewUserTag("bob"),
+		DisplayName: "bob",
+		Access:      "admin",
+	}
+	modelDescription.AddUser(userArgs)
+	modelInfo := migration.ModelInfo{
+		UUID:                   "00000001-0000-0000-0000-000000000001",
+		Owner:                  names.NewUserTag("bob"),
+		Name:                   "test-model",
+		AgentVersion:           version.MustParse("3.2.1"),
+		ControllerAgentVersion: version.MustParse("3.2.1"),
+		ModelDescription:       modelDescription,
+	}
+	return modelInfo
+}

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -170,7 +170,7 @@ func newMigrationInfo(owner string) migration.ModelInfo {
 	modelDescription.AddUser(userArgs)
 	modelInfo := migration.ModelInfo{
 		UUID:                   "00000001-0000-0000-0000-000000000001",
-		Owner:                  names.NewUserTag("bob"),
+		Owner:                  names.NewUserTag(owner),
 		Name:                   "test-model",
 		AgentVersion:           version.MustParse("3.2.1"),
 		ControllerAgentVersion: version.MustParse("3.2.1"),

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -56,5 +56,9 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 		AgentVersion:           args.AgentVersion,
 		ControllerAgentVersion: args.ControllerAgentVersion,
 	}
-	return r.jimm.JujuManager().Prechecks(ctx, r.user, model)
+	err = r.jimm.JujuManager().Prechecks(ctx, r.user, model)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	return nil
 }

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Canonical.
+
+package jujuapi
+
+import (
+	"context"
+
+	"github.com/juju/juju/core/migration"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
+)
+
+/*
+Below are the remaining RPC methods to add to the MigrationTarget facade.
+There are additional HTTP endpoints not included here that also need to be implemented.
+
+func (api *API) Abort(args params.ModelArgs) error
+func (api *API) Activate(args params.ActivateModelArgs) error
+func (api *API) AdoptResources(args params.AdoptResourcesArgs) error
+func (api *API) CACert() (params.BytesResult, error)
+func (api *API) CheckMachines(args params.ModelArgs) (params.ErrorResults, error)
+func (api *API) Import(serialized params.SerializedModel) error
+func (api *API) LatestLogTime(args params.ModelArgs) (time.Time, error)
+func (api *API) Prechecks(model params.MigrationModelInfo) error
+*/
+
+func init() {
+	facadeInit["MigrationTarget"] = func(r *controllerRoot) []int {
+		preChecks := rpc.Method(r.Prechecks)
+
+		r.AddMethod("MigrationTarget", 4, "Abort", preChecks)
+
+		return []int{4}
+	}
+}
+
+// Prechecks implements the Prechecks method of the MigrationTarget facade.
+func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfo) error {
+	const op = errors.Op("jujuapi.Prechecks")
+
+	if !r.user.JimmAdmin {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	ownerTag, err := names.ParseUserTag(args.OwnerTag)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	model := migration.ModelInfo{
+		UUID:                   args.UUID,
+		Name:                   args.Name,
+		Owner:                  ownerTag,
+		AgentVersion:           args.AgentVersion,
+		ControllerAgentVersion: args.ControllerAgentVersion,
+	}
+	return r.jimm.JujuManager().Prechecks(ctx, r.user, model)
+}

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -31,7 +31,7 @@ func init() {
 	facadeInit["MigrationTarget"] = func(r *controllerRoot) []int {
 		preChecks := rpc.Method(r.Prechecks)
 
-		r.AddMethod("MigrationTarget", 4, "Abort", preChecks)
+		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 
 		return []int{4}
 	}

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Canonical.
+
+package jujuapi_test
+
+import (
+	"github.com/juju/description/v8"
+	"github.com/juju/juju/api/controller/migrationtarget"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type migrationTargetSuite struct {
+	websocketSuite
+}
+
+var _ = gc.Suite(&migrationTargetSuite{})
+
+func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	modelDescriptionArgs := description.ModelArgs{
+		Type:        description.IAAS,
+		Owner:       names.NewUserTag("alice"),
+		Cloud:       jimmtest.TestCloudName,
+		CloudRegion: jimmtest.TestCloudRegionName,
+	}
+	modelDescription := description.NewModel(modelDescriptionArgs)
+	model := migration.ModelInfo{
+		UUID:                   "00000001-0000-0000-0000-000000000001",
+		Owner:                  names.NewUserTag("alice"),
+		Name:                   "test-model",
+		ControllerAgentVersion: version.MustParse("3.5.0"),
+		AgentVersion:           version.MustParse("3.5.0"),
+		ModelDescription:       modelDescription,
+	}
+	client := migrationtarget.NewClient(conn)
+	err := client.Prechecks(model)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+
+	// TODO: Run a prepare model migration call and then call preChecks again.
+}

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -11,6 +11,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/pkg/api"
+	"github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 type migrationTargetSuite struct {
@@ -29,9 +31,10 @@ func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 		Cloud:       jimmtest.TestCloudName,
 		CloudRegion: jimmtest.TestCloudRegionName,
 	}
+	modelUUID := "00000001-0000-0000-0000-000000000001"
 	modelDescription := description.NewModel(modelDescriptionArgs)
 	model := migration.ModelInfo{
-		UUID:                   "00000001-0000-0000-0000-000000000001",
+		UUID:                   modelUUID,
 		Owner:                  names.NewUserTag("alice"),
 		Name:                   "test-model",
 		ControllerAgentVersion: version.MustParse("3.5.0"),
@@ -42,5 +45,15 @@ func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 	err := client.Prechecks(model)
 	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
 
-	// TODO: Run a prepare model migration call and then call preChecks again.
+	prepareModelMigration := params.PrepareModelMigrationRequest{
+		ModelTag:             names.NewModelTag(modelUUID).String(),
+		TargetControllerName: "controller-1", // Default name of the initial controller added to JIMM.
+		UserMapping:          map[string]string{"alice": "alice@canonical.com"},
+	}
+	jimmClient := api.NewClient(conn)
+	err = jimmClient.PrepareModelMigration(&prepareModelMigration)
+	c.Assert(err, gc.IsNil)
+
+	err = client.Prechecks(model)
+	c.Assert(err, gc.IsNil)
 }

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -19,16 +19,9 @@ import (
 )
 
 type migrationTargetUnitSuite struct {
-	cleanupFuncs []func()
 }
 
 var _ = gc.Suite(&migrationTargetUnitSuite{})
-
-func (s *migrationTargetUnitSuite) TearDownTest(c *gc.C) {
-	for _, cleanup := range s.cleanupFuncs {
-		cleanup()
-	}
-}
 
 func (s *migrationTargetUnitSuite) TestMigrationTarget(c *gc.C) {
 	ctx := context.Background()

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+
+	"github.com/juju/juju/core/migration"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+type migrationTargetUnitSuite struct {
+	cleanupFuncs []func()
+}
+
+var _ = gc.Suite(&migrationTargetUnitSuite{})
+
+func (s *migrationTargetUnitSuite) TearDownTest(c *gc.C) {
+	for _, cleanup := range s.cleanupFuncs {
+		cleanup()
+	}
+}
+
+func (s *migrationTargetUnitSuite) TestMigrationTarget(c *gc.C) {
+	ctx := context.Background()
+
+	preChecksCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			Prechecks_: func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
+				preChecksCalled = true
+				c.Assert(model.UUID, gc.Equals, "00000001-0000-0000-0000-000000000001")
+				c.Assert(model.Owner.Id(), gc.Equals, "bob")
+				return nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.MigrationModelInfo{
+		UUID:     "00000001-0000-0000-0000-000000000001",
+		Name:     "test-model",
+		OwnerTag: names.NewUserTag("bob").String(),
+	}
+
+	// Validate access denied without JIMM admin permissions.
+	err := cr.Prechecks(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+	c.Assert(preChecksCalled, gc.Equals, false)
+
+	// Validate the precheck method is called when the user is a JIMM admin.
+	user.JimmAdmin = true
+	err = cr.Prechecks(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(preChecksCalled, gc.Equals, true)
+
+	// Validate that an invalid owner tag is rejected.
+	args.OwnerTag = "invalid-owner-tag"
+	err = cr.Prechecks(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-owner-tag" is not a valid tag`)
+}

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -67,7 +67,6 @@ type ModelManager interface {
 	ForEachModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	ForEachUserModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
-	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
 	ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error
 	ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelInfo, error)

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -1,0 +1,13 @@
+package jujuclient
+
+import (
+	"github.com/juju/juju/api/controller/migrationtarget"
+	"github.com/juju/juju/core/migration"
+)
+
+// PreChecks checks that the target controller is able to accept the
+// model being migrated.
+func (c Connection) Prechecks(model migration.ModelInfo) error {
+	migrationTarget := migrationtarget.NewClient(&c)
+	return migrationTarget.Prechecks(model)
+}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/version"
 	"github.com/juju/names/v5"
@@ -152,6 +153,7 @@ type API struct {
 	Offer_                             func(context.Context, crossmodel.OfferURL, jujuparams.AddApplicationOffer) error
 	Ping_                              func(context.Context) error
 	RemoveCloud_                       func(names.CloudTag) error
+	Prechecks_                         func(migration.ModelInfo) error
 	RevokeApplicationOfferAccess_      func(context.Context, string, names.UserTag, jujuparams.OfferAccessPermission) error
 	RevokeCredential_                  func(context.Context, names.CloudCredentialTag) error
 	RevokeModelAccess_                 func(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
@@ -352,6 +354,13 @@ func (a *API) Ping(ctx context.Context) error {
 		return nil
 	}
 	return a.Ping_(ctx)
+}
+
+func (a *API) Prechecks(model migration.ModelInfo) error {
+	if a.Prechecks_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.Prechecks_(model)
 }
 
 func (a *API) RemoveCloud(tag names.CloudTag) error {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical.
+package mocks
+
+import (
+	"context"
+
+	"github.com/juju/juju/core/migration"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+type MigrationMocks struct {
+	Prechecks_ func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
+}
+
+func (j *MigrationMocks) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
+	if j.Prechecks_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return j.Prechecks_(ctx, user, model)
+}

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -26,6 +26,7 @@ import (
 type JujuManager struct {
 	ControllerService
 	ModelManager
+	MigrationMocks
 	AddAuditLogEntry_                  func(ale *dbmodel.AuditLogEntry)
 	AddCloudToController_              func(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	AddHostedCloud_                    func(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error


### PR DESCRIPTION
## Description
This PR starts to implement the `MigrationTarget` facade on JIMM. It introduces the `Prechecks` method used to start a model migration. There is a TODO around modifying the model description that we receive, that will be handled in a separate PR.

Fixes [JUJU-8031](https://warthogs.atlassian.net/browse/JUJU-8031)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8031]: https://warthogs.atlassian.net/browse/JUJU-8031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ