### PR TITLE
feat(model): add migration-mode column to model

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -1,10 +1,11 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
 import (
 	"context"
 
+	"github.com/juju/juju/state"
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -250,4 +251,44 @@ func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Cont
 		return 0, errors.E(op, dbError(err))
 	}
 	return int(count), nil
+}
+
+// SetMigrationMode sets the migration mode for a model with the specified UUID.
+func (d *Database) SetMigrationMode(ctx context.Context, model *dbmodel.Model, mode state.MigrationMode) (err error) {
+	const op = errors.Op("db.SetMigrationMode")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	switch {
+	case model.UUID.Valid:
+		db = db.Where("uuid = ?", model.UUID.String)
+	default:
+		return errors.E(op, "missing uuid", errors.CodeBadRequest)
+	}
+	// Check if the model doesn't exist or the current migration mode is already set to the desired value.
+	var currentModel dbmodel.Model
+	if err := db.First(&currentModel).Error; err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.E(op, err, "model not found")
+		}
+		return errors.E(op, dbError(err))
+	}
+	if currentModel.MigrationMode == mode {
+		return nil
+	}
+	db = d.DB.WithContext(ctx)
+	if err := db.Where("uuid = ?", model.UUID.String).Model(model).Update("migration_mode", mode).Error; err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.E(op, err, "model not found")
+		}
+		return errors.E(op, dbError(err))
+	}
+
+	return nil
 }

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -702,3 +702,104 @@ func (s *dbSuite) TestCountModelsByController(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(count, qt.Equals, 3)
 }
+
+const testSetMigrationModeEnv = `clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+cloud-credentials:
+- name: test-cred
+  cloud: test
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: test
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region
+models:
+- name: test-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  owner: alice@canonical.com
+  cloud: test
+  region: test-region
+  cloud-credential: test-cred
+  controller: test
+`
+
+func (s *dbSuite) TestSetMigrationMode(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	env := jimmtest.ParseEnvironment(c, testSetMigrationModeEnv)
+	env.PopulateDB(c, s.Database)
+	modelUUID := env.Models[0].UUID
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+
+	err = s.Database.GetModel(context.Background(), model)
+	c.Assert(err, qt.IsNil)
+
+	modelToChange := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err = s.Database.SetMigrationMode(context.Background(), modelToChange, state.MigrationModeExporting)
+	c.Assert(err, qt.IsNil)
+
+	modelToCompare := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	err = s.Database.GetModel(context.Background(), modelToCompare)
+	c.Assert(err, qt.IsNil)
+	model.MigrationMode = state.MigrationModeExporting
+	c.Check(modelToCompare, jimmtest.DBObjectEquals, model)
+}
+
+func (s *dbSuite) TestSetMigrationModeInvalidModel(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: "00000002-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+	}
+	err = s.Database.SetMigrationMode(context.Background(), model, state.MigrationModeExporting)
+	c.Assert(err, qt.Not(qt.IsNil))
+	eError, ok := err.(*errors.Error)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+}
+
+func (s *dbSuite) TestSetMigrationModeNotValid(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	env := jimmtest.ParseEnvironment(c, testSetMigrationModeEnv)
+	env.PopulateDB(c, s.Database)
+	modelUUID := env.Models[0].UUID
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+
+	err = s.Database.SetMigrationMode(context.Background(), model, "invalid-mode")
+	c.Assert(err, qt.Not(qt.IsNil))
+	eError, ok := err.(*errors.Error)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(eError.Err, qt.ErrorMatches, "^ERROR: invalid input value.*")
+}

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel
 
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/core/life"
 	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -48,6 +49,12 @@ type Model struct {
 
 	// Offers are the ApplicationOffers attached to the model.
 	Offers []ApplicationOffer
+
+	// MigrationMode is the migration mode of the model.
+	// In JIMM it can have two values:
+	// - state.MigrationModeNone: the model is not being migrated.
+	// - state.MigrationModeImporting: the model is being migrated to JIMM.
+	MigrationMode state.MigrationMode `gorm:"default:''"`
 }
 
 // Tag returns a names.Tag for the model.

--- a/internal/dbmodel/model_test.go
+++ b/internal/dbmodel/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package dbmodel_test
 
@@ -162,6 +162,64 @@ func TestModelUniqueConstraint(t *testing.T) {
 	pdb = pdb.Preload("Owner")
 	c.Assert(pdb.First(&m3).Error, qt.IsNil)
 	c.Check(m3, qt.DeepEquals, m1)
+}
+
+func TestModelSetMigrationModeEnumType(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+	cl1, cred1, ctl1, u := initModelEnv(c, db)
+
+	m1 := dbmodel.Model{
+		Name: "staging1",
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		Owner:           u,
+		Controller:      ctl1,
+		CloudRegion:     cl1.Regions[0],
+		CloudCredential: cred1,
+		Life:            state.Alive.String(),
+	}
+	c.Assert(db.Create(&m1).Error, qt.IsNil)
+	// Check default migration mode is set to empty string.
+	m := dbmodel.Model{
+		UUID: m1.UUID,
+	}
+	c.Assert(db.First(&m).Error, qt.IsNil)
+	c.Check(m.MigrationMode, qt.Equals, state.MigrationModeNone)
+
+	// Check that we can set the migration mode to a valid value.
+	m2 := dbmodel.Model{
+		Name: "staging2",
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-0000-000000000002",
+			Valid:  true,
+		},
+		Owner:           u,
+		Controller:      ctl1,
+		CloudRegion:     cl1.Regions[0],
+		CloudCredential: cred1,
+		Life:            state.Alive.String(),
+		MigrationMode:   state.MigrationModeNone,
+	}
+	c.Assert(db.Create(&m2).Error, qt.IsNil)
+
+	// Check migration mode set to a random value is not allowed.
+	m3 := dbmodel.Model{
+		Name: "staging3",
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-0000-000000000003",
+			Valid:  true,
+		},
+		Owner:           u,
+		Controller:      ctl1,
+		CloudRegion:     cl1.Regions[0],
+		CloudCredential: cred1,
+		Life:            state.Alive.String(),
+		MigrationMode:   "random-mode",
+	}
+	c.Assert(db.Create(&m3).Error, qt.ErrorMatches, `.*invalid input value for enum migration_mode_type: "random-mode".*`)
 }
 
 func TestToJujuModel(t *testing.T) {

--- a/internal/dbmodel/sql/postgres/027_migration_mode.up.sql
+++ b/internal/dbmodel/sql/postgres/027_migration_mode.up.sql
@@ -1,0 +1,6 @@
+-- adds migration_mode column to model table.
+-- sets migration_mode to '' for all existing models.
+
+CREATE TYPE migration_mode_type AS ENUM ('', 'exporting', 'importing');
+
+ALTER TABLE models ADD COLUMN IF NOT EXISTS migration_mode migration_mode_type NOT NULL DEFAULT '';

--- a/internal/jimm/juju/model_cleanup.go
+++ b/internal/jimm/juju/model_cleanup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -24,6 +25,10 @@ func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) (err error) {
 	defer durationObserver()
 
 	err = j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
+		// we don't want to delete models that are in the process of being migrated.
+		if m.MigrationMode != state.MigrationModeNone {
+			return nil
+		}
 		api, err := j.dialController(ctx, &m.Controller)
 		if err != nil {
 			zapctx.Error(ctx, fmt.Sprintf("cannot dial controller %s: %s\n", m.Controller.UUID, err))

--- a/internal/jimm/juju/model_cleanup_test.go
+++ b/internal/jimm/juju/model_cleanup_test.go
@@ -70,6 +70,7 @@ models:
   cloud-credential: cred-1
   owner: alice@canonical.com
   life: alive
+  migration-mode: importing
   users:
   - user: alice@canonical.com
     access: admin
@@ -97,9 +98,10 @@ func (s *modelCleanupSuite) Init(c *qt.C) {
 
 	s.env = jimmtest.ParseEnvironment(c, modelPollerTestEnv)
 	s.env.PopulateDBAndPermissions(c, s.jujuManager.ResourceTag(), s.jujuManager.Database, s.jujuManager.OpenFGAClient)
+
 }
 
-func (s *modelCleanupSuite) TestPollModelsDying(c *qt.C) {
+func (s *modelCleanupSuite) TestModelCleanup(c *qt.C) {
 	ctx := context.Background()
 
 	s.jujuManager.Dialer = &jimmtest.Dialer{
@@ -109,6 +111,9 @@ func (s *modelCleanupSuite) TestPollModelsDying(c *qt.C) {
 				case s.env.Models[0].UUID:
 					return errors.E(errors.CodeNotFound)
 				case s.env.Models[1].UUID:
+					return nil
+				case s.env.Models[2].UUID:
+					c.Fatalf("unexpected call to ModelInfo_ for model %s", mi.UUID)
 					return nil
 				default:
 					return errors.E("new error")

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -10,6 +10,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
 	"sigs.k8s.io/yaml"
 
@@ -471,6 +472,7 @@ type Model struct {
 	Type          string                   `json:"type"`
 	DefaultSeries string                   `json:"default-series"`
 	Life          string                   `json:"life"`
+	MigrationMode state.MigrationMode      `json:"migration-mode"`
 	Status        jujuparams.EntityStatus  `json:"status"`
 	SLA           *jujuparams.ModelSLAInfo `json:"sla"`
 	AgentVersion  string                   `json:"agent-version"`
@@ -504,6 +506,7 @@ func (m *Model) DBObject(c Tester, db *db.Database) dbmodel.Model {
 	m.dbo.CloudCredential = m.env.CloudCredential(m.Owner, m.Cloud, m.CloudCredential).DBObject(c, db)
 
 	m.dbo.Life = m.Life
+	m.dbo.MigrationMode = m.MigrationMode
 
 	err := db.AddModel(context.Background(), &m.dbo)
 	if err != nil {


### PR DESCRIPTION
## Description

migration-mode tracks the state of a model being migrated. It is set during the `Import` facade, and it is checked in our cleanup routine to make sure not to delete migrating models if they are not found in the target controller.

## Note

Set a default for a column does this:
"""
From PostgreSQL 11, adding a column with a constant default value no longer means that each row of the table needs to be updated when the ALTER TABLE statement is executed. Instead, the default value will be returned the next time the row is accessed, and applied when the table is rewritten, making the ALTER TABLE very fast even on large tables.
"""

[doc](https://www.postgresql.org/docs/current/ddl-alter.html#:~:text=5.-,Changing%20a%20Column's%20Default%20Value,default%20for%20future%20INSERT%20commands.)