### PR TITLE
chore: implement Abort method for migrations

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -244,6 +244,7 @@ type JujuManager interface {
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
+	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
 
 	// Other methods
 

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -37,6 +37,9 @@ type API interface {
 	// use the juju api clients to interact with juju controllers.
 	base.APICallCloser
 
+	// Abort aborts a model migration.
+	Abort(modelUUID string) error
+
 	// AddCloud adds a new cloud.
 	AddCloud(names.CloudTag, jujucloud.Cloud, bool) error
 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -10,11 +10,51 @@ import (
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
+
+// AbortMigration aborts a model migration with the given model UUID.
+// It does this by calling the Abort methodon the target Juju controller.
+// It also deletes the migration record from the database, but does not return an error
+// if the deletion fails, as the migration has already been aborted on the target controller.
+func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
+	const op = errors.Op("jimm.Abort")
+
+	incomingModel := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+	}
+
+	api, err := j.dialController(ctx, &incomingModel.TargetController)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	err = api.Abort(modelUUID)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to abort migration: %w", err))
+	}
+
+	err = j.Database.DeleteIncomingModelMigration(ctx, &incomingModel)
+	if err != nil {
+		// Don't return an error if we fail to delete the migration record,
+		// as the migration has already been aborted on the target controller.
+		zapctx.Error(ctx, "failed to delete incoming model migration", zap.Error(err), zap.String("modelUUID", modelUUID))
+	}
+	return nil
+}
 
 // Prechecks checks that the model can be migrated to the target controller.
 // It does this by calling the method of the same name on the target Juju controller.

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -35,6 +35,59 @@ users:
   controller-access: superuser
 `
 
+func TestAbortMigration_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	abortCalled := false
+	// Validate that the API request to Juju is made.
+	api := &jimmtest.API{
+		Abort_: func(uuid string) error {
+			abortCalled = true
+			c.Check(uuid, qt.Equals, modelUUID)
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	err = j.AbortMigration(ctx, user, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(abortCalled, qt.IsTrue)
+}
+
+func TestAbortMigration_MissingIncomingModel(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	err := j.AbortMigration(ctx, user, "foo")
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+}
+
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -37,6 +37,7 @@ func init() {
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
 		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
+		r.AddMethod("MigrationTarget", 4, "Abort", adoptResources)
 
 		return []int{4}
 	}
@@ -57,6 +58,22 @@ func init() {
 // but doesn't actually require the result to have len() > 0, we can return an empty result.
 func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 	return jujuparams.BytesResult{}, nil
+}
+
+// Abort implements the Abort method of the MigrationTarget facade.
+// It is used by the source Juju controller to abort a model migration.
+func (r *controllerRoot) Abort(ctx context.Context, args params.ModelArgs) error {
+	const op = errors.Op("jujuapi.Abort")
+
+	if !r.user.JimmAdmin {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	return r.jimm.JujuManager().AbortMigration(ctx, r.user, modelTag.Id())
 }
 
 // AdoptResources implements the AdoptResources method of the MigrationTarget facade.

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -21,6 +21,16 @@ type migrationTargetSuite struct {
 
 var _ = gc.Suite(&migrationTargetSuite{})
 
+func (s *migrationTargetSuite) TestAbort(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	client := migrationtarget.NewClient(conn)
+	err := client.Abort(modelUUID)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+}
+
 func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 	conn := s.open(c, nil, "alice")
 	defer conn.Close()

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -24,6 +24,52 @@ type migrationTargetUnitSuite struct {
 
 var _ = gc.Suite(&migrationTargetUnitSuite{})
 
+func (s *migrationTargetUnitSuite) TestAbort(c *gc.C) {
+	ctx := context.Background()
+
+	abortCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			AbortMigration_: func(ctx context.Context, user *openfga.User, modelUUID string) error {
+				abortCalled = true
+				c.Check(modelUUID, gc.Equals, "00000001-0000-0000-0000-000000000001")
+				return nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ModelArgs{
+		ModelTag: names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+	}
+
+	// Validate access denied without JIMM admin permissions.
+	err := cr.Abort(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+	c.Assert(abortCalled, gc.Equals, false)
+
+	// Validate the method is called when the user is a JIMM admin.
+	user.JimmAdmin = true
+	err = cr.Abort(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(abortCalled, gc.Equals, true)
+
+	// Validate that an invalid model tag is rejected.
+	args.ModelTag = "invalid-model-tag"
+	err = cr.Abort(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
+}
+
 func (s *migrationTargetUnitSuite) TestPreChecks(c *gc.C) {
 	ctx := context.Background()
 

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -36,3 +36,9 @@ func (c Connection) AdoptResources(modelUUID string, controllerVersion version.N
 	}
 	return nil
 }
+
+// Abort aborts a model migration.
+func (c Connection) Abort(modelUUID string) error {
+	migrationTarget := migrationtarget.NewClient(&c)
+	return migrationTarget.Abort(modelUUID)
+}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -125,6 +125,7 @@ func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.M
 type API struct {
 	base.APICaller
 
+	Abort_                             func(modelUUID string) error
 	AddCloud_                          func(names.CloudTag, jujucloud.Cloud, bool) error
 	AdoptResources_                    func(modelUUID string, controllerVersion version.Number) error
 	ChangeModelCredential_             func(context.Context, names.ModelTag, names.CloudCredentialTag) error
@@ -170,6 +171,14 @@ type API struct {
 	ListVolumes_                       func(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error)
 	ListStorageDetails_                func(ctx context.Context) ([]jujuparams.StorageDetails, error)
 	ListModels_                        func(ctx context.Context) ([]base.UserModel, error)
+}
+
+// Abort aborts the current operation on the controller.
+func (a *API) Abort(modelUUID string) error {
+	if a.Abort_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.Abort_(modelUUID)
 }
 
 func (a *API) AddCloud(tag names.CloudTag, cld jujucloud.Cloud, force bool) error {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -14,6 +14,14 @@ import (
 type MigrationMocks struct {
 	Prechecks_      func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 	AdoptResources_ func(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
+	AbortMigration_ func(ctx context.Context, user *openfga.User, modelUUID string) error
+}
+
+func (j *MigrationMocks) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
+	if j.AbortMigration_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return j.AbortMigration_(ctx, user, modelUUID)
 }
 
 func (j *MigrationMocks) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {


### PR DESCRIPTION
## Description
This PR implements the `Abort` migration on the `MigrationTarget` facade for migrating models through JIMM. The method is essentially just a pass-through to the Juju controller. 

One bit that is noteworthy is that after the API call to Juju completes successfully, we delete the `IncomingModelMigration` entry from our database. If the deletion operation fails we do not return an error because the abort was already successful on the target controller. This does imply we could have a dangling resource in JIMM. That will need to be handled in a separate PR (I've added a note in [JUJU-8030](https://warthogs.atlassian.net/browse/JUJU-8030) about this).

Fixes [JUJU-8084](https://warthogs.atlassian.net/browse/JUJU-8084)
## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8084]: https://warthogs.atlassian.net/browse/JUJU-8084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[JUJU-8030]: https://warthogs.atlassian.net/browse/JUJU-8030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ