### PR TITLE
fix: incorrect logic during model migration

### DIFF
--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -184,18 +184,18 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
 	const op = errors.Op("jimm.AdoptResources")
 
-	modelMigration := dbmodel.IncomingModelMigration{
-		ModelUUID: sql.NullString{
+	model := dbmodel.Model{
+		UUID: sql.NullString{
 			String: modelUUID,
 			Valid:  true,
 		},
 	}
-	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
+	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
 	}
 
-	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	api, err := j.dialController(ctx, &model.Controller)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
 	}

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -181,6 +181,9 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 // and controller version. This is used to adopt resources from a
 // model that is being migrated. It calls the method of the same name
 // on the target Juju controller.
+//
+// Adopt resources is called after the model has been activated so the
+// incoming model migration does not exist and the model is used instead.
 func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
 	const op = errors.Op("jimm.AdoptResources")
 

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -309,13 +309,18 @@ func TestAdoptResources_Success(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
+	// Note that adopt resources is called after the model
+	// has been activated so the incoming model migration
+	// row was deleted and the model has been created.
+
 	controllerVersion := version.MustParse("3.2.1")
+	modelUUID := "00000002-0000-0000-0000-000000000001"
 
 	// Validate that the API request to Juju is made with a modified version
 	// of the model description, where the owner is replaced with an external user.
 	api := &jimmtest.API{
 		AdoptResources_: func(uuid string, v version.Number) error {
-			c.Check(uuid, qt.Equals, migratingModelUUID)
+			c.Check(uuid, qt.Equals, modelUUID)
 			c.Check(v, qt.DeepEquals, controllerVersion)
 			return nil
 		},
@@ -327,30 +332,24 @@ func TestAdoptResources_Success(t *testing.T) {
 		},
 	})
 
-	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
+	env := jimmtest.ParseEnvironment(c, migratedModelEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
-	err := j.AdoptResources(ctx, user, migratingModelUUID, controllerVersion)
+	err := j.AdoptResources(ctx, user, modelUUID, controllerVersion)
 	c.Assert(err, qt.IsNil)
 }
 
-func TestAdoptResources_NoIncomingModelMigration(t *testing.T) {
+func TestAdoptResources_NoModel(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
 	j := newTestJujuManager(c, nil)
 
-	env := jimmtest.ParseEnvironment(c, testEnvNoIncomingMigration)
-	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
-	user := openfga.NewUser(&dbUser, nil)
-
-	err := j.AdoptResources(ctx, user, "foo", version.MustParse("3.2.1"))
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	err := j.AdoptResources(ctx, nil, "foo", version.MustParse("3.2.1"))
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 }
 
 const testEnvWithIncomingMigrationAndModel = `clouds:

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -40,12 +40,13 @@ func init() {
 		checkMachines := rpc.Method(r.CheckMachines)
 		importMethod := rpc.Method(r.Import)
 		latestLogTime := rpc.Method(r.LatestLogTime)
+		abort := rpc.Method(r.Abort)
 
 		r.AddMethod("MigrationTarget", 4, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 4, "CACert", caCert)
 		r.AddMethod("MigrationTarget", 4, "Activate", activate)
 		r.AddMethod("MigrationTarget", 4, "AdoptResources", adoptResources)
-		r.AddMethod("MigrationTarget", 4, "Abort", adoptResources)
+		r.AddMethod("MigrationTarget", 4, "Abort", abort)
 		r.AddMethod("MigrationTarget", 4, "CheckMachines", checkMachines)
 		r.AddMethod("MigrationTarget", 4, "Import", importMethod)
 		r.AddMethod("MigrationTarget", 4, "LatestLogTime", latestLogTime)
@@ -198,11 +199,17 @@ func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModel
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("invalid model tag: %w", err))
 	}
-	controllerTag, err := names.ParseControllerTag(args.ControllerTag)
-	if err != nil {
-		return errors.E(op, err)
+	// The controller tag is optional, so we parse it only if provided.
+	// It is only provided when args.CrossModelUUIDs is not empty.
+	var controllerTag names.ControllerTag
+	if args.ControllerTag != "" {
+		controllerTag, err = names.ParseControllerTag(args.ControllerTag)
+		if err != nil {
+
+			return errors.E(op, fmt.Errorf("invalid controller tag: %w", err))
+		}
 	}
 
 	err = r.jimm.JujuManager().Activate(

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -101,7 +101,7 @@ func (s *migrationTargetSuite) TestAdoptResources(c *gc.C) {
 	modelUUID := "00000001-0000-0000-0000-000000000001"
 	client := migrationtarget.NewClient(conn)
 	err := client.AdoptResources(modelUUID)
-	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model not found`)
 }
 
 func (s *migrationTargetSuite) TestActivate(c *gc.C) {

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -354,7 +354,7 @@ func (s *migrationTargetUnitSuite) TestActivateInvalidModelTag(c *gc.C) {
 	// Validate that an invalid model tag is rejected.
 	user.JimmAdmin = true
 	err := cr.Activate(ctx, args)
-	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag`)
+	c.Assert(err, gc.ErrorMatches, `.*"invalid-model-tag" is not a valid tag`)
 }
 
 func (s *migrationTargetUnitSuite) TestActivateInvalidControllerTag(c *gc.C) {
@@ -384,7 +384,7 @@ func (s *migrationTargetUnitSuite) TestActivateInvalidControllerTag(c *gc.C) {
 	// Validate that an invalid controller tag is rejected.
 	user.JimmAdmin = true
 	err := cr.Activate(ctx, args)
-	c.Assert(err, gc.ErrorMatches, `"invalid-controller-tag" is not a valid tag`)
+	c.Assert(err, gc.ErrorMatches, `.*"invalid-controller-tag" is not a valid tag`)
 }
 
 func (s *migrationTargetUnitSuite) TestActivateMissingControllerTag(c *gc.C) {

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -387,6 +387,41 @@ func (s *migrationTargetUnitSuite) TestActivateInvalidControllerTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"invalid-controller-tag" is not a valid tag`)
 }
 
+func (s *migrationTargetUnitSuite) TestActivateMissingControllerTag(c *gc.C) {
+	ctx := context.Background()
+
+	jujuManager := mocks.JujuManager{
+		MigrationMocks: mocks.MigrationMocks{
+			Activate_: func(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+				// This function should not be called
+				return nil
+			},
+		},
+	}
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &jujuManager
+		},
+	}
+
+	var u dbmodel.Identity
+	u.SetTag(names.NewUserTag("alice@canonical.com"))
+	user := openfga.NewUser(&u, nil)
+
+	cr := jujuapi.NewControllerRoot(jimm, jujuapi.Params{})
+	jujuapi.SetUser(cr, user)
+
+	// The only required field is the model tag.
+	args := jujuparams.ActivateModelArgs{
+		ModelTag: names.NewModelTag("00000001-0000-0000-0000-000000000001").String(),
+	}
+
+	// Validate that an invalid controller tag is rejected.
+	user.JimmAdmin = true
+	err := cr.Activate(ctx, args)
+	c.Assert(err, gc.IsNil)
+}
+
 func (s *migrationTargetUnitSuite) TestLatestLogTime(c *gc.C) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description
This PR fixes 3 issues in the model migration logic:
1. The `Abort` RPC method was calling the `AdoptResources` domain function.
2. In `Activate` the controller-tag field is optional but was always being checked.
3. The `AdoptResources` method is called after `Activate`. By this point we have deleted the `IncomingModelMigration` entry. Ideally we should always look for the `model` in any case since we create it near the start of model migration and only use the `IncomingModelMigration` entry for holding the user-mapping.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
I've identified these issues during my manual QA. An automated QA script will come in a follow-up.