### PR TITLE
feat(model-migration): implement Activate from the MigrationTarget facade

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -14,6 +14,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -253,7 +254,7 @@ type JujuManager interface {
 	CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
-
+	Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error
 	// Other methods
 
 	AddCloudToController(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -40,6 +40,10 @@ type API interface {
 	// Abort aborts a model migration.
 	Abort(modelUUID string) error
 
+	// Activate activates a model on the controller.
+	// It is used to activate a model that has been migrated from another controller.
+	Activate(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error
+
 	// AddCloud adds a new cloud.
 	AddCloud(names.CloudTag, jujucloud.Cloud, bool) error
 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -171,5 +173,58 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 	model.Owner = names.NewUserTag(newOwner)
 	// TODO: Replace fields on the model description including the model owner and users.
 
+	return nil
+}
+
+// Activate gets the model migration, proxies the Activate call to the target controller,
+// and then deletes the model migration from the database.
+func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error {
+	const op = errors.Op("jimm.Activate")
+
+	modelMigration := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelTag.Id(),
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err))
+	}
+	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	err = api.Activate(modelTag.Id(), migrationInfo, relatedModels)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+	}
+
+	// This is done in a transaction to ensure that the model migration is only deleted
+	// if user mappings have been created.
+	err = j.Database.Transaction(func(db *db.Database) error {
+		for localUser, externalUser := range modelMigration.UserMapping {
+			userMapping := &dbmodel.UserMapping{
+				ModelUUID:        modelMigration.ModelUUID,
+				LocalUser:        localUser,
+				ExternalUserName: externalUser,
+			}
+			err = db.AddUserMapping(ctx, userMapping)
+			if err != nil {
+				return errors.E(op, fmt.Errorf("failed to add user mapping for model %q: %w", modelTag.Id(), err))
+			}
+		}
+		// TODO(SimoneDutto): set the model we've created in Import to active.
+		err = db.DeleteIncomingModelMigration(ctx, &modelMigration)
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to delete model migration for model %q: %w", modelTag.Id(), err))
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+	}
 	return nil
 }

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -304,6 +304,118 @@ func TestAdoptResources_NoIncomingModelMigration(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
+func TestActivate_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	sourceInfo := migration.SourceControllerInfo{
+		ControllerTag: names.NewControllerTag("00000001-0000-0000-0000-000000000002"),
+	}
+	relatedModels := []string{"related-model-1", "related-model-2"}
+
+	// Validate that the API request to Juju is made with the correct parameters.
+	api := &jimmtest.API{
+		Activate_: func(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error {
+			c.Check(modelUUID, qt.Equals, modelUUID)
+			c.Check(sourceInfo.ControllerTag.Id(), qt.Equals, "00000001-0000-0000-0000-000000000002")
+			c.Check(relatedModels, qt.DeepEquals, []string{"related-model-1", "related-model-2"})
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	err = j.Activate(ctx, names.NewModelTag(modelUUID), sourceInfo, relatedModels)
+	c.Assert(err, qt.IsNil)
+
+	modelMigration = dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	// Check the model migration has been removed from the database.
+	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	userMapping := dbmodel.UserMapping{
+		ModelUUID: modelMigration.ModelUUID,
+		LocalUser: "bob",
+	}
+
+	err = j.Database.GetUserMapping(ctx, &userMapping)
+	c.Assert(err, qt.IsNil)
+	c.Assert(userMapping.ExternalUserName, qt.Equals, "alice@canonical.com")
+}
+
+func TestActivate_APIFailure(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	sourceInfo := migration.SourceControllerInfo{}
+	relatedModels := []string{"related-model-1", "related-model-2"}
+
+	// Simulate an API failure.
+	api := &jimmtest.API{
+		Activate_: func(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error {
+			return errors.New("API failure")
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userMap := map[string]string{"bob": "alice@canonical.com"}
+	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
+	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	err = j.Activate(ctx, names.NewModelTag(modelUUID), sourceInfo, relatedModels)
+	c.Assert(err, qt.ErrorMatches, `.*API failure`)
+
+	modelMigration = dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	// Check the model migration has not been removed from the database.
+	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestActivate_NoIncomingModelMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	err := j.Activate(ctx, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+}
+
 func newIncomingMigration(userMap map[string]string, ctl dbmodel.Controller) dbmodel.IncomingModelMigration {
 	return dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -31,12 +31,14 @@ func (api *API) Prechecks(model params.MigrationModelInfo) error
 func init() {
 	facadeInit["MigrationTarget"] = func(r *controllerRoot) []int {
 		preChecks := rpc.Method(r.Prechecks)
+		activate := rpc.Method(r.Activate)
 		caCert := rpc.Method(r.CACert)
 		adoptResources := rpc.Method(r.AdoptResources)
 		checkMachines := rpc.Method(r.CheckMachines)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
+		r.AddMethod("MigrationTarget", 4, "Activate", activate)
 		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
 		r.AddMethod("MigrationTarget", 4, "Abort", adoptResources)
 		r.AddMethod("MigrationTarget", 4, "CheckMachines", checkMachines)
@@ -146,6 +148,38 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 	err = r.jimm.JujuManager().Prechecks(ctx, r.user, model)
 	if err != nil {
 		return errors.E(op, err)
+	}
+	return nil
+}
+
+// Activate is the implementation of the Activate method of the MigrationTarget facade.
+func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModelArgs) error {
+	const op = errors.Op("jujuapi.Activate")
+
+	if !r.user.JimmAdmin {
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	controllerTag, err := names.ParseControllerTag(args.ControllerTag)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	err = r.jimm.JujuManager().Activate(
+		ctx,
+		modelTag, migration.SourceControllerInfo{
+			ControllerTag:   controllerTag,
+			ControllerAlias: args.ControllerAlias,
+			Addrs:           args.SourceAPIAddrs,
+			CACert:          args.SourceCACert,
+		},
+		args.CrossModelUUIDs)
+	if err != nil {
+		return errors.E(errors.Op("jujuapi.Activate"), err)
 	}
 	return nil
 }

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -97,3 +97,18 @@ func (s *migrationTargetSuite) TestAdoptResources(c *gc.C) {
 	err := client.AdoptResources(modelUUID)
 	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
 }
+
+func (s *migrationTargetSuite) TestActivate(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	modelUUID := "00000001-0000-0000-0000-000000000001"
+	sourceInfo := migration.SourceControllerInfo{
+		ControllerTag: names.NewControllerTag("00000001-0000-0000-0000-000000000002"),
+	}
+	relatedModels := []string{"related-model-1", "related-model-2"}
+
+	client := migrationtarget.NewClient(conn)
+	err := client.Activate(modelUUID, sourceInfo, relatedModels)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+}

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -217,3 +217,133 @@ func (s *migrationTargetUnitSuite) TestAdoptResources(c *gc.C) {
 	err = cr.AdoptResources(ctx, args)
 	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
 }
+
+func (s *migrationTargetUnitSuite) TestActivateUnauthorized(c *gc.C) {
+	ctx := context.Background()
+
+	jujuManager := mocks.JujuManager{}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ActivateModelArgs{
+		ModelTag:        names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+		ControllerTag:   names.NewControllerTag("00000001-0000-0000-0000-000000000002").String(),
+		ControllerAlias: "controller-1",
+		CrossModelUUIDs: []string{"related-model-1", "related-model-2"},
+	}
+
+	// Validate access denied without JIMM admin permissions.
+	err := cr.Activate(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+}
+
+func (s *migrationTargetUnitSuite) TestActivateValid(c *gc.C) {
+	ctx := context.Background()
+
+	activateCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			Activate_: func(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+				activateCalled = true
+				c.Assert(modelTag.Id(), gc.Equals, "00000001-0000-0000-0000-000000000001")
+				c.Assert(sourceControllerInfo.ControllerAlias, gc.Equals, "controller-1")
+				c.Assert(relatedModels, gc.DeepEquals, []string{"related-model-1", "related-model-2"})
+				return nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ActivateModelArgs{
+		ModelTag:        names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+		ControllerTag:   names.NewControllerTag("00000001-0000-0000-0000-000000000002").String(),
+		ControllerAlias: "controller-1",
+		CrossModelUUIDs: []string{"related-model-1", "related-model-2"},
+	}
+
+	// Validate the activate method is called when the user is a JIMM admin.
+	user.JimmAdmin = true
+	err := cr.Activate(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(activateCalled, gc.Equals, true)
+}
+
+func (s *migrationTargetUnitSuite) TestActivateInvalidModelTag(c *gc.C) {
+	ctx := context.Background()
+
+	jujuManager := mocks.JujuManager{}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ActivateModelArgs{
+		ModelTag:        "invalid-model-tag",
+		ControllerTag:   names.NewControllerTag("00000001-0000-0000-0000-000000000002").String(),
+		ControllerAlias: "controller-1",
+		CrossModelUUIDs: []string{"related-model-1", "related-model-2"},
+	}
+
+	// Validate that an invalid model tag is rejected.
+	user.JimmAdmin = true
+	err := cr.Activate(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
+}
+
+func (s *migrationTargetUnitSuite) TestActivateInvalidControllerTag(c *gc.C) {
+	ctx := context.Background()
+
+	jujuManager := mocks.JujuManager{}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ActivateModelArgs{
+		ModelTag:        names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+		ControllerTag:   "invalid-controller-tag",
+		ControllerAlias: "controller-1",
+		CrossModelUUIDs: []string{"related-model-1", "related-model-2"},
+	}
+
+	// Validate that an invalid controller tag is rejected.
+	user.JimmAdmin = true
+	err := cr.Activate(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-controller-tag" is not a valid tag`)
+}

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -5,6 +5,7 @@ package jujuclient
 import (
 	"github.com/juju/juju/api/controller/migrationtarget"
 	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -47,4 +48,9 @@ func (c Connection) Abort(modelUUID string) error {
 func (c Connection) CheckMachines(modelUUID string) ([]error, error) {
 	migrationTarget := migrationtarget.NewClient(&c)
 	return migrationTarget.CheckMachines(modelUUID)
+}
+
+// Activate activates a model on the controller.
+func (c Connection) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
+	return migrationtarget.NewClient(&c).Activate(modelUUID, sourceInfo, relatedModels)
 }

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -13,6 +13,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/migration"
+	coremigration "github.com/juju/juju/core/migration"
 	jujuparams "github.com/juju/juju/rpc/params"
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/names/v5"
@@ -125,6 +126,7 @@ func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.M
 type API struct {
 	base.APICaller
 
+	Activate_                          func(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error
 	Abort_                             func(modelUUID string) error
 	AddCloud_                          func(names.CloudTag, jujucloud.Cloud, bool) error
 	AdoptResources_                    func(modelUUID string, controllerVersion version.Number) error
@@ -172,6 +174,13 @@ type API struct {
 	ListVolumes_                       func(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error)
 	ListStorageDetails_                func(ctx context.Context) ([]jujuparams.StorageDetails, error)
 	ListModels_                        func(ctx context.Context) ([]base.UserModel, error)
+}
+
+func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
+	if a.Activate_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return a.Activate_(modelUUID, sourceInfo, relatedModels)
 }
 
 // Abort aborts the current operation on the controller.

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/migration"
+	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -14,6 +15,7 @@ import (
 type MigrationMocks struct {
 	Prechecks_      func(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 	AdoptResources_ func(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
+	Activate_       func(ctx context.Context, modelUUID names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error
 	AbortMigration_ func(ctx context.Context, user *openfga.User, modelUUID string) error
 	CheckMachines_  func(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 }
@@ -37,6 +39,13 @@ func (j *MigrationMocks) AdoptResources(ctx context.Context, user *openfga.User,
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return j.AdoptResources_(ctx, user, modelUUID, sourceControllerVersion)
+}
+
+func (j *MigrationMocks) Activate(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+	if j.Activate_ == nil {
+		return errors.E(errors.CodeNotImplemented)
+	}
+	return j.Activate_(ctx, modelTag, sourceControllerInfo, relatedModels)
 }
 
 func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {


### PR DESCRIPTION
# Description
This PR implements the Activate method on the MigrationTarget facade for migrating models through JIMM. The implementation is:
- check IncomingMigration
- pass the request through
- (in another PR) set the model to `alive`
- delete IncomingMigration