### PR TITLE
feat: implements a jobtracker package

### DIFF
--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -60,7 +60,7 @@ func (d *Database) GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopS
 
 	db := d.DB.WithContext(ctx)
 	var entry dbmodel.JobTrackerEntry
-	if err := db.Select("stop_signal").First(&entry, "job_id = ?", jobId).Error; err != nil {
+	if err := db.Select("stop_signal").Where("job_id = ?", jobId).First(&entry).Error; err != nil {
 		return false, dbError(err)
 	}
 
@@ -164,7 +164,7 @@ func (d *Database) GetJobStatus(ctx context.Context, jobId uuid.UUID) (status db
 
 	db := d.DB.WithContext(ctx)
 	entry := &dbmodel.JobTrackerEntry{}
-	if err := db.First(entry, "job_id = ?", jobId).Error; err != nil {
+	if err := db.Where("job_id = ?", jobId).First(entry).Error; err != nil {
 		return status, dbError(err)
 	}
 

--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -46,6 +46,27 @@ func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID,
 	return jobId, nil
 }
 
+// GetJobStopSignal retrieves the stop signal for a job by its ID.
+// It returns true if the stop signal is set, false otherwise, and an error if the job does not exist or if the query fails.
+func (d *Database) GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopSignal bool, err error) {
+	const op = errors.Op("db.GetJobStopSignal")
+	if err := d.ready(); err != nil {
+		return false, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	var entry dbmodel.JobTrackerEntry
+	if err := db.Select("stop_signal").First(&entry, "job_id = ?", jobId).Error; err != nil {
+		return false, dbError(err)
+	}
+
+	return entry.StopSignal, nil
+}
+
 // StopJob marks a job as stopped.
 // It returns an error if the job does not exist or if the update fails.
 func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {

--- a/internal/db/job_tracker_test.go
+++ b/internal/db/job_tracker_test.go
@@ -30,6 +30,32 @@ func (s *dbSuite) TestJobTracker_CreateJob(c *qt.C) {
 	c.Assert(entry.Error, qt.Equals, "")
 }
 
+func (s *dbSuite) TestJobTracker_GetJobStopSignal(c *qt.C) {
+	ctx := c.Context()
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	_, err = s.Database.GetJobStopSignal(ctx, uuid.New())
+	c.Assert(err, qt.ErrorMatches, ".*not found.*")
+
+	jobId, err := s.Database.AddJob(ctx, "test-job-type")
+	c.Assert(err, qt.IsNil)
+
+	// By default, stop signal should be false
+	stopSignal, err := s.Database.GetJobStopSignal(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stopSignal, qt.IsFalse)
+
+	// Set stop signal
+	err = s.Database.StopJob(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+
+	// Now stop signal should be true
+	stopSignal, err = s.Database.GetJobStopSignal(ctx, jobId)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stopSignal, qt.IsTrue)
+}
+
 func (s *dbSuite) TestJobTracker_StopJob(c *qt.C) {
 	ctx := c.Context()
 	err := s.Database.Migrate(ctx)

--- a/internal/db/job_tracker_test.go
+++ b/internal/db/job_tracker_test.go
@@ -32,7 +32,10 @@ func (s *dbSuite) TestJobTracker_CreateJob(c *qt.C) {
 
 func (s *dbSuite) TestJobTracker_GetJobStopSignal(c *qt.C) {
 	ctx := c.Context()
-	err := s.Database.Migrate(ctx)
+	_, err := s.Database.GetJobStopSignal(ctx, uuid.New())
+	c.Assert(err, qt.ErrorMatches, "upgrade in progress")
+
+	err = s.Database.Migrate(ctx)
 	c.Assert(err, qt.IsNil)
 
 	_, err = s.Database.GetJobStopSignal(ctx, uuid.New())

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -38,20 +38,20 @@ type Tracker struct {
 // NewJobTracker creates and returns a new Tracker instance using the provided JobTrackerStore and stopInterval.
 // It returns an error if the store is nil or if stopInterval is not greater than zero.
 func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
-	tracker := &Tracker{}
 	if store == nil {
-		return tracker, errors.New("store cannot be nil")
+		return nil, errors.New("store cannot be nil")
 	}
 	if stopInterval <= 0 {
-		return tracker, errors.New("stopInterval must be greater than zero")
+		return nil, errors.New("stopInterval must be greater than zero")
 	}
-	tracker.stopInterval = stopInterval
-	tracker.store = store
 
-	return tracker, nil
+	return &Tracker{
+		stopInterval: stopInterval,
+		store:        store,
+	}, nil
 }
 
-// Run runs a new job and reurns the job ID.
+// Run runs a new job and returns the job ID.
 func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
 	jobId, err := j.store.AddJob(ctx, jobType)
 	if err != nil {
@@ -63,7 +63,7 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 	return jobId, nil
 }
 
-// handleJob runs a job with a given context, job ID, polling interval, and deadline.
+// handleJob runs a job with a given context, job ID, and deadline.
 // It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
 // and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
 // is updated as running, successful, or failed based on its result or context expiration.

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -56,7 +56,7 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 		return jobId, err
 	}
 
-	// no context is passed to handleJob as this is a background
+	// No context is passed to handleJob as this is a background
 	// job and is not tied to the request context.
 	go j.handleJob(jobId, maxDuration, job)
 
@@ -83,7 +83,6 @@ func (j *Tracker) handleJob(
 }
 
 func (j *Tracker) runJob(ctx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
-
 	if err := j.store.SetJobRunning(ctx, id); err != nil {
 		jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
 		return

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -39,7 +39,7 @@ func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
 	if store == nil {
 		return nil, errors.New("store cannot be nil")
 	}
-	if stopInterval <= 0 {
+	if stopInterval <= 4 {
 		return nil, errors.New("stopInterval must be greater than zero")
 	}
 
@@ -50,13 +50,14 @@ func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
 }
 
 // Run runs a new job and returns the job ID.
-func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
-	jobId, err := j.store.AddJob(ctx, jobType)
+func (j *Tracker) Run(jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
+	parentCtx := context.Background()
+	jobId, err := j.store.AddJob(parentCtx, jobType)
 	if err != nil {
 		return jobId, err
 	}
 
-	go j.handleJob(ctx, jobId, maxDuration, job)
+	go j.handleJob(parentCtx, jobId, maxDuration, job)
 
 	return jobId, nil
 }
@@ -68,18 +69,18 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 // If a stop signal is received or the context is canceled or times out, the job is marked as failed.
 // Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
 func (j *Tracker) handleJob(
-	ctx context.Context,
+	parentCtx context.Context,
 	id uuid.UUID,
 	maxDuration time.Duration,
 	job func(ctx context.Context) error,
 ) {
-	jobCtx, cancelJob := context.WithTimeout(ctx, maxDuration)
+	jobCtx, cancelJob := context.WithTimeout(parentCtx, maxDuration)
 	defer cancelJob()
 
 	jobErrCh := make(chan error)
 
-	go j.runJob(ctx, jobCtx, id, jobErrCh, job)
-	j.monitorJob(ctx, jobCtx, id, jobErrCh, cancelJob)
+	go j.runJob(parentCtx, jobCtx, id, jobErrCh, job)
+	j.monitorJob(parentCtx, jobCtx, id, jobErrCh, cancelJob)
 }
 
 func (j *Tracker) runJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
@@ -98,12 +99,11 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 	for {
 		select {
 		case <-jobCtx.Done():
-			err := jobCtx.Err()
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				if err := j.store.SetJobFailed(ctx, id, err); err != nil {
-					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
-				}
+			ctxErr := jobCtx.Err()
+			if err := j.store.SetJobFailed(ctx, id, ctxErr); err != nil {
+				zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 			}
+
 			return
 		case err := <-jobErrCh:
 			if err != nil {

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/juju/clock"
-	"github.com/juju/retry"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 )
@@ -89,38 +87,36 @@ func (j *Tracker) runJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh cha
 		jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
 		return
 	}
-	err := job(jobCtx)
-	jobErrCh <- err
+	jobErrCh <- job(jobCtx)
 }
 
 func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
 	ticker := time.NewTicker(j.stopInterval)
 	defer ticker.Stop()
 
+	// TODO(ale8k): Add mo
 	for {
 		select {
 		case <-jobCtx.Done():
-			switch err := jobCtx.Err(); err {
-			case context.Canceled:
-				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.Canceled) }); err != nil {
-					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
-				}
-			case context.DeadlineExceeded:
-				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.DeadlineExceeded) }); err != nil {
+			err := jobCtx.Err()
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				if err := j.store.SetJobFailed(ctx, id, err); err != nil {
 					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 				}
 			}
 			return
 		case err := <-jobErrCh:
 			if err != nil {
-				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, err) }); err != nil {
+				if err := j.store.SetJobFailed(ctx, id, err); err != nil {
 					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 				}
-			} else {
-				if err := retryCall(func() error { return j.store.SetJobSuccessful(ctx, id) }); err != nil {
-					zapctx.Error(ctx, "error marking the job as successful", zap.Error(err), zap.String("id", id.String()))
-				}
+				return
 			}
+
+			if err := j.store.SetJobSuccessful(ctx, id); err != nil {
+				zapctx.Error(ctx, "error marking the job as successful", zap.Error(err), zap.String("id", id.String()))
+			}
+
 			return
 		case <-ticker.C:
 			shouldStop, err := j.store.GetJobStopSignal(ctx, id)
@@ -135,16 +131,4 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 		}
 	}
 
-}
-
-func retryCall(f func() error) error {
-	if err := retry.Call(retry.CallArgs{
-		Attempts: 5,
-		Delay:    time.Second * 30,
-		Func:     f,
-		Clock:    clock.WallClock,
-	}); err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -94,7 +94,7 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 	ticker := time.NewTicker(j.stopInterval)
 	defer ticker.Stop()
 
-	// TODO(ale8k): Add mo
+	// TODO(ale8k): Add monitoring for failed status settings.
 	for {
 		select {
 		case <-jobCtx.Done():

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -2,7 +2,6 @@
 
 // Package jobtracker provides a way to run routines in one instance of JIMM and track them in another.
 // That is, their status can be checked and they can be stopped.
-
 package jobtracker
 
 import (
@@ -18,10 +17,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// JobTrackerStore defines the interface for tracking the lifecycle and status of jobs.
+// Store defines the interface for tracking the lifecycle and status of jobs.
 // It provides methods to add a new job, update its status (running, successful, or failed),
 // and retrieve a stop signal for a specific job.
-type JobTrackerStore interface {
+type Store interface {
 	AddJob(ctx context.Context, jobType string) (uuid.UUID, error)
 	SetJobRunning(ctx context.Context, jobId uuid.UUID) error
 	SetJobSuccessful(ctx context.Context, jobId uuid.UUID) error
@@ -32,13 +31,13 @@ type JobTrackerStore interface {
 // Tracker manages job tracking operations using a provided JobTrackerStore.
 // It periodically performs tasks based on the specified stopInterval duration.
 type Tracker struct {
-	store        JobTrackerStore
+	store        Store
 	stopInterval time.Duration
 }
 
 // NewJobTracker creates and returns a new Tracker instance using the provided JobTrackerStore and stopInterval.
 // It returns an error if the store is nil or if stopInterval is not greater than zero.
-func NewJobTracker(store JobTrackerStore, stopInterval time.Duration) (*Tracker, error) {
+func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
 	tracker := &Tracker{}
 	if store == nil {
 		return tracker, errors.New("store cannot be nil")
@@ -53,30 +52,30 @@ func NewJobTracker(store JobTrackerStore, stopInterval time.Duration) (*Tracker,
 }
 
 // Run runs a new job and reurns the job ID.
-func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, deadline time.Duration) (uuid.UUID, error) {
+func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
 	jobId, err := j.store.AddJob(ctx, jobType)
 	if err != nil {
 		return jobId, err
 	}
 
-	go j.manageJob(ctx, jobId, deadline, job)
+	go j.handleJob(ctx, jobId, maxDuration, job)
 
 	return jobId, nil
 }
 
-// manageJob runs a job with a given context, job ID, polling interval, and deadline.
+// handleJob runs a job with a given context, job ID, polling interval, and deadline.
 // It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
 // and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
 // is updated as running, successful, or failed based on its result or context expiration.
 // If a stop signal is received or the context is canceled or times out, the job is marked as failed.
 // Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
-func (j *Tracker) manageJob(
+func (j *Tracker) handleJob(
 	ctx context.Context,
 	id uuid.UUID,
-	deadline time.Duration,
+	maxDuration time.Duration,
 	job func(ctx context.Context) error,
 ) {
-	jobCtx, cancelJob := context.WithTimeout(ctx, deadline)
+	jobCtx, cancelJob := context.WithTimeout(ctx, maxDuration)
 	defer cancelJob()
 
 	jobErrCh := make(chan error)
@@ -104,22 +103,22 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 			switch err := jobCtx.Err(); err {
 			case context.Canceled:
 				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.Canceled) }); err != nil {
-					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 				}
 			case context.DeadlineExceeded:
 				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.DeadlineExceeded) }); err != nil {
-					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 				}
 			}
 			return
 		case err := <-jobErrCh:
 			if err != nil {
 				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, err) }); err != nil {
-					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+					zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
 				}
 			} else {
 				if err := retryCall(func() error { return j.store.SetJobSuccessful(ctx, id) }); err != nil {
-					zapctx.Error(ctx, "failed to set job successful", zap.Error(err))
+					zapctx.Error(ctx, "error marking the job as successful", zap.Error(err), zap.String("id", id.String()))
 				}
 			}
 			return

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -59,9 +59,7 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 		return jobId, err
 	}
 
-	stopPollInterval := time.Second * 5
-
-	go j.runJob(ctx, jobId, stopPollInterval, deadline, job)
+	go j.runJob(ctx, jobId, deadline, job)
 
 	return jobId, nil
 }
@@ -75,12 +73,11 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 func (j *Tracker) runJob(
 	ctx context.Context,
 	id uuid.UUID,
-	stopPollInterval time.Duration,
 	deadline time.Duration,
 	job func(ctx context.Context) error,
 ) {
 	jobCtx, cancelJob := context.WithTimeout(ctx, deadline)
-	ticker := time.NewTicker(stopPollInterval)
+	ticker := time.NewTicker(j.stopInterval)
 	defer ticker.Stop()
 	defer cancelJob()
 

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -59,50 +59,44 @@ func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.
 		return jobId, err
 	}
 
-	go j.runJob(ctx, jobId, deadline, job)
+	go j.manageJob(ctx, jobId, deadline, job)
 
 	return jobId, nil
 }
 
-// runJob runs a job with a given context, job ID, polling interval, and deadline.
+// manageJob runs a job with a given context, job ID, polling interval, and deadline.
 // It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
 // and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
 // is updated as running, successful, or failed based on its result or context expiration.
 // If a stop signal is received or the context is canceled or times out, the job is marked as failed.
 // Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
-func (j *Tracker) runJob(
+func (j *Tracker) manageJob(
 	ctx context.Context,
 	id uuid.UUID,
 	deadline time.Duration,
 	job func(ctx context.Context) error,
 ) {
 	jobCtx, cancelJob := context.WithTimeout(ctx, deadline)
-	ticker := time.NewTicker(j.stopInterval)
-	defer ticker.Stop()
 	defer cancelJob()
 
 	jobErrCh := make(chan error)
 
-	retryCall := func(f func() error) error {
-		if err := retry.Call(retry.CallArgs{
-			Attempts: 5,
-			Delay:    time.Second * 30,
-			Func:     f,
-			Clock:    clock.WallClock,
-		}); err != nil {
-			return err
-		}
-		return nil
-	}
+	go j.runJob(ctx, jobCtx, id, jobErrCh, job)
+	j.monitorJob(ctx, jobCtx, id, jobErrCh, cancelJob)
+}
 
-	go func() {
-		if err := j.store.SetJobRunning(ctx, id); err != nil {
-			jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
-			return
-		}
-		err := job(jobCtx)
-		jobErrCh <- err
-	}()
+func (j *Tracker) runJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
+	if err := j.store.SetJobRunning(ctx, id); err != nil {
+		jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
+		return
+	}
+	err := job(jobCtx)
+	jobErrCh <- err
+}
+
+func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
+	ticker := time.NewTicker(j.stopInterval)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -131,19 +125,27 @@ func (j *Tracker) runJob(
 			return
 		case <-ticker.C:
 			shouldStop, err := j.store.GetJobStopSignal(ctx, id)
-			if err != nil {
-				// If we fail to get the stop signal for any reason, we do a best
-				// effort (as the db probably is died on us), so we stop the job,
-				// and hope our status setters on context cancellation
-				// do eventually write the correct status.
-				cancelJob()
-				continue
-			}
 
-			if shouldStop {
+			// If we fail to get the stop signal for any reason, we do a best
+			// effort (as the db probably has died on us), so we stop the job,
+			// and hope our status setters on context cancellation
+			// do eventually write the correct status.
+			if err != nil || shouldStop {
 				cancelJob()
-				continue
 			}
 		}
 	}
+
+}
+
+func retryCall(f func() error) error {
+	if err := retry.Call(retry.CallArgs{
+		Attempts: 5,
+		Delay:    time.Second * 30,
+		Func:     f,
+		Clock:    clock.WallClock,
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -50,61 +50,56 @@ func NewJobTracker(store Store, stopInterval time.Duration) (*Tracker, error) {
 }
 
 // Run runs a new job and returns the job ID.
-func (j *Tracker) Run(jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
-	parentCtx := context.Background()
-	jobId, err := j.store.AddJob(parentCtx, jobType)
+func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, maxDuration time.Duration) (uuid.UUID, error) {
+	jobId, err := j.store.AddJob(ctx, jobType)
 	if err != nil {
 		return jobId, err
 	}
 
-	go j.handleJob(parentCtx, jobId, maxDuration, job)
+	// no context is passed to handleJob as this is a background
+	// job and is not tied to the request context.
+	go j.handleJob(jobId, maxDuration, job)
 
 	return jobId, nil
 }
 
-// handleJob runs a job with a given context, job ID, and deadline.
+// handleJob runs a job with a given job ID, and deadline.
 // It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
-// and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
-// is updated as running, successful, or failed based on its result or context expiration.
-// If a stop signal is received or the context is canceled or times out, the job is marked as failed.
-// Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
+// and responding to stop signals. The job is run in a separate goroutine, and its status is updated as running,
+// successful, or failed based on its result or context expiration.
+// If a stop signal is received or the job reaches its maximum duration, the job is marked as failed.
 func (j *Tracker) handleJob(
-	parentCtx context.Context,
 	id uuid.UUID,
 	maxDuration time.Duration,
 	job func(ctx context.Context) error,
 ) {
-	jobCtx, cancelJob := context.WithTimeout(parentCtx, maxDuration)
+	jobCtx, cancelJob := context.WithTimeout(context.Background(), maxDuration)
 	defer cancelJob()
 
 	jobErrCh := make(chan error)
 
-	go j.runJob(parentCtx, jobCtx, id, jobErrCh, job)
-	j.monitorJob(parentCtx, jobCtx, id, jobErrCh, cancelJob)
+	go j.runJob(jobCtx, id, jobErrCh, job)
+	j.monitorJob(id, jobErrCh, cancelJob)
 }
 
-func (j *Tracker) runJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
+func (j *Tracker) runJob(ctx context.Context, id uuid.UUID, jobErrCh chan error, job func(context.Context) error) {
+
 	if err := j.store.SetJobRunning(ctx, id); err != nil {
 		jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
 		return
 	}
-	jobErrCh <- job(jobCtx)
+	jobErrCh <- job(ctx)
 }
 
-func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
+func (j *Tracker) monitorJob(id uuid.UUID, jobErrCh chan error, cancelJob context.CancelFunc) {
 	ticker := time.NewTicker(j.stopInterval)
 	defer ticker.Stop()
 
+	ctx := context.Background()
+	stopped := false
 	// TODO(ale8k): Add monitoring for failed status settings.
 	for {
 		select {
-		case <-jobCtx.Done():
-			ctxErr := jobCtx.Err()
-			if err := j.store.SetJobFailed(ctx, id, ctxErr); err != nil {
-				zapctx.Error(ctx, "error marking the job as failed", zap.Error(err), zap.String("id", id.String()))
-			}
-
-			return
 		case err := <-jobErrCh:
 			if err != nil {
 				if err := j.store.SetJobFailed(ctx, id, err); err != nil {
@@ -119,6 +114,10 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 
 			return
 		case <-ticker.C:
+			if stopped {
+				// If we are already stopped, we don't need to check the stop signal again.
+				continue
+			}
 			shouldStop, err := j.store.GetJobStopSignal(ctx, id)
 
 			// If we fail to get the stop signal for any reason, we do a best
@@ -127,6 +126,7 @@ func (j *Tracker) monitorJob(ctx, jobCtx context.Context, id uuid.UUID, jobErrCh
 			// do eventually write the correct status.
 			if err != nil || shouldStop {
 				cancelJob()
+				stopped = true
 			}
 		}
 	}

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Canonical.
+
+// Package jobtracker provides a way to run routines in one instance of JIMM and track them in another.
+// That is, their status can be checked and they can be stopped.
+
+package jobtracker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/juju/clock"
+	"github.com/juju/retry"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+)
+
+// JobTrackerStore defines the interface for tracking the lifecycle and status of jobs.
+// It provides methods to add a new job, update its status (running, successful, or failed),
+// and retrieve a stop signal for a specific job.
+type JobTrackerStore interface {
+	AddJob(ctx context.Context, jobType string) (uuid.UUID, error)
+	SetJobRunning(ctx context.Context, jobId uuid.UUID) error
+	SetJobSuccessful(ctx context.Context, jobId uuid.UUID) error
+	SetJobFailed(ctx context.Context, jobId uuid.UUID, jobErr error) error
+	GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopSignal bool, err error)
+}
+
+// Tracker manages job tracking operations using a provided JobTrackerStore.
+// It periodically performs tasks based on the specified stopInterval duration.
+type Tracker struct {
+	store        JobTrackerStore
+	stopInterval time.Duration
+}
+
+// NewJobTracker creates and returns a new Tracker instance using the provided JobTrackerStore and stopInterval.
+// It returns an error if the store is nil or if stopInterval is not greater than zero.
+func NewJobTracker(store JobTrackerStore, stopInterval time.Duration) (*Tracker, error) {
+	tracker := &Tracker{}
+	if store == nil {
+		return tracker, errors.New("store cannot be nil")
+	}
+	if stopInterval <= 0 {
+		return tracker, errors.New("stopInterval must be greater than zero")
+	}
+	tracker.stopInterval = stopInterval
+	tracker.store = store
+
+	return tracker, nil
+}
+
+// Run runs a new job and reurns the job ID.
+func (j *Tracker) Run(ctx context.Context, jobType string, job func(ctx context.Context) error, deadline time.Duration) (uuid.UUID, error) {
+	jobId, err := j.store.AddJob(ctx, jobType)
+	if err != nil {
+		return jobId, err
+	}
+
+	stopPollInterval := time.Second * 5
+
+	go j.runJob(ctx, jobId, stopPollInterval, deadline, job)
+
+	return jobId, nil
+}
+
+// runJob runs a job with a given context, job ID, polling interval, and deadline.
+// It manages the job's lifecycle, including setting its status in the store, handling retries on store operations,
+// and responding to stop signals or context cancellations. The job is run in a separate goroutine, and its status
+// is updated as running, successful, or failed based on its result or context expiration.
+// If a stop signal is received or the context is canceled or times out, the job is marked as failed.
+// Store operations are retried up to 5 times with a 30-second delay between attempts in case of transient errors.
+func (j *Tracker) runJob(
+	ctx context.Context,
+	id uuid.UUID,
+	stopPollInterval time.Duration,
+	deadline time.Duration,
+	job func(ctx context.Context) error,
+) {
+	jobCtx, cancelJob := context.WithTimeout(ctx, deadline)
+	ticker := time.NewTicker(stopPollInterval)
+	defer ticker.Stop()
+	defer cancelJob()
+
+	jobErrCh := make(chan error)
+
+	retryCall := func(f func() error) error {
+		if err := retry.Call(retry.CallArgs{
+			Attempts: 5,
+			Delay:    time.Second * 30,
+			Func:     f,
+			Clock:    clock.WallClock,
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	go func() {
+		if err := j.store.SetJobRunning(ctx, id); err != nil {
+			jobErrCh <- fmt.Errorf("failed to set job running, job not starting: %w", err)
+			return
+		}
+		err := job(jobCtx)
+		jobErrCh <- err
+	}()
+
+	for {
+		select {
+		case <-jobCtx.Done():
+			switch err := jobCtx.Err(); err {
+			case context.Canceled:
+				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.Canceled) }); err != nil {
+					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+				}
+			case context.DeadlineExceeded:
+				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, context.DeadlineExceeded) }); err != nil {
+					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+				}
+			}
+			return
+		case err := <-jobErrCh:
+			if err != nil {
+				if err := retryCall(func() error { return j.store.SetJobFailed(ctx, id, err) }); err != nil {
+					zapctx.Error(ctx, "failed to set job failed", zap.Error(err))
+				}
+			} else {
+				if err := retryCall(func() error { return j.store.SetJobSuccessful(ctx, id) }); err != nil {
+					zapctx.Error(ctx, "failed to set job successful", zap.Error(err))
+				}
+			}
+			return
+		case <-ticker.C:
+			shouldStop, err := j.store.GetJobStopSignal(ctx, id)
+			if err != nil {
+				// If we fail to get the stop signal for any reason, we do a best
+				// effort (as the db probably is died on us), so we stop the job,
+				// and hope our status setters on context cancellation
+				// do eventually write the correct status.
+				cancelJob()
+				continue
+			}
+
+			if shouldStop {
+				cancelJob()
+				continue
+			}
+		}
+	}
+}

--- a/internal/jobtracker/jobtracker_test.go
+++ b/internal/jobtracker/jobtracker_test.go
@@ -56,7 +56,7 @@ func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 		return errors.New("I died really fast")
 	}
 
-	id, err := s.tracker.Run(testCtx, "test-job-type", aFastDyingJob, time.Second*1000)
+	id, err := s.tracker.Run("test-job-type", aFastDyingJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
@@ -79,7 +79,7 @@ func (s *jobTrackerSuite) TestRun_DeadlineExceeded(c *qt.C) {
 		}
 	}
 
-	id, err := s.tracker.Run(testCtx, "test-job-type", aDeadendJob, time.Millisecond*100)
+	id, err := s.tracker.Run("test-job-type", aDeadendJob, time.Millisecond*100)
 	c.Assert(err, qt.IsNil)
 
 	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
@@ -106,7 +106,7 @@ func (s *jobTrackerSuite) TestRun_CancelledJob(c *qt.C) {
 		}
 	}
 
-	id, err := tracker.Run(testCtx, "test-job-type", aStoppedJob, time.Second*1000)
+	id, err := tracker.Run("test-job-type", aStoppedJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(s.db.StopJob(testCtx, id), qt.IsNil)
@@ -123,20 +123,25 @@ func (s *jobTrackerSuite) TestRun_JobSetRunning(c *qt.C) {
 	testCtx := c.Context()
 
 	jobRunning := make(chan bool)
-	aRunnignJob := func(ctx context.Context) error {
+	jobCtx, cancelJobCtx := context.WithCancel(testCtx)
+	aRunnignJob := func(_ context.Context) error {
 		jobRunning <- true
-		for range ctx.Done() {
+		for range jobCtx.Done() {
 		}
 		return nil
 	}
 
-	id, err := s.tracker.Run(testCtx, "test-job-type", aRunnignJob, time.Second*1000)
+	id, err := s.tracker.Run("test-job-type", aRunnignJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	<-jobRunning
 	status, err := s.db.GetJobStatus(testCtx, id)
 	c.Assert(err, qt.IsNil)
 	c.Assert(status, qt.Equals, dbmodel.StatusRunning)
+
+	// Check the job is marked successful on completion.
+	cancelJobCtx()
+	s.pollJob(testCtx, id, c, dbmodel.StatusSuccessful)
 }
 
 func (s *jobTrackerSuite) TestRun_JobSetSuccessful(c *qt.C) {
@@ -146,7 +151,7 @@ func (s *jobTrackerSuite) TestRun_JobSetSuccessful(c *qt.C) {
 		return nil
 	}
 
-	id, err := s.tracker.Run(testCtx, "test-job-type", aSuccessfulJob, time.Second*1000)
+	id, err := s.tracker.Run("test-job-type", aSuccessfulJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	s.pollJob(testCtx, id, c, dbmodel.StatusSuccessful)

--- a/internal/jobtracker/jobtracker_test.go
+++ b/internal/jobtracker/jobtracker_test.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Canonical.
+package jobtracker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jobtracker"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+type jobTrackerSuite struct {
+	db      *db.Database
+	tracker *jobtracker.Tracker
+}
+
+func (s *jobTrackerSuite) Init(c *qt.C) {
+	db := &db.Database{
+		DB: jimmtest.PostgresDB(c, time.Now),
+	}
+	err := db.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	s.db = db
+	tracker, err := jobtracker.NewJobTracker(db, time.Second*5)
+	c.Assert(err, qt.IsNil)
+	s.tracker = tracker
+}
+
+// !!! --- For PR reviewers, currently we're polling the job status as we are waiting
+// for the forselect to update. We could use gomock / some mock and capture the call. What would you prefer?
+// Gomock would allow us to see the order of calls and expected params, so perhaps a bit cleaner.
+//
+// Or we leave it polling.
+func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_JobError(c *qt.C) {
+	testCtx := c.Context()
+
+	aFastDyingJob := func(ctx context.Context) error {
+		return errors.New("I died really fast")
+	}
+
+	id, err := s.tracker.Run(testCtx, "test-job-type", aFastDyingJob, time.Second*1000)
+	c.Assert(err, qt.IsNil)
+
+	var status dbmodel.JobStatus
+	var pollerr error
+	for i := 0; i < 10; i++ {
+		status, pollerr = s.db.GetJobStatus(testCtx, id)
+		c.Assert(pollerr, qt.IsNil)
+		if status == dbmodel.StatusFailed {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	j := dbmodel.JobTrackerEntry{}
+	var jobErr string
+	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
+	c.Assert(jobErr, qt.Equals, "I died really fast")
+}
+
+func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_DeadlineExceeded(c *qt.C) {
+	testCtx := c.Context()
+
+	aDeadendJob := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return nil
+		}
+	}
+
+	id, err := s.tracker.Run(testCtx, "test-job-type", aDeadendJob, time.Millisecond*100)
+	c.Assert(err, qt.IsNil)
+
+	var status dbmodel.JobStatus
+	var pollerr error
+	for i := 0; i < 10; i++ {
+		status, pollerr = s.db.GetJobStatus(testCtx, id)
+		c.Assert(pollerr, qt.IsNil)
+		if status == dbmodel.StatusFailed {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	c.Assert(status, qt.Equals, dbmodel.StatusFailed)
+
+	j := dbmodel.JobTrackerEntry{}
+	var jobErr string
+	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
+	c.Assert(jobErr, qt.Equals, "context deadline exceeded")
+}
+
+func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_CancelledByStop(c *qt.C) {
+	testCtx := c.Context()
+
+	// Create a new tracker, specific to this test.
+	tracker, err := jobtracker.NewJobTracker(s.db, time.Millisecond*50)
+	c.Assert(err, qt.IsNil)
+
+	aStoppedJob := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return errors.New("timedout")
+		}
+	}
+
+	id, err := tracker.Run(testCtx, "test-job-type", aStoppedJob, time.Second*1000)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(s.db.StopJob(testCtx, id), qt.IsNil)
+
+	var status dbmodel.JobStatus
+	var pollerr error
+	for i := 0; i < 10; i++ {
+		status, pollerr = s.db.GetJobStatus(testCtx, id)
+		c.Assert(pollerr, qt.IsNil)
+		if status == dbmodel.StatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	c.Assert(status, qt.Equals, dbmodel.StatusFailed)
+
+	j := dbmodel.JobTrackerEntry{}
+	var jobErr string
+	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
+	c.Assert(jobErr, qt.Equals, "context canceled")
+}
+
+func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetRunning(c *qt.C) {
+	testCtx := c.Context()
+
+	jobRunning := make(chan bool)
+	aRunnignJob := func(ctx context.Context) error {
+		jobRunning <- true
+		for range ctx.Done() {
+		}
+		return nil
+	}
+
+	id, err := s.tracker.Run(testCtx, "test-job-type", aRunnignJob, time.Second*1000)
+	c.Assert(err, qt.IsNil)
+
+	<-jobRunning
+	status, err := s.db.GetJobStatus(testCtx, id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.Equals, dbmodel.StatusRunning)
+}
+
+func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetSuccessful(c *qt.C) {
+	testCtx := c.Context()
+
+	aSuccessfulJob := func(ctx context.Context) error {
+		return nil
+	}
+
+	id, err := s.tracker.Run(testCtx, "test-job-type", aSuccessfulJob, time.Second*1000)
+	c.Assert(err, qt.IsNil)
+
+	var status dbmodel.JobStatus
+	var pollerr error
+	for i := 0; i < 10; i++ {
+		status, pollerr = s.db.GetJobStatus(testCtx, id)
+		c.Assert(pollerr, qt.IsNil)
+		if status == dbmodel.StatusSuccessful {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	c.Assert(status, qt.Equals, dbmodel.StatusSuccessful)
+}
+
+func TestJobTrackerSuite(t *testing.T) {
+	qtsuite.Run(qt.New(t), &jobTrackerSuite{})
+}

--- a/internal/jobtracker/jobtracker_test.go
+++ b/internal/jobtracker/jobtracker_test.go
@@ -34,12 +34,7 @@ func (s *jobTrackerSuite) Init(c *qt.C) {
 	s.tracker = tracker
 }
 
-// !!! --- For PR reviewers, currently we're polling the job status as we are waiting
-// for the forselect to update. We could use gomock / some mock and capture the call. What would you prefer?
-// Gomock would allow us to see the order of calls and expected params, so perhaps a bit cleaner.
-//
-// Or we leave it polling.
-func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_JobError(c *qt.C) {
+func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 	testCtx := c.Context()
 
 	aFastDyingJob := func(ctx context.Context) error {
@@ -66,7 +61,7 @@ func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_JobError(c *qt.C) {
 	c.Assert(jobErr, qt.Equals, "I died really fast")
 }
 
-func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_DeadlineExceeded(c *qt.C) {
+func (s *jobTrackerSuite) TestRun_DeadlineExceeded(c *qt.C) {
 	testCtx := c.Context()
 
 	aDeadendJob := func(ctx context.Context) error {
@@ -100,7 +95,7 @@ func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_DeadlineExceeded(c *
 	c.Assert(jobErr, qt.Equals, "context deadline exceeded")
 }
 
-func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_CancelledByStop(c *qt.C) {
+func (s *jobTrackerSuite) TestRun_CancelledJob(c *qt.C) {
 	testCtx := c.Context()
 
 	// Create a new tracker, specific to this test.
@@ -140,7 +135,7 @@ func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetFailed_CancelledByStop(c *q
 	c.Assert(jobErr, qt.Equals, "context canceled")
 }
 
-func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetRunning(c *qt.C) {
+func (s *jobTrackerSuite) TestRun_JobSetRunning(c *qt.C) {
 	testCtx := c.Context()
 
 	jobRunning := make(chan bool)
@@ -160,7 +155,7 @@ func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetRunning(c *qt.C) {
 	c.Assert(status, qt.Equals, dbmodel.StatusRunning)
 }
 
-func (s *jobTrackerSuite) TestJobTracker_Run_JobIsSetSuccessful(c *qt.C) {
+func (s *jobTrackerSuite) TestRun_JobSetSuccessful(c *qt.C) {
 	testCtx := c.Context()
 
 	aSuccessfulJob := func(ctx context.Context) error {

--- a/internal/jobtracker/jobtracker_test.go
+++ b/internal/jobtracker/jobtracker_test.go
@@ -56,7 +56,7 @@ func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 		return errors.New("I died really fast")
 	}
 
-	id, err := s.tracker.Run("test-job-type", aFastDyingJob, time.Second*1000)
+	id, err := s.tracker.Run(testCtx, "test-job-type", aFastDyingJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
@@ -65,58 +65,6 @@ func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 	var jobErr string
 	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
 	c.Assert(jobErr, qt.Equals, "I died really fast")
-}
-
-func (s *jobTrackerSuite) TestRun_DeadlineExceeded(c *qt.C) {
-	testCtx := c.Context()
-
-	aDeadendJob := func(ctx context.Context) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(10 * time.Second):
-			return nil
-		}
-	}
-
-	id, err := s.tracker.Run("test-job-type", aDeadendJob, time.Millisecond*100)
-	c.Assert(err, qt.IsNil)
-
-	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
-
-	j := dbmodel.JobTrackerEntry{}
-	var jobErr string
-	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
-	c.Assert(jobErr, qt.Equals, "context deadline exceeded")
-}
-
-func (s *jobTrackerSuite) TestRun_CancelledJob(c *qt.C) {
-	testCtx := c.Context()
-
-	// Create a new tracker, specific to this test.
-	tracker, err := jobtracker.NewJobTracker(s.db, time.Millisecond*50)
-	c.Assert(err, qt.IsNil)
-
-	aStoppedJob := func(ctx context.Context) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(10 * time.Second):
-			return errors.New("timedout")
-		}
-	}
-
-	id, err := tracker.Run("test-job-type", aStoppedJob, time.Second*1000)
-	c.Assert(err, qt.IsNil)
-
-	c.Assert(s.db.StopJob(testCtx, id), qt.IsNil)
-
-	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
-
-	j := dbmodel.JobTrackerEntry{}
-	var jobErr string
-	c.Assert(s.db.DB.First(&j).Where("job_id = ?", id).Select("error").Scan(&jobErr).Error, qt.IsNil)
-	c.Assert(jobErr, qt.Equals, "context canceled")
 }
 
 func (s *jobTrackerSuite) TestRun_JobSetRunning(c *qt.C) {
@@ -131,7 +79,7 @@ func (s *jobTrackerSuite) TestRun_JobSetRunning(c *qt.C) {
 		return nil
 	}
 
-	id, err := s.tracker.Run("test-job-type", aRunnignJob, time.Second*1000)
+	id, err := s.tracker.Run(testCtx, "test-job-type", aRunnignJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	<-jobRunning
@@ -151,7 +99,7 @@ func (s *jobTrackerSuite) TestRun_JobSetSuccessful(c *qt.C) {
 		return nil
 	}
 
-	id, err := s.tracker.Run("test-job-type", aSuccessfulJob, time.Second*1000)
+	id, err := s.tracker.Run(testCtx, "test-job-type", aSuccessfulJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
 	s.pollJob(testCtx, id, c, dbmodel.StatusSuccessful)

--- a/internal/jobtracker/jobtracker_test.go
+++ b/internal/jobtracker/jobtracker_test.go
@@ -9,6 +9,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
+	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -34,6 +35,20 @@ func (s *jobTrackerSuite) Init(c *qt.C) {
 	s.tracker = tracker
 }
 
+func (s *jobTrackerSuite) pollJob(ctx context.Context, id uuid.UUID, c *qt.C, expectedStatus dbmodel.JobStatus) {
+	var status dbmodel.JobStatus
+	var pollerr error
+	for i := 0; i < 10; i++ {
+		status, pollerr = s.db.GetJobStatus(ctx, id)
+		c.Assert(pollerr, qt.IsNil)
+		if status == expectedStatus {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	c.Assert(status, qt.Equals, expectedStatus)
+}
+
 func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 	testCtx := c.Context()
 
@@ -44,16 +59,7 @@ func (s *jobTrackerSuite) TestRun_JobError(c *qt.C) {
 	id, err := s.tracker.Run(testCtx, "test-job-type", aFastDyingJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
-	var status dbmodel.JobStatus
-	var pollerr error
-	for i := 0; i < 10; i++ {
-		status, pollerr = s.db.GetJobStatus(testCtx, id)
-		c.Assert(pollerr, qt.IsNil)
-		if status == dbmodel.StatusFailed {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
 
 	j := dbmodel.JobTrackerEntry{}
 	var jobErr string
@@ -76,18 +82,7 @@ func (s *jobTrackerSuite) TestRun_DeadlineExceeded(c *qt.C) {
 	id, err := s.tracker.Run(testCtx, "test-job-type", aDeadendJob, time.Millisecond*100)
 	c.Assert(err, qt.IsNil)
 
-	var status dbmodel.JobStatus
-	var pollerr error
-	for i := 0; i < 10; i++ {
-		status, pollerr = s.db.GetJobStatus(testCtx, id)
-		c.Assert(pollerr, qt.IsNil)
-		if status == dbmodel.StatusFailed {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	c.Assert(status, qt.Equals, dbmodel.StatusFailed)
+	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
 
 	j := dbmodel.JobTrackerEntry{}
 	var jobErr string
@@ -116,18 +111,7 @@ func (s *jobTrackerSuite) TestRun_CancelledJob(c *qt.C) {
 
 	c.Assert(s.db.StopJob(testCtx, id), qt.IsNil)
 
-	var status dbmodel.JobStatus
-	var pollerr error
-	for i := 0; i < 10; i++ {
-		status, pollerr = s.db.GetJobStatus(testCtx, id)
-		c.Assert(pollerr, qt.IsNil)
-		if status == dbmodel.StatusFailed {
-			break
-		}
-		time.Sleep(10 * time.Second)
-	}
-
-	c.Assert(status, qt.Equals, dbmodel.StatusFailed)
+	s.pollJob(testCtx, id, c, dbmodel.StatusFailed)
 
 	j := dbmodel.JobTrackerEntry{}
 	var jobErr string
@@ -165,18 +149,7 @@ func (s *jobTrackerSuite) TestRun_JobSetSuccessful(c *qt.C) {
 	id, err := s.tracker.Run(testCtx, "test-job-type", aSuccessfulJob, time.Second*1000)
 	c.Assert(err, qt.IsNil)
 
-	var status dbmodel.JobStatus
-	var pollerr error
-	for i := 0; i < 10; i++ {
-		status, pollerr = s.db.GetJobStatus(testCtx, id)
-		c.Assert(pollerr, qt.IsNil)
-		if status == dbmodel.StatusSuccessful {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	c.Assert(status, qt.Equals, dbmodel.StatusSuccessful)
+	s.pollJob(testCtx, id, c, dbmodel.StatusSuccessful)
 }
 
 func TestJobTrackerSuite(t *testing.T) {


### PR DESCRIPTION
## Description
The jobtracker packages provides a means to run a routine on a unit of jimm, and cancel it by a signal.

I missed the GetStopSignal in the previous PR for the job tracker dbmodel & methods, so I've quickly added it here.

For testing, I've put some simple polling in. I've left a comment above one of the tests explaining we can mock this. The benefit of polling is we can see it running in an integration fashion. 

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
