### PR TITLE
feat: add multi-backend transport implementation

### DIFF
--- a/internal/rpc/export_test.go
+++ b/internal/rpc/export_test.go
@@ -2,4 +2,14 @@
 
 package rpc
 
+import (
+	"net/http"
+	"net/url"
+)
+
 type Message = message
+type MultiBackendTransport = multiBackendTransport
+
+func NewMultiBackendTransport(transport http.RoundTripper, urls []*url.URL) (*MultiBackendTransport, error) {
+	return newMultiBackendTransport(transport, urls)
+}

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -8,7 +8,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -43,6 +43,13 @@ func ProxyHTTP(ctx context.Context, ctl juju.ControllerConnectionDetails, w http
 		return
 	}
 
+	// Shuffle for initial load balancing
+	if len(urls) > 1 {
+		rand.Shuffle(len(urls), func(i, j int) {
+			urls[i], urls[j] = urls[j], urls[i]
+		})
+	}
+
 	var tlsConfig *tls.Config
 	if ctl.CACertificate != "" {
 		cp := x509.NewCertPool()
@@ -57,25 +64,25 @@ func ProxyHTTP(ctx context.Context, ctl juju.ControllerConnectionDetails, w http
 		}
 	}
 
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = tlsConfig
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.TLSClientConfig = tlsConfig
 
-	if len(urls) > 1 {
-		rand.Shuffle(len(urls), func(i, j int) {
-			urls[i], urls[j] = urls[j], urls[i]
-		})
+	// Create custom transport that handles multiple backends
+	multiBackendTransport, err := newMultiBackendTransport(baseTransport, urls)
+	if err != nil {
+		zapctx.Error(ctx, "failed to create multiBackendTransport", zap.Error(err))
+		http.Error(w, fmt.Sprintf("failed to create multiBackendTransport: %v", err), http.StatusInternalServerError)
+		return
 	}
 
-	// TODO: Consider implementing a better load balancing mechanism that handles
-	// multiples URLs and handles failing backends gracefully e.g. try send to first
-	// URL and on failure, try second, etc.
 	adminUsername := names.NewUserTag(ctl.Credentials.AdminIdentityName).String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(urls[0])
+			// The multiBackendTransport will handle URL selection and failover
+			// We just need to set up basic auth here
 			pr.Out.SetBasicAuth(adminUsername, ctl.Credentials.AdminPassword)
 		},
-		Transport: transport,
+		Transport: multiBackendTransport,
 		ErrorLog:  log.New(&proxyErrorLogger{}, "", 0), // flag=0 to avoid printing extra info that zap already gives us
 	}
 	proxy.ServeHTTP(w, req)

--- a/internal/rpc/multitransport.go
+++ b/internal/rpc/multitransport.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Canonical.
+
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+)
+
+// multiBackendTransport is a custom HTTP transport that attempts to make requests
+// to multiple backend URLs in succession until one succeeds. It will not
+// continue to retry if a request fails partway through (e.g., if the body
+// was partially read), as we don't store the original request body.
+//
+// Reusing a multiBackendTransport object will ensure that requests
+// are made in a round-robin fashion across the provided URLs.
+//
+// If a new multiBackendTransport is created per request, it will always start
+// from the first URL, so the caller should randomise the list of URLs first.
+type multiBackendTransport struct {
+	// baseTransport is the underlying transport used for actual HTTP requests
+	baseTransport http.RoundTripper
+	// urls contains the list of backend urls to try in order
+	urls []*url.URL
+	// currentURLIndex tracks which URL should be tried next (for round-robin)
+	currentURLIndex int
+}
+
+// RoundTrip implements the http.RoundTripper interface and attempts to make
+// requests to multiple backends in succession.
+func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var lastErr error
+
+	// Try each URL in succession
+	for i := 0; i < len(m.urls); i++ {
+		// Calculate the URL index to try (round-robin starting from currentURLIndex)
+		urlIndex := (m.currentURLIndex + i) % len(m.urls)
+		targetURL := m.urls[urlIndex]
+
+		// Clone the request to avoid modifying the original
+		clonedReq := req.Clone(req.Context())
+		clonedReq.URL.Scheme = targetURL.Scheme
+		clonedReq.URL.Host = targetURL.Host
+		newPath, err := url.JoinPath("/", targetURL.Path, clonedReq.URL.Path)
+		if err != nil {
+			zapctx.Debug(context.Background(), "failed to join URL path", zap.Error(err))
+			lastErr = err
+			continue
+		}
+		clonedReq.URL.Path = newPath
+		clonedReq.Host = targetURL.Host
+
+		// Attempt the request
+		resp, err := m.baseTransport.RoundTrip(clonedReq)
+		if err == nil {
+			// Success - update the current URL index for next time (round-robin)
+			m.currentURLIndex = (urlIndex + 1) % len(m.urls)
+			return resp, nil
+		}
+		if err == io.EOF {
+			// If we hit EOF, it likely means that we failed partway through
+			// the request and without the original body of the request
+			// stored, we cannot safely retry.
+			return nil, errors.New("backend failure during request")
+		}
+
+		// Log the failure and try the next URL
+		zapctx.Debug(context.Background(), "request to backend failed, trying next",
+			zap.String("backend", targetURL.String()),
+			zap.Error(err),
+			zap.Int("attempt", i+1),
+			zap.Int("total_backends", len(m.urls)))
+
+		lastErr = err
+	}
+
+	// All backends failed
+	return nil, fmt.Errorf("all backends failed, last error: %w", lastErr)
+}
+
+// newMultiBackendTransport creates a new MultiBackendTransport with the given
+// base transport and URLs.
+func newMultiBackendTransport(baseTransport http.RoundTripper, urls []*url.URL) (*multiBackendTransport, error) {
+	if len(urls) == 0 {
+		return nil, errors.New("no backend URLs configured")
+	}
+	return &multiBackendTransport{
+		baseTransport: baseTransport,
+		urls:          urls,
+	}, nil
+}

--- a/internal/rpc/multitransport.go
+++ b/internal/rpc/multitransport.go
@@ -33,6 +33,18 @@ type multiBackendTransport struct {
 	currentURLIndex int
 }
 
+// newMultiBackendTransport creates a new MultiBackendTransport with the given
+// base transport and URLs.
+func newMultiBackendTransport(baseTransport http.RoundTripper, urls []*url.URL) (*multiBackendTransport, error) {
+	if len(urls) == 0 {
+		return nil, errors.New("no backend URLs configured")
+	}
+	return &multiBackendTransport{
+		baseTransport: baseTransport,
+		urls:          urls,
+	}, nil
+}
+
 // RoundTrip implements the http.RoundTripper interface and attempts to make
 // requests to multiple backends in succession.
 func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -83,16 +95,4 @@ func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	// All backends failed
 	return nil, fmt.Errorf("all backends failed, last error: %w", lastErr)
-}
-
-// newMultiBackendTransport creates a new MultiBackendTransport with the given
-// base transport and URLs.
-func newMultiBackendTransport(baseTransport http.RoundTripper, urls []*url.URL) (*multiBackendTransport, error) {
-	if len(urls) == 0 {
-		return nil, errors.New("no backend URLs configured")
-	}
-	return &multiBackendTransport{
-		baseTransport: baseTransport,
-		urls:          urls,
-	}, nil
 }

--- a/internal/rpc/multitransport_test.go
+++ b/internal/rpc/multitransport_test.go
@@ -117,9 +117,7 @@ func TestMultiBackendTransport(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			c = qt.New(t)
-
+		c.Run(test.description, func(c *qt.C) {
 			body := strings.NewReader(expectedBody)
 			limitReader := io.LimitReader(body, int64(len(expectedBody))) // Ensure we can only read the data once.
 			req, err := http.NewRequest("POST", test.path, limitReader)

--- a/internal/rpc/multitransport_test.go
+++ b/internal/rpc/multitransport_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Canonical.
+
+package rpc_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/rpc"
+)
+
+// TestMultiBackendTransport tests the multiBackendTransport
+// implementation by simulating various server responses and ensuring
+// that the transport correctly handles them specifically for failover scenarios.
+func TestMultiBackendTransport(t *testing.T) {
+	c := qt.New(t)
+	expectedBody := "this is the request body"
+
+	// Success server
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		if string(res) != expectedBody {
+			http.Error(w, "unexpected request body", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer successServer.Close()
+
+	// Failing server that returns 500
+	failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer failingServer.Close()
+
+	// Server that intentionally panics after a partial read
+	partialReadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 3)
+		n, err := io.ReadFull(r.Body, buf)
+		if err != nil {
+			http.Error(w, "failed to read request body", http.StatusInternalServerError)
+			return
+		}
+		if n != 3 {
+			http.Error(w, "unexpected number of bytes read from request body", http.StatusInternalServerError)
+			return
+		}
+		panic("foo")
+	}))
+	defer partialReadServer.Close()
+
+	successServerURL, err := url.Parse(successServer.URL)
+	c.Assert(err, qt.IsNil)
+
+	failingServerURL, err := url.Parse(failingServer.URL)
+	c.Assert(err, qt.IsNil)
+
+	partialReadServerURL, err := url.Parse(partialReadServer.URL)
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		description    string
+		urls           []*url.URL
+		path           string
+		statusExpected int
+		shouldError    bool
+	}{
+		{
+			description:    "1 working address",
+			urls:           []*url.URL{successServerURL},
+			statusExpected: http.StatusOK,
+		}, {
+			description:    "1 working address on a path segment",
+			path:           "/foo",
+			urls:           []*url.URL{successServerURL},
+			statusExpected: http.StatusOK,
+		}, {
+			description: "2 addresses, first unreachable (connection error), second works",
+			urls: []*url.URL{
+				{Scheme: "http", Host: "unreachable:61213"},
+				successServerURL,
+			},
+			statusExpected: http.StatusOK,
+		}, {
+			description: "2 addresses, first returns HTTP 500 (not a transport failure, so no failover)",
+			urls: []*url.URL{
+				failingServerURL,
+				successServerURL,
+			},
+			statusExpected: http.StatusInternalServerError,
+		}, {
+			description: "multiple addresses fail with connection errors",
+			urls: []*url.URL{
+				{Scheme: "https", Host: "unreachable:61213"},
+				{Scheme: "https", Host: "another-unreachable:61214"},
+			},
+			shouldError: true,
+		}, {
+			description: "server panics after partial read - no retry since request data is lost",
+			urls: []*url.URL{
+				partialReadServerURL,
+				successServerURL,
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			c = qt.New(t)
+
+			body := strings.NewReader(expectedBody)
+			limitReader := io.LimitReader(body, int64(len(expectedBody))) // Ensure we can only read the data once.
+			req, err := http.NewRequest("POST", test.path, limitReader)
+			c.Assert(err, qt.IsNil)
+
+			transport, err := rpc.NewMultiBackendTransport(http.DefaultTransport, test.urls)
+			c.Assert(err, qt.IsNil)
+
+			resp, err := transport.RoundTrip(req)
+			if test.shouldError {
+				c.Assert(err, qt.IsNotNil)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			defer resp.Body.Close()
+			c.Assert(resp.StatusCode, qt.Equals, test.statusExpected)
+		})
+	}
+}
+
+func TestMultiBackendTransport_NoURLs(t *testing.T) {
+	c := qt.New(t)
+
+	// Attempt to create a multiBackendTransport with no URLs should return an error
+	transport, err := rpc.NewMultiBackendTransport(http.DefaultTransport, []*url.URL{})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(transport, qt.IsNil)
+}
+
+// TestMultiBackendTransport_RoundRobin tests the multiBackendTransport
+// implementation specifically for round-robin behavior across multiple backends.
+func TestMultiBackendTransport_RoundRobin(t *testing.T) {
+	c := qt.New(t)
+
+	serverOneCount := atomic.Int32{}
+	serverOne := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverOneCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer serverOne.Close()
+
+	serverTwoCount := atomic.Int32{}
+	serverTwo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverTwoCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer serverTwo.Close()
+
+	serverOneURL, err := url.Parse(serverOne.URL)
+	c.Assert(err, qt.IsNil)
+
+	serverTwoURL, err := url.Parse(serverTwo.URL)
+	c.Assert(err, qt.IsNil)
+
+	req, err := http.NewRequest("POST", "", nil)
+	c.Assert(err, qt.IsNil)
+
+	urls := []*url.URL{serverOneURL, serverTwoURL}
+	transport, err := rpc.NewMultiBackendTransport(http.DefaultTransport, urls)
+	c.Assert(err, qt.IsNil)
+
+	makeRequest := func() {
+		resp, err := transport.RoundTrip(req)
+		c.Assert(err, qt.IsNil)
+		defer resp.Body.Close()
+		c.Assert(resp.StatusCode, qt.Equals, http.StatusOK)
+	}
+
+	makeRequest() // First request should go to serverOne
+	c.Assert(serverOneCount.Load(), qt.Equals, int32(1))
+	c.Assert(serverTwoCount.Load(), qt.Equals, int32(0))
+
+	makeRequest() // Second request should go to serverTwo
+	c.Assert(serverOneCount.Load(), qt.Equals, int32(1))
+	c.Assert(serverTwoCount.Load(), qt.Equals, int32(1))
+
+	makeRequest() // Then back to serverOne
+	c.Assert(serverOneCount.Load(), qt.Equals, int32(2))
+	c.Assert(serverTwoCount.Load(), qt.Equals, int32(1))
+}


### PR DESCRIPTION
## Description
This PR builds on #1621.
This PR introduces a `multiBackendTransport` struct that implements the `http.RoundTripper` interface. It attempts to forward a request to multiple backends in succession with logic to fail early if a request fails partway through. Additionally, the transport will also do round-robin selection of the next backend if the struct is re-used.

I tried to come up with many failure scenarios to cover all the important cases e.g. 2 backends and the first is unreachable, 2 backends and the first fails partway through, etc. Let me know if you can think of anything that is missing.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests