### PR TITLE
feat: implement latestLogTime method

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -251,16 +251,20 @@ type JujuManager interface {
 	// ControllerDetailsForIncomingModel retrieves details about the
 	// target controller for a model that is being migrated.
 	ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
-	// The migration methods below are sorted roughly
-	// in the order they are expected to be called.
+
+	// The remaining migration methods below are sorted roughly in the order they are expected to be called.
+	// Please MAINTAIN this order as it is helpful to understand the migration flow and which methods
+	// can use the IncomingModelMigration table versus which must use the plain Models table.
+
 	PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) error
 	Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error
 	CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
-	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
-	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
 	Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error
-	// Other methods
+	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
+	LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error)
+	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
 
+	// Other methods
 	AddCloudToController(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	AddHostedCloud(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	CopyCredential(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error)

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -122,6 +122,10 @@ type API interface {
 	// IsBroken returns true if the API connection has failed.
 	IsBroken() bool
 
+	// LatestLogTime returns the time of the latest log record
+	// seen by the controller for the given model.
+	LatestLogTime(string) (time.Time, error)
+
 	// ListApplicationOffers lists application offers that match the
 	// filter.
 	ListApplicationOffers(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/juju/juju/core/migration"
 	coremigration "github.com/juju/juju/core/migration"
@@ -209,6 +210,35 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 	model.ModelDescription.SetOwner(newOwnerTag)
 	model.ModelDescription.SetUsers(nil) // Clear users with access since JIMM gates access.
 	return nil
+}
+
+// LatestLogTime asks the target controller for the time of the latest
+// log record it has seen.
+func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error) {
+	const op = errors.Op("jimm.LatestLogTime")
+
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err := j.Database.GetModel(ctx, &model)
+	if err != nil {
+		return time.Time{}, errors.E(op, fmt.Errorf("failed to get model %q: %w", modelUUID, err))
+	}
+
+	api, err := j.dialController(ctx, &model.Controller)
+	if err != nil {
+		return time.Time{}, errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+	}
+	defer api.Close()
+
+	t, err := api.LatestLogTime(modelUUID)
+	if err != nil {
+		return time.Time{}, errors.E(op, fmt.Errorf("failed to get latest log time for model %q: %w", modelUUID, err))
+	}
+	return t, nil
 }
 
 // Activate gets the model migration, proxies the Activate call to the target controller,

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/description/v9"
@@ -487,4 +488,65 @@ func newMigrationInfo(owner string) migration.ModelInfo {
 		ModelDescription:       modelDescription,
 	}
 	return modelInfo
+}
+
+const migratedModelEnv = `clouds:
+- name: test-cloud
+  type: test
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+- owner: alice@canonical.com
+  name: cred-1
+  cloud: test-cloud
+controllers:
+- name: test-controller
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: 3.2.1
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: test-controller
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: alice@canonical.com
+  life: alive
+`
+
+func TestLatestLogTime_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	modelUUID := "00000002-0000-0000-0000-000000000001"
+	latestLogTimeCalled := false
+	// Validate that the API request to Juju is made.
+	api := &jimmtest.API{
+		LatestLogTime_: func(s string) (time.Time, error) {
+			latestLogTimeCalled = true
+			c.Check(s, qt.Equals, modelUUID)
+			return time.Now(), nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, migratedModelEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	// Test a model UUID that does not exist
+	_, err := j.LatestLogTime(ctx, "does-not-exist")
+	c.Assert(err, qt.IsNotNil)
+
+	// Test a model UUID that exists
+	logTime, err := j.LatestLogTime(ctx, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(logTime, qt.Not(qt.IsNil))
+	c.Assert(latestLogTimeCalled, qt.IsTrue)
 }

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -5,6 +5,7 @@ package jujuapi
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/juju/description/v9"
 	"github.com/juju/juju/core/migration"
@@ -37,6 +38,7 @@ func init() {
 		caCert := rpc.Method(r.CACert)
 		adoptResources := rpc.Method(r.AdoptResources)
 		checkMachines := rpc.Method(r.CheckMachines)
+		latestLogTime := rpc.Method(r.LatestLogTime)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
@@ -44,6 +46,7 @@ func init() {
 		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
 		r.AddMethod("MigrationTarget", 4, "Abort", adoptResources)
 		r.AddMethod("MigrationTarget", 4, "CheckMachines", checkMachines)
+		r.AddMethod("MigrationTarget", 4, "LatestLogTime", latestLogTime)
 
 		return []int{4}
 	}
@@ -126,6 +129,28 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args params.AdoptRe
 		return errors.E(op, err)
 	}
 	return r.jimm.JujuManager().AdoptResources(ctx, r.user, modelTag.Id(), args.SourceControllerVersion)
+}
+
+// LatestLogTime implements the LatestLogTime method of the MigrationTarget facade.
+// It is used by the source Juju controller to retrieve the time of the
+// latest log record it has seen.
+func (r *controllerRoot) LatestLogTime(ctx context.Context, args params.ModelArgs) (time.Time, error) {
+	const op = errors.Op("jujuapi.LatestLogTime")
+
+	if !r.user.JimmAdmin {
+		return time.Time{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return time.Time{}, errors.E(op, err)
+	}
+
+	t, err := r.jimm.JujuManager().LatestLogTime(ctx, modelTag.Id())
+	if err != nil {
+		return time.Time{}, errors.E(op, err)
+	}
+	return t, nil
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -113,3 +113,12 @@ func (s *migrationTargetSuite) TestActivate(c *gc.C) {
 	err := client.Activate(modelUUID, sourceInfo, relatedModels)
 	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
 }
+
+func (s *migrationTargetSuite) TestLatestLogTime(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	client := migrationtarget.NewClient(conn)
+	_, err := client.LatestLogTime(s.Model.UUID.String)
+	c.Assert(err, gc.IsNil)
+}

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -5,6 +5,7 @@ package jujuapi_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/juju/description/v9"
 	"github.com/juju/juju/core/migration"
@@ -384,4 +385,51 @@ func (s *migrationTargetUnitSuite) TestActivateInvalidControllerTag(c *gc.C) {
 	user.JimmAdmin = true
 	err := cr.Activate(ctx, args)
 	c.Assert(err, gc.ErrorMatches, `"invalid-controller-tag" is not a valid tag`)
+}
+
+func (s *migrationTargetUnitSuite) TestLatestLogTime(c *gc.C) {
+	ctx := context.Background()
+
+	latestLogTimeCalled := false
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			LatestLogTime_: func(ctx context.Context, modelUUID string) (time.Time, error) {
+				latestLogTimeCalled = true
+				c.Check(modelUUID, gc.Equals, "00000001-0000-0000-0000-000000000001")
+				return time.Now(), nil
+			},
+		}}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	args := jujuparams.ModelArgs{}
+
+	// Validate access denied without JIMM admin permissions.
+	_, err := cr.LatestLogTime(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `unauthorized`)
+	c.Assert(latestLogTimeCalled, gc.Equals, false)
+
+	// Validate the latest log time method is not called with an invalid model tag.
+	user.JimmAdmin = true
+	args.ModelTag = "invalid-model-tag"
+	_, err = cr.LatestLogTime(ctx, args)
+	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
+	c.Assert(latestLogTimeCalled, gc.Equals, false)
+
+	// Validate the latest log time method is called when the user is a JIMM admin
+	// with a valid model tag.
+	args.ModelTag = names.NewModelTag("00000001-0000-0000-0000-000000000001").String()
+	logTime, err := cr.LatestLogTime(ctx, args)
+	c.Assert(err, gc.IsNil)
+	c.Assert(logTime, gc.Not(gc.IsNil))
+	c.Assert(latestLogTimeCalled, gc.Equals, true)
 }

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -3,6 +3,8 @@
 package jujuclient
 
 import (
+	"time"
+
 	"github.com/juju/juju/api/controller/migrationtarget"
 	"github.com/juju/juju/core/migration"
 	coremigration "github.com/juju/juju/core/migration"
@@ -53,4 +55,12 @@ func (c Connection) CheckMachines(modelUUID string) ([]error, error) {
 // Activate activates a model on the controller.
 func (c Connection) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
 	return migrationtarget.NewClient(&c).Activate(modelUUID, sourceInfo, relatedModels)
+}
+
+// LatestLogTime asks the target controller for the time of the latest
+// log record it has seen. This can be used to make the log transfer
+// restartable.
+func (c Connection) LatestLogTime(modelUUID string) (time.Time, error) {
+	migrationTarget := migrationtarget.NewClient(&c)
+	return migrationTarget.LatestLogTime(modelUUID)
 }

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -150,6 +150,7 @@ type API struct {
 	GrantJIMMModelAdmin_               func(context.Context, names.ModelTag) error
 	GrantModelAccess_                  func(context.Context, names.ModelTag, names.UserTag, jujuparams.UserAccessPermission) error
 	IsBroken_                          bool
+	LatestLogTime_                     func(string) (time.Time, error)
 	ListApplicationOffers_             func(context.Context, []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
 	ModelInfo_                         func(context.Context, *jujuparams.ModelInfo) error
 	ModelStatus_                       func(context.Context, *jujuparams.ModelStatus) error
@@ -368,6 +369,13 @@ func (a *API) ModelSummaryWatcherStop(ctx context.Context, id string) error {
 		return errors.E(errors.CodeNotImplemented)
 	}
 	return a.ModelSummaryWatcherStop_(ctx, id)
+}
+
+func (a *API) LatestLogTime(modelUUID string) (time.Time, error) {
+	if a.LatestLogTime_ == nil {
+		return time.Time{}, errors.E(errors.CodeNotImplemented)
+	}
+	return a.LatestLogTime_(modelUUID)
 }
 
 func (a *API) ListModelSummaries(ctx context.Context, req jujuparams.ModelSummariesRequest) (jujuparams.ModelSummaryResults, error) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -3,6 +3,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/names/v5"
@@ -18,6 +19,7 @@ type MigrationMocks struct {
 	Activate_       func(ctx context.Context, modelUUID names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error
 	AbortMigration_ func(ctx context.Context, user *openfga.User, modelUUID string) error
 	CheckMachines_  func(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
+	LatestLogTime_  func(ctx context.Context, modelUUID string) (time.Time, error)
 }
 
 func (j *MigrationMocks) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
@@ -53,4 +55,11 @@ func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, 
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
 	return j.CheckMachines_(ctx, user, modelUUID)
+}
+
+func (j *MigrationMocks) LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error) {
+	if j.LatestLogTime_ == nil {
+		return time.Time{}, errors.E(errors.CodeNotImplemented)
+	}
+	return j.LatestLogTime_(ctx, modelUUID)
 }


### PR DESCRIPTION
## Description
This PR implements the `LatestLogTime` facade method on JIMM. The method used by the source controller when transferring model logs. Note that this method is called after `Activate`, when the migration is marked as completed. For that reason, we can no longer refer to the `IncomingModelMigration` table as our implementation of `Activate` cleans up the details for the incoming model. At this point, the model is assumed to exist so we can safely access the models table.

Fixes [JUJU-8090](https://warthogs.atlassian.net/browse/JUJU-8090)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8090]: https://warthogs.atlassian.net/browse/JUJU-8090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ