### PR TITLE
test: enable logging sql by param

### DIFF
--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -29,7 +29,7 @@ import (
 
 func setupTestAuthSvc(ctx context.Context, c *qt.C, expiry time.Duration) (*auth.AuthenticationService, *db.Database, sessions.Store, func()) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	c.Assert(db.Migrate(ctx), qt.IsNil)
 

--- a/internal/db/advisory_locks_test.go
+++ b/internal/db/advisory_locks_test.go
@@ -21,7 +21,7 @@ type advisoryLocksSuite struct {
 
 func (s *advisoryLocksSuite) Init(c *qt.C) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	s.Database = db
 }

--- a/internal/db/pgx_test.go
+++ b/internal/db/pgx_test.go
@@ -77,7 +77,7 @@ func (s *postgresSuite) Init(c *qt.C) {
 
 	cfg := gorm.Config{
 		NowFunc: func() time.Time { return time.Now().UTC().Round(time.Millisecond) },
-		Logger:  logger.NewGormTestLogger(c),
+		Logger:  logger.NewGormTestLogger(c, false),
 	}
 	pCfg := postgres.Config{
 		Conn: sqlDB,

--- a/internal/db/sshkeys_test.go
+++ b/internal/db/sshkeys_test.go
@@ -30,7 +30,7 @@ type sshKeysSuite struct {
 func (s *sshKeysSuite) Init(c *qt.C) {
 	ctx := context.Background()
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	s.Database = db
 	err := s.Database.Migrate(context.Background())

--- a/internal/dbmodel/gorm_test.go
+++ b/internal/dbmodel/gorm_test.go
@@ -17,7 +17,7 @@ import (
 // If any objects are specified the database automatically performs the
 // migrations for those objects.
 func gormDB(t testing.TB) *gorm.DB {
-	database := db.Database{DB: jimmtest.PostgresDB(t, nil)}
+	database := db.Database{DB: jimmtest.PostgresDB(t, nil, false)}
 	err := database.Migrate(context.Background())
 	if err != nil {
 		t.Fail()

--- a/internal/discharger/discharger_test.go
+++ b/internal/discharger/discharger_test.go
@@ -33,7 +33,7 @@ var _ = gc.Suite(&dischargerSuite{})
 
 func (s *dischargerSuite) Init(c *qt.C) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/auditlog/auditlog_test.go
+++ b/internal/jimm/auditlog/auditlog_test.go
@@ -31,7 +31,7 @@ type auditLogManagerSuite struct {
 
 func (s *auditLogManagerSuite) Init(c *qt.C) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/auditlog/cleanup_test.go
+++ b/internal/jimm/auditlog/cleanup_test.go
@@ -23,7 +23,7 @@ func TestAuditLogCleanupServicePurgesLogs(t *testing.T) {
 	ctx := context.Background()
 
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/group/group_test.go
+++ b/internal/jimm/group/group_test.go
@@ -32,7 +32,7 @@ type groupManagerSuite struct {
 
 func (s *groupManagerSuite) Init(c *qt.C) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/identity/identity_test.go
+++ b/internal/jimm/identity/identity_test.go
@@ -28,7 +28,7 @@ type identityManagerSuite struct {
 func (s *identityManagerSuite) Init(c *qt.C) {
 	// Setup DB
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -578,7 +578,7 @@ func TestFillMigrationTarget(t *testing.T) {
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
 			db := &db.Database{
-				DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
+				DB: jimmtest.PostgresDB(c, func() time.Time { return now }, false),
 			}
 			err := db.Migrate(ctx)
 			c.Assert(err, qt.IsNil)

--- a/internal/jimm/juju/juju_test.go
+++ b/internal/jimm/juju/juju_test.go
@@ -32,7 +32,7 @@ func newTestJujuManager(c *qt.C, p *parameters) *juju.JujuManager {
 		p.CrossModelQueryTimeout = time.Second * 5
 	}
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, func() time.Time { return now }),
+		DB: jimmtest.PostgresDB(c, func() time.Time { return now }, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -140,7 +140,7 @@ func TestModelSummaryWatcher(t *testing.T) {
 			w := &juju.Watcher{
 				Pubsub: publisher,
 				Database: &db.Database{
-					DB: jimmtest.PostgresDB(c, nil),
+					DB: jimmtest.PostgresDB(c, nil, false),
 				},
 				Dialer: &jimmtest.Dialer{
 					API: &jimmtest.API{
@@ -223,7 +223,7 @@ func TestWatcherSetsControllerUnavailable(t *testing.T) {
 	controllerUnavailableChannel := make(chan error, 1)
 	w := juju.NewWatcherWithControllerUnavailableChan(
 		&db.Database{
-			DB: jimmtest.PostgresDB(c, nil),
+			DB: jimmtest.PostgresDB(c, nil, false),
 		},
 		&jimmtest.Dialer{
 			Err: errors.E("test error"),
@@ -269,7 +269,7 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 
 	w := juju.Watcher{
 		Database: &db.Database{
-			DB: jimmtest.PostgresDB(c, nil),
+			DB: jimmtest.PostgresDB(c, nil, false),
 		},
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{

--- a/internal/jimm/login/login_test.go
+++ b/internal/jimm/login/login_test.go
@@ -35,7 +35,7 @@ type loginManagerSuite struct {
 func (s *loginManagerSuite) Init(c *qt.C) {
 	// Setup DB
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/offer/authorizer_test.go
+++ b/internal/jimm/offer/authorizer_test.go
@@ -68,7 +68,7 @@ var _ = gc.Suite(&offerAuthorizerSuite{})
 
 func (s *offerAuthorizerSuite) Init(c *qt.C) {
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/permissions/suite_test.go
+++ b/internal/jimm/permissions/suite_test.go
@@ -33,7 +33,7 @@ func (s *permissionManagerSuite) Init(c *qt.C) {
 	ctx := context.Background()
 
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/role/role_test.go
+++ b/internal/jimm/role/role_test.go
@@ -33,7 +33,7 @@ type roleManagerSuite struct {
 func (s *roleManagerSuite) Init(c *qt.C) {
 	// Setup DB
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -86,7 +86,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	// Setup DB
 
 	s.database = &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := s.database.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimm/sshkeys/sshkeys_test.go
+++ b/internal/jimm/sshkeys/sshkeys_test.go
@@ -34,7 +34,7 @@ func (s *sshKeysManagerSuite) Init(c *qt.C) {
 	ctx := context.Background()
 	// Setup DB
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -25,7 +25,7 @@ import (
 func setupDbAndSessionStore(c *qt.C) (*db.Database, sessions.Store) {
 	// Setup db ahead of time so we have access to session store
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	c.Assert(db.Migrate(context.Background()), qt.IsNil)
 

--- a/internal/logger/gormtest_logger.go
+++ b/internal/logger/gormtest_logger.go
@@ -1,4 +1,5 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package logger
 
 import (
@@ -28,7 +29,7 @@ type gormLogger struct {
 
 // NewGormLogger returns a gorm logger.Interface that can be used in a test
 // All output is logged to the test.
-func NewGormTestLogger(t Tester) logger.Interface {
+func NewGormTestLogger(t Tester, logSQL bool) logger.Interface {
 	output := gormTesterZapWriter{t}
 
 	devConfig := zap.NewDevelopmentEncoderConfig()
@@ -42,11 +43,18 @@ func NewGormTestLogger(t Tester) logger.Interface {
 			zap.DebugLevel,
 		))
 	zapctx.Default = logger
-	logSQL, _ := strconv.ParseBool(os.Getenv("JIMM_TEST_LOG_SQL"))
+	shouldLogSQL := false
+	if logSQL {
+		shouldLogSQL = true
+	} else {
+		logSQLEnv, _ := strconv.ParseBool(os.Getenv("JIMM_TEST_LOG_SQL"))
+		shouldLogSQL = logSQLEnv
+	}
+
 	return &gormLogger{
 		t: t,
 		GormLogger: GormLogger{
-			LogSQL: logSQL,
+			LogSQL: shouldLogSQL,
 		},
 	}
 }

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -49,7 +49,7 @@ func (s *sshSuite) Init(c *qt.C) {
 	ctx := context.Background()
 	// Setup DB
 	db := &db.Database{
-		DB: jimmtest.PostgresDB(c, time.Now),
+		DB: jimmtest.PostgresDB(c, time.Now, false),
 	}
 	err := db.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)

--- a/internal/testutils/jimmtest/gorm.go
+++ b/internal/testutils/jimmtest/gorm.go
@@ -39,16 +39,15 @@ type Tester interface {
 // is already-migrated).
 // In cases where you need an entirely empty database, you should use
 // `CreateEmptyDatabase` function in this package.
-func PostgresDB(t Tester, nowFunc func() time.Time) *gorm.DB {
-	db, _ := PostgresDBWithDbName(t, nowFunc)
+func PostgresDB(t Tester, nowFunc func() time.Time, logSQL bool) *gorm.DB {
+	db, _ := PostgresDBWithDbName(t, nowFunc, logSQL)
 	return db
 }
 
 // PostgresDBWithDbName creates a Postgres DB for tests, returning the DB name.
 // Useful for GoCheck tests that don't support a cleanup function and require the DB
 // name for manual cleanup.
-func PostgresDBWithDbName(t Tester, nowFunc func() time.Time) (*gorm.DB, string) {
-
+func PostgresDBWithDbName(t Tester, nowFunc func() time.Time, logSQL bool) (*gorm.DB, string) {
 	wrappedNowFunc := func() time.Time {
 		var now time.Time
 		if nowFunc != nil {
@@ -59,7 +58,7 @@ func PostgresDBWithDbName(t Tester, nowFunc func() time.Time) (*gorm.DB, string)
 		return now.Truncate(time.Microsecond)
 	}
 	cfg := gorm.Config{
-		Logger:  logger.NewGormTestLogger(t),
+		Logger:  logger.NewGormTestLogger(t, logSQL),
 		NowFunc: wrappedNowFunc,
 	}
 

--- a/internal/testutils/jimmtest/jimm.go
+++ b/internal/testutils/jimmtest/jimm.go
@@ -64,7 +64,7 @@ func NewJIMM(t Tester, additionalParameters *jimm.Parameters, options ...Option)
 
 	if p.Database == nil {
 		p.Database = &db.Database{
-			DB: PostgresDB(t, func() time.Time { return now }),
+			DB: PostgresDB(t, func() time.Time { return now }, false),
 		}
 	}
 	if p.CredentialStore == nil {

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -101,7 +101,7 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 		},
 	}
 
-	pgdb, databaseName := PostgresDBWithDbName(gct, nil)
+	pgdb, databaseName := PostgresDBWithDbName(gct, nil, false)
 	s.databaseName = databaseName
 
 	database := &db.Database{


### PR DESCRIPTION

## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->
Allows logging sql per jimmtest.PostgresDB. It overrides the environment variable and can be done per test.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
