### PR TITLE
feat: proxy http endpoints for model migration

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -499,12 +499,16 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	// Websockets require extra care when cookies are used for authentication
 	// to avoid CSRF attacks. https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking
 	websocketCors := middleware.NewWebsocketCors(p.CorsAllowedOrigins)
+	// Juju API handlers
 	s.mux.Handle("/api", websocketCors.Handler(jujuapi.APIHandler(ctx, s.jimm, params)))
 	s.mux.Handle("/model/*", websocketCors.Handler(http.StripPrefix("/model", jujuapi.ModelHandler(ctx, s.jimm, params))))
-	mountHandler(
-		"/model/{uuid}/{type:charms|applications}",
-		jimmhttp.NewHTTPProxyHandler(s.jimm),
-	)
+	// Uploading local charms
+	mountHandler("/model/{uuid}/{type:charms|applications}", jimmhttp.NewHTTPProxyHandler(s.jimm))
+	// HTTP Migration endpoints
+	mountHandler("/migrate", jimmhttp.NewMigrationHTTPProxyHandler(s.jimm))
+	// Log transfer endpoint
+	// TODO: Implement log transfer, this uses a websocket rather than HTTP.
+	// s.mux.Handle("/migrate/logtransfer", jimmhttp.NewHTTPProxyHandler(s.jimm).Routes())
 
 	// serve the ssh public key fingerprint
 	s.mux.Get("/ssh/public-key-fingerprints", jimmhttp.WriteFingerprints(p.HostKeyFingerprints))

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -247,6 +247,10 @@ type JujuManager interface {
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 
 	// Migration related methods
+
+	// ControllerDetailsForIncomingModel retrieves details about the
+	// target controller for a model that is being migrated.
+	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
 	// The migration methods below are sorted roughly
 	// in the order they are expected to be called.
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
@@ -270,6 +274,7 @@ type JujuManager interface {
 	GetCloud(ctx context.Context, u *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error)
 	GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
+	ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
 	GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -250,7 +250,7 @@ type JujuManager interface {
 
 	// ControllerDetailsForIncomingModel retrieves details about the
 	// target controller for a model that is being migrated.
-	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
+	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
 	// The migration methods below are sorted roughly
 	// in the order they are expected to be called.
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
@@ -274,7 +274,7 @@ type JujuManager interface {
 	GetCloud(ctx context.Context, u *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error)
 	GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
-	ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
+	ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
 	GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -250,7 +250,7 @@ type JujuManager interface {
 
 	// ControllerDetailsForIncomingModel retrieves details about the
 	// target controller for a model that is being migrated.
-	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
+	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
 	// The migration methods below are sorted roughly
 	// in the order they are expected to be called.
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
@@ -274,7 +274,7 @@ type JujuManager interface {
 	GetCloud(ctx context.Context, u *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error)
 	GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
-	ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
+	ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
 	GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -772,6 +772,10 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 		return ControllerDetails{}, errors.E(op, err)
 	}
 
+	if username == "" || password == "" {
+		return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
+	}
+
 	return ControllerDetails{
 		Controller: model.Controller,
 		Credentials: ControllerCreds{

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -750,7 +750,7 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName strin
 
 // ControllerDetailsForModel returns the controller details for the specified model
 // including the controller, and the admin credentials (username and password) for the controller.
-func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (ControllerDetails, error) {
 	const op = errors.Op("jimm.ControllerDetailsForModel")
 
 	model := dbmodel.Model{
@@ -761,13 +761,22 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return dbmodel.Controller{}, "", "", errors.E(op, err)
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+		}
+		return ControllerDetails{}, errors.E(op, err)
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
 	if err != nil {
-		return dbmodel.Controller{}, "", "", errors.E(op, err)
+		return ControllerDetails{}, errors.E(op, err)
 	}
 
-	return model.Controller, username, password, nil
+	return ControllerDetails{
+		Controller: model.Controller,
+		Credentials: ControllerCreds{
+			AdminIdentityName: username,
+			AdminPassword:     password,
+		},
+	}, nil
 }

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -747,3 +747,27 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName strin
 	}
 	return jujucontroller.Config(cfg.Config), nil
 }
+
+// ControllerDetailsForModel returns the controller details for the specified model
+// including the controller, and the admin credentials (username and password) for the controller.
+func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+	const op = errors.Op("jimm.ControllerDetailsForModel")
+
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetModel(ctx, &model)
+	if err != nil {
+		return dbmodel.Controller{}, "", "", errors.E(op, err)
+	}
+
+	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
+	if err != nil {
+		return dbmodel.Controller{}, "", "", errors.E(op, err)
+	}
+
+	return model.Controller, username, password, nil
+}

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -750,7 +750,7 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName strin
 
 // ControllerDetailsForModel returns the controller details for the specified model
 // including the controller, and the admin credentials (username and password) for the controller.
-func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (ControllerDetails, error) {
+func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (ControllerConnectionDetails, error) {
 	const op = errors.Op("jimm.ControllerDetailsForModel")
 
 	model := dbmodel.Model{
@@ -762,25 +762,19 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerDetails{}, errors.E(op, err)
+		return ControllerConnectionDetails{}, errors.E(op, err)
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
 	if err != nil {
-		return ControllerDetails{}, errors.E(op, err)
+		return ControllerConnectionDetails{}, errors.E(op, err)
 	}
 
 	if username == "" || password == "" {
-		return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
+		return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
 	}
 
-	return ControllerDetails{
-		Controller: model.Controller,
-		Credentials: ControllerCreds{
-			AdminIdentityName: username,
-			AdminPassword:     password,
-		},
-	}, nil
+	return toControllerConnectionDetails(model.Controller, username, password), nil
 }

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1492,3 +1492,57 @@ func (c *testControllerClient) InitiateMigration(spec controller.MigrationSpec) 
 func (c *testControllerClient) Close() error {
 	return nil
 }
+
+const testControllerDetailsForModelEnv = `clouds:
+- name: test-cloud
+  type: test
+  regions:
+  - name: test-region-1
+cloud-credentials:
+- name: test-cred
+  cloud: test-cloud
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: 3.3
+  public-address: test-address.com
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000003
+  controller: controller-1
+  cloud: test-cloud
+  region: test-region-1
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+`
+
+func TestControllerDetailsForModel(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	invalidUUID := "invalid-uuid"
+	validUUID := "00000002-0000-0000-0000-000000000003"
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testControllerDetailsForModelEnv)
+	env.PopulateDB(c, j.Database)
+
+	err := j.CredentialStore.PutControllerCredentials(ctx, "controller-1", "test-user", "test-password")
+	c.Assert(err, qt.IsNil)
+
+	_, _, _, err = j.ControllerDetailsForModel(ctx, invalidUUID)
+	c.Assert(err, qt.ErrorMatches, `model not found`)
+
+	ctl, username, password, err := j.ControllerDetailsForModel(ctx, validUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctl.ID, qt.Not(qt.Equals), 0)
+	c.Assert(ctl.Name, qt.Equals, "controller-1")
+	c.Assert(ctl.PublicAddress, qt.Equals, "test-address.com")
+	c.Assert(username, qt.Equals, "test-user")
+	c.Assert(password, qt.Equals, "test-password")
+}

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1535,14 +1535,15 @@ func TestControllerDetailsForModel(t *testing.T) {
 	err := j.CredentialStore.PutControllerCredentials(ctx, "controller-1", "test-user", "test-password")
 	c.Assert(err, qt.IsNil)
 
-	_, _, _, err = j.ControllerDetailsForModel(ctx, invalidUUID)
-	c.Assert(err, qt.ErrorMatches, `model not found`)
+	_, err = j.ControllerDetailsForModel(ctx, invalidUUID)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
-	ctl, username, password, err := j.ControllerDetailsForModel(ctx, validUUID)
+	controllerDetails, err := j.ControllerDetailsForModel(ctx, validUUID)
 	c.Assert(err, qt.IsNil)
-	c.Assert(ctl.ID, qt.Not(qt.Equals), 0)
-	c.Assert(ctl.Name, qt.Equals, "controller-1")
-	c.Assert(ctl.PublicAddress, qt.Equals, "test-address.com")
-	c.Assert(username, qt.Equals, "test-user")
-	c.Assert(password, qt.Equals, "test-password")
+	c.Assert(controllerDetails.Controller.ID, qt.Not(qt.Equals), 0)
+	c.Assert(controllerDetails.Controller.Name, qt.Equals, "controller-1")
+	c.Assert(controllerDetails.Controller.PublicAddress, qt.Equals, "test-address.com")
+	c.Assert(controllerDetails.Credentials.AdminIdentityName, qt.Equals, "test-user")
+	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1549,9 +1549,7 @@ func TestControllerDetailsForModel(t *testing.T) {
 	// Expect a successful retrieval of controller details with valid UUID and credentials
 	controllerDetails, err := j.ControllerDetailsForModel(ctx, validUUID)
 	c.Assert(err, qt.IsNil)
-	c.Assert(controllerDetails.Controller.ID, qt.Not(qt.Equals), 0)
-	c.Assert(controllerDetails.Controller.Name, qt.Equals, "controller-1")
-	c.Assert(controllerDetails.Controller.PublicAddress, qt.Equals, "test-address.com")
+	c.Assert(controllerDetails.PublicAddress, qt.Equals, "test-address.com")
 	c.Assert(controllerDetails.Credentials.AdminIdentityName, qt.Equals, "test-user")
 	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1532,13 +1532,21 @@ func TestControllerDetailsForModel(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testControllerDetailsForModelEnv)
 	env.PopulateDB(c, j.Database)
 
-	err := j.CredentialStore.PutControllerCredentials(ctx, "controller-1", "test-user", "test-password")
-	c.Assert(err, qt.IsNil)
-
-	_, err = j.ControllerDetailsForModel(ctx, invalidUUID)
+	// Expect a failure with an invalid UUID
+	_, err := j.ControllerDetailsForModel(ctx, invalidUUID)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
+	// Expect a failure with a valid UUID but no credentials
+	_, err = j.ControllerDetailsForModel(ctx, validUUID)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Set up credentials for the controller
+	err = j.CredentialStore.PutControllerCredentials(ctx, "controller-1", "test-user", "test-password")
+	c.Assert(err, qt.IsNil)
+
+	// Expect a successful retrieval of controller details with valid UUID and credentials
 	controllerDetails, err := j.ControllerDetailsForModel(ctx, validUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(controllerDetails.Controller.ID, qt.Not(qt.Equals), 0)

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -90,8 +90,8 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 
 // ControllerDetailsForIncomingModel retrieves the target controller details for a model that is being migrated.
 // It returns the controller information, username, and password for the target controller.
-func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
-	const op = errors.Op("jimm.GetControllerForIncomingModel")
+func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (ControllerDetails, error) {
+	const op = errors.Op("jimm.ControllerDetailsForIncomingModel")
 
 	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -103,17 +103,23 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return dbmodel.Controller{}, "", "", errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return dbmodel.Controller{}, "", "", errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
+		return ControllerDetails{}, errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, incomingModel.TargetController.Name)
 	if err != nil {
-		return dbmodel.Controller{}, "", "", err
+		return ControllerDetails{}, err
 	}
 
-	return incomingModel.TargetController, username, password, nil
+	return ControllerDetails{
+		Controller: incomingModel.TargetController,
+		Credentials: ControllerCreds{
+			AdminIdentityName: username,
+			AdminPassword:     password,
+		},
+	}, nil
 }
 
 // Prechecks checks that the model can be migrated to the target controller.

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -88,6 +88,34 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 	return machineErrors, nil
 }
 
+// ControllerDetailsForIncomingModel retrieves the target controller details for a model that is being migrated.
+// It returns the controller information, username, and password for the target controller.
+func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+	const op = errors.Op("jimm.GetControllerForIncomingModel")
+
+	incomingModel := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+
+	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
+	if err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return dbmodel.Controller{}, "", "", errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+		}
+		return dbmodel.Controller{}, "", "", errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
+	}
+
+	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, incomingModel.TargetController.Name)
+	if err != nil {
+		return dbmodel.Controller{}, "", "", err
+	}
+
+	return incomingModel.TargetController, username, password, nil
+}
+
 // Prechecks checks that the model can be migrated to the target controller.
 // It does this by calling the method of the same name on the target Juju controller.
 // As part of all model migrations passing through JIMM, it modifies the model description

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -113,6 +113,10 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 		return ControllerDetails{}, err
 	}
 
+	if username == "" || password == "" {
+		return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
+	}
+
 	return ControllerDetails{
 		Controller: incomingModel.TargetController,
 		Credentials: ControllerCreds{

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -90,7 +90,7 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 
 // ControllerDetailsForIncomingModel retrieves the target controller details for a model that is being migrated.
 // It returns the controller information, username, and password for the target controller.
-func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (ControllerDetails, error) {
+func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (ControllerConnectionDetails, error) {
 	const op = errors.Op("jimm.ControllerDetailsForIncomingModel")
 
 	incomingModel := dbmodel.IncomingModelMigration{
@@ -103,27 +103,21 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerDetails{}, errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
+		return ControllerConnectionDetails{}, errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, incomingModel.TargetController.Name)
 	if err != nil {
-		return ControllerDetails{}, err
+		return ControllerConnectionDetails{}, err
 	}
 
 	if username == "" || password == "" {
-		return ControllerDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
+		return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
 	}
 
-	return ControllerDetails{
-		Controller: incomingModel.TargetController,
-		Credentials: ControllerCreds{
-			AdminIdentityName: username,
-			AdminPassword:     password,
-		},
-	}, nil
+	return toControllerConnectionDetails(incomingModel.TargetController, username, password), nil
 }
 
 // Prechecks checks that the model can be migrated to the target controller.

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -404,7 +404,7 @@ func TestActivate_APIFailure(t *testing.T) {
 	// Simulate an API failure.
 	api := &jimmtest.API{
 		Activate_: func(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error {
-			return errors.New("API failure")
+			return errors.E("API failure")
 		},
 	}
 

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -154,10 +154,8 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	err := j.CredentialStore.PutControllerCredentials(ctx, "test1", "test-user", "test-password")
-	c.Assert(err, qt.IsNil)
-
-	_, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	// Expect an error when there is no incoming model migration.
+	_, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
@@ -167,6 +165,15 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	err = j.Database.AddIncomingModelMigration(ctx, &modelMigration)
 	c.Assert(err, qt.IsNil)
 
+	// Expect an error when the controller credentials are not set.
+	_, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	err = j.CredentialStore.PutControllerCredentials(ctx, "test1", "test-user", "test-password")
+	c.Assert(err, qt.IsNil)
+
+	// Expect to retrieve the controller details successfully.
 	controllerDetails, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(controllerDetails.Controller.Name, qt.Equals, "test1")
@@ -341,7 +348,6 @@ func TestActivate_Success(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	modelUUID := "00000001-0000-0000-0000-000000000001"
 	sourceInfo := migration.SourceControllerInfo{
 		ControllerTag: names.NewControllerTag("00000001-0000-0000-0000-000000000002"),
 	}
@@ -371,12 +377,12 @@ func TestActivate_Success(t *testing.T) {
 	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
 	c.Assert(err, qt.IsNil)
 
-	err = j.Activate(ctx, names.NewModelTag(modelUUID), sourceInfo, relatedModels)
+	err = j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.IsNil)
 
 	modelMigration = dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
-			String: modelUUID,
+			String: migratingModelUUID,
 			Valid:  true,
 		},
 	}
@@ -397,7 +403,6 @@ func TestActivate_APIFailure(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	modelUUID := "00000001-0000-0000-0000-000000000001"
 	sourceInfo := migration.SourceControllerInfo{}
 	relatedModels := []string{"related-model-1", "related-model-2"}
 
@@ -422,12 +427,12 @@ func TestActivate_APIFailure(t *testing.T) {
 	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
 	c.Assert(err, qt.IsNil)
 
-	err = j.Activate(ctx, names.NewModelTag(modelUUID), sourceInfo, relatedModels)
+	err = j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.ErrorMatches, `.*API failure`)
 
 	modelMigration = dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
-			String: modelUUID,
+			String: migratingModelUUID,
 			Valid:  true,
 		},
 	}

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -176,9 +176,7 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	// Expect to retrieve the controller details successfully.
 	controllerDetails, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
-	c.Assert(controllerDetails.Controller.Name, qt.Equals, "test1")
-	c.Assert(controllerDetails.Controller.ID, qt.Not(qt.Equals), 0)
-	c.Assert(controllerDetails.Controller.PublicAddress, qt.Equals, "foo.com")
+	c.Assert(controllerDetails.PublicAddress, qt.Equals, "foo.com")
 	c.Assert(controllerDetails.Credentials.AdminIdentityName, qt.Equals, "test-user")
 	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -96,13 +96,12 @@ func TestCheckMachines_Success(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	modelUUID := "00000001-0000-0000-0000-000000000001"
 	checkMachinesCalled := false
 	// Validate that the API request to Juju is made.
 	api := &jimmtest.API{
 		CheckMachines_: func(uuid string) ([]error, error) {
 			checkMachinesCalled = true
-			c.Check(uuid, qt.Equals, modelUUID)
+			c.Check(uuid, qt.Equals, migratingModelUUID)
 			return nil, nil
 		},
 	}
@@ -124,7 +123,7 @@ func TestCheckMachines_Success(t *testing.T) {
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	res, err := j.CheckMachines(ctx, user, modelUUID)
+	res, err := j.CheckMachines(ctx, user, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(res, qt.IsNil)
 	c.Assert(checkMachinesCalled, qt.IsTrue)
@@ -158,7 +157,7 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	err := j.CredentialStore.PutControllerCredentials(ctx, "test1", "test-user", "test-password")
 	c.Assert(err, qt.IsNil)
 
-	_, _, _, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	_, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
@@ -168,13 +167,13 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	err = j.Database.AddIncomingModelMigration(ctx, &modelMigration)
 	c.Assert(err, qt.IsNil)
 
-	ctl, username, password, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	controllerDetails, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
-	c.Assert(ctl.Name, qt.Equals, "test1")
-	c.Assert(ctl.ID, qt.Not(qt.Equals), 0)
-	c.Assert(ctl.PublicAddress, qt.Equals, "foo.com")
-	c.Assert(username, qt.Equals, "test-user")
-	c.Assert(password, qt.Equals, "test-password")
+	c.Assert(controllerDetails.Controller.Name, qt.Equals, "test1")
+	c.Assert(controllerDetails.Controller.ID, qt.Not(qt.Equals), 0)
+	c.Assert(controllerDetails.Controller.PublicAddress, qt.Equals, "foo.com")
+	c.Assert(controllerDetails.Credentials.AdminIdentityName, qt.Equals, "test-user")
+	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }
 
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -5,7 +5,6 @@ package juju_test
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -15,8 +14,13 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+const (
+	migratingModelUUID = "00000000-0000-0000-0000-000000000001"
 )
 
 const testMigrationEnv = `clouds:
@@ -30,6 +34,7 @@ controllers:
   cloud: test
   region: test-region-1
   agent-version: 3.2.1
+  public-address: foo.com
 users:
 - username: alice@canonical.com
   controller-access: superuser
@@ -39,13 +44,12 @@ func TestAbortMigration_Success(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	modelUUID := "00000001-0000-0000-0000-000000000001"
 	abortCalled := false
 	// Validate that the API request to Juju is made.
 	api := &jimmtest.API{
 		Abort_: func(uuid string) error {
 			abortCalled = true
-			c.Check(uuid, qt.Equals, modelUUID)
+			c.Check(uuid, qt.Equals, migratingModelUUID)
 			return nil
 		},
 	}
@@ -67,7 +71,7 @@ func TestAbortMigration_Success(t *testing.T) {
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	err = j.AbortMigration(ctx, user, modelUUID)
+	err = j.AbortMigration(ctx, user, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(abortCalled, qt.IsTrue)
 }
@@ -142,6 +146,37 @@ func TestCheckMachines_MissingIncomingModel(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
+func TestControllerDetailsForIncomingModel(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	err := j.CredentialStore.PutControllerCredentials(ctx, "test1", "test-user", "test-password")
+	c.Assert(err, qt.IsNil)
+
+	_, _, _, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Create an incoming model migration in the database.
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err = j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	ctl, username, password, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctl.Name, qt.Equals, "test1")
+	c.Assert(ctl.ID, qt.Not(qt.Equals), 0)
+	c.Assert(ctl.PublicAddress, qt.Equals, "foo.com")
+	c.Assert(username, qt.Equals, "test-user")
+	c.Assert(password, qt.Equals, "test-password")
+}
+
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
@@ -150,7 +185,7 @@ func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 	// of the model description, where the owner is replaced with an external user.
 	api := &jimmtest.API{
 		Prechecks_: func(mi migration.ModelInfo) error {
-			c.Check(mi.UUID, qt.Equals, "00000001-0000-0000-0000-000000000001")
+			c.Check(mi.UUID, qt.Equals, migratingModelUUID)
 			c.Check(mi.Owner.Id(), qt.Equals, "alice@canonical.com")
 			// TODO: Check the description has been modified to use the external user mapping.
 			return nil
@@ -185,7 +220,7 @@ func TestPrechecks_ControllerUnreachable(t *testing.T) {
 
 	api := &jimmtest.API{
 		Prechecks_: func(mi migration.ModelInfo) error {
-			return errors.New("controller unreachable")
+			return errors.E("controller unreachable")
 		},
 	}
 
@@ -254,14 +289,13 @@ func TestAdoptResources_Success(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	modelUUID := "00000001-0000-0000-0000-000000000001"
 	controllerVersion := version.MustParse("3.2.1")
 
 	// Validate that the API request to Juju is made with a modified version
 	// of the model description, where the owner is replaced with an external user.
 	api := &jimmtest.API{
 		AdoptResources_: func(uuid string, v version.Number) error {
-			c.Check(uuid, qt.Equals, modelUUID)
+			c.Check(uuid, qt.Equals, migratingModelUUID)
 			c.Check(v, qt.DeepEquals, controllerVersion)
 			return nil
 		},
@@ -284,7 +318,7 @@ func TestAdoptResources_Success(t *testing.T) {
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	err = j.AdoptResources(ctx, user, modelUUID, controllerVersion)
+	err = j.AdoptResources(ctx, user, migratingModelUUID, controllerVersion)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -419,7 +453,7 @@ func TestActivate_NoIncomingModelMigration(t *testing.T) {
 func newIncomingMigration(userMap map[string]string, ctl dbmodel.Controller) dbmodel.IncomingModelMigration {
 	return dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
-			String: "00000001-0000-0000-0000-000000000001",
+			String: migratingModelUUID,
 			Valid:  true,
 		},
 		TargetControllerID: ctl.ID,
@@ -442,7 +476,7 @@ func newMigrationInfo(owner string) migration.ModelInfo {
 	}
 	modelDescription.AddUser(userArgs)
 	modelInfo := migration.ModelInfo{
-		UUID:                   "00000001-0000-0000-0000-000000000001",
+		UUID:                   migratingModelUUID,
 		Owner:                  names.NewUserTag(owner),
 		Name:                   "test-model",
 		AgentVersion:           version.MustParse("3.2.1"),

--- a/internal/jimm/juju/types.go
+++ b/internal/jimm/juju/types.go
@@ -2,9 +2,18 @@
 
 package juju
 
+import "github.com/canonical/jimm/v3/internal/dbmodel"
+
 // ControllerCreds represent the admin username and password
 // used to authenticate with a Juju controller via basic auth.
 type ControllerCreds struct {
 	AdminIdentityName string
 	AdminPassword     string
+}
+
+// ControllerDetails contains the details of a Juju controller,
+// including the controller itself and the credentials used to access it.
+type ControllerDetails struct {
+	Controller  dbmodel.Controller
+	Credentials ControllerCreds
 }

--- a/internal/jimm/juju/types.go
+++ b/internal/jimm/juju/types.go
@@ -2,7 +2,11 @@
 
 package juju
 
-import "github.com/canonical/jimm/v3/internal/dbmodel"
+import (
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/juju/juju/core/network"
+	jujuparams "github.com/juju/juju/rpc/params"
+)
 
 // ControllerCreds represent the admin username and password
 // used to authenticate with a Juju controller via basic auth.
@@ -11,9 +15,37 @@ type ControllerCreds struct {
 	AdminPassword     string
 }
 
-// ControllerDetails contains the details of a Juju controller,
-// including the controller itself and the credentials used to access it.
-type ControllerDetails struct {
-	Controller  dbmodel.Controller
+// ControllerConnectionDetails contains details for connecting
+// to a Juju controller and the credentials used to access it.
+type ControllerConnectionDetails struct {
+	// CACertificate is the CA certificate required to access this
+	// controller. This is only set if the controller endpoint's
+	// certificate is not signed by a public CA.
+	CACertificate string
+	// PublicAddress is the public address registered with the controller
+	// when it was added. This address will normally be a resolvable DNS
+	// name and port.
+	PublicAddress string
+	// TLSHostname provides a hostname that should be used for TLS verfication.
+	// Useful for local dev to avoid TLS issues.
+	TLSHostname string `gorm:"column:tls_hostname"`
+	// Addresses holds the known addresses on which the controller is
+	// listening.
+	Addresses []network.MachineHostPorts
+	// Credentials holds admin credentials for the controller.
 	Credentials ControllerCreds
+}
+
+func toControllerConnectionDetails(controller dbmodel.Controller, username, password string) ControllerConnectionDetails {
+	addresses := jujuparams.ToMachineHostsPorts(controller.Addresses)
+	return ControllerConnectionDetails{
+		CACertificate: controller.CACertificate,
+		PublicAddress: controller.PublicAddress,
+		TLSHostname:   controller.TLSHostname,
+		Addresses:     addresses,
+		Credentials: ControllerCreds{
+			AdminIdentityName: username,
+			AdminPassword:     password,
+		},
+	}
 }

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
@@ -54,11 +55,18 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 
 	modelUUID := chi.URLParam(req, "uuid")
 	if modelUUID == "" {
-		writeError(ctx, w, http.StatusUnprocessableEntity, errors.E("cannot parse path"), "cannot parse path")
+		msg := "cannot parse model UUID from path"
+		writeError(ctx, w, http.StatusBadRequest, errors.E(msg), msg)
 		return
 	}
 
-	controller, username, password, err := hph.jimm.JujuManager().ControllerDetailsForModel(ctx, modelUUID)
+	if !names.IsValidModel(modelUUID) {
+		msg := "invalid model UUID format"
+		writeError(ctx, w, http.StatusBadRequest, errors.E(msg), msg)
+		return
+	}
+
+	controllerDetails, err := hph.jimm.JujuManager().ControllerDetailsForModel(ctx, modelUUID)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
@@ -68,10 +76,10 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	proxyDetails := rpc.ControllerProxy{
-		Controller: controller,
-		Username:   username,
-		Password:   password,
+	proxyDetails := rpc.ControllerDetails{
+		Controller: controllerDetails.Controller,
+		Username:   controllerDetails.Credentials.AdminIdentityName,
+		Password:   controllerDetails.Credentials.AdminPassword,
 	}
 	rpc.ProxyHTTP(ctx, proxyDetails, w, req)
 }

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -3,11 +3,11 @@
 package jimmhttp
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/middleware"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
@@ -54,24 +54,24 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 
 	modelUUID := chi.URLParam(req, "uuid")
 	if modelUUID == "" {
-		writeError(ctx, w, http.StatusUnprocessableEntity, errors.New("cannot parse path"), "cannot parse path")
+		writeError(ctx, w, http.StatusUnprocessableEntity, errors.E("cannot parse path"), "cannot parse path")
 		return
 	}
-	model, err := hph.jimm.JujuManager().GetModel(ctx, modelUUID)
+
+	controller, username, password, err := hph.jimm.JujuManager().ControllerDetailsForModel(ctx, modelUUID)
 	if err != nil {
-		writeError(ctx, w, http.StatusNotFound, err, "cannot get model")
-		return
-	}
-	u, p, err := hph.jimm.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
-	if err != nil {
-		writeError(ctx, w, http.StatusNotFound, err, "cannot retrieve credentials")
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
+			return
+		}
+		writeError(ctx, w, http.StatusInternalServerError, err, "failed to get controller details")
 		return
 	}
 
 	proxyDetails := rpc.ControllerProxy{
-		Controller: model.Controller,
-		Username:   u,
-		Password:   p,
+		Controller: controller,
+		Username:   username,
+		Password:   password,
 	}
 	rpc.ProxyHTTP(ctx, proxyDetails, w, req)
 }

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -69,7 +69,7 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 	controllerDetails, err := hph.jimm.JujuManager().ControllerDetailsForModel(ctx, modelUUID)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
+			writeError(ctx, w, http.StatusNotFound, err, "model not found")
 			return
 		}
 		writeError(ctx, w, http.StatusInternalServerError, err, "failed to get controller details")

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -3,11 +3,10 @@
 package jimmhttp
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/juju/names/v4"
-	"gopkg.in/errgo.v1"
 
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/middleware"
@@ -55,7 +54,7 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 
 	modelUUID := chi.URLParam(req, "uuid")
 	if modelUUID == "" {
-		writeError(ctx, w, http.StatusUnprocessableEntity, errgo.New("cannot parse path"), "cannot parse path")
+		writeError(ctx, w, http.StatusUnprocessableEntity, errors.New("cannot parse path"), "cannot parse path")
 		return
 	}
 	model, err := hph.jimm.JujuManager().GetModel(ctx, modelUUID)
@@ -68,10 +67,11 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 		writeError(ctx, w, http.StatusNotFound, err, "cannot retrieve credentials")
 		return
 	}
-	req.SetBasicAuth(names.NewUserTag(u).String(), p)
 
-	err = rpc.ProxyHTTP(ctx, &model.Controller, w, req)
-	if err != nil {
-		writeError(ctx, w, http.StatusGatewayTimeout, err, "Gateway timeout")
+	proxyDetails := rpc.ControllerProxy{
+		Controller: model.Controller,
+		Username:   u,
+		Password:   p,
 	}
+	rpc.ProxyHTTP(ctx, proxyDetails, w, req)
 }

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -76,10 +76,5 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	proxyDetails := rpc.ControllerDetails{
-		Controller: controllerDetails.Controller,
-		Username:   controllerDetails.Credentials.AdminIdentityName,
-		Password:   controllerDetails.Credentials.AdminPassword,
-	}
-	rpc.ProxyHTTP(ctx, proxyDetails, w, req)
+	rpc.ProxyHTTP(ctx, controllerDetails, w, req)
 }

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -119,7 +119,7 @@ func (s *httpProxySuite) TestHTTPProxyHandler(c *gc.C) {
 			url:            fmt.Sprintf("/model/%s/charms", "54d9f921-c45a-4825-8253-74e7edc28066"),
 			modelUUID:      "54d9f921-c45a-4825-8253-74e7edc28066",
 			statusExpected: http.StatusNotFound,
-			bodyExpected:   ".*failed to get model.*",
+			bodyExpected:   "Not Found - model not found",
 		},
 	}
 

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -113,17 +113,31 @@ func (s *httpProxySuite) TestHTTPProxyHandler(c *gc.C) {
 			bodyExpected:   "OK",
 		},
 		{
+			description: "invalid model UUID",
+			setup: func() {
+				newURL, _ := url.Parse(fakeController.URL)
+				controller.PublicAddress = newURL.Host
+				err := s.JIMM.Database.UpdateController(ctx, &controller)
+				c.Assert(err, gc.IsNil)
+			},
+			url:            fmt.Sprintf("/model/%s/charms", "fake-uuid"),
+			modelUUID:      "fake-uuid",
+			statusExpected: http.StatusBadRequest,
+			bodyExpected:   "Bad Request - invalid model UUID format",
+		},
+		{
 			description: "model not existing",
 			setup: func() {
 			},
 			url:            fmt.Sprintf("/model/%s/charms", "54d9f921-c45a-4825-8253-74e7edc28066"),
 			modelUUID:      "54d9f921-c45a-4825-8253-74e7edc28066",
 			statusExpected: http.StatusNotFound,
-			bodyExpected:   "Not Found - model not found",
+			bodyExpected:   "Not Found - migrating model .* not found",
 		},
 	}
 
 	for _, test := range tests {
+		c.Log(test.description)
 		if test.setup != nil {
 			test.setup()
 		}

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmhttp_test
 
@@ -78,10 +78,10 @@ func (s *httpProxySuite) TestHTTPProxyHandler(c *gc.C) {
 	// we expect the controller to respond with TLS
 	fakeController := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, p, _ := r.BasicAuth()
-		c.Assert(u, gc.Equals, names.NewUserTag(expectU).String())
-		c.Assert(p, gc.Equals, expectP)
-		_, err = w.Write([]byte("OK"))
-		c.Assert(err, gc.IsNil)
+		c.Check(u, gc.Equals, names.NewUserTag(expectU).String())
+		c.Check(p, gc.Equals, expectP)
+		_, err := w.Write([]byte("OK"))
+		c.Check(err, gc.IsNil)
 	}))
 	defer fakeController.Close()
 	controller := s.model.Controller
@@ -104,7 +104,7 @@ func (s *httpProxySuite) TestHTTPProxyHandler(c *gc.C) {
 			setup: func() {
 				newURL, _ := url.Parse(fakeController.URL)
 				controller.PublicAddress = newURL.Host
-				err = s.JIMM.Database.UpdateController(ctx, &controller)
+				err := s.JIMM.Database.UpdateController(ctx, &controller)
 				c.Assert(err, gc.IsNil)
 			},
 			url:            fmt.Sprintf("/model/%s/charms", s.model.UUID.String),

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -76,10 +76,5 @@ func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http
 		return
 	}
 
-	controllerProxy := rpc.ControllerDetails{
-		Controller: controllerDetails.Controller,
-		Username:   controllerDetails.Credentials.AdminIdentityName,
-		Password:   controllerDetails.Credentials.AdminPassword,
-	}
-	rpc.ProxyHTTP(ctx, controllerProxy, w, req)
+	rpc.ProxyHTTP(ctx, controllerDetails, w, req)
 }

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -30,11 +30,6 @@ type MigrationHTTPProxyHandler struct {
 	jimm   *jimm.JIMM
 }
 
-const (
-	// all endpoints managed by this handler
-	migrationProxyEndpoints = "/*"
-)
-
 // NewMigrationHTTPProxyHandler creates a model migration proxy http handler.
 func NewMigrationHTTPProxyHandler(jimm *jimm.JIMM) *MigrationHTTPProxyHandler {
 	return &MigrationHTTPProxyHandler{Router: chi.NewRouter(), jimm: jimm}
@@ -43,7 +38,9 @@ func NewMigrationHTTPProxyHandler(jimm *jimm.JIMM) *MigrationHTTPProxyHandler {
 // Routes returns the grouped routers routes with group specific middlewares.
 func (hph *MigrationHTTPProxyHandler) Routes() chi.Router {
 	hph.SetupMiddleware()
-	hph.Router.HandleFunc(migrationProxyEndpoints, hph.ProxyHTTP)
+	hph.Router.HandleFunc("/charms/*", hph.ProxyHTTP)
+	hph.Router.HandleFunc("/tools", hph.ProxyHTTP)
+	hph.Router.HandleFunc("/resources", hph.ProxyHTTP)
 	return hph.Router
 }
 
@@ -66,7 +63,7 @@ func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http
 		return
 	}
 
-	ctl, username, password, err := hph.jimm.JujuManager().ControllerDetailsForIncomingModel(ctx, modelUUID)
+	controllerDetails, err := hph.jimm.JujuManager().ControllerDetailsForIncomingModel(ctx, modelUUID)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
@@ -76,10 +73,10 @@ func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http
 		return
 	}
 
-	controllerProxy := rpc.ControllerProxy{
-		Controller: ctl,
-		Username:   username,
-		Password:   password,
+	controllerProxy := rpc.ControllerDetails{
+		Controller: controllerDetails.Controller,
+		Username:   controllerDetails.Credentials.AdminIdentityName,
+		Password:   controllerDetails.Credentials.AdminPassword,
 	}
 	rpc.ProxyHTTP(ctx, controllerProxy, w, req)
 }

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -66,7 +66,7 @@ func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http
 	controllerDetails, err := hph.jimm.JujuManager().ControllerDetailsForIncomingModel(ctx, modelUUID)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
+			writeError(ctx, w, http.StatusNotFound, err, "migrating model not found")
 			return
 		}
 		writeError(ctx, w, http.StatusInternalServerError, err, "cannot retrieve controller")

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
@@ -55,6 +57,7 @@ func (hph *MigrationHTTPProxyHandler) SetupMiddleware() {
 // ProxyHTTP extracts the model uuid from an HTTP header to proxy the request to the right controller.
 func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	zapctx.Debug(ctx, "starting migration proxy request", zap.String("path", req.URL.Path))
 
 	modelUUID := req.Header.Get(jujuparams.MigrationModelHTTPHeader)
 	if modelUUID == "" {

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Canonical.
+
+package jimmhttp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm"
+	"github.com/canonical/jimm/v3/internal/middleware"
+	"github.com/canonical/jimm/v3/internal/rpc"
+)
+
+// MigrationProxyHandler is an handler that provides proxying,
+// specifically for HTTP-based model migration endpoints. These
+// are used primarily to send data like charms/resources/tools
+// to the target controller during a model migration.
+// It differs slighly from the regular HTTPProxyHandler in that it
+// 1. Uses a custom HTTP header to pass the model UUID instead of extracting it
+// from the URL path.
+// 2. Performs different checks to ensure the model is in a
+// migration state before proxying the request to the controller.
+// 3. Requires the user to be a JIMM admin, rather than just a model writer.
+type MigrationHTTPProxyHandler struct {
+	Router *chi.Mux
+	jimm   *jimm.JIMM
+}
+
+const (
+	// all endpoints managed by this handler
+	migrationProxyEndpoints = "/*"
+)
+
+// NewMigrationHTTPProxyHandler creates a model migration proxy http handler.
+func NewMigrationHTTPProxyHandler(jimm *jimm.JIMM) *MigrationHTTPProxyHandler {
+	return &MigrationHTTPProxyHandler{Router: chi.NewRouter(), jimm: jimm}
+}
+
+// Routes returns the grouped routers routes with group specific middlewares.
+func (hph *MigrationHTTPProxyHandler) Routes() chi.Router {
+	hph.SetupMiddleware()
+	hph.Router.HandleFunc(migrationProxyEndpoints, hph.ProxyHTTP)
+	return hph.Router
+}
+
+// SetupMiddleware applies authn and authz middlewares.
+func (hph *MigrationHTTPProxyHandler) SetupMiddleware() {
+	hph.Router.Use(func(h http.Handler) http.Handler {
+		return middleware.AuthenticateWithSessionTokenViaBasicAuth(h, hph.jimm.LoginManager())
+	})
+	hph.Router.Use(middleware.AuthorizeUserAsJIMMAdmin)
+}
+
+// ProxyHTTP extracts the model uuid from an HTTP header to proxy the request to the right controller.
+func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	modelUUID := req.Header.Get(jujuparams.MigrationModelHTTPHeader)
+	if modelUUID == "" {
+		errMsg := fmt.Sprintf("missing %s header value", jujuparams.MigrationModelHTTPHeader)
+		writeError(ctx, w, http.StatusBadRequest, errors.E(errMsg), errMsg)
+		return
+	}
+
+	ctl, username, password, err := hph.jimm.JujuManager().ControllerDetailsForIncomingModel(ctx, modelUUID)
+	if err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			writeError(ctx, w, http.StatusNotFound, err, "controller details not found")
+			return
+		}
+		writeError(ctx, w, http.StatusInternalServerError, err, "cannot retrieve controller")
+		return
+	}
+
+	controllerProxy := rpc.ControllerProxy{
+		Controller: ctl,
+		Username:   username,
+		Password:   password,
+	}
+	rpc.ProxyHTTP(ctx, controllerProxy, w, req)
+}

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -74,10 +74,10 @@ func (s *migrationHTTPProxySuite) TestMigrationHTTPProxyHandler(c *gc.C) {
 	// we expect the controller to respond with TLS
 	fakeController := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, p, _ := r.BasicAuth()
-		c.Assert(u, gc.Equals, names.NewUserTag(expectUsername).String())
-		c.Assert(p, gc.Equals, expectPassword)
+		c.Check(u, gc.Equals, names.NewUserTag(expectUsername).String())
+		c.Check(p, gc.Equals, expectPassword)
 		_, err = w.Write([]byte("OK"))
-		c.Assert(err, gc.IsNil)
+		c.Check(err, gc.IsNil)
 	}))
 	defer fakeController.Close()
 

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Canonical.
+
+package jimmhttp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimmhttp"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type migrationHTTPProxySuite struct {
+	jimmtest.JIMMSuite
+	incomingModel *dbmodel.IncomingModelMigration
+}
+
+var _ = gc.Suite(&migrationHTTPProxySuite{})
+
+const (
+	incomingModelUUID = "00000001-0000-0000-0000-000000000001"
+
+	migrationTestEnv = `
+clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+`
+)
+
+func (s *migrationHTTPProxySuite) SetUpTest(c *gc.C) {
+	s.JIMMSuite.SetUpTest(c)
+	ctx := context.Background()
+	tester := jimmtest.GocheckTester{C: c}
+	env := jimmtest.ParseEnvironment(tester, migrationTestEnv)
+	env.PopulateDB(tester, s.JIMM.Database)
+
+	incomingModel := &dbmodel.IncomingModelMigration{
+		TargetControllerID: env.Controllers[0].DBObject(tester, s.JIMM.Database).ID,
+		ModelUUID:          sql.NullString{String: incomingModelUUID, Valid: true},
+		UserMapping:        map[string]string{"bob": "alice@canonical.com"},
+	}
+	err := s.JIMM.Database.AddIncomingModelMigration(ctx, incomingModel)
+	c.Assert(err, gc.IsNil)
+	s.incomingModel = incomingModel
+
+	err = s.JIMM.CredentialStore.PutControllerCredentials(ctx, env.Controllers[0].Name, "user", "psw")
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *migrationHTTPProxySuite) TestMigrationHTTPProxyHandler(c *gc.C) {
+	ctx := context.Background()
+
+	controllerName := "controller-1"
+	migrationProxier := jimmhttp.NewMigrationHTTPProxyHandler(s.JIMM)
+	expectUsername, expectPassword, err := s.JIMM.CredentialStore.GetControllerCredentials(ctx, controllerName)
+	c.Assert(err, gc.IsNil)
+
+	// we expect the controller to respond with TLS
+	fakeController := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+		c.Assert(u, gc.Equals, names.NewUserTag(expectUsername).String())
+		c.Assert(p, gc.Equals, expectPassword)
+		_, err = w.Write([]byte("OK"))
+		c.Assert(err, gc.IsNil)
+	}))
+	defer fakeController.Close()
+
+	// Change a controller in the database to have the address of our fake server.
+	controller := dbmodel.Controller{
+		Name: controllerName,
+	}
+	err = s.JIMM.Database.GetController(ctx, &controller)
+	c.Assert(err, gc.IsNil)
+
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: fakeController.Certificate().Raw,
+	})
+	controller.CACertificate = string(pemData)
+	newURL, _ := url.Parse(fakeController.URL)
+	controller.PublicAddress = newURL.Host
+
+	err = s.JIMM.Database.UpdateController(ctx, &controller)
+	c.Assert(err, gc.IsNil)
+
+	tests := []struct {
+		description    string
+		headers        http.Header
+		url            string
+		statusExpected int
+		bodyExpected   string
+	}{
+		{
+			description:    "success",
+			url:            "/foo",
+			headers:        http.Header{"X-Juju-Migration-Model-UUID": []string{s.incomingModel.ModelUUID.String}},
+			statusExpected: http.StatusOK,
+			bodyExpected:   "OK",
+		},
+		{
+			description:    "model isn't migrating",
+			url:            "/foo",
+			headers:        http.Header{"X-Juju-Migration-Model-UUID": []string{"non-existent-model-uuid"}},
+			statusExpected: http.StatusNotFound,
+			bodyExpected:   `Not Found - migrating model "non-existent-model-uuid" not found`,
+		},
+		{
+			description:    "missing model header",
+			url:            "/foo",
+			headers:        http.Header{"X-Juju-Migration-Model-UUID": []string{""}},
+			statusExpected: http.StatusBadRequest,
+			bodyExpected:   "Bad Request - missing X-Juju-Migration-Model-UUID header value",
+		},
+	}
+
+	for _, test := range tests {
+		req, err := http.NewRequest("POST", test.url, nil)
+		c.Assert(err, gc.IsNil)
+		for key, values := range test.headers {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+
+		recorder := httptest.NewRecorder()
+		migrationProxier.ProxyHTTP(recorder, req)
+
+		resp := recorder.Result()
+		defer resp.Body.Close()
+		c.Assert(resp.StatusCode, gc.Equals, test.statusExpected)
+
+		body, err := io.ReadAll(resp.Body)
+		c.Assert(err, gc.IsNil)
+		c.Assert(string(body), gc.Matches, test.bodyExpected)
+	}
+}

--- a/internal/middleware/authz.go
+++ b/internal/middleware/authz.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package middleware
 
@@ -12,7 +12,7 @@ import (
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
-// AuthorizeUserForModelAccess extract the user from the context, and checks for permission on the model uuid extracted from the path.
+// AuthorizeUserForModelAccess extracts the user from the context, and checks for permission on the model uuid extracted from the path.
 func AuthorizeUserForModelAccess(next http.Handler, accessNeeded cofga.Relation) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -49,6 +49,28 @@ func AuthorizeUserForModelAccess(next http.Handler, accessNeeded cofga.Relation)
 			_, _ = w.Write([]byte("no access to the resource"))
 			return
 		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// AuthorizeUserAsJIMMAdmin extracts the user from the context, and check that they are a JIMM admin.
+func AuthorizeUserAsJIMMAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		user, err := IdentityFromContext(ctx)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+
+		if !user.JimmAdmin {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("unauthorized"))
+			return
+		}
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/middleware/authz_test.go
+++ b/internal/middleware/authz_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package middleware_test
 
@@ -95,4 +95,32 @@ func TestAuthorizeUserForModelAccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthorizeUserAsJIMMAdmin(t *testing.T) {
+	c := qt.New(t)
+
+	bobIdentity, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+	bob := openfga.NewUser(bobIdentity, nil)
+	// Normally this field is set on login.
+	bob.JimmAdmin = false
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.AuthorizeUserAsJIMMAdmin(handler)
+
+	// Verify that a user without JIMM admin rights gets a 403 Forbidden response.
+	h.ServeHTTP(w, req.WithContext(middleware.WithIdentity(context.Background(), bob)))
+	c.Assert(w.Code, qt.Equals, http.StatusForbidden)
+
+	// Create a new response recorder (cannot reuse the previous one)
+	// and verify that a user with JIMM admin rights gets a 200 OK response.
+	w = httptest.NewRecorder()
+	bob.JimmAdmin = true
+	h.ServeHTTP(w, req.WithContext(middleware.WithIdentity(context.Background(), bob)))
+	c.Assert(w.Code, qt.Equals, http.StatusOK)
 }

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -75,7 +75,7 @@ func GetAddressesAndTLSConfig(ctx context.Context, ctl *dbmodel.Controller) ([]s
 
 	for _, hps := range ctl.Addresses {
 		for _, hp := range hps {
-			if maybeReachable(hp.Scope) {
+			if maybeReachable(network.Scope(hp.Scope)) {
 				var ip string
 				if hp.Type == string(network.IPv6Address) {
 					ip = fmt.Sprintf("[%s]:%d", hp.Value, hp.Port)
@@ -111,11 +111,11 @@ func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag,
 
 // maybeReachable decides what kinds of links JIMM should try to connect via.
 // Local IPs like localhost for example are excluded but public IPs and Cloud local IPs are potentially reachable.
-func maybeReachable(scope string) bool {
+func maybeReachable(scope network.Scope) bool {
 	switch scope {
-	case string(network.ScopeCloudLocal):
+	case network.ScopeCloudLocal:
 		return true
-	case string(network.ScopePublic):
+	case network.ScopePublic:
 		return true
 	case "":
 		return true

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rpc
 
@@ -7,98 +7,117 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io"
+	"math/rand"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
+	"strings"
+	"time"
 
-	"github.com/juju/zaputil"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/names/v4"
 	"github.com/juju/zaputil/zapctx"
-	"gopkg.in/errgo.v1"
+	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
 
-type httpOptions struct {
-	TLSConfig *tls.Config
-	URL       url.URL
+const (
+	defaultScheme = "https"
+)
+
+type ControllerProxy struct {
+	Controller dbmodel.Controller
+	Username   string
+	Password   string
 }
 
-// ProxyHTTP proxies the request to the controller using the info contained in dbmodel.Controller.
-// It tries for a controller, if it errors, it logs the error and go to the next, if no controller responds it returns a 504.
-func ProxyHTTP(ctx context.Context, ctl *dbmodel.Controller, w http.ResponseWriter, req *http.Request) error {
+func ProxyHTTP(ctx context.Context, ctl ControllerProxy, w http.ResponseWriter, req *http.Request) {
+	urls, err := getControllerAddresses(ctl.Controller)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get controller addresses", zap.Error(err))
+		http.Error(w, fmt.Sprintf("failed to get controller addresses: %v", err), http.StatusInternalServerError)
+		return
+	}
+
 	var tlsConfig *tls.Config
-	if ctl.CACertificate != "" {
+	if ctl.Controller.CACertificate != "" {
 		cp := x509.NewCertPool()
-		ok := cp.AppendCertsFromPEM([]byte(ctl.CACertificate))
+		ok := cp.AppendCertsFromPEM([]byte(ctl.Controller.CACertificate))
 		if !ok {
 			zapctx.Warn(ctx, "no CA certificates added")
 		}
 		tlsConfig = &tls.Config{
 			RootCAs:    cp,
-			ServerName: ctl.TLSHostname,
+			ServerName: ctl.Controller.TLSHostname,
 			MinVersion: tls.VersionTLS12,
 		}
 	}
 
-	if ctl.PublicAddress != "" {
-		err := doRequest(ctx, w, req, httpOptions{
-			TLSConfig: tlsConfig,
-			URL:       createURLWithNewHost(*req.URL, ctl.PublicAddress),
-		})
-		if err == nil {
-			return nil
-		}
+	// transport is the default HTTP transport config with TLS configuration.
+	transport := &http.Transport{
+		TLSClientConfig:       tlsConfig,
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
+
+	if len(urls) == 0 {
+		zapctx.Error(ctx, "no controller addresses found", zap.String("controller", ctl.Controller.Name))
+		http.Error(w, "no controller addresses found", http.StatusInternalServerError)
+		return
+	}
+
+	if len(urls) > 1 {
+		rand.Shuffle(len(urls), func(i, j int) {
+			urls[i], urls[j] = urls[j], urls[i]
+		})
+	}
+
+	// TODO: Consider implementing a better load balancing mechanism that handles
+	// multiples URLs and handles failing backends gracefully e.g. try send to first
+	// URL and on failure, try second, etc.
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(urls[0])
+			pr.Out.SetBasicAuth(names.NewUserTag(ctl.Username).String(), ctl.Password)
+		},
+		Transport: transport,
+	}
+	proxy.ServeHTTP(w, req)
+}
+
+func getControllerAddresses(ctl dbmodel.Controller) ([]*url.URL, error) {
+	urls := make([]*url.URL, 0, 1)
+	if ctl.PublicAddress != "" {
+		address := ctl.PublicAddress
+		if !strings.Contains(address, "://") {
+			address = defaultScheme + "://" + address // ensure the address has a scheme
+		}
+		newURL, err := url.Parse(address)
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, newURL)
+		return urls, nil
+	}
+
 	for _, hps := range ctl.Addresses {
 		for _, hp := range hps {
-			err := doRequest(ctx, w, req, httpOptions{
-				TLSConfig: tlsConfig,
-				URL:       createURLWithNewHost(*req.URL, fmt.Sprintf("%s:%d", hp.Value, hp.Port)),
-			})
-			if err == nil {
-				return nil
-			} else {
-				zapctx.Error(ctx, "failed to proxy request: continue to next addr", zaputil.Error(err))
+			if maybeReachable(hp.Scope) {
+				var ip string
+				if hp.Type == string(network.IPv6Address) {
+					ip = fmt.Sprintf("[%s]:%d", hp.Value, hp.Port)
+				} else {
+					ip = fmt.Sprintf("%s:%d", hp.Value, hp.Port)
+				}
+				newURL := url.URL{Scheme: defaultScheme, Host: ip}
+				urls = append(urls, &newURL)
 			}
 		}
 	}
-
-	return errgo.New("couldn't reach a valid address for controller")
-}
-
-func doRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, opt httpOptions) error {
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: opt.TLSConfig,
-		},
-	}
-	req = req.Clone(ctx)
-	req.RequestURI = ""
-	req.URL = &opt.URL
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// copy headers
-	for k, vv := range resp.Header {
-		for _, v := range vv {
-			w.Header().Add(k, v)
-		}
-	}
-	w.WriteHeader(resp.StatusCode)
-	// copy body
-	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// createURLWithNewHost takes a url.URL as parameter and return a url.URL with new host set and https enforced.
-func createURLWithNewHost(reqUrl url.URL, host string) url.URL {
-	reqUrl.Scheme = "https"
-	reqUrl.Host = host
-	return reqUrl
+	return urls, nil
 }

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -26,17 +27,29 @@ const (
 	defaultScheme = "https"
 )
 
-type ControllerProxy struct {
+// ControllerDetails contains the details
+// used to connect to a Juju controller
+// as well as the admin user's credentials.
+type ControllerDetails struct {
 	Controller dbmodel.Controller
 	Username   string
 	Password   string
 }
 
-func ProxyHTTP(ctx context.Context, ctl ControllerProxy, w http.ResponseWriter, req *http.Request) {
+// ProxyHTTP handles HTTP requests by proxying them to the Juju controller.
+// It retrieves the controller's addresses, sets up TLS if necessary,
+// and acts as a reverse proxy to forward the request.
+func ProxyHTTP(ctx context.Context, ctl ControllerDetails, w http.ResponseWriter, req *http.Request) {
 	urls, err := getControllerAddresses(ctl.Controller)
 	if err != nil {
 		zapctx.Error(ctx, "failed to get controller addresses", zap.Error(err))
 		http.Error(w, fmt.Sprintf("failed to get controller addresses: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if len(urls) == 0 {
+		zapctx.Error(ctx, "no controller addresses found", zap.String("controller", ctl.Controller.Name))
+		http.Error(w, "no controller addresses found", http.StatusInternalServerError)
 		return
 	}
 
@@ -65,12 +78,6 @@ func ProxyHTTP(ctx context.Context, ctl ControllerProxy, w http.ResponseWriter, 
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	if len(urls) == 0 {
-		zapctx.Error(ctx, "no controller addresses found", zap.String("controller", ctl.Controller.Name))
-		http.Error(w, "no controller addresses found", http.StatusInternalServerError)
-		return
-	}
-
 	if len(urls) > 1 {
 		rand.Shuffle(len(urls), func(i, j int) {
 			urls[i], urls[j] = urls[j], urls[i]
@@ -86,8 +93,16 @@ func ProxyHTTP(ctx context.Context, ctl ControllerProxy, w http.ResponseWriter, 
 			pr.Out.SetBasicAuth(names.NewUserTag(ctl.Username).String(), ctl.Password)
 		},
 		Transport: transport,
+		ErrorLog:  log.New(&proxyErrorLogger{}, "", 0), // flag=0 to avoid printing extra info that zap already gives us
 	}
 	proxy.ServeHTTP(w, req)
+}
+
+type proxyErrorLogger struct{}
+
+func (pl *proxyErrorLogger) Write(p []byte) (n int, err error) {
+	zapctx.Error(context.Background(), "HTTP proxy error", zap.String("error", string(p)))
+	return len(p), nil
 }
 
 func getControllerAddresses(ctl dbmodel.Controller) ([]*url.URL, error) {

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/juju/juju/core/network"
 	"github.com/juju/names/v4"
@@ -67,16 +66,8 @@ func ProxyHTTP(ctx context.Context, ctl ControllerDetails, w http.ResponseWriter
 		}
 	}
 
-	// transport is the default HTTP transport config with TLS configuration.
-	transport := &http.Transport{
-		TLSClientConfig:       tlsConfig,
-		Proxy:                 http.ProxyFromEnvironment,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 
 	if len(urls) > 1 {
 		rand.Shuffle(len(urls), func(i, j int) {

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -19,27 +19,18 @@ import (
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
-	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
 )
 
 const (
 	defaultScheme = "https"
 )
 
-// ControllerDetails contains the details
-// used to connect to a Juju controller
-// as well as the admin user's credentials.
-type ControllerDetails struct {
-	Controller dbmodel.Controller
-	Username   string
-	Password   string
-}
-
 // ProxyHTTP handles HTTP requests by proxying them to the Juju controller.
 // It retrieves the controller's addresses, sets up TLS if necessary,
 // and acts as a reverse proxy to forward the request.
-func ProxyHTTP(ctx context.Context, ctl ControllerDetails, w http.ResponseWriter, req *http.Request) {
-	urls, err := getControllerAddresses(ctl.Controller)
+func ProxyHTTP(ctx context.Context, ctl juju.ControllerConnectionDetails, w http.ResponseWriter, req *http.Request) {
+	urls, err := getControllerAddresses(ctl)
 	if err != nil {
 		zapctx.Error(ctx, "failed to get controller addresses", zap.Error(err))
 		http.Error(w, fmt.Sprintf("failed to get controller addresses: %v", err), http.StatusInternalServerError)
@@ -47,21 +38,21 @@ func ProxyHTTP(ctx context.Context, ctl ControllerDetails, w http.ResponseWriter
 	}
 
 	if len(urls) == 0 {
-		zapctx.Error(ctx, "no controller addresses found", zap.String("controller", ctl.Controller.Name))
+		zapctx.Error(ctx, "no controller addresses found")
 		http.Error(w, "no controller addresses found", http.StatusInternalServerError)
 		return
 	}
 
 	var tlsConfig *tls.Config
-	if ctl.Controller.CACertificate != "" {
+	if ctl.CACertificate != "" {
 		cp := x509.NewCertPool()
-		ok := cp.AppendCertsFromPEM([]byte(ctl.Controller.CACertificate))
+		ok := cp.AppendCertsFromPEM([]byte(ctl.CACertificate))
 		if !ok {
 			zapctx.Warn(ctx, "no CA certificates added")
 		}
 		tlsConfig = &tls.Config{
 			RootCAs:    cp,
-			ServerName: ctl.Controller.TLSHostname,
+			ServerName: ctl.TLSHostname,
 			MinVersion: tls.VersionTLS12,
 		}
 	}
@@ -78,10 +69,11 @@ func ProxyHTTP(ctx context.Context, ctl ControllerDetails, w http.ResponseWriter
 	// TODO: Consider implementing a better load balancing mechanism that handles
 	// multiples URLs and handles failing backends gracefully e.g. try send to first
 	// URL and on failure, try second, etc.
+	adminUsername := names.NewUserTag(ctl.Credentials.AdminIdentityName).String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(urls[0])
-			pr.Out.SetBasicAuth(names.NewUserTag(ctl.Username).String(), ctl.Password)
+			pr.Out.SetBasicAuth(adminUsername, ctl.Credentials.AdminPassword)
 		},
 		Transport: transport,
 		ErrorLog:  log.New(&proxyErrorLogger{}, "", 0), // flag=0 to avoid printing extra info that zap already gives us
@@ -96,7 +88,7 @@ func (pl *proxyErrorLogger) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func getControllerAddresses(ctl dbmodel.Controller) ([]*url.URL, error) {
+func getControllerAddresses(ctl juju.ControllerConnectionDetails) ([]*url.URL, error) {
 	urls := make([]*url.URL, 0, 1)
 	if ctl.PublicAddress != "" {
 		address := ctl.PublicAddress
@@ -115,10 +107,10 @@ func getControllerAddresses(ctl dbmodel.Controller) ([]*url.URL, error) {
 		for _, hp := range hps {
 			if maybeReachable(hp.Scope) {
 				var ip string
-				if hp.Type == string(network.IPv6Address) {
-					ip = fmt.Sprintf("[%s]:%d", hp.Value, hp.Port)
+				if hp.Type == network.IPv6Address {
+					ip = fmt.Sprintf("[%s]:%d", hp.Value, hp.Port())
 				} else {
-					ip = fmt.Sprintf("%s:%d", hp.Value, hp.Port)
+					ip = fmt.Sprintf("%s:%d", hp.Value, hp.Port())
 				}
 				newURL := url.URL{Scheme: defaultScheme, Host: ip}
 				urls = append(urls, &newURL)

--- a/internal/rpc/httpproxy_test.go
+++ b/internal/rpc/httpproxy_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
 
-	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
@@ -31,69 +31,87 @@ func TestProxyHTTP(t *testing.T) {
 		_, _ = w.Write([]byte("OK"))
 	}))
 	defer fakeController.Close()
-	controller := dbmodel.Controller{}
 	pemData := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: fakeController.Certificate().Raw,
 	})
-	controller.CACertificate = string(pemData)
+	controllerCACert := string(pemData)
+	fakeControllerURL, err := url.Parse(fakeController.URL)
+	c.Assert(err, qt.IsNil)
 
 	tests := []struct {
-		description    string
-		setup          func()
-		path           string
-		statusExpected int
+		description          string
+		getConnectionDetails func(c *qt.C) juju.ControllerConnectionDetails
+		path                 string
+		statusExpected       int
 	}{
 		{
 			description: "good",
-			setup: func() {
-				newURL, _ := url.Parse(fakeController.URL)
-				controller.PublicAddress = newURL.Host
+			getConnectionDetails: func(c *qt.C) juju.ControllerConnectionDetails {
+
+				return juju.ControllerConnectionDetails{
+					CACertificate: controllerCACert,
+					PublicAddress: fakeControllerURL.Host,
+				}
 			},
 			statusExpected: http.StatusOK,
 		}, {
 			description: "controller no public address, only addresses",
-			setup: func() {
+			getConnectionDetails: func(c *qt.C) juju.ControllerConnectionDetails {
 				hp, err := network.ParseMachineHostPort(fakeController.Listener.Addr().String())
 				c.Assert(err, qt.Equals, nil)
 				hp.Scope = network.ScopePublic
-				controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
+
+				hostPorts := [][]jujuparams.HostPort{[]jujuparams.HostPort{{
 					Address: jujuparams.FromMachineAddress(hp.MachineAddress),
 					Port:    hp.Port(),
-				}})
-				controller.PublicAddress = ""
+				}}}
+				controllerAddresses := jujuparams.ToMachineHostsPorts(hostPorts)
+				return juju.ControllerConnectionDetails{
+					CACertificate: controllerCACert,
+					Addresses:     controllerAddresses,
+				}
 			},
 			statusExpected: http.StatusOK,
 		},
 		{
 			description: "controller public address with unreachable alternatives",
-			setup: func() {
+			getConnectionDetails: func(c *qt.C) juju.ControllerConnectionDetails {
 				hp, err := network.ParseMachineHostPort("unreachable:61213")
 				c.Assert(err, qt.Equals, nil)
 				hp.Scope = network.ScopePublic
-				controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
+
+				hostPorts := [][]jujuparams.HostPort{[]jujuparams.HostPort{{
 					Address: jujuparams.FromMachineAddress(hp.MachineAddress),
 					Port:    hp.Port(),
-				}})
-
-				controller.PublicAddress = fakeController.Listener.Addr().String()
+				}}}
+				controllerAddresses := jujuparams.ToMachineHostsPorts(hostPorts)
+				return juju.ControllerConnectionDetails{
+					PublicAddress: fakeController.Listener.Addr().String(),
+					Addresses:     controllerAddresses,
+					CACertificate: controllerCACert,
+				}
 			},
 			statusExpected: http.StatusOK,
 		},
 		{
 			description: "controller responds unauthorized",
-			setup: func() {
-				newURL, _ := url.Parse(fakeController.URL)
-				controller.PublicAddress = newURL.Host
+			getConnectionDetails: func(c *qt.C) juju.ControllerConnectionDetails {
+				return juju.ControllerConnectionDetails{
+					PublicAddress: fakeControllerURL.Host,
+					CACertificate: controllerCACert,
+				}
 			},
 			path:           "/unauth",
 			statusExpected: http.StatusUnauthorized,
 		},
 		{
 			description: "controller not reachable",
-			setup: func() {
-				controller.Addresses = nil
-				controller.PublicAddress = "localhost-not-found:61213"
+			getConnectionDetails: func(c *qt.C) juju.ControllerConnectionDetails {
+				return juju.ControllerConnectionDetails{
+					PublicAddress: "localhost-not-found:61213",
+					CACertificate: controllerCACert,
+				}
 			},
 			statusExpected: http.StatusBadGateway,
 		},
@@ -101,17 +119,18 @@ func TestProxyHTTP(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			test.setup()
+			c := qt.New(t)
+
 			req, err := http.NewRequest("POST", test.path, nil)
 			c.Assert(err, qt.IsNil)
 			recorder := httptest.NewRecorder()
 
-			proxyInfo := rpc.ControllerDetails{
-				Controller: controller,
-				Username:   "test-user",
-				Password:   "test-password",
+			connectionDetails := test.getConnectionDetails(c)
+			connectionDetails.Credentials = juju.ControllerCreds{
+				AdminIdentityName: "test-user",
+				AdminPassword:     "test-password",
 			}
-			rpc.ProxyHTTP(ctx, proxyInfo, recorder, req)
+			rpc.ProxyHTTP(ctx, connectionDetails, recorder, req)
 
 			resp := recorder.Result()
 			defer resp.Body.Close()

--- a/internal/rpc/httpproxy_test.go
+++ b/internal/rpc/httpproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package rpc_test
 
@@ -28,8 +28,7 @@ func TestProxyHTTP(t *testing.T) {
 			w.WriteHeader(401)
 			return
 		}
-		_, err := w.Write([]byte("OK"))
-		c.Assert(err, qt.IsNil)
+		_, _ = w.Write([]byte("OK"))
 	}))
 	defer fakeController.Close()
 	controller := dbmodel.Controller{}
@@ -44,7 +43,6 @@ func TestProxyHTTP(t *testing.T) {
 		setup          func()
 		path           string
 		statusExpected int
-		errorMatches   string
 	}{
 		{
 			description: "good",
@@ -53,32 +51,32 @@ func TestProxyHTTP(t *testing.T) {
 				controller.PublicAddress = newURL.Host
 			},
 			statusExpected: http.StatusOK,
-		},
-		{
+		}, {
 			description: "controller no public address, only addresses",
 			setup: func() {
 				hp, err := network.ParseMachineHostPort(fakeController.Listener.Addr().String())
 				c.Assert(err, qt.Equals, nil)
+				hp.Scope = network.ScopePublic
 				controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
 					Address: jujuparams.FromMachineAddress(hp.MachineAddress),
 					Port:    hp.Port(),
 				}})
-				controller.Addresses = append(controller.Addresses, []jujuparams.HostPort{})
 				controller.PublicAddress = ""
 			},
 			statusExpected: http.StatusOK,
 		},
 		{
-			description: "controller no public address, only addresses",
+			description: "controller public address with unreachable alternatives",
 			setup: func() {
-				hp, err := network.ParseMachineHostPort(fakeController.Listener.Addr().String())
+				hp, err := network.ParseMachineHostPort("unreachable:61213")
 				c.Assert(err, qt.Equals, nil)
+				hp.Scope = network.ScopePublic
 				controller.Addresses = append(make([][]jujuparams.HostPort, 0), []jujuparams.HostPort{{
 					Address: jujuparams.FromMachineAddress(hp.MachineAddress),
 					Port:    hp.Port(),
 				}})
-				controller.Addresses = append(controller.Addresses, []jujuparams.HostPort{})
-				controller.PublicAddress = ""
+
+				controller.PublicAddress = fakeController.Listener.Addr().String()
 			},
 			statusExpected: http.StatusOK,
 		},
@@ -97,23 +95,27 @@ func TestProxyHTTP(t *testing.T) {
 				controller.Addresses = nil
 				controller.PublicAddress = "localhost-not-found:61213"
 			},
-			errorMatches: "couldn't reach a valid address for controller",
+			statusExpected: http.StatusBadGateway,
 		},
 	}
 
 	for _, test := range tests {
-		test.setup()
-		req, err := http.NewRequest("POST", test.path, nil)
-		c.Assert(err, qt.IsNil)
-		recorder := httptest.NewRecorder()
-		err = rpc.ProxyHTTP(ctx, &controller, recorder, req)
-		if test.errorMatches == "" {
+		t.Run(test.description, func(t *testing.T) {
+			test.setup()
+			req, err := http.NewRequest("POST", test.path, nil)
 			c.Assert(err, qt.IsNil)
+			recorder := httptest.NewRecorder()
+
+			proxyInfo := rpc.ControllerProxy{
+				Controller: controller,
+				Username:   "test-user",
+				Password:   "test-password",
+			}
+			rpc.ProxyHTTP(ctx, proxyInfo, recorder, req)
+
 			resp := recorder.Result()
 			defer resp.Body.Close()
 			c.Assert(resp.StatusCode, qt.Equals, test.statusExpected)
-		} else {
-			c.Assert(err, qt.ErrorMatches, test.errorMatches)
-		}
+		})
 	}
 }

--- a/internal/rpc/httpproxy_test.go
+++ b/internal/rpc/httpproxy_test.go
@@ -106,7 +106,7 @@ func TestProxyHTTP(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			recorder := httptest.NewRecorder()
 
-			proxyInfo := rpc.ControllerProxy{
+			proxyInfo := rpc.ControllerDetails{
 				Controller: controller,
 				Username:   "test-user",
 				Password:   "test-password",

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -16,13 +16,15 @@ import (
 
 // ControllerService is an implementation of the jujuapi.ControllerService interface.
 type ControllerService struct {
-	AddController_             func(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
-	ControllerInfo_            func(ctx context.Context, name string) (*dbmodel.Controller, error)
-	EarliestControllerVersion_ func(ctx context.Context) (version.Number, error)
-	ListControllers_           func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
-	RemoveController_          func(ctx context.Context, user *openfga.User, controllerName string, force bool) error
-	SetControllerDeprecated_   func(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error
-	ControllerConfig_          func(ctx context.Context, controllerName string) (jujucontroller.Config, error)
+	AddController_                     func(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
+	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
+	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
+	ControllerInfo_                    func(ctx context.Context, name string) (*dbmodel.Controller, error)
+	EarliestControllerVersion_         func(ctx context.Context) (version.Number, error)
+	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
+	RemoveController_                  func(ctx context.Context, user *openfga.User, controllerName string, force bool) error
+	SetControllerDeprecated_           func(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error
+	ControllerConfig_                  func(ctx context.Context, controllerName string) (jujucontroller.Config, error)
 }
 
 func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error {
@@ -30,6 +32,20 @@ func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, 
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return j.AddController_(ctx, u, ctl, creds)
+}
+
+func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+	if j.ControllerDetailsForModel_ == nil {
+		return dbmodel.Controller{}, "", "", errors.E(errors.CodeNotImplemented)
+	}
+	return j.ControllerDetailsForModel_(ctx, modelUUID)
+}
+
+func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+	if j.ControllerDetailsForIncomingModel_ == nil {
+		return dbmodel.Controller{}, "", "", errors.E(errors.CodeNotImplemented)
+	}
+	return j.ControllerDetailsForIncomingModel_(ctx, modelUUID)
 }
 
 func (j *ControllerService) ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -17,8 +17,8 @@ import (
 // ControllerService is an implementation of the jujuapi.ControllerService interface.
 type ControllerService struct {
 	AddController_                     func(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
-	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
-	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
+	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
+	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
 	ControllerInfo_                    func(ctx context.Context, name string) (*dbmodel.Controller, error)
 	EarliestControllerVersion_         func(ctx context.Context) (version.Number, error)
 	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
@@ -34,16 +34,16 @@ func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, 
 	return j.AddController_(ctx, u, ctl, creds)
 }
 
-func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error) {
+func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 	if j.ControllerDetailsForModel_ == nil {
-		return juju.ControllerDetails{}, errors.E(errors.CodeNotImplemented)
+		return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotImplemented)
 	}
 	return j.ControllerDetailsForModel_(ctx, modelUUID)
 }
 
-func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error) {
+func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 	if j.ControllerDetailsForIncomingModel_ == nil {
-		return juju.ControllerDetails{}, errors.E(errors.CodeNotImplemented)
+		return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotImplemented)
 	}
 	return j.ControllerDetailsForIncomingModel_(ctx, modelUUID)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -17,8 +17,8 @@ import (
 // ControllerService is an implementation of the jujuapi.ControllerService interface.
 type ControllerService struct {
 	AddController_                     func(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
-	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
-	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error)
+	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
+	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (juju.ControllerDetails, error)
 	ControllerInfo_                    func(ctx context.Context, name string) (*dbmodel.Controller, error)
 	EarliestControllerVersion_         func(ctx context.Context) (version.Number, error)
 	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
@@ -34,16 +34,16 @@ func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, 
 	return j.AddController_(ctx, u, ctl, creds)
 }
 
-func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error) {
 	if j.ControllerDetailsForModel_ == nil {
-		return dbmodel.Controller{}, "", "", errors.E(errors.CodeNotImplemented)
+		return juju.ControllerDetails{}, errors.E(errors.CodeNotImplemented)
 	}
 	return j.ControllerDetailsForModel_(ctx, modelUUID)
 }
 
-func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (dbmodel.Controller, string, string, error) {
+func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerDetails, error) {
 	if j.ControllerDetailsForIncomingModel_ == nil {
-		return dbmodel.Controller{}, "", "", errors.E(errors.CodeNotImplemented)
+		return juju.ControllerDetails{}, errors.E(errors.CodeNotImplemented)
 	}
 	return j.ControllerDetailsForIncomingModel_(ctx, modelUUID)
 }


### PR DESCRIPTION
## Description
This PR introduces HTTP handlers for Juju's migration endpoints located at `migration/*` which are used to send charms/resources/tools from one controller to another when a model is migrating. The handlers are implemented in a similar fashion to the existing `HTTPProxyHandler` in `internal/jimmhttp/httpproxy_handler.go` with the caveat that I have refactored those existing handlers to move the application logic they were performing into the appropriate place. The new handlers feature slightly different authentication and logic because the model UUID is contained in a header value rather than as a path segment.

I've kept the handler tests as integration tests. While I have moved the application logic associated with fetch a model migration and then fetching the controller details into the domain layer, I have not opted to mock out the proxyHTTP call so the tests remain the same for the time being.

I have also refactored the proxy logic to use the standard library's `net/http/httputil.ReverseProxy` struct which provides an extensive implementation of HTTP reverse proxy logic. Currently the approach when reverse proxying is to either:
- Try the controller's public address if it is not empty.
- Randomise and select 1 of the controller's addresses that are potentially reachable depending on the network scope.

In a follow-up PR I will add additional logic to the proxy to try the controller's addresses in sequential order.

Fixes [JUJU-8120](https://warthogs.atlassian.net/browse/JUJU-8120)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8120]: https://warthogs.atlassian.net/browse/JUJU-8120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ