### PR TITLE
chore: implement CheckMachines method

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -243,6 +243,7 @@ type JujuManager interface {
 	// in the order they are expected to be called.
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
+	CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
 

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -55,6 +55,10 @@ type API interface {
 	// with the associated models.
 	CheckCredentialModels(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error)
 
+	// CheckMachines compares the machines in state with the ones
+	// reported by the provider and reports any discrepancies.
+	CheckMachines(modelUUID string) ([]error, error)
+
 	// Close closes the API connection.
 	Close() error
 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -56,6 +56,36 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 	return nil
 }
 
+// CheckMachines checks the machines in the model with the given UUID
+// and compares them with the ones reported by the provider.
+// It calls the CheckMachines method on the target Juju controller.
+func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
+	const op = errors.Op("jimm.CheckMachines")
+
+	incomingModel := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
+	if err != nil {
+		return nil, errors.E(op, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+	}
+
+	api, err := j.dialController(ctx, &incomingModel.TargetController)
+	if err != nil {
+		return nil, errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	machineErrors, err := api.CheckMachines(modelUUID)
+	if err != nil {
+		return nil, errors.E(op, fmt.Errorf("failed to check machines: %w", err))
+	}
+	return machineErrors, nil
+}
+
 // Prechecks checks that the model can be migrated to the target controller.
 // It does this by calling the method of the same name on the target Juju controller.
 // As part of all model migrations passing through JIMM, it modifies the model description

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -88,6 +88,60 @@ func TestAbortMigration_MissingIncomingModel(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
+func TestCheckMachines_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	checkMachinesCalled := false
+	// Validate that the API request to Juju is made.
+	api := &jimmtest.API{
+		CheckMachines_: func(uuid string) ([]error, error) {
+			checkMachinesCalled = true
+			c.Check(uuid, qt.Equals, modelUUID)
+			return nil, nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	res, err := j.CheckMachines(ctx, user, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res, qt.IsNil)
+	c.Assert(checkMachinesCalled, qt.IsTrue)
+}
+
+func TestCheckMachines_MissingIncomingModel(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	_, err := j.CheckMachines(ctx, user, "foo")
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+}
+
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -33,11 +33,13 @@ func init() {
 		preChecks := rpc.Method(r.Prechecks)
 		caCert := rpc.Method(r.CACert)
 		adoptResources := rpc.Method(r.AdoptResources)
+		checkMachines := rpc.Method(r.CheckMachines)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
 		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
 		r.AddMethod("MigrationTarget", 4, "Abort", adoptResources)
+		r.AddMethod("MigrationTarget", 4, "CheckMachines", checkMachines)
 
 		return []int{4}
 	}
@@ -58,6 +60,33 @@ func init() {
 // but doesn't actually require the result to have len() > 0, we can return an empty result.
 func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 	return jujuparams.BytesResult{}, nil
+}
+
+func (r *controllerRoot) CheckMachines(ctx context.Context, args params.ModelArgs) (params.ErrorResults, error) {
+	const op = errors.Op("jujuapi.CheckMachines")
+
+	if !r.user.JimmAdmin {
+		return params.ErrorResults{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return params.ErrorResults{}, errors.E(op, err)
+	}
+
+	results, err := r.jimm.JujuManager().CheckMachines(ctx, r.user, modelTag.Id())
+	if err != nil {
+		return params.ErrorResults{}, errors.E(op, err)
+	}
+	var errorResults []params.ErrorResult
+	for _, result := range results {
+		jujuError := jujuparams.Error{
+			Message: result.Error(),
+		}
+		errorResults = append(errorResults, jujuparams.ErrorResult{Error: &jujuError})
+	}
+
+	return params.ErrorResults{Results: errorResults}, nil
 }
 
 // Abort implements the Abort method of the MigrationTarget facade.

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -31,6 +31,16 @@ func (s *migrationTargetSuite) TestAbort(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
 }
 
+func (s *migrationTargetSuite) TestCheckMachines(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	client := migrationtarget.NewClient(conn)
+	_, err := client.CheckMachines(modelUUID)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+}
+
 func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 	conn := s.open(c, nil, "alice")
 	defer conn.Close()

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -4,6 +4,7 @@ package jujuapi_test
 
 import (
 	"context"
+	"errors"
 
 	"github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -67,6 +68,56 @@ func (s *migrationTargetUnitSuite) TestAbort(c *gc.C) {
 	// Validate that an invalid model tag is rejected.
 	args.ModelTag = "invalid-model-tag"
 	err = cr.Abort(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
+}
+
+func (s *migrationTargetUnitSuite) TestCheckMachines(c *gc.C) {
+	ctx := context.Background()
+
+	checkMachinesCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			CheckMachines_: func(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
+				checkMachinesCalled = true
+				c.Check(modelUUID, gc.Equals, "00000001-0000-0000-0000-000000000001")
+				return []error{errors.New("fake-error")}, nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ModelArgs{
+		ModelTag: names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+	}
+
+	// Validate access denied without JIMM admin permissions.
+	_, err := cr.CheckMachines(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+	c.Assert(checkMachinesCalled, gc.Equals, false)
+
+	// Validate the checkMachines method is called when the user is a JIMM admin.
+	user.JimmAdmin = true
+	res, err := cr.CheckMachines(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Results[0].Error.Message, gc.Equals, "fake-error")
+	c.Assert(res.Results[0].Error.Code, gc.Equals, "")
+	c.Assert(res.Results[0].Error.Info, gc.IsNil)
+	c.Assert(checkMachinesCalled, gc.Equals, true)
+
+	// Validate that an invalid model tag is rejected.
+	args.ModelTag = "invalid-model-tag"
+	_, err = cr.CheckMachines(ctx, args)
 	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
 }
 

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -42,3 +42,9 @@ func (c Connection) Abort(modelUUID string) error {
 	migrationTarget := migrationtarget.NewClient(&c)
 	return migrationTarget.Abort(modelUUID)
 }
+
+// CheckMachines compares the machines in state with the ones reported by the provider and reports any discrepancies.
+func (c Connection) CheckMachines(modelUUID string) ([]error, error) {
+	migrationTarget := migrationtarget.NewClient(&c)
+	return migrationTarget.CheckMachines(modelUUID)
+}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -130,6 +130,7 @@ type API struct {
 	AdoptResources_                    func(modelUUID string, controllerVersion version.Number) error
 	ChangeModelCredential_             func(context.Context, names.ModelTag, names.CloudCredentialTag) error
 	CheckCredentialModels_             func(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error)
+	CheckMachines_                     func(modelUUID string) ([]error, error)
 	Close_                             func() error
 	Cloud_                             func(names.CloudTag, *jujucloud.Cloud) error
 	Clouds_                            func() (map[names.CloudTag]jujucloud.Cloud, error)
@@ -200,6 +201,13 @@ func (a *API) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedC
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
 	return a.CheckCredentialModels_(ctx, cred)
+}
+
+func (a *API) CheckMachines(modelUUID string) ([]error, error) {
+	if a.CheckMachines_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return a.CheckMachines_(modelUUID)
 }
 
 func (a *API) Close() error {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -15,6 +15,7 @@ type MigrationMocks struct {
 	Prechecks_      func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 	AdoptResources_ func(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 	AbortMigration_ func(ctx context.Context, user *openfga.User, modelUUID string) error
+	CheckMachines_  func(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 }
 
 func (j *MigrationMocks) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
@@ -36,4 +37,11 @@ func (j *MigrationMocks) AdoptResources(ctx context.Context, user *openfga.User,
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return j.AdoptResources_(ctx, user, modelUUID, sourceControllerVersion)
+}
+
+func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
+	if j.CheckMachines_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return j.CheckMachines_(ctx, user, modelUUID)
 }


### PR DESCRIPTION
## Description
This PR implements the `CheckMachines` method on the `MigrationTarget` facade for migrating models through JIMM. The implementation is mostly a pass-through to calling the target Juju controller.

The one area of interest is in the `jujuapi` implementation, where we take the `[]errors` returned by the Juju controller and turn these back into error structs according to Juju's RPC params. One might wonder whether we need to ensure the error code is maintained, beyond just the error message as is done in this PR. Taking a look at the Juju client source code [here](https://github.com/juju/juju/blob/3.6/api/controller/migrationtarget/client.go#L290) shows that only the error message is extracted and the error code and error info are not inspected so we are safe in what we are doing. In fact, because the Juju client package does not extract the code and info fields, we do not have this information at all.

Fixes [JUJU-8088](https://warthogs.atlassian.net/browse/JUJU-8088)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8088]: https://warthogs.atlassian.net/browse/JUJU-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ