### PR TITLE
feat(model-migration): cleanup failed or partial model migrations

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -51,7 +51,8 @@ import (
 )
 
 const (
-	localDischargePath = "/macaroons"
+	localDischargePath                        = "/macaroons"
+	INTERVAL_BETWEEN_MODEL_MIGRATIONS_CLEANUP = 10 * time.Minute
 )
 
 // OpenFGAParams holds parameters needed to connect to the OpenFGA server.
@@ -285,6 +286,23 @@ func (s *Service) CleanupNotFoundModels(ctx context.Context, trigger <-chan time
 			}
 		case <-ctx.Done():
 			zapctx.Info(ctx, "exiting dying model cleanup polling")
+			return nil
+		}
+	}
+}
+
+// CleanupPartialModelMigrations triggers every `trigger` time and calls the jimm methods to cleanup partial model migrations.
+func (s *Service) CleanupPartialModelMigrations(ctx context.Context, trigger <-chan time.Time) error {
+	for {
+		select {
+		case <-trigger:
+			err := s.jimm.JujuManager().CleanupPartialModelMigrations(ctx)
+			if err != nil {
+				zapctx.Error(ctx, "partial model migrations cleanup", zap.Error(err))
+				continue
+			}
+		case <-ctx.Done():
+			zapctx.Info(ctx, "exiting partial model migration cleanup polling")
 			return nil
 		}
 	}
@@ -560,6 +578,11 @@ func (s *Service) StartServices(ctx context.Context, svc *service.Service) {
 		// CleanupNotFoundModels cleanup - cleans up all models not found on the respective controller.
 		svc.Go(func() error {
 			return s.CleanupNotFoundModels(ctx, time.NewTicker(time.Minute).C)
+		})
+
+		// CleanupPartialModelMigration cleanup - cleans up all partial model migrations.
+		svc.Go(func() error {
+			return s.CleanupPartialModelMigrations(ctx, time.NewTicker(INTERVAL_BETWEEN_MODEL_MIGRATIONS_CLEANUP).C)
 		})
 	}
 

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"time"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -76,4 +77,23 @@ func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigrat
 		return errors.E(op, dbError(err))
 	}
 	return nil
+}
+
+// GetIncomingModelMigrationsCreatedBefore returns all incoming model migrations created before the specified time.
+func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, createBefore time.Time) (migrations []dbmodel.IncomingModelMigration, err error) {
+	const op = errors.Op("db.GetIncomingModelMigrations")
+	if err := d.ready(); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	if err := db.Where("created_at < ?", createBefore).Find(&migrations).Error; err != nil {
+		return nil, errors.E(op, dbError(err))
+	}
+	return migrations, nil
 }

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -5,6 +5,7 @@ package db_test
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -84,6 +85,40 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	eError, ok := err.(*errors.Error)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+}
+
+func (s *dbSuite) TestGetModelMigrationsCreatedBefore(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		CloudName: cloud.Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+
+	migration := dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.StringMap{"local": "external"},
+	}
+	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
+
+	migrations, err := s.Database.GetIncomingModelMigrationsCreatedBefore(context.Background(), migration.CreatedAt.Add(1*time.Hour))
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].ModelUUID, qt.DeepEquals, migration.ModelUUID)
+
+	migrations, err = s.Database.GetIncomingModelMigrationsCreatedBefore(context.Background(), migration.CreatedAt.Add(-1*time.Hour))
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(migrations, qt.HasLen, 0)
 }
 
 func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -79,3 +79,21 @@ func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.U
 	}
 	return nil
 }
+
+// DeleteUserMappingsByModelUUID removes all user mappings for a given model UUID.
+func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID string) (err error) {
+	const op = errors.Op("db.DeleteUserMappingsByModelUUID")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Where("model_uuid = ?", modelUUID).Delete(&dbmodel.UserMapping{}).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/usermapping_test.go
+++ b/internal/db/usermapping_test.go
@@ -107,3 +107,40 @@ func (s *dbSuite) TestDeleteUserMapping(c *qt.C) {
 	err = s.Database.GetUserMapping(ctx, userMapping)
 	c.Assert(err, qt.ErrorMatches, ".*user mapping not found.*")
 }
+
+func (s *dbSuite) TestDeleteUserMappingsByModelUUID(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	localUser := "localuser1"
+	identityName := "externaluser@canonical.com"
+
+	u, err := dbmodel.NewIdentity(identityName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+
+	userMapping := &dbmodel.UserMapping{
+		ModelUUID:        modelUUID,
+		LocalUser:        localUser,
+		ExternalUserName: identityName,
+	}
+	c.Assert(s.Database.AddUserMapping(ctx, userMapping), qt.IsNil)
+
+	userMapping2 := &dbmodel.UserMapping{
+		ModelUUID:        modelUUID,
+		LocalUser:        "localuser2",
+		ExternalUserName: identityName,
+	}
+	c.Assert(s.Database.AddUserMapping(ctx, userMapping2), qt.IsNil)
+
+	err = s.Database.DeleteUserMappingsByModelUUID(ctx, modelUUID.String)
+	c.Assert(err, qt.IsNil)
+
+	// Check that both mappings are deleted
+	err = s.Database.GetUserMapping(ctx, userMapping)
+	c.Assert(err, qt.ErrorMatches, ".*user mapping not found.*")
+	err = s.Database.GetUserMapping(ctx, userMapping2)
+	c.Assert(err, qt.ErrorMatches, ".*user mapping not found.*")
+}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -264,6 +264,7 @@ type JujuManager interface {
 	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
 	LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error)
 	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
+	CleanupPartialModelMigrations(ctx context.Context) error
 
 	// Other methods
 	AddCloudToController(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"database/sql"
+	goerr "errors"
 	"fmt"
 	"time"
 
@@ -25,8 +26,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
+const TIMEOUT_PENDING_MIGRATION = 24 * time.Hour
+
 // AbortMigration aborts a model migration with the given model UUID.
-// It does this by calling the Abort methodon the target Juju controller.
+// It does this by calling the Abort method on the target Juju controller.
 // It also deletes the migration record from the database, but does not return an error
 // if the deletion fails, as the migration has already been aborted on the target controller.
 func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
@@ -60,7 +63,27 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 		// as the migration has already been aborted on the target controller.
 		zapctx.Error(ctx, "failed to delete incoming model migration", zap.Error(err), zap.String("modelUUID", modelUUID))
 	}
-	// TODO(SimoneDutto): delete the model from JIMM's state.
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUID,
+			Valid:  true,
+		},
+	}
+	// Don't return an error if we fail to delete the model from JIMM's state,
+	// as the migration has already been aborted on the target controller.
+	// The model will be cleanup eventually by JIMM's cleanup routine.
+	err = j.Database.GetModel(ctx, &model)
+	if err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return nil
+		}
+		zapctx.Error(ctx, "failed to get model for abort migration", zap.Error(err), zap.String("modelUUID", modelUUID))
+		return nil
+	}
+	err = j.Database.DeleteModel(ctx, &model)
+	if err != nil {
+		zapctx.Error(ctx, "failed to delete incoming model migration", zap.Error(err), zap.String("modelUUID", modelUUID))
+	}
 	return nil
 }
 
@@ -465,4 +488,65 @@ func (j *JujuManager) importModelFromDescription(ctx context.Context, targetCont
 		return errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
 	}
 	return nil
+}
+
+// CleanupPartialModelMigrations cleans up any partial model migrations that have exceeded the timeout.
+// It deletes the incoming model migration record, deletes the user mappings for the model,
+// and deletes the model record from JIMM's state.
+func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
+	const op = errors.Op("jimm.CleanupPartialModelMigrations")
+
+	// Get all incoming model migrations that have exceeded the timeout.
+	migrations, err := j.Database.GetIncomingModelMigrationsCreatedBefore(ctx, time.Now().Add(-TIMEOUT_PENDING_MIGRATION))
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to get incoming model migrations: %w", err))
+	}
+	var errs []error
+	for _, migration := range migrations {
+		err := j.cleanupPartialModelMigration(ctx, migration)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return goerr.Join(errs...)
+}
+
+// cleanupPartialModelMigration cleans up a partial model migration by deleting the incoming model migration record,
+// deleting the user mappings for the model, and deleting the model record from JIMM's state.
+func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migration dbmodel.IncomingModelMigration) error {
+	const op = errors.Op("jimm.cleanupPartialModelMigration")
+
+	return j.Database.Transaction(func(db *db.Database) error {
+		// Delete the incoming model migration record.
+		err := j.Database.DeleteIncomingModelMigration(ctx, &migration)
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		// Delete user mappings for the model.
+		err = j.Database.DeleteUserMappingsByModelUUID(ctx, migration.ModelUUID.String)
+		if err != nil {
+			return errors.E(op, err)
+		}
+
+		// Delete the model record from JIMM's state.
+		model := dbmodel.Model{
+			UUID: sql.NullString{
+				String: migration.ModelUUID.String,
+				Valid:  true,
+			},
+		}
+		err = j.Database.GetModel(ctx, &model)
+		if err != nil {
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				return nil
+			}
+			return errors.E(op, err)
+		}
+		err = j.Database.DeleteModel(ctx, &model)
+		if err != nil {
+			return errors.E(op, err)
+		}
+		return nil
+	})
 }

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -26,7 +26,30 @@ const (
 	migratingModelUUID = "00000000-0000-0000-0000-000000000001"
 )
 
-const testMigrationEnv = `clouds:
+const testEnvWithIncomingMigration = `clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+controllers:
+- name: test1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region-1
+  agent-version: 3.2.1
+  public-address: foo.com
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+incoming-migrations:
+- model-uuid: ` + migratingModelUUID + `
+  target-controller: test1
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
+`
+
+const testEnvNoIncomingMigration = `clouds:
 - name: test
   type: test
   regions:
@@ -63,20 +86,35 @@ func TestAbortMigration_Success(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigrationAndModel)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	err = j.AbortMigration(ctx, user, migratingModelUUID)
+	err := j.AbortMigration(ctx, user, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(abortCalled, qt.IsTrue)
+
+	// Check the model migration has been removed from the database.
+	modelMigration := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: migratingModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+
+	// Check the model has been deleted from the database.
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: migratingModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetModel(ctx, model)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 }
 
 func TestAbortMigration_MissingIncomingModel(t *testing.T) {
@@ -85,7 +123,7 @@ func TestAbortMigration_MissingIncomingModel(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
@@ -115,13 +153,8 @@ func TestCheckMachines_Success(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
@@ -138,7 +171,7 @@ func TestCheckMachines_MissingIncomingModel(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
@@ -154,19 +187,13 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	// Expect an error when there is no incoming model migration.
 	_, err := j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
-
-	// Create an incoming model migration in the database.
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err = j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	// Expect an error when the controller credentials are not set.
 	_, err = j.ControllerDetailsForIncomingModel(ctx, migratingModelUUID)
@@ -206,19 +233,14 @@ func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
 	model := newMigrationInfo("bob")
-	err = j.Prechecks(ctx, user, model)
+	err := j.Prechecks(ctx, user, model)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -238,19 +260,14 @@ func TestPrechecks_ControllerUnreachable(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
 	model := newMigrationInfo("bob")
-	err = j.Prechecks(ctx, user, model)
+	err := j.Prechecks(ctx, user, model)
 	c.Assert(err, qt.ErrorMatches, `.*controller unreachable`)
 }
 
@@ -260,20 +277,15 @@ func TestPrechecks_MissingUserMapping(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"random-user": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	model := newMigrationInfo("bob")
-	err = j.Prechecks(ctx, user, model)
-	c.Assert(err, qt.ErrorMatches, `.*no external user mapping found for local user "bob"`)
+	model := newMigrationInfo("not-found-user")
+	err := j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.ErrorMatches, `.*no external user mapping found for local user "not-found-user"`)
 }
 
 func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
@@ -282,7 +294,7 @@ func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvNoIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
@@ -315,18 +327,13 @@ func TestAdoptResources_Success(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	err = j.AdoptResources(ctx, user, migratingModelUUID, controllerVersion)
+	err := j.AdoptResources(ctx, user, migratingModelUUID, controllerVersion)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -336,7 +343,7 @@ func TestAdoptResources_NoIncomingModelMigration(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvNoIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
@@ -346,7 +353,7 @@ func TestAdoptResources_NoIncomingModelMigration(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
-const testActivateEnv = `clouds:
+const testEnvWithIncomingMigrationAndModel = `clouds:
 - name: test-cloud
   type: test-provider
   regions:
@@ -378,6 +385,12 @@ models:
 users:
 - username: alice@canonical.com
   controller-access: superuser
+incoming-migrations:
+- model-uuid: ` + migratingModelUUID + `
+  target-controller: test1
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
 `
 
 func TestActivate_Success(t *testing.T) {
@@ -405,18 +418,13 @@ func TestActivate_Success(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testActivateEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigrationAndModel)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
+	err := j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.IsNil)
 
-	err = j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
-	c.Assert(err, qt.IsNil)
-
-	modelMigration = dbmodel.IncomingModelMigration{
+	modelMigration := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
 			String: migratingModelUUID,
 			Valid:  true,
@@ -465,18 +473,13 @@ func TestActivate_APIFailure(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
-
-	err = j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
+	err := j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.ErrorMatches, `.*API failure`)
 
-	modelMigration = dbmodel.IncomingModelMigration{
+	modelMigration := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
 			String: migratingModelUUID,
 			Valid:  true,
@@ -493,22 +496,11 @@ func TestActivate_NoIncomingModelMigration(t *testing.T) {
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvNoIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	err := j.Activate(ctx, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
-}
-
-func newIncomingMigration(userMap map[string]string, ctl dbmodel.Controller) dbmodel.IncomingModelMigration {
-	return dbmodel.IncomingModelMigration{
-		ModelUUID: sql.NullString{
-			String: migratingModelUUID,
-			Valid:  true,
-		},
-		TargetControllerID: ctl.ID,
-		UserMapping:        userMap,
-	}
 }
 
 func newModelDescription(owner string) description.Model {
@@ -635,6 +627,12 @@ controllers:
 users:
 - username: alice@canonical.com
   controller-access: superuser
+incoming-migrations:
+- model-uuid: ` + migratingModelUUID + `
+  target-controller: test1
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
 `
 
 func TestImport_Success(t *testing.T) {
@@ -665,11 +663,6 @@ func TestImport_Success(t *testing.T) {
 
 	env := jimmtest.ParseEnvironment(c, testImportEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
@@ -707,11 +700,6 @@ func TestImport_MissingCloudCredentialsFromDescription(t *testing.T) {
 
 	env := jimmtest.ParseEnvironment(c, testImportEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
@@ -752,11 +740,6 @@ func TestImport_UserNotFoundInUserMapping(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testImportEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
-
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
@@ -792,13 +775,8 @@ func TestImport_MissingCloudCredentialFromJIMMState(t *testing.T) {
 	})
 
 	// we intentionally parse an environment that does not have the cloud credential.
-	env := jimmtest.ParseEnvironment(c, testMigrationEnv)
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
@@ -845,11 +823,6 @@ func TestImport_APIFailure(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testImportEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	userMap := map[string]string{"bob": "alice@canonical.com"}
-	modelMigration := newIncomingMigration(userMap, env.Controller("test1").DBObject(c, j.Database))
-	err := j.Database.AddIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.IsNil)
-
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
@@ -872,4 +845,153 @@ func TestImport_APIFailure(t *testing.T) {
 	err = j.Database.GetModel(ctx, m)
 	c.Assert(err, qt.IsNil)
 	c.Assert(m.MigrationMode, qt.Equals, state.MigrationModeImporting)
+}
+
+// environment for testing cleanup of partial model migrations.
+// It contains:
+// - one valid incoming migration to be kept
+// - one stale incoming migration without user-mapping and a model to be deleted
+// - one stale incoming migration with model to be deleted
+// - one stale incoming migration
+const testCleanupEnv = `clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+cloud-credentials:
+- name: test-cred
+  cloud: test
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: test1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region
+  agent-version: 3.2.1
+  public-address: foo.com
+models:
+- name: test-model
+  uuid: "00000000-0000-0000-0000-000000000002"
+  controller: test1
+  cloud: test
+  region: test-region
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+  migration-mode: importing
+- name: test-model-2
+  uuid: "00000000-0000-0000-0000-000000000003"
+  controller: test1
+  cloud: test
+  region: test-region
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+  migration-mode: importing
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+incoming-migrations:
+- model-uuid: "00000000-0000-0000-0000-000000000001"
+  target-controller: test1
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
+- model-uuid: "00000000-0000-0000-0000-000000000002"
+  target-controller: test1
+  created-at: 2024-01-01T00:00:00Z
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
+  create-user-mapping: true
+- model-uuid: "00000000-0000-0000-0000-000000000003"
+  target-controller: test1
+  created-at: 2024-01-01T00:00:00Z
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
+- model-uuid: "00000000-0000-0000-0000-000000000004"
+  target-controller: test1
+  created-at: 2024-01-01T00:00:00Z
+  user-mapping:
+  - local-user: bob
+    external-user: alice@canonical.com
+`
+
+func TestCleanupPartialModelMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testCleanupEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	err := j.CleanupPartialModelMigrations(t.Context())
+	c.Assert(err, qt.IsNil)
+
+	// Check the first incoming migration is kept.
+	modelMigration := dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: env.IncomingMigrations[0].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
+	c.Assert(err, qt.IsNil)
+
+	// Check the second incoming migration has been deleted, with its mapping, and model.
+	modelMigration = dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: env.IncomingMigrations[1].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+
+	userMapping := dbmodel.UserMapping{
+		ModelUUID:        modelMigration.ModelUUID,
+		LocalUser:        "bob",
+		ExternalUserName: "alice@canonical.com",
+	}
+	err = j.Database.GetUserMapping(t.Context(), &userMapping)
+	c.Assert(err, qt.ErrorMatches, `.*user mapping not found`)
+
+	// Check the model has been deleted.
+	model := &dbmodel.Model{
+		UUID: sql.NullString{
+			String: env.IncomingMigrations[1].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetModel(t.Context(), model)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+
+	// Check the third incoming migration has been deleted, with its model.
+	modelMigration = dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: env.IncomingMigrations[2].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+
+	model = &dbmodel.Model{
+		UUID: sql.NullString{
+			String: env.IncomingMigrations[2].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetModel(t.Context(), model)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+
+	// Check the fourth incoming migration has been deleted.
+	modelMigration = dbmodel.IncomingModelMigration{
+		ModelUUID: sql.NullString{
+			String: env.IncomingMigrations[3].ModelUUID,
+			Valid:  true,
+		},
+	}
+	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"strconv"
 	"strings"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -30,13 +31,14 @@ const (
 )
 
 type Environment struct {
-	ApplicationOffers []ApplicationOffer `json:"application-offers"`
-	Clouds            []Cloud            `json:"clouds"`
-	CloudCredentials  []CloudCredential  `json:"cloud-credentials"`
-	CloudDefaults     []CloudDefaults    `json:"cloud-defaults"`
-	Controllers       []Controller       `json:"controllers"`
-	Models            []Model            `json:"models"`
-	Users             []User             `json:"users"`
+	ApplicationOffers  []ApplicationOffer  `json:"application-offers"`
+	Clouds             []Cloud             `json:"clouds"`
+	CloudCredentials   []CloudCredential   `json:"cloud-credentials"`
+	CloudDefaults      []CloudDefaults     `json:"cloud-defaults"`
+	Controllers        []Controller        `json:"controllers"`
+	Models             []Model             `json:"models"`
+	Users              []User              `json:"users"`
+	IncomingMigrations []IncomingMigration `json:"incoming-migrations"`
 }
 
 func ParseEnvironment(c Tester, env string) *Environment {
@@ -266,6 +268,10 @@ func (e *Environment) PopulateDB(c Tester, db *db.Database) {
 	for i := range e.ApplicationOffers {
 		e.ApplicationOffers[i].env = e
 		e.ApplicationOffers[i].DBObject(c, db)
+	}
+	for i := range e.IncomingMigrations {
+		e.IncomingMigrations[i].env = e
+		e.IncomingMigrations[i].DBObject(c, db)
 	}
 }
 
@@ -538,6 +544,65 @@ func (u *User) DBObject(c Tester, db *db.Database) dbmodel.Identity {
 	}
 
 	return u.dbo
+}
+
+type IncomingMigration struct {
+	ModelUUID         string    `json:"model-uuid"`
+	TargetController  string    `json:"target-controller"`
+	UserMapping       []UserMap `json:"user-mapping"`
+	CreatedAt         time.Time `json:"created-at"`
+	CreateUserMapping bool      `json:"create-user-mapping"`
+
+	env *Environment
+	dbo dbmodel.IncomingModelMigration
+}
+
+type UserMap struct {
+	LocalUser        string `json:"local-user"`
+	ExternalUserName string `json:"external-user"`
+}
+
+func (im *IncomingMigration) DBObject(c Tester, db *db.Database) dbmodel.IncomingModelMigration {
+	if im.dbo.ID != 0 {
+		return im.dbo
+	}
+
+	im.dbo.ModelUUID = sql.NullString{String: im.ModelUUID, Valid: true}
+	im.dbo.TargetControllerID = 0
+	if im.TargetController != "" {
+		im.dbo.TargetController = im.env.Controller(im.TargetController).DBObject(c, db)
+		im.dbo.TargetControllerID = im.dbo.TargetController.ID
+	}
+	if im.CreatedAt.IsZero() {
+		im.CreatedAt = time.Now()
+	}
+	im.dbo.CreatedAt = im.CreatedAt
+
+	im.dbo.UserMapping = make(dbmodel.StringMap, len(im.UserMapping))
+	for um := range im.UserMapping {
+		im.dbo.UserMapping[im.UserMapping[um].LocalUser] = im.UserMapping[um].ExternalUserName
+	}
+
+	err := db.AddIncomingModelMigration(context.Background(), &im.dbo)
+	if err != nil {
+		c.Fatalf("err is not nil: %s", err)
+	}
+
+	if im.CreateUserMapping {
+		for _, um := range im.UserMapping {
+			userMapping := &dbmodel.UserMapping{
+				ModelUUID:        im.dbo.ModelUUID,
+				LocalUser:        um.LocalUser,
+				ExternalUserName: um.ExternalUserName,
+			}
+			err = db.AddUserMapping(context.Background(), userMapping)
+			if err != nil {
+				c.Fatalf("err is not nil: %s", err)
+			}
+		}
+	}
+
+	return im.dbo
 }
 
 // UserAccess represents user access to am object in a test environment.

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -31,6 +31,7 @@ type JujuManager struct {
 	AddCloudToController_              func(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	AddHostedCloud_                    func(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	CopyCredential_                    func(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error)
+	CleanupPartialModelMigrations_     func(ctx context.Context) error
 	DestroyOffer_                      func(ctx context.Context, user *openfga.User, offerURL string, force bool) error
 	FindApplicationOffers_             func(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
 	FindAuditEvents_                   func(ctx context.Context, user *openfga.User, filter db.AuditLogFilter) ([]dbmodel.AuditLogEntry, error)
@@ -274,4 +275,11 @@ func (j *JujuManager) PrepareModelMigration(ctx context.Context, user *openfga.U
 		return nil
 	}
 	return j.PrepareModelMigration_(ctx, user, modelUUID, targetControllerName, userMapping)
+}
+
+func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
+	if j.CleanupPartialModelMigrations_ == nil {
+		return nil
+	}
+	return j.CleanupPartialModelMigrations_(ctx)
 }


### PR DESCRIPTION
## Description
In this pr we introduce two cleanups: the first is just to remove from JIMM's state the model created during Import on Abort. The second is a routine that runs periodically and it removes the stale migrations with eventual user mappings and models.

To accomplish this:
- created db method to query all stale model migrations
- created db model to delete user mapping associated to a model_uuid
- add method to juju manager to do the cleanup
- improve the tests by adding the model-migration to our `env`