### PR TITLE
feat: implement advisory (none table linked) locks for jimm

### DIFF
--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 )
 
-// LockDI represents a unique identifier for an advisory lock in the database.
+// LockID represents a unique identifier for an advisory lock in the database.
 type LockID int64
 
 const (
@@ -16,7 +16,7 @@ const (
 	ControllerBootstrapLock LockID = iota + 1
 )
 
-// LockAdvisory attempts to acquire an advisory lock with the given ID.
+// lockAdvisory attempts to acquire an advisory lock with the given ID.
 // It returns an error if the lock is already held by another session.
 func (d *Database) lockAdvisory(ctx context.Context, id LockID) error {
 	var success bool
@@ -31,7 +31,7 @@ func (d *Database) lockAdvisory(ctx context.Context, id LockID) error {
 	return nil
 }
 
-// UnlockAdvisory releases an advisory lock with the given ID.
+// unlockAdvisory releases an advisory lock with the given ID.
 // It returns an error if the lock was not held or could not be released.
 func (d *Database) unlockAdvisory(ctx context.Context, id LockID) error {
 	var released bool

--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -18,7 +18,7 @@ const (
 
 // LockAdvisory attempts to acquire an advisory lock with the given ID.
 // It returns an error if the lock is already held by another session.
-func (d *Database) LockAdvisory(ctx context.Context, id LockID) error {
+func (d *Database) lockAdvisory(ctx context.Context, id LockID) error {
 	var success bool
 	err := d.DB.WithContext(ctx).Raw("SELECT pg_try_advisory_lock(?)", id).Scan(&success).Error
 	if err != nil {
@@ -33,7 +33,7 @@ func (d *Database) LockAdvisory(ctx context.Context, id LockID) error {
 
 // UnlockAdvisory releases an advisory lock with the given ID.
 // It returns an error if the lock was not held or could not be released.
-func (d *Database) UnlockAdvisory(ctx context.Context, id LockID) error {
+func (d *Database) unlockAdvisory(ctx context.Context, id LockID) error {
 	var released bool
 
 	err := d.DB.WithContext(ctx).Raw("SELECT pg_advisory_unlock(?)", id).Scan(&released).Error
@@ -46,4 +46,16 @@ func (d *Database) UnlockAdvisory(ctx context.Context, id LockID) error {
 	}
 
 	return nil
+}
+
+// LockBootstrap acquires the advisory lock for controller bootstrap operations.
+// It returns an error if the lock cannot be acquired.
+func (d *Database) LockBootstrap(ctx context.Context) error {
+	return d.lockAdvisory(ctx, ControllerBootstrapLock)
+}
+
+// UnlockBootstrap releases the advisory lock for controller bootstrap operations.
+// It returns an error if the lock was not held or could not be released.
+func (d *Database) UnlockBootstrap(ctx context.Context) error {
+	return d.unlockAdvisory(ctx, ControllerBootstrapLock)
 }

--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -13,7 +13,7 @@ type LockID int64
 
 const (
 	// ControllerBootstrapLock is the advisory lock ID used for controller bootstrap operations.
-	ControllerBootstrapLock LockID = 1001
+	ControllerBootstrapLock LockID = iota + 1
 )
 
 // LockAdvisory attempts to acquire an advisory lock with the given ID.

--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Canonical.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// LockDI represents a unique identifier for an advisory lock in the database.
+type LockID int64
+
+const (
+	// ControllerBootstrapLock is the advisory lock ID used for controller bootstrap operations.
+	ControllerBootstrapLock LockID = 1001
+)
+
+func (d *Database) LockAdvisory(ctx context.Context, id LockID) error {
+	var success bool
+	err := d.DB.WithContext(ctx).Raw("SELECT pg_try_advisory_lock(?)", id).Scan(&success).Error
+	if err != nil {
+		return fmt.Errorf("error acquiring advisory lock: %w", err)
+	}
+	if !success {
+		return errors.New("lock is already held")
+	}
+
+	return nil
+}
+
+func (d *Database) UnlockAdvisory(ctx context.Context, id LockID) error {
+	var released bool
+
+	err := d.DB.WithContext(ctx).Raw("SELECT pg_advisory_unlock(?)", id).Scan(&released).Error
+	if err != nil {
+		return fmt.Errorf("error releasing advisory lock: %w", err)
+	}
+
+	if !released {
+		return errors.New("failed to release lock, it may not have been held")
+	}
+
+	return nil
+}

--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -16,6 +16,8 @@ const (
 	ControllerBootstrapLock LockID = 1001
 )
 
+// LockAdvisory attempts to acquire an advisory lock with the given ID.
+// It returns an error if the lock is already held by another session.
 func (d *Database) LockAdvisory(ctx context.Context, id LockID) error {
 	var success bool
 	err := d.DB.WithContext(ctx).Raw("SELECT pg_try_advisory_lock(?)", id).Scan(&success).Error
@@ -29,6 +31,8 @@ func (d *Database) LockAdvisory(ctx context.Context, id LockID) error {
 	return nil
 }
 
+// UnlockAdvisory releases an advisory lock with the given ID.
+// It returns an error if the lock was not held or could not be released.
 func (d *Database) UnlockAdvisory(ctx context.Context, id LockID) error {
 	var released bool
 

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -15,18 +15,21 @@ import (
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
-type advisoryLocksSuite struct{}
+type advisoryLocksSuite struct {
+	Database *db.Database
+}
+
+func (s *advisoryLocksSuite) Init(c *qt.C) {
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	s.Database = db
+}
 
 func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	ctx := c.Context()
 
-	gdb1, _ := jimmtest.PostgresDBWithDbName(c, time.Now)
-
-	db1 := &db.Database{
-		DB: gdb1,
-	}
-
-	sqldb, err := db1.DB.DB()
+	sqldb, err := s.Database.DB.DB()
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL DB connection"))
 	sqlconn, err := sqldb.Conn(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL connection"))
@@ -40,7 +43,7 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	}
 
 	// Acquire lock in db session 1.
-	err = db1.LockBootstrap(ctx)
+	err = s.Database.LockBootstrap(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock"))
 
 	// Attempt to acquire lock in session 2, should fail.
@@ -53,7 +56,7 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	)
 
 	// Now unlock from session 1 and attempt to acquire in session 2 again.
-	err = db1.UnlockBootstrap(ctx)
+	err = s.Database.UnlockBootstrap(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock"))
 
 	err = db2.LockBootstrap(ctx)

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -20,28 +20,31 @@ type advisoryLocksSuite struct{}
 func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	ctx := c.Context()
 
-	gdb1, dbName := jimmtest.PostgresDBWithDbName(c, time.Now)
-	dsn, _, err := jimmtest.GetTestDBDSN()
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get test DB DSN"))
-
-	dsn.Path = dbName
-	gdb2, err := gorm.Open(postgres.Open(dsn.String()))
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to open second DB connection"))
+	gdb1, _ := jimmtest.PostgresDBWithDbName(c, time.Now)
 
 	db1 := &db.Database{
 		DB: gdb1,
 	}
+
+	sqldb, err := db1.DB.DB()
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL DB connection"))
+	sqlconn, err := sqldb.Conn(ctx)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL connection"))
+	gdb2, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: sqlconn,
+	}))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to open second GORM DB connection"))
 
 	db2 := &db.Database{
 		DB: gdb2,
 	}
 
 	// Acquire lock in db session 1.
-	err = db1.LockAdvisory(ctx, db.ControllerBootstrapLock)
+	err = db1.LockBootstrap(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock"))
 
 	// Attempt to acquire lock in session 2, should fail.
-	err = db2.LockAdvisory(ctx, db.ControllerBootstrapLock)
+	err = db2.LockBootstrap(ctx)
 	c.Assert(
 		err,
 		qt.ErrorMatches,
@@ -50,10 +53,10 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	)
 
 	// Now unlock from session 1 and attempt to acquire in session 2 again.
-	err = db1.UnlockAdvisory(ctx, db.ControllerBootstrapLock)
+	err = db1.UnlockBootstrap(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock"))
 
-	err = db2.LockAdvisory(ctx, db.ControllerBootstrapLock)
+	err = db2.LockBootstrap(ctx)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock in second session"))
 }
 

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Canonical.
+
+package db_test
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	jimmdb "github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type advisoryLocksSuite struct{}
+
+func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
+	ctx := c.Context()
+
+	gdb1, dbName := jimmtest.PostgresDBWithDbName(c, time.Now)
+	dsn, _, err := jimmtest.GetTestDBDSN()
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get test DB DSN"))
+
+	dsn.Path = dbName
+	gdb2, err := gorm.Open(postgres.Open(dsn.String()))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to open second DB connection"))
+
+	db1 := &db.Database{
+		DB: gdb1,
+	}
+
+	db2 := &db.Database{
+		DB: gdb2,
+	}
+
+	// Acquite lock in db session 1.
+	err = db1.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock"))
+
+	// Attempt to acquire lock in session 2, should fail.
+	err = db2.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		"lock is already held",
+		qt.Commentf("Expected lock acquisition to fail in second session"),
+	)
+
+	// Now unlock from session 1 and attempt to acquire in session 2 again.
+	err = db1.UnlockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock"))
+
+	err = db2.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock in second session"))
+}
+
+func TestAdvisoryLocks(t *testing.T) {
+	qtsuite.Run(qt.New(t), &advisoryLocksSuite{})
+}

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -12,7 +12,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/db"
-	jimmdb "github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
@@ -37,12 +36,12 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 		DB: gdb2,
 	}
 
-	// Acquite lock in db session 1.
-	err = db1.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	// Acquire lock in db session 1.
+	err = db1.LockAdvisory(ctx, db.ControllerBootstrapLock)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock"))
 
 	// Attempt to acquire lock in session 2, should fail.
-	err = db2.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	err = db2.LockAdvisory(ctx, db.ControllerBootstrapLock)
 	c.Assert(
 		err,
 		qt.ErrorMatches,
@@ -51,10 +50,10 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	)
 
 	// Now unlock from session 1 and attempt to acquire in session 2 again.
-	err = db1.UnlockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	err = db1.UnlockAdvisory(ctx, db.ControllerBootstrapLock)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock"))
 
-	err = db2.LockAdvisory(ctx, jimmdb.ControllerBootstrapLock)
+	err = db2.LockAdvisory(ctx, db.ControllerBootstrapLock)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock in second session"))
 }
 

--- a/internal/testutils/jimmtest/gorm.go
+++ b/internal/testutils/jimmtest/gorm.go
@@ -159,13 +159,7 @@ func randSeq(n int) string {
 var createDatabaseMutex = sync.Mutex{}
 var deleteDatabaseMutex = sync.Mutex{}
 
-// createDatabaseFromTemplate creates a Postgres database from a given template
-// and returns the created database name (which may be different than the
-// requested name due to sanitization) and DSN.
-// If the database was already exist, it'll be dropped and re-created.
-func createDatabaseFromTemplate(suggestedName string, templateName string) (string, string, error) {
-	databaseName := computeSafeDatabaseName(suggestedName)
-
+func GetTestDBDSN() (*url.URL, string, error) {
 	dsn := defaultDSN
 	if envTestDSN, exists := os.LookupEnv("JIMM_TEST_PGXDSN"); exists {
 		dsn = envTestDSN
@@ -173,7 +167,22 @@ func createDatabaseFromTemplate(suggestedName string, templateName string) (stri
 
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", errors.E("error parsing DSN as a URI: %s", err)
+		return nil, dsn, errors.E("error parsing DSN as a URI: %s", err)
+	}
+
+	return u, dsn, nil
+}
+
+// createDatabaseFromTemplate creates a Postgres database from a given template
+// and returns the created database name (which may be different than the
+// requested name due to sanitization) and DSN.
+// If the database was already exist, it'll be dropped and re-created.
+func createDatabaseFromTemplate(suggestedName string, templateName string) (string, string, error) {
+	databaseName := computeSafeDatabaseName(suggestedName)
+
+	u, dsn, err := GetTestDBDSN()
+	if err != nil {
+		return "", "", err
 	}
 
 	createDatabaseMutex.Lock()

--- a/internal/testutils/jimmtest/gorm.go
+++ b/internal/testutils/jimmtest/gorm.go
@@ -159,20 +159,6 @@ func randSeq(n int) string {
 var createDatabaseMutex = sync.Mutex{}
 var deleteDatabaseMutex = sync.Mutex{}
 
-func GetTestDBDSN() (*url.URL, string, error) {
-	dsn := defaultDSN
-	if envTestDSN, exists := os.LookupEnv("JIMM_TEST_PGXDSN"); exists {
-		dsn = envTestDSN
-	}
-
-	u, err := url.Parse(dsn)
-	if err != nil {
-		return nil, dsn, errors.E("error parsing DSN as a URI: %s", err)
-	}
-
-	return u, dsn, nil
-}
-
 // createDatabaseFromTemplate creates a Postgres database from a given template
 // and returns the created database name (which may be different than the
 // requested name due to sanitization) and DSN.
@@ -180,9 +166,14 @@ func GetTestDBDSN() (*url.URL, string, error) {
 func createDatabaseFromTemplate(suggestedName string, templateName string) (string, string, error) {
 	databaseName := computeSafeDatabaseName(suggestedName)
 
-	u, dsn, err := GetTestDBDSN()
+	dsn := defaultDSN
+	if envTestDSN, exists := os.LookupEnv("JIMM_TEST_PGXDSN"); exists {
+		dsn = envTestDSN
+	}
+
+	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", err
+		return "", "", errors.E("error parsing DSN as a URI: %s", err)
 	}
 
 	createDatabaseMutex.Lock()


### PR DESCRIPTION
Implements advisory locks in JIMM. Has a single const id for bootstrap lock.


See [locks](https://www.postgresql.org/docs/current/explicit-locking.html#There%20are%20two%20ways%20to%20acquire%20an%20advisory%20lock) for usage.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
