### PR TITLE
chore: implement CACert method

### DIFF
--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -30,11 +30,29 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error
 func init() {
 	facadeInit["MigrationTarget"] = func(r *controllerRoot) []int {
 		preChecks := rpc.Method(r.Prechecks)
+		caCert := rpc.Method(r.CACert)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
+		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
 
 		return []int{4}
 	}
+}
+
+// CACert implements the CACert method of the MigrationTarget facade.
+// It is used by the source Juju controller to retrieve the CA cert of
+// the target controller during model migration, if the client did not
+// send a CA cert to the source controller.
+//
+// The above is nonsensical because if the source controller can reach
+// the target controller (and because Juju enforces WSS), it already has
+// everything it needs i.e. it either has the self-signed CA cert or it
+// was able to connect thanks to a public CA.
+//
+// However, because the source controller requires this call to be successful,
+// but doesn't actually require the result to have len() > 0, we can return an empty result.
+func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
+	return jujuparams.BytesResult{}, nil
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -42,7 +42,8 @@ func init() {
 // CACert implements the CACert method of the MigrationTarget facade.
 // It is used by the source Juju controller to retrieve the CA cert of
 // the target controller during model migration, if the client did not
-// send a CA cert to the source controller.
+// send a CA cert to the source controller (possible if the controller
+// uses a public CA rather than a self-signed cert).
 //
 // The above is nonsensical because if the source controller can reach
 // the target controller (and because Juju enforces WSS), it already has

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -57,3 +57,13 @@ func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 	err = client.Prechecks(model)
 	c.Assert(err, gc.IsNil)
 }
+
+func (s *migrationTargetSuite) TestCACert(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	client := migrationtarget.NewClient(conn)
+	cert, err := client.CACert()
+	c.Assert(err, gc.IsNil)
+	c.Assert(cert, gc.Equals, "")
+}


### PR DESCRIPTION
## Description
This PR builds on #1616.

This PR implements the CACert method on the MigrationTarget facade. The implementation of the CACert method is very straightforward and explained thoroughly in godoc. One useful piece to add is [a link](https://github.com/juju/juju/blob/3.6/apiserver/facades/client/controller/controller.go#L854) to the Juju code where the CACert call is made.

Fixes [JUJU-8087](https://warthogs.atlassian.net/browse/JUJU-8087)
## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8087]: https://warthogs.atlassian.net/browse/JUJU-8087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ