### PR TITLE
feat: proxy log transfer websocket handler

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -507,8 +507,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	// HTTP Migration endpoints
 	mountHandler("/migrate", jimmhttp.NewMigrationHTTPProxyHandler(s.jimm))
 	// Log transfer endpoint
-	// TODO: Implement log transfer, this uses a websocket rather than HTTP.
-	// s.mux.Handle("/migrate/logtransfer", jimmhttp.NewHTTPProxyHandler(s.jimm).Routes())
+	s.mux.Handle("/migrate/logtransfer", jujuapi.LogTransferHandler(ctx, s.jimm, params))
 
 	// serve the ssh public key fingerprint
 	s.mux.Get("/ssh/public-key-fingerprints", jimmhttp.WriteFingerprints(p.HostKeyFingerprints))

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package errors contains types to help handle errors in the system.
 package errors
@@ -121,6 +121,7 @@ const (
 	CodeServerConfiguration          Code = "server configuration"
 	CodeStillAlive                   Code = apiparams.CodeStillAlive
 	CodeUnauthorized                 Code = jujuparams.CodeUnauthorized
+	CodeServerError                  Code = "server error"
 	CodeSessionTokenInvalid          Code = jujuparams.CodeSessionTokenInvalid
 	CodeUpgradeInProgress            Code = jujuparams.CodeUpgradeInProgress
 	CodeFailedToParseTupleKey        Code = "failed to parse tuple"

--- a/internal/jimmhttp/utils.go
+++ b/internal/jimmhttp/utils.go
@@ -13,12 +13,28 @@ import (
 	"go.uber.org/zap"
 )
 
-type contextPathKey string
+type contextPathKey struct{}
+type migratingModelUUIDKey struct{}
+type clientVersionKey struct{}
 
 // PathElementFromContext returns the value of the path element previously
 // extracted in a StripPathElement handler.
-func PathElementFromContext(ctx context.Context, key string) string {
-	s, _ := ctx.Value(contextPathKey(key)).(string)
+func PathElementFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(contextPathKey{}).(string)
+	return s
+}
+
+// MigratingModelUUIDFromContext returns the value of the migrating model UUID
+// sent in an HTTP header if one was sent.
+func MigratingModelUUIDFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(migratingModelUUIDKey{}).(string)
+	return s
+}
+
+// ClientVersionFromContext returns the value of the client version sent in an
+// HTTP header if one was sent.
+func ClientVersionFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(clientVersionKey{}).(string)
 	return s
 }
 
@@ -42,7 +58,7 @@ func StripPathElement(key string, h http.Handler) http.Handler {
 		// clear the RawPath if it was previously set.
 		req2.URL.RawPath = ""
 		if key != "" {
-			req2 = req2.WithContext(context.WithValue(req2.Context(), contextPathKey(key), v))
+			req2 = req2.WithContext(context.WithValue(req2.Context(), contextPathKey{}, v))
 		}
 		h.ServeHTTP(w, req2)
 	})

--- a/internal/jimmhttp/utils_test.go
+++ b/internal/jimmhttp/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmhttp_test
 
@@ -50,7 +50,7 @@ func TestStripPathElement(t *testing.T) {
 	for _, test := range stripPathElementTests {
 		c.Run(test.name, func(c *qt.C) {
 			var hnd http.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				c.Check(jimmhttp.PathElementFromContext(req.Context(), "key"), qt.Equals, test.expectVar)
+				c.Check(jimmhttp.PathElementFromContext(req.Context()), qt.Equals, test.expectVar)
 				c.Check(req.URL.Path, qt.Equals, test.expectPath)
 				c.Check(req.URL.RawPath, qt.Equals, "")
 			})

--- a/internal/jimmhttp/websocket.go
+++ b/internal/jimmhttp/websocket.go
@@ -50,8 +50,13 @@ func (h *WSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Set the request context with additional values that will be used by the websocket server.
+
+	// Set the path of the request to the context for handling different endpoints.
 	ctx = context.WithValue(ctx, contextPathKey{}, req.URL.EscapedPath())
+	// Set the migrating model UUID if it exists in the request header.
 	ctx = context.WithValue(ctx, migratingModelUUIDKey{}, req.Header.Get(jujuparams.MigrationModelHTTPHeader))
+	// Set the client version from the request header, expected by Juju controllers.
 	ctx = context.WithValue(ctx, clientVersionKey{}, req.Header.Get(jujuparams.JujuClientVersion))
 
 	conn, err := h.Upgrader.Upgrade(w, req, nil)

--- a/internal/jimmhttp/websocket.go
+++ b/internal/jimmhttp/websocket.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmhttp
 
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -49,7 +50,10 @@ func (h *WSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ctx = context.WithValue(ctx, contextPathKey("path"), req.URL.EscapedPath())
+	ctx = context.WithValue(ctx, contextPathKey{}, req.URL.EscapedPath())
+	ctx = context.WithValue(ctx, migratingModelUUIDKey{}, req.Header.Get(jujuparams.MigrationModelHTTPHeader))
+	ctx = context.WithValue(ctx, clientVersionKey{}, req.Header.Get(jujuparams.JujuClientVersion))
+
 	conn, err := h.Upgrader.Upgrade(w, req, nil)
 	if err != nil {
 		// If the upgrader returns an error it will have written an

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -51,11 +51,10 @@ func ModelHandler(ctx context.Context, jimm *jimm.JIMM, p Params) http.Handler {
 	return mux
 }
 
+// LogTransferHandler creates an http.Handler for the "/migrate/logtransfer" endpoint.
 func LogTransferHandler(ctx context.Context, jimm *jimm.JIMM, p Params) http.Handler {
 	return &jimmhttp.WSHandler{
 		Upgrader: websocketUpgrader,
-		Server: &streamControllerProxier{apiServer: apiServer{
-			jimm: jimm,
-		}},
+		Server:   &streamControllerProxier{jimm: jimm},
 	}
 }

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -38,15 +38,24 @@ func ModelHandler(ctx context.Context, jimm *jimm.JIMM, p Params) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/{uuid}/api", &jimmhttp.WSHandler{
 		Upgrader: websocketUpgrader,
-		Server: &apiProxier{apiServer: apiServer{
+		Server: &apiModelProxier{apiServer: apiServer{
 			jimm: jimm,
 		}},
 	})
 	mux.Handle("/{uuid}/log", &jimmhttp.WSHandler{
 		Upgrader: websocketUpgrader,
-		Server: &streamProxier{apiServer: apiServer{
+		Server: &streamModelProxier{apiServer: apiServer{
 			jimm: jimm,
 		}},
 	})
 	return mux
+}
+
+func LogTransferHandler(ctx context.Context, jimm *jimm.JIMM, p Params) http.Handler {
+	return &jimmhttp.WSHandler{
+		Upgrader: websocketUpgrader,
+		Server: &streamControllerProxier{apiServer: apiServer{
+			jimm: jimm,
+		}},
+	}
 }

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Canonical.
+
+package jujuapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+
+	"github.com/canonical/jimm/v3/internal/auth"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimmhttp"
+	"github.com/canonical/jimm/v3/internal/streamproxy"
+)
+
+const (
+	logTransferPath = "/migrate/logtransfer"
+)
+
+// streamControllerProxier serves any HTTP endpoints
+// served against a controller's root address rather than
+// a model specific path segment i.e. /model/{uuid}/*.
+// Messages are handled by proxying them between the
+// controller and client.
+type streamControllerProxier struct {
+	apiServer
+}
+
+// Authenticate implements WSServer.Authenticate
+// It attempts to perform basic auth and will return an unauthorized error if auth fails.
+func (s streamControllerProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
+	_, password, ok := req.BasicAuth()
+	if !ok {
+		return ctx, errors.E(errors.CodeUnauthorized, "authentication missing")
+	}
+	jwtToken, err := s.jimm.OAuthAuthenticator.VerifySessionToken(password)
+	if err != nil {
+		return ctx, errors.E(errors.CodeUnauthorized, err)
+	}
+	email := jwtToken.Subject()
+	ctx = auth.ContextWithSessionIdentity(ctx, email)
+	return ctx, nil
+}
+
+// ServeWS implements jimmhttp.WSServer.
+//
+// Currently the only endpoint we handle is /migrate/logtransfer for transferring
+// logs after a model was successfully migrated.
+// We expect the model UUID to be in the context, set by the http handler.
+// If other handlers are added in the future, we may need to differentiate
+// them and adjust the logic based on the path or some other criteria.
+func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
+	writeError := func(msg string, code errors.Code) {
+		var errResult jujuparams.ErrorResult
+		errResult.Error = &jujuparams.Error{
+			Message: msg,
+			Code:    string(code),
+		}
+		err := clientConn.WriteJSON(errResult)
+		if err != nil {
+			zapctx.Error(ctx, "failed to write error message to client", zap.Error(err), zap.Any("client message", errResult))
+		}
+	}
+
+	user, err := s.jimm.LoginManager().UserLogin(ctx, auth.SessionIdentityFromContext(ctx))
+	if err != nil {
+		zapctx.Error(ctx, "user login error", zap.Error(err))
+		writeError(err.Error(), errors.CodeUnauthorized)
+		return
+	}
+
+	if !user.JimmAdmin {
+		writeError("unauthorized", errors.CodeUnauthorized)
+		return
+	}
+
+	// Note that by the time we reach log transfer, the model has been "activated"
+	// meaning that we have removed the model from the IncomingModelMigration table as
+	// migration was successful and we can now treat the UUID as one for a regular model.
+	modelUUID := jimmhttp.MigratingModelUUIDFromContext(ctx)
+	model, err := s.jimm.JujuManager().GetModel(ctx, modelUUID)
+	if err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			zapctx.Error(ctx, "model not found", zap.String("modelUUID", modelUUID))
+			writeError(fmt.Sprintf("model %q not found", modelUUID), errors.CodeModelNotFound)
+			return
+		}
+		zapctx.Error(ctx, "failed to get model", zap.Error(err), zap.String("modelUUID", modelUUID))
+		writeError(fmt.Sprintf("failed to get model: %s", err.Error()), errors.CodeServerError)
+		return
+	}
+
+	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil, nil)
+	if err != nil {
+		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
+		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)
+		return
+	}
+	defer api.Close()
+
+	headers := http.Header{
+		jujuparams.MigrationModelHTTPHeader: []string{modelUUID},
+		jujuparams.JujuClientVersion:        []string{jimmhttp.ClientVersionFromContext(ctx)},
+	}
+
+	controllerStream, err := api.ConnectControllerStream(logTransferPath, nil, headers)
+	if err != nil {
+		zapctx.Error(ctx, "failed to connect stream", zap.Error(err))
+		writeError(fmt.Sprintf("failed to connect stream: %s", err.Error()), errors.CodeConnectionFailed)
+		return
+	}
+
+	streamproxy.ProxyStreams(ctx, clientConn, controllerStream)
+}

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/streamproxy"
 )
@@ -29,7 +30,7 @@ const (
 // Messages are handled by proxying them between the
 // controller and client.
 type streamControllerProxier struct {
-	apiServer
+	jimm *jimm.JIMM
 }
 
 // Authenticate implements WSServer.Authenticate

--- a/internal/jujuapi/streamcontrollerproxy_test.go
+++ b/internal/jujuapi/streamcontrollerproxy_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Canonical.
+
+package jujuapi_test
+
+import (
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/controller/migrationtarget"
+	gc "gopkg.in/check.v1"
+)
+
+type logTransferProxySuite struct {
+	websocketSuite
+}
+
+var _ = gc.Suite(&logTransferProxySuite{})
+
+func (s *logTransferProxySuite) TestImportLogs(c *gc.C) {
+	conn := s.open(c, &api.Info{}, s.AdminUser.Name)
+	defer conn.Close()
+	client := migrationtarget.NewClient(conn)
+	_, err := client.OpenLogTransferStream(s.Model.UUID.String)
+	c.Assert(err, gc.IsNil)
+}
+
+// TestImportLogsError tests that an error is returned when
+// a user is not a JIMM admin.
+func (s *logTransferProxySuite) TestImportLogsError(c *gc.C) {
+	conn := s.open(c, &api.Info{}, s.AdminUser.Name)
+	defer conn.Close()
+	client := migrationtarget.NewClient(conn)
+	_, err := client.OpenLogTransferStream(s.Model.UUID.String)
+	c.Assert(err, gc.IsNil)
+}

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -45,6 +45,10 @@ func (s streamModelProxier) Authenticate(ctx context.Context, w http.ResponseWri
 }
 
 // ServeWS implements jimmhttp.WSServer.
+//
+// This endpoint serves any /model/{uuid}/* endpoint by proxying messages
+// between the controller and client. Most notably used for the /model/{uuid}/log
+// endpoint for streaming model logs from the controller to the client.
 func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
 	writeError := func(msg string, code errors.Code) {
 		var errResult jujuparams.ErrorResult

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -20,17 +20,17 @@ import (
 	"github.com/canonical/jimm/v3/internal/streamproxy"
 )
 
-// A streamProxier serves the the /log endpoint by proxying
+// A streamModelProxier serves any /model/{uuid}/* endpoint by proxying
 // messages between the controller and client.
-type streamProxier struct {
-	// TODO(Kian): Refactor the apiServer to use the JIMM API rather than a concrete struct
+type streamModelProxier struct {
+	// TODO(Kian): Refactor the apiServer to use an interface rather than a concrete struct
 	// then we can write unit tests for the stream proxier.
 	apiServer
 }
 
-// Authenticate implements WSServer.Authenticate
+// Authenticate implements WSServer.Authenticate.
 // It attempts to perform basic auth and will return an unauthorized error if auth fails.
-func (s streamProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
+func (s streamModelProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	_, password, ok := req.BasicAuth()
 	if !ok {
 		return ctx, errors.E(errors.CodeUnauthorized, "authentication missing")
@@ -45,7 +45,7 @@ func (s streamProxier) Authenticate(ctx context.Context, w http.ResponseWriter, 
 }
 
 // ServeWS implements jimmhttp.WSServer.
-func (s streamProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
+func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
 	writeError := func(msg string, code errors.Code) {
 		var errResult jujuparams.ErrorResult
 		errResult.Error = &jujuparams.Error{
@@ -65,7 +65,7 @@ func (s streamProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) 
 		return
 	}
 
-	uuid, finalPath, err := modelInfoFromPath(jimmhttp.PathElementFromContext(ctx, "path"))
+	uuid, finalPath, err := modelInfoFromPath(jimmhttp.PathElementFromContext(ctx))
 	if err != nil {
 		zapctx.Error(ctx, "error parsing path", zap.Error(err))
 		writeError(fmt.Sprintf("error parsing path: %s", err.Error()), errors.CodeBadRequest)

--- a/internal/jujuapi/streammodelproxy_test.go
+++ b/internal/jujuapi/streammodelproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -139,9 +139,9 @@ func mapError(err error) *jujuparams.Error {
 	}
 }
 
-// apiProxier serves the /commands and /api server for a model by
+// apiModelProxier serves the /commands and /api server for a model by
 // proxying all requests through to the controller.
-type apiProxier struct {
+type apiModelProxier struct {
 	apiServer
 }
 
@@ -173,7 +173,7 @@ func modelInfoFromPath(path string) (uuid string, finalPath string, err error) {
 // ServeWS implements jimmhttp.WSServer.
 // We act as a proxier, handling auth on requests before forwarding the
 // requests to the appropriate Juju controller.
-func (s apiProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
+func (s apiModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
 	jwtGenerator := s.jimm.NewJujuAuthenticator()
 	connectionFunc := controllerConnectionFunc(s, &jwtGenerator)
 	zapctx.Debug(ctx, "Starting proxier")
@@ -194,10 +194,10 @@ func (s apiProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
 
 // controllerConnectionFunc returns a function that will be used to
 // connect to a controller when a client makes a request.
-func controllerConnectionFunc(s apiProxier, jwtGenerator *jujuauth.LoginTokenGenerator) func(context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
+func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTokenGenerator) func(context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
 	return func(ctx context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
 		const op = errors.Op("proxy.controllerConnectionFunc")
-		path := jimmhttp.PathElementFromContext(ctx, "path")
+		path := jimmhttp.PathElementFromContext(ctx)
 		zapctx.Debug(ctx, "grabbing model info from path", zap.String("path", path))
 		uuid, finalPath, err := modelInfoFromPath(path)
 		if err != nil {

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -69,6 +69,7 @@ func (s *websocketSuite) SetUpTest(c *gc.C) {
 	mux.Handle("/model/*", http.StripPrefix("/model", jujuapi.ModelHandler(ctx, s.JIMM, s.Params)))
 	jwks := jimmhttp.NewWellKnownHandler(s.JIMM.CredentialStore)
 	mux.HandleFunc("/.well-known/jwks.json", jwks.JWKS)
+	mux.Handle("/migrate/logtransfer", jujuapi.LogTransferHandler(ctx, s.JIMM, s.Params))
 
 	s.APIHandler = mux
 	s.HTTP = httptest.NewTLSServer(s.APIHandler)

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -362,6 +362,25 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 // values are used as URL query values when making the initial
 // HTTP request. Headers passed in will be added to the HTTP
 // request.
-func (c *Connection) ConnectControllerStream(path string, attrs url.Values, headers http.Header) (base.Stream, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extraHeaders http.Header) (base.Stream, error) {
+	const op = errors.Op("jujuclient.ConnectControllerStream")
+
+	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	header := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
+	for key, vals := range extraHeaders {
+		for _, val := range vals {
+			header.Add(key, val)
+		}
+	}
+
+	conn, err := rpc.Dial(c.ctx, c.ctl, names.ModelTag{}, path, header)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	return conn, nil
 }

--- a/internal/jujuclient/dial_test.go
+++ b/internal/jujuclient/dial_test.go
@@ -117,3 +117,35 @@ func (s *dialSuite) TestDialWithJWT(c *gc.C) {
 	}
 	c.Check(addrs, gc.DeepEquals, info.Addrs)
 }
+
+// TestConnectStreams tests the ConnectStream and ConnectControllerStream methods
+// of our Juju dialer. It verifies that we can connect to valid endpoints
+// on a Juju controller, and that invalid endpoints return errors.
+func (s *dialSuite) TestConnectStreams(c *gc.C) {
+	ctl := dbmodel.Controller{
+		UUID: s.ControllerConfig.ControllerUUID(),
+	}
+	err := s.JIMM.Database.GetController(context.Background(), &ctl)
+	c.Assert(err, gc.IsNil)
+	api, err := s.Dialer.Dial(context.Background(), &ctl, s.Model.ModelTag(), nil, nil)
+	c.Assert(err, gc.IsNil)
+	defer api.Close()
+
+	// Connect to the model stream for a valid endpoint
+	modelStream, err := api.ConnectStream("/log", nil)
+	c.Assert(err, gc.IsNil)
+	defer modelStream.Close()
+
+	// Connect to the model stream for an invalid endpoint
+	_, err = api.ConnectStream("/log2", nil)
+	c.Assert(err, gc.NotNil)
+
+	// Connect to the controller stream for a valid endpoint
+	controllerStream, err := api.ConnectControllerStream("/migrate/logtransfer", nil, nil)
+	c.Assert(err, gc.IsNil)
+	defer controllerStream.Close()
+
+	// Connect to the controller stream for an invalid endpoint
+	_, err = api.ConnectControllerStream("/migrate/logtransfer2", nil, nil)
+	c.Assert(err, gc.NotNil)
+}


### PR DESCRIPTION
## Description
This PR builds on #1621.

This PR implements a websocket handler at `/migrate/logtransfer` that is used during model migration to transfer the model logs to a new controller. In JIMM, we authenticate that the incoming user is a controller superuser and that a model exists for the specified model UUID. Then we connect to the target controller and proxy the websocket messages between the source and target controller.

Fixes [JUJU-8122](https://warthogs.atlassian.net/browse/JUJU-8122)

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8122]: https://warthogs.atlassian.net/browse/JUJU-8122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ