### PR TITLE
chore: implement AdoptResources method

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/oauth2"
 
@@ -243,6 +243,7 @@ type JujuManager interface {
 	// in the order they are expected to be called.
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
+	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 
 	// Other methods
 

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -14,7 +14,7 @@ import (
 	jujucontroller "github.com/juju/juju/controller"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -21,7 +21,7 @@ import (
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
-	semversion "github.com/juju/version"
+	semversion "github.com/juju/version/v2"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -38,6 +39,11 @@ type API interface {
 
 	// AddCloud adds a new cloud.
 	AddCloud(names.CloudTag, jujucloud.Cloud, bool) error
+
+	// AdoptResources adopts resources from a model with the given UUID
+	// and controller version. This is used to adopt resources from a
+	// model that is being migrated.
+	AdoptResources(modelUUID string, controllerVersion version.Number) error
 
 	// ChangeModelCredential replaces cloud credential for a given model with the provided one.
 	ChangeModelCredential(context.Context, names.ModelTag, names.CloudCredentialTag) error

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -47,6 +48,37 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 	err = api.Prechecks(model)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to run pre-checks for migration: %w", err))
+	}
+	return nil
+}
+
+// AdoptResources adopts resources from a model with the given UUID
+// and controller version. This is used to adopt resources from a
+// model that is being migrated. It calls the method of the same name
+// on the target Juju controller.
+func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
+	const op = errors.Op("jimm.AdoptResources")
+
+	modelMigration := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
+	}
+
+	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	err = api.AdoptResources(modelUUID, sourceControllerVersion)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to adopt resources: %w", err))
 	}
 	return nil
 }

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -143,6 +143,60 @@ func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
+func TestAdoptResources_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	controllerVersion := version.MustParse("3.2.1")
+
+	// Validate that the API request to Juju is made with a modified version
+	// of the model description, where the owner is replaced with an external user.
+	api := &jimmtest.API{
+		AdoptResources_: func(uuid string, v version.Number) error {
+			c.Check(uuid, qt.Equals, modelUUID)
+			c.Check(v, qt.DeepEquals, controllerVersion)
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	err = j.AdoptResources(ctx, user, modelUUID, controllerVersion)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestAdoptResources_NoIncomingModelMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	err := j.AdoptResources(ctx, user, "foo", version.MustParse("3.2.1"))
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+}
+
 func newIncomingMigration(userMap map[string]string, ctl dbmodel.Controller) dbmodel.IncomingModelMigration {
 	return dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -9,7 +9,7 @@ import (
 	jujucontroller "github.com/juju/juju/controller"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/rpc/params"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 
@@ -31,9 +32,11 @@ func init() {
 	facadeInit["MigrationTarget"] = func(r *controllerRoot) []int {
 		preChecks := rpc.Method(r.Prechecks)
 		caCert := rpc.Method(r.CACert)
+		adoptResources := rpc.Method(r.AdoptResources)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
+		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
 
 		return []int{4}
 	}
@@ -54,6 +57,25 @@ func init() {
 // but doesn't actually require the result to have len() > 0, we can return an empty result.
 func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 	return jujuparams.BytesResult{}, nil
+}
+
+// AdoptResources implements the AdoptResources method of the MigrationTarget facade.
+// It is used by the source Juju controller to update the tags of the
+// resources of a model that has been migrated to a new controller.
+// This prevents the resources from being destroyed if the source controller
+// is destroyed after the model is migrated away.
+func (r *controllerRoot) AdoptResources(ctx context.Context, args params.AdoptResourcesArgs) error {
+	const op = errors.Op("jujuapi.AdoptResources")
+
+	if !r.user.JimmAdmin {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	return r.jimm.JujuManager().AdoptResources(ctx, r.user, modelTag.Id(), args.SourceControllerVersion)
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -67,3 +67,13 @@ func (s *migrationTargetSuite) TestCACert(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(cert, gc.Equals, "")
 }
+
+func (s *migrationTargetSuite) TestAdoptResources(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	client := migrationtarget.NewClient(conn)
+	err := client.AdoptResources(modelUUID)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+}

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -23,7 +24,7 @@ type migrationTargetUnitSuite struct {
 
 var _ = gc.Suite(&migrationTargetUnitSuite{})
 
-func (s *migrationTargetUnitSuite) TestMigrationTarget(c *gc.C) {
+func (s *migrationTargetUnitSuite) TestPreChecks(c *gc.C) {
 	ctx := context.Background()
 
 	preChecksCalled := false
@@ -70,4 +71,52 @@ func (s *migrationTargetUnitSuite) TestMigrationTarget(c *gc.C) {
 	args.OwnerTag = "invalid-owner-tag"
 	err = cr.Prechecks(ctx, args)
 	c.Assert(err, gc.ErrorMatches, `"invalid-owner-tag" is not a valid tag`)
+}
+
+func (s *migrationTargetUnitSuite) TestAdoptResources(c *gc.C) {
+	ctx := context.Background()
+
+	adoptResourcesCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			AdoptResources_: func(ctx context.Context, user *openfga.User, modelUUID string, controllerVersion version.Number) error {
+				adoptResourcesCalled = true
+				c.Assert(modelUUID, gc.Equals, "00000001-0000-0000-0000-000000000001")
+				c.Assert(controllerVersion, gc.DeepEquals, version.MustParse("3.2.1"))
+				return nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.AdoptResourcesArgs{
+		ModelTag:                names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+		SourceControllerVersion: version.MustParse("3.2.1"),
+	}
+
+	// Validate access denied without JIMM admin permissions.
+	err := cr.AdoptResources(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+	c.Assert(adoptResourcesCalled, gc.Equals, false)
+
+	// Validate the precheck method is called when the user is a JIMM admin.
+	user.JimmAdmin = true
+	err = cr.AdoptResources(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(adoptResourcesCalled, gc.Equals, true)
+
+	// Validate that an invalid model tag is rejected.
+	args.ModelTag = "invalid-model-tag"
+	err = cr.AdoptResources(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
 }

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -1,8 +1,13 @@
+// Copyright 2025 Canonical.
+
 package jujuclient
 
 import (
 	"github.com/juju/juju/api/controller/migrationtarget"
 	"github.com/juju/juju/core/migration"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 )
 
 // PreChecks checks that the target controller is able to accept the
@@ -10,4 +15,24 @@ import (
 func (c Connection) Prechecks(model migration.ModelInfo) error {
 	migrationTarget := migrationtarget.NewClient(&c)
 	return migrationTarget.Prechecks(model)
+}
+
+// AdoptResources asks the cloud provider to update the controller
+// tags for a model's resources. This prevents the resources from
+// being destroyed if the source controller is destroyed after the
+// model is migrated away.
+//
+// Note that we can't use the migrationTarget client here because it
+// fetches the SourceControllerVersion from a global var based on the
+// Juju version we are using, which doesn't work for JIMM since we
+// want to use the controller version that was passed to us.
+func (c Connection) AdoptResources(modelUUID string, controllerVersion version.Number) error {
+	args := jujuparams.AdoptResourcesArgs{
+		ModelTag:                names.NewModelTag(modelUUID).String(),
+		SourceControllerVersion: controllerVersion,
+	}
+	if err := c.CallHighestFacadeVersion(c.Context(), "MigrationTarget", []int{1, 2, 3, 4}, "", "AdoptResources", &args, nil); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -14,8 +14,9 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/version"
+	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -67,7 +68,7 @@ func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelT
 	}
 	ctl.AgentVersion = d.AgentVersion
 	if ctl.AgentVersion == "" {
-		ctl.AgentVersion = version.Current.String()
+		ctl.AgentVersion = jujuversion.Current.String()
 	}
 	ctl.Addresses = dbmodel.HostPorts(d.Addresses)
 	return apiWrapper{
@@ -125,6 +126,7 @@ type API struct {
 	base.APICaller
 
 	AddCloud_                          func(names.CloudTag, jujucloud.Cloud, bool) error
+	AdoptResources_                    func(modelUUID string, controllerVersion version.Number) error
 	ChangeModelCredential_             func(context.Context, names.ModelTag, names.CloudCredentialTag) error
 	CheckCredentialModels_             func(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error)
 	Close_                             func() error
@@ -175,6 +177,13 @@ func (a *API) AddCloud(tag names.CloudTag, cld jujucloud.Cloud, force bool) erro
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return a.AddCloud_(tag, cld, force)
+}
+
+func (a *API) AdoptResources(modelUUID string, controllerVersion version.Number) error {
+	if a.AdoptResources_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.AdoptResources_(modelUUID, controllerVersion)
 }
 
 func (a *API) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -5,13 +5,15 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
 type MigrationMocks struct {
-	Prechecks_ func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
+	Prechecks_      func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
+	AdoptResources_ func(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 }
 
 func (j *MigrationMocks) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
@@ -19,4 +21,11 @@ func (j *MigrationMocks) Prechecks(ctx context.Context, user *openfga.User, mode
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return j.Prechecks_(ctx, user, model)
+}
+
+func (j *MigrationMocks) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
+	if j.AdoptResources_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return j.AdoptResources_(ctx, user, modelUUID, sourceControllerVersion)
 }


### PR DESCRIPTION
## Description
This PR is based on top of #1617 
This PR implements the `AdoptResources` method on the migrationTarget facade used as part of migrating models through JIMM. It is effectively a pass-through to the target Juju controller. 

The only interesting bit to note is that the method receives a "SourceControllerVersion" field but the Juju client for the `migrationTarget` facade doesn't accept a "SourceControllerVersion" field  and instead fetches the value from a global variable that is set based on the version of Juju imported. This is an issue since we want to populate the field with the value we've received, rather than send a value based on whatever version of Juju that is imported. To resolve this we drop down to raw facade calls rather than using the client.

Fixes [JUJU-8086](https://warthogs.atlassian.net/browse/JUJU-8086)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8086]: https://warthogs.atlassian.net/browse/JUJU-8086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ