### PR TITLE
feat: add job tracker db model & methods

### DIFF
--- a/internal/db/advisory_locks.go
+++ b/internal/db/advisory_locks.go
@@ -8,17 +8,20 @@ import (
 	"fmt"
 )
 
-// LockID represents a unique identifier for an advisory lock in the database.
-type LockID int64
+// lockID represents a unique identifier for an advisory lock in the database.
+type lockID int64
 
 const (
-	// ControllerBootstrapLock is the advisory lock ID used for controller bootstrap operations.
-	ControllerBootstrapLock LockID = iota + 1
+	// The following IDs should NEVER under any circumstance be changed.
+	// If changed, thou be in deep trouble from the Git Blame god!
+
+	// controllerBootstrapLock is the advisory lock ID used for controller bootstrap operations.
+	controllerBootstrapLock lockID = iota + 1
 )
 
 // lockAdvisory attempts to acquire an advisory lock with the given ID.
 // It returns an error if the lock is already held by another session.
-func (d *Database) lockAdvisory(ctx context.Context, id LockID) error {
+func (d *Database) lockAdvisory(ctx context.Context, id lockID) error {
 	var success bool
 	err := d.DB.WithContext(ctx).Raw("SELECT pg_try_advisory_lock(?)", id).Scan(&success).Error
 	if err != nil {
@@ -33,7 +36,7 @@ func (d *Database) lockAdvisory(ctx context.Context, id LockID) error {
 
 // unlockAdvisory releases an advisory lock with the given ID.
 // It returns an error if the lock was not held or could not be released.
-func (d *Database) unlockAdvisory(ctx context.Context, id LockID) error {
+func (d *Database) unlockAdvisory(ctx context.Context, id lockID) error {
 	var released bool
 
 	err := d.DB.WithContext(ctx).Raw("SELECT pg_advisory_unlock(?)", id).Scan(&released).Error
@@ -51,11 +54,11 @@ func (d *Database) unlockAdvisory(ctx context.Context, id LockID) error {
 // LockBootstrap acquires the advisory lock for controller bootstrap operations.
 // It returns an error if the lock cannot be acquired.
 func (d *Database) LockBootstrap(ctx context.Context) error {
-	return d.lockAdvisory(ctx, ControllerBootstrapLock)
+	return d.lockAdvisory(ctx, controllerBootstrapLock)
 }
 
 // UnlockBootstrap releases the advisory lock for controller bootstrap operations.
 // It returns an error if the lock was not held or could not be released.
 func (d *Database) UnlockBootstrap(ctx context.Context) error {
-	return d.unlockAdvisory(ctx, ControllerBootstrapLock)
+	return d.unlockAdvisory(ctx, controllerBootstrapLock)
 }

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -30,13 +30,13 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 	ctx := c.Context()
 
 	sqldb, err := s.Database.DB.DB()
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL DB connection"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL DB connection."))
 	sqlconn, err := sqldb.Conn(ctx)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL connection"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to get SQL connection."))
 	gdb2, err := gorm.Open(postgres.New(postgres.Config{
 		Conn: sqlconn,
 	}))
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to open second GORM DB connection"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to open second GORM DB connection."))
 
 	db2 := &db.Database{
 		DB: gdb2,
@@ -44,7 +44,7 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 
 	// Acquire lock in db session 1.
 	err = s.Database.LockBootstrap(ctx)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock."))
 
 	// Attempt to acquire lock in session 2, should fail.
 	err = db2.LockBootstrap(ctx)
@@ -52,15 +52,15 @@ func (s *advisoryLocksSuite) TestAdvisory_LockAndUnlock(c *qt.C) {
 		err,
 		qt.ErrorMatches,
 		"lock is already held",
-		qt.Commentf("Expected lock acquisition to fail in second session"),
+		qt.Commentf("Expected lock acquisition to fail in second session."),
 	)
 
 	// Now unlock from session 1 and attempt to acquire in session 2 again.
 	err = s.Database.UnlockBootstrap(ctx)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to release lock."))
 
 	err = db2.LockBootstrap(ctx)
-	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock in second session"))
+	c.Assert(err, qt.IsNil, qt.Commentf("Failed to acquire lock in second session."))
 }
 
 func TestAdvisoryLocks(t *testing.T) {

--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Canonical.
+
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// AddJob adds a new job to the job tracker.
+// It returns the job ID and an error if the job already exists or if the creation fails
+func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID, err error) {
+	const op = errors.Op("db.AddJob")
+	if err := d.ready(); err != nil {
+		return jobId, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	entry := dbmodel.NewJobTrackerEntry(jobType)
+	if err := db.Create(entry).Error; err != nil {
+		err := dbError(err)
+		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+			zapctx.Debug(ctx, "job already exists", zap.String("jobID", entry.JobID.String()))
+			return jobId, errors.E(op, fmt.Sprintf("job %s already exists", entry.JobID), err)
+		}
+		return jobId, errors.E(op, err)
+	}
+
+	jobId = entry.JobID
+	return jobId, nil
+}
+
+// StopJob marks a job as stopped.
+// It returns an error if the job does not exist or if the update fails.
+func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {
+	const op = errors.Op("db.StopJob")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Model(&dbmodel.JobTrackerEntry{}).Where("job_id = ?", jobId).Update("stop", true).Error; err != nil {
+		return dbError(err)
+	}
+
+	return nil
+}
+
+// SetJobSuccessful sets the job status to successful.
+// It returns an error if the job does not exist or if the update fails.
+func (d *Database) SetJobRunning(ctx context.Context, jobId uuid.UUID) (err error) {
+	entry := dbmodel.JobTrackerEntry{
+		JobID: jobId,
+	}
+	entry.SetRunning()
+	return d.updateJobStatus(ctx, entry)
+}
+
+// SetJobSuccessful sets the job status to successful.
+// It returns an error if the job does not exist or if the update fails.
+func (d *Database) SetJobSuccessful(ctx context.Context, jobId uuid.UUID) (err error) {
+	entry := dbmodel.JobTrackerEntry{
+		JobID: jobId,
+	}
+	entry.SetSuccessful()
+	return d.updateJobStatus(ctx, entry)
+}
+
+// SetJobFailed sets the job status to failed and records the error message.
+// It returns an error if the job does not exist or if the update fails.
+func (d *Database) SetJobFailed(ctx context.Context, jobId uuid.UUID, jobErr error) (err error) {
+	const op = errors.Op("db.SetJobFailed")
+	entry := dbmodel.JobTrackerEntry{
+		JobID: jobId,
+	}
+	if err := entry.SetFailed(jobErr); err != nil {
+		return errors.E(op, err)
+	}
+
+	return d.updateJobStatus(ctx, entry)
+}
+
+func (d *Database) updateJobStatus(ctx context.Context, entry dbmodel.JobTrackerEntry) (err error) {
+	const op = errors.Op("db.updateJobStatus")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Model(&entry).Select("status", "error").Updates(entry).Error; err != nil {
+		return dbError(err)
+	}
+
+	return nil
+}
+
+// GetJobStatus retrieves the status of a job by its ID.
+// It returns the job status and an error if the job does not exist or if the query fails.
+func (d *Database) GetJobStatus(ctx context.Context, jobId uuid.UUID) (status dbmodel.JobStatus, err error) {
+	const op = errors.Op("db.GetJobStatus")
+	if err := d.ready(); err != nil {
+		return status, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	entry := &dbmodel.JobTrackerEntry{}
+	if err := db.First(entry, "job_id = ?", jobId).Error; err != nil {
+		return status, dbError(err)
+	}
+
+	return entry.GetStatus(), nil
+}

--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -29,7 +29,10 @@ func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID,
 
 	db := d.DB.WithContext(ctx)
 
-	entry := dbmodel.NewJobTrackerEntry(jobType)
+	entry, err := dbmodel.NewJobTrackerEntry(jobType)
+	if err != nil {
+		return jobId, errors.E(op, fmt.Sprintf("failed to create new job tracker entry: %v", err))
+	}
 	if err := db.Create(entry).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
@@ -56,8 +59,14 @@ func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	db := d.DB.WithContext(ctx)
-	if err := db.Model(&dbmodel.JobTrackerEntry{}).Where("job_id = ?", jobId).Update("stop", true).Error; err != nil {
+
+	result := db.Model(&dbmodel.JobTrackerEntry{}).Where("job_id = ?", jobId).Update("stop_signal", true)
+	if err := result.Error; err != nil {
 		return dbError(err)
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("job %s not found", jobId))
 	}
 
 	return nil
@@ -70,7 +79,7 @@ func (d *Database) SetJobRunning(ctx context.Context, jobId uuid.UUID) (err erro
 		JobID: jobId,
 	}
 	entry.SetRunning()
-	return d.updateJobStatus(ctx, entry)
+	return d.updateJob(ctx, entry)
 }
 
 // SetJobSuccessful sets the job status to successful.
@@ -80,7 +89,7 @@ func (d *Database) SetJobSuccessful(ctx context.Context, jobId uuid.UUID) (err e
 		JobID: jobId,
 	}
 	entry.SetSuccessful()
-	return d.updateJobStatus(ctx, entry)
+	return d.updateJob(ctx, entry)
 }
 
 // SetJobFailed sets the job status to failed and records the error message.
@@ -94,10 +103,10 @@ func (d *Database) SetJobFailed(ctx context.Context, jobId uuid.UUID, jobErr err
 		return errors.E(op, err)
 	}
 
-	return d.updateJobStatus(ctx, entry)
+	return d.updateJob(ctx, entry)
 }
 
-func (d *Database) updateJobStatus(ctx context.Context, entry dbmodel.JobTrackerEntry) (err error) {
+func (d *Database) updateJob(ctx context.Context, entry dbmodel.JobTrackerEntry) (err error) {
 	const op = errors.Op("db.updateJobStatus")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -108,8 +117,13 @@ func (d *Database) updateJobStatus(ctx context.Context, entry dbmodel.JobTracker
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	db := d.DB.WithContext(ctx)
-	if err := db.Model(&entry).Select("status", "error").Updates(entry).Error; err != nil {
+	result := db.Model(&entry).Select("status", "error").Updates(entry)
+	if err := result.Error; err != nil {
 		return dbError(err)
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("job %s not found", entry.JobID))
 	}
 
 	return nil

--- a/internal/db/job_tracker_test.go
+++ b/internal/db/job_tracker_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
@@ -25,7 +26,7 @@ func (s *dbSuite) TestJobTracker_CreateJob(c *qt.C) {
 	c.Assert(entry.JobID, qt.Equals, jobId)
 	c.Assert(entry.JobType, qt.Equals, "test-job-type")
 	c.Assert(entry.Status, qt.Equals, dbmodel.StatusPending)
-	c.Assert(entry.Stop, qt.IsFalse)
+	c.Assert(entry.StopSignal, qt.IsFalse)
 	c.Assert(entry.Error, qt.Equals, "")
 }
 
@@ -33,6 +34,9 @@ func (s *dbSuite) TestJobTracker_StopJob(c *qt.C) {
 	ctx := c.Context()
 	err := s.Database.Migrate(ctx)
 	c.Assert(err, qt.IsNil)
+
+	err = s.Database.StopJob(ctx, uuid.New())
+	c.Assert(err, qt.ErrorMatches, ".*not found.*")
 
 	jobId, err := s.Database.AddJob(ctx, "test-job-type")
 	c.Assert(err, qt.IsNil)
@@ -44,13 +48,16 @@ func (s *dbSuite) TestJobTracker_StopJob(c *qt.C) {
 	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(entry.Stop, qt.IsTrue)
+	c.Assert(entry.StopSignal, qt.IsTrue)
 }
 
 func (s *dbSuite) TestJobTracker_StatusSetters(c *qt.C) {
 	ctx := c.Context()
 	err := s.Database.Migrate(ctx)
 	c.Assert(err, qt.IsNil)
+
+	err = s.Database.SetJobRunning(ctx, uuid.New())
+	c.Assert(err, qt.ErrorMatches, ".*not found.*")
 
 	jobId, err := s.Database.AddJob(ctx, "test-job-type")
 	c.Assert(err, qt.IsNil)
@@ -94,6 +101,9 @@ func (s *dbSuite) TestJobTracker_GetStatus(c *qt.C) {
 	ctx := c.Context()
 	err := s.Database.Migrate(ctx)
 	c.Assert(err, qt.IsNil)
+
+	_, err = s.Database.GetJobStatus(ctx, uuid.New())
+	c.Assert(err, qt.ErrorMatches, ".*not found.*")
 
 	jobId, err := s.Database.AddJob(ctx, "test-job-type")
 	c.Assert(err, qt.IsNil)

--- a/internal/db/job_tracker_test.go
+++ b/internal/db/job_tracker_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Canonical.
+
+package db_test
+
+import (
+	"errors"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+func (s *dbSuite) TestJobTracker_CreateJob(c *qt.C) {
+	ctx := c.Context()
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	jobId, err := s.Database.AddJob(ctx, "test-job-type")
+	c.Assert(err, qt.IsNil)
+
+	entry := &dbmodel.JobTrackerEntry{}
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(entry.JobID, qt.Equals, jobId)
+	c.Assert(entry.JobType, qt.Equals, "test-job-type")
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusPending)
+	c.Assert(entry.Stop, qt.IsFalse)
+	c.Assert(entry.Error, qt.Equals, "")
+}
+
+func (s *dbSuite) TestJobTracker_StopJob(c *qt.C) {
+	ctx := c.Context()
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	jobId, err := s.Database.AddJob(ctx, "test-job-type")
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.StopJob(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+
+	entry := &dbmodel.JobTrackerEntry{}
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(entry.Stop, qt.IsTrue)
+}
+
+func (s *dbSuite) TestJobTracker_StatusSetters(c *qt.C) {
+	ctx := c.Context()
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	jobId, err := s.Database.AddJob(ctx, "test-job-type")
+	c.Assert(err, qt.IsNil)
+
+	// Pending
+	entry := &dbmodel.JobTrackerEntry{}
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusPending)
+	c.Assert(entry.Error, qt.Equals, "")
+
+	// Failed
+	err = s.Database.SetJobFailed(ctx, jobId, errors.New("test error"))
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusFailed)
+	c.Assert(entry.Error, qt.Equals, "test error")
+
+	// Running
+	err = s.Database.SetJobRunning(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusRunning)
+	c.Assert(entry.Error, qt.Equals, "")
+
+	// Successful
+	err = s.Database.SetJobSuccessful(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+
+	err = s.Database.DB.First(entry, "job_id = ?", jobId).Error
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusSuccessful)
+	c.Assert(entry.Error, qt.Equals, "")
+}
+
+func (s *dbSuite) TestJobTracker_GetStatus(c *qt.C) {
+	ctx := c.Context()
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	jobId, err := s.Database.AddJob(ctx, "test-job-type")
+	c.Assert(err, qt.IsNil)
+
+	status, err := s.Database.GetJobStatus(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.Equals, dbmodel.StatusPending)
+}

--- a/internal/dbmodel/job_tracker.go
+++ b/internal/dbmodel/job_tracker.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Canonical.
+
+package dbmodel
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// JobStatus represents the status of a job in the job tracker.
+// The status can be one of the following:
+// [statusPending], [StatusRunning], [StatusSuccessful], or [statusFailed].
+// It is stored as a custom enum in the database.
+// StatusFailed must be set using the [JobTrackerEntry.SetFailed] method.
+type JobStatus string
+
+const (
+	StatusRunning    JobStatus = "running"
+	StatusSuccessful JobStatus = "successful"
+	StatusPending    JobStatus = "pending"
+	StatusFailed     JobStatus = "failed"
+)
+
+// JobTrackerEntry represents a job that is being tracked within an instance of JIMM.
+type JobTrackerEntry struct {
+	// JobID is the unique identifier for the job. This is not to be set manually, please
+	// use the constructor [NewJobTrackerEntry] instead.
+	JobID uuid.UUID `gorm:"type:uuid;primaryKey"`
+	// JobType is the type of the job, e.g., bootstrap, destroy, etc.
+	JobType string `gorm:"type:varchar(128);not null"`
+	// Stop signals whether the job should be stopped. This is set to true when the job is
+	// requested to be stopped, but it does not mean the job has stopped yet.
+	// This can be determined by the Status field.
+	Stop bool `gorm:"not null;default:false"`
+	// Status holds the current status of the job.
+	Status JobStatus `gorm:"type:job_tracker_status;not null;default:'pending'"`
+	// Error holds any error message associated with the job. Not to be set manually
+	// and will only ever be set if the status is [StatusFailed].
+	Error string `gorm:"type:text"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+}
+
+// NewJobTrackerEntry creates a new JobTrackerEntry with the given jobType.
+// The Status is set to [statusPending] by default.
+// And a new JobID is generated automatically.
+func NewJobTrackerEntry(jobType string) *JobTrackerEntry {
+	return &JobTrackerEntry{
+		JobID:   uuid.New(),
+		JobType: jobType,
+		Status:  StatusPending,
+	}
+}
+
+// SetFailed marks the job as failed and sets the error message.
+func (j *JobTrackerEntry) SetFailed(err error) error {
+	if err == nil {
+		return errors.New("error cannot be nil")
+	}
+
+	j.Error = err.Error()
+	j.Status = StatusFailed
+
+	return nil
+}
+
+// SetRunning marks the job as running.
+func (j *JobTrackerEntry) SetRunning() {
+	j.Error = ""
+	j.Status = StatusRunning
+}
+
+// SetSuccessful marks the job as successful.
+func (j *JobTrackerEntry) SetSuccessful() {
+	j.Error = ""
+	j.Status = StatusSuccessful
+}
+
+// GetStatus returns the current status of the job.
+func (j *JobTrackerEntry) GetStatus() JobStatus {
+	return j.Status
+}

--- a/internal/dbmodel/job_tracker.go
+++ b/internal/dbmodel/job_tracker.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 )
 
 // JobStatus represents the status of a job in the job tracker.
@@ -31,10 +30,10 @@ type JobTrackerEntry struct {
 	JobID uuid.UUID `gorm:"type:uuid;primaryKey"`
 	// JobType is the type of the job, e.g., bootstrap, destroy, etc.
 	JobType string `gorm:"type:varchar(128);not null"`
-	// Stop signals whether the job should be stopped. This is set to true when the job is
+	// StopSignal signals whether the job should be stopped. This is set to true when the job is
 	// requested to be stopped, but it does not mean the job has stopped yet.
 	// This can be determined by the Status field.
-	Stop bool `gorm:"not null;default:false"`
+	StopSignal bool `gorm:"not null;default:false"`
 	// Status holds the current status of the job.
 	Status JobStatus `gorm:"type:job_tracker_status;not null;default:'pending'"`
 	// Error holds any error message associated with the job. Not to be set manually
@@ -43,18 +42,22 @@ type JobTrackerEntry struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 // NewJobTrackerEntry creates a new JobTrackerEntry with the given jobType.
 // The Status is set to [statusPending] by default.
 // And a new JobID is generated automatically.
-func NewJobTrackerEntry(jobType string) *JobTrackerEntry {
+func NewJobTrackerEntry(jobType string) (*JobTrackerEntry, error) {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
 	return &JobTrackerEntry{
-		JobID:   uuid.New(),
+		JobID:   uuid,
 		JobType: jobType,
 		Status:  StatusPending,
-	}
+	}, nil
 }
 
 // SetFailed marks the job as failed and sets the error message.

--- a/internal/dbmodel/job_tracker_test.go
+++ b/internal/dbmodel/job_tracker_test.go
@@ -58,7 +58,11 @@ func (j *jobTrackerSuite) TestJobTracker_CannotSetArbritaryStatus(c *qt.C) {
 func (j *jobTrackerSuite) TestJobTracker_StatusesSetCorrectly(c *qt.C) {
 	entry := dbmodel.JobTrackerEntry{}
 
-	entry.SetFailed(errors.New("test error"))
+	err := entry.SetFailed(nil)
+	c.Assert(err, qt.ErrorMatches, ".*error cannot be nil.*")
+
+	err = entry.SetFailed(errors.New("test error"))
+	c.Assert(err, qt.IsNil)
 	c.Assert(entry.Status, qt.Equals, dbmodel.StatusFailed)
 	c.Assert(entry.Error, qt.Equals, "test error")
 

--- a/internal/dbmodel/job_tracker_test.go
+++ b/internal/dbmodel/job_tracker_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Canonical.
+
+package dbmodel_test
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"gorm.io/gorm"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+type jobTrackerSuite struct {
+	Database *gorm.DB
+}
+
+func (j *jobTrackerSuite) Init(c *qt.C) {
+	j.Database = gormDB(c)
+}
+
+func (j *jobTrackerSuite) TestJobTracker(c *qt.C) {
+	db := j.Database
+
+	badEntry := &dbmodel.JobTrackerEntry{}
+	c.Assert(db.First(badEntry).Error, qt.IsNotNil)
+
+	entry := dbmodel.NewJobTrackerEntry("test-job")
+	c.Assert(db.Create(entry).Error, qt.IsNil)
+
+	c.Assert(entry.Error, qt.Equals, "")
+
+	// Now we set the status, update it, and check the error in a fresh instance.
+	c.Assert(entry.SetFailed(errors.New("test error")), qt.IsNil)
+	c.Assert(db.Save(entry).Error, qt.IsNil)
+
+	entry2 := dbmodel.JobTrackerEntry{JobID: entry.JobID}
+	c.Assert(db.First(&entry2).Error, qt.IsNil)
+	c.Assert(entry2.Status, qt.Equals, dbmodel.StatusFailed)
+	c.Assert(entry2.Error, qt.Equals, "test error")
+}
+
+func (j *jobTrackerSuite) TestJobTracker_CannotSetArbritaryStatus(c *qt.C) {
+	db := j.Database
+
+	badEntry := &dbmodel.JobTrackerEntry{}
+	c.Assert(db.First(badEntry).Error, qt.IsNotNil)
+
+	entry := dbmodel.NewJobTrackerEntry("test-job")
+	c.Assert(db.Create(entry).Error, qt.IsNil)
+
+	entry.Status = "not a real status"
+	c.Assert(db.Save(entry).Error, qt.ErrorMatches, ".*invalid input value for enum job_tracker_status.*")
+}
+
+func (j *jobTrackerSuite) TestJobTracker_StatusesSetCorrectly(c *qt.C) {
+	entry := dbmodel.JobTrackerEntry{}
+
+	entry.SetFailed(errors.New("test error"))
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusFailed)
+	c.Assert(entry.Error, qt.Equals, "test error")
+
+	entry.Error = "some error"
+	entry.SetRunning()
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusRunning)
+	c.Assert(entry.Error, qt.Equals, "")
+
+	entry.Error = "some error"
+	entry.SetSuccessful()
+	c.Assert(entry.Status, qt.Equals, dbmodel.StatusSuccessful)
+	c.Assert(entry.Error, qt.Equals, "")
+
+	entry.Status = dbmodel.StatusPending
+	c.Assert(entry.GetStatus(), qt.Equals, dbmodel.StatusPending)
+}
+
+func TestJobTrackerSuite(t *testing.T) {
+	qtsuite.Run(qt.New(t), &jobTrackerSuite{})
+}

--- a/internal/dbmodel/job_tracker_test.go
+++ b/internal/dbmodel/job_tracker_test.go
@@ -27,7 +27,8 @@ func (j *jobTrackerSuite) TestJobTracker(c *qt.C) {
 	badEntry := &dbmodel.JobTrackerEntry{}
 	c.Assert(db.First(badEntry).Error, qt.IsNotNil)
 
-	entry := dbmodel.NewJobTrackerEntry("test-job")
+	entry, err := dbmodel.NewJobTrackerEntry("test-job")
+	c.Assert(err, qt.IsNil)
 	c.Assert(db.Create(entry).Error, qt.IsNil)
 
 	c.Assert(entry.Error, qt.Equals, "")
@@ -48,7 +49,8 @@ func (j *jobTrackerSuite) TestJobTracker_CannotSetArbritaryStatus(c *qt.C) {
 	badEntry := &dbmodel.JobTrackerEntry{}
 	c.Assert(db.First(badEntry).Error, qt.IsNotNil)
 
-	entry := dbmodel.NewJobTrackerEntry("test-job")
+	entry, err := dbmodel.NewJobTrackerEntry("test-job")
+	c.Assert(err, qt.IsNil)
 	c.Assert(db.Create(entry).Error, qt.IsNil)
 
 	entry.Status = "not a real status"

--- a/internal/dbmodel/sql/postgres/026_job_tracker.up.sql
+++ b/internal/dbmodel/sql/postgres/026_job_tracker.up.sql
@@ -1,0 +1,20 @@
+-- adds tracker status enum and job tracker table
+
+CREATE TYPE job_tracker_status AS ENUM (
+    'pending',
+    'running',
+    'successful',
+    'failed'
+);
+
+CREATE TABLE IF NOT EXISTS job_tracker_entries (
+    job_id UUID PRIMARY KEY,
+    job_type VARCHAR(128) NOT NULL,
+    stop BOOLEAN NOT NULL DEFAULT FALSE,
+    status job_tracker_status NOT NULL DEFAULT 'pending',
+    error TEXT,
+
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
+);

--- a/internal/dbmodel/sql/postgres/026_job_tracker.up.sql
+++ b/internal/dbmodel/sql/postgres/026_job_tracker.up.sql
@@ -10,11 +10,10 @@ CREATE TYPE job_tracker_status AS ENUM (
 CREATE TABLE IF NOT EXISTS job_tracker_entries (
     job_id UUID PRIMARY KEY,
     job_type VARCHAR(128) NOT NULL,
-    stop BOOLEAN NOT NULL DEFAULT FALSE,
+    stop_signal BOOLEAN NOT NULL DEFAULT FALSE,
     status job_tracker_status NOT NULL DEFAULT 'pending',
     error TEXT,
 
     created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
+    updated_at TIMESTAMP
 );


### PR DESCRIPTION
## Description
Adds the db model and methods for the job tracker.

I made slight adjustment away from the spec to the table name to leverage GORMs automatic pluralisation of entry/entries. 

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
N/A
