### PR TITLE
feat: add support for running juju cmds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -344,26 +344,18 @@ require (
 	cloud.google.com/go/auth v0.13.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.6 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect
-	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 // indirect
-	github.com/canonical/pebble v1.19.2 // indirect
-	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/juju/packaging/v4 v4.0.0 // indirect
 	github.com/juju/terms-client/v2 v2.0.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
-	github.com/pkg/term v1.1.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/zitadel/logging v0.6.1 // indirect
 	github.com/zitadel/oidc/v3 v3.35.0 // indirect
 	github.com/zitadel/schema v1.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/tools v0.34.0 // indirect
 )
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.28.0 // indirect
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb // indirect
+	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mittwald/vaultgo v0.1.4 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -350,7 +350,9 @@ require (
 	github.com/canonical/pebble v1.19.2 // indirect
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/juju/packaging/v4 v4.0.0 // indirect
+	github.com/juju/terms-client/v2 v2.0.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,14 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cjlapao/common-go v0.0.39 h1:bAAUrj2B9v0kMzbAOhzjSmiyDy+rd56r2sy7oEiQLlA=
 github.com/cjlapao/common-go v0.0.39/go.mod h1:M3dzazLjTjEtZJbbxoA5ZDiGCiHmpwqW9l4UWaddwOA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -703,6 +709,8 @@ github.com/juju/rpcreflect v1.2.0/go.mod h1:yWSyMkWOwQGqUVxvboHn1c3CuCQrQ5LgV//8
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.2.0 h1:+XywM0pYzuhGebQiK1aR4Bj7Q7nLV5MihcOgq6dLLxs=
 github.com/juju/schema v1.2.0/go.mod h1:VdljuJLc45loM79LYm4yKKmPJwK1bPKRekvMVlfywU0=
+github.com/juju/terms-client/v2 v2.0.0 h1:8DGcK9JW5Q7gmuvTzB2qIXsa/KY70jWM54rtGFAmyak=
+github.com/juju/terms-client/v2 v2.0.0/go.mod h1:ezOEZrFZZ0c9Kc0xeHH7SCmniWPkjuxiAm82wwg+fpE=
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
@@ -1347,6 +1355,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 h1:IEjq88XO4PuBDcvmjQJcQGg+w+UaafSy8G5Kcb5tBhI=
-github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5/go.mod h1:exZ0C/1emQJAw5tHOaUDyY1ycttqBAPcxuzf7QbY6ec=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -157,20 +155,14 @@ github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f h1:gOO/tNZMjjvTKZWpY
 github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVyM+QKFJagiyrM91Ke5S9htoL1D470g6E=
-github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/go-service v1.0.0 h1:TF6TsEp04xAoI5pPoWjTYmEwLjbPATSnHEyeJCvzElg=
 github.com/canonical/go-service v1.0.0/go.mod h1:GzNLXpkGdglL0kjREXoLXj2rB2Qx+EvAGncRDqCENYQ=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7 h1:D+lFLV2E9um9NcknxFVBzboPSXpxJDEXspBbHMs4KxQ=
 github.com/canonical/lxd v0.0.0-20241209155119-76da976c6ee7/go.mod h1:RJwBW5w8gxwp7W4+tZJDDKp3uA5vB1W9f4qveoWA59U=
 github.com/canonical/ofga v0.10.0 h1:DHXhG/DAXWWQT/I+2jzr4qm0uTIYrILmtMxd6ZqmEzE=
 github.com/canonical/ofga v0.10.0/go.mod h1:u4Ou8dbIhO7FmVlT7W3rX2roD9AOGz/CqmGh7AdF0Lo=
-github.com/canonical/pebble v1.19.2 h1:5KTtTu4OK0q2+MCrlEm2hfar2kcdbJvIyM9JlvLfsFo=
-github.com/canonical/pebble v1.19.2/go.mod h1:fPtK3xrfuiRQBKSzfm3iBfdmIxlD/nup8yS1FVS8ZKQ=
 github.com/canonical/rebac-admin-ui-handlers v0.1.2 h1:tQU/NWQVD9IEgy3ct8JWZXpLK/dedWjKcy9E8W4glpo=
 github.com/canonical/rebac-admin-ui-handlers v0.1.2/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
-github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
-github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
@@ -431,8 +423,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
@@ -645,8 +635,6 @@ github.com/juju/idmclient/v2 v2.0.0 h1:PsGa092JGy6iFNHZCcao+bigVsTyz1C+tHNRdYmKv
 github.com/juju/idmclient/v2 v2.0.0/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
 github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
 github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
-github.com/juju/juju v0.0.0-20250625073532-2ce1f500e8b5 h1:likeg6sbFdGYSDgVDi9vj9PR6Cd3YUgCYH6hQV9fftU=
-github.com/juju/juju v0.0.0-20250625073532-2ce1f500e8b5/go.mod h1:QfOxk8g0MX1oe+PtOeIEeeobkDkDu+ZvGB6nytufJZg=
 github.com/juju/juju v0.0.0-20250630072737-cdafe8cdeaef h1:zoF6HiKNBhKmq+5E7O18nFpqiJwPSQeBN8Uk6zlIdB4=
 github.com/juju/juju v0.0.0-20250630072737-cdafe8cdeaef/go.mod h1:QfOxk8g0MX1oe+PtOeIEeeobkDkDu+ZvGB6nytufJZg=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
@@ -963,8 +951,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.7 h1:uv+I3nNJvlKZIQGSr8JVQLNHFU9YhhNpvC14Y6KgmSM=
 github.com/pkg/sftp v1.13.7/go.mod h1:KMKI0t3T6hfA+lTR/ssZdunHo+uwq7ghoN09/FSu3DY=
-github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
-github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pkg/xattr v0.4.10 h1:Qe0mtiNFHQZ296vRgUjRCoPHPqH7VdTOrZx3g0T+pGA=
 github.com/pkg/xattr v0.4.10/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -1336,7 +1322,6 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/jujucommands/export_test.go
+++ b/internal/jujucommands/export_test.go
@@ -1,0 +1,7 @@
+// Copyright 2025 Canonical.
+
+package jujucommands
+
+var (
+	RunCmdWithOutputRetriever = runCmdWithOutputRetriever
+)

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -46,6 +46,8 @@ type outputLine struct {
 //	}
 //
 // The OutputLine channel is closed once all output from the command has finished an the error has been captured.
+//
+// Lines returned are returned with no newlines.
 func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) (<-chan outputLine, error) {
 	cmdReader, cmdWriter := io.Pipe()
 

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -58,20 +58,17 @@ func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) 
 	cmdCtx.Stdout = cmdWriter
 
 	outputCh := make(chan outputLine)
-	// We buffer cmdFinishedCh with capacity 1 to avoid a deadlock here.
-	// In runCmd, the writer (cmdWriter) is deferred to close only after runCmd completes.
-	// When sending the final error down cmdFinishedCh, if it's unbuffered,
-	// the send blocks because no goroutine is receiving yet.
-	// This blocks runCmd from completing, so the deferred writer.Close() never runs,
-	// meaning no EOF is sent to the reader, which keeps blocking forever.
-	// By buffering cmdFinishedCh, the send won't block, allowing runCmd to complete,
-	// the writer to close, and the reader to receive EOF and finish reading.
+	// We buffer cmdFinishedCh (capacity 1) to avoid deadlock.
+	// runCmd defers cmdWriter.Close(), which only runs after runCmd finishes.
+	// If cmdFinishedCh were unbuffered, sending the final error would block
+	// (since no goroutine is receiving yet), which prevents runCmd from finishing.
+	// This means cmdWriter.Close() never runs, so the reader never gets EOF and hangs.
+	// With a buffered channel, the send doesn't block, allowing runCmd to finish,
+	// the writer to close, and the reader to eventually see EOF and exit.
 	//
-	// There's no need to worry about it blocking, as we'll only ever send one value down
-	// once the command completes.
-	//
-	// We could alternatively manually call cmdWriter.Close() immediately after running the command.
-	cmdFinishedCh := make(chan error, 1)
+	// This is safe because we only send once, after the command finishes.
+	// Alternatively, we could manually close cmdWriter right after the command.
+	cmdFinishedCh := make(chan int, 1)
 
 	go func() {
 		// Read cmdoutput.
@@ -81,9 +78,9 @@ func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) 
 		}
 
 		// Wait for cmd to finish.
-		err := <-cmdFinishedCh
-		if err != nil {
-			outputCh <- outputLine{Err: err}
+		code := <-cmdFinishedCh
+		if code != 0 {
+			outputCh <- outputLine{Err: fmt.Errorf("cmd failed with code: %d", code)}
 		}
 
 		close(outputCh)
@@ -98,14 +95,14 @@ func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) 
 // The function splits cmdAndArgs into arguments, constructs a Juju command, and runs it.
 // On non-zero exit code, it sends an error to cmdFinishedCh; otherwise, it signals successful completion.
 //
-// Note, the cmdAndArgs argument expects a fully-qualified command strings. I.e.,
+// Note, the cmdAndArgs argument expects a fully-qualified command string. I.e.,
 //
 //	"bootstrap lxd a --add-model=\"my-initial-model\""
 func runCmd(
 	cmdCtx *cmd.Context,
 	cmdWriter *io.PipeWriter,
 	store jujuclient.ClientStore,
-	cmdFinishedCh chan<- error,
+	cmdFinishedCh chan<- int,
 	cmdAndArgs string,
 ) {
 	defer cmdWriter.Close()
@@ -128,9 +125,5 @@ func runCmd(
 
 	code := cmd.Main(jujuCmd, cmdCtx, strings.Split(cmdAndArgs, " "))
 
-	if code != 0 {
-		cmdFinishedCh <- fmt.Errorf("cmd failed with code %d", code)
-	} else {
-		cmdFinishedCh <- nil
-	}
+	cmdFinishedCh <- code
 }

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Canonical.
+
+// Package jujucommands provides functions run juju cmds from a JIMM instance.
+// Each command function is run with its own isolated in-mem store.
+
+package jujucommands
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/jujuclient"
+	"github.com/mitchellh/go-linereader"
+)
+
+var (
+	whitelist = []string{"help", "bootstrap"}
+)
+
+type outputLine struct {
+	Line string
+	Err  error
+}
+
+// runCmdWithOutputRetriever runs the command given by cmdAndArgs using the provided jujuclient.ClientStore.
+// It returns a channel that streams OutputLine values for each line of command output and any final error.
+//
+// Upon receiving an error in an OutputLine, the line previously streamed is guaranteed to be the error line written by
+// the command.
+// I.e., if you run: "help -b"
+// You will get:
+//
+//	Output line: ERROR option provided but not defined: -b // The error line from juju (Which is a none-erroneous OutputLine)
+//	Command finished with error: cmd failed with code 2 // The command error code line (Contains an error in the OutputLine)
+//
+// Consumers are expected to simply read from the OutputLine channel and check for an error like so:
+//
+//	for out := range outputCh {
+//		if out.Err != nil {
+//			fmt.Println("Command finished with error:", out.Err)
+//			break
+//		}
+//		fmt.Println("Output line:", out.Line)
+//	}
+//
+// The OutputLine channel is closed once all output from the command has finished an the error has been captured.
+func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) (<-chan outputLine, error) {
+	// memStore := jujuclient.NewEmbeddedMemStore()
+	cmdReader, cmdWriter := io.Pipe()
+
+	cmdCtx, err := cmd.DefaultContext()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdCtx.Stderr = cmdWriter
+	cmdCtx.Stdout = cmdWriter
+
+	outputCh := make(chan outputLine)
+	// We buffer cmdFinishedCh with capacity 1 to avoid a deadlock here.
+	// In runCmd, the writer (cmdWriter) is deferred to close only after runCmd completes.
+	// When sending the final error down cmdFinishedCh, if it's unbuffered,
+	// the send blocks because no goroutine is receiving yet.
+	// This blocks runCmd from completing, so the deferred writer.Close() never runs,
+	// meaning no EOF is sent to the reader, which keeps blocking forever.
+	// By buffering cmdFinishedCh, the send won't block, allowing runCmd to complete,
+	// the writer to close, and the reader to receive EOF and finish reading.
+	//
+	// There's no need to worry about it blocking, as we'll only ever send one value down
+	// once the command completes.
+	//
+	// We could alternatively manually call cmdWriter.Close() immediately after running the command.
+	cmdFinishedCh := make(chan error, 1)
+
+	go func() {
+		// Read cmdoutput.
+		lr := linereader.New(cmdReader)
+		for line := range lr.Ch {
+			outputCh <- outputLine{Line: line}
+		}
+
+		// Wait for cmd to finish.
+		err := <-cmdFinishedCh
+		if err != nil {
+			outputCh <- outputLine{Err: err}
+		}
+
+		close(outputCh)
+	}()
+	go runCmd(cmdCtx, cmdWriter, store, cmdFinishedCh, cmdAndArgs)
+
+	return outputCh, nil
+}
+
+// runCmd executes a Juju command using the provided context, client store, and command arguments.
+// It writes command output to the given io.PipeWriter and signals completion or error via cmdFinishedCh.
+// The function splits cmdAndArgs into arguments, constructs a Juju command, and runs it.
+// On non-zero exit code, it sends an error to cmdFinishedCh; otherwise, it signals successful completion.
+//
+// Note, the cmdAndArgs argument expects a fully-qualified command strings. I.e.,
+//
+//	"bootstrap lxd a --add-model=\"my-initial-model\""
+func runCmd(
+	cmdCtx *cmd.Context,
+	cmdWriter *io.PipeWriter,
+	store jujuclient.ClientStore,
+	cmdFinishedCh chan<- error,
+	cmdAndArgs string,
+) {
+	defer cmdWriter.Close()
+
+	jujuCmd := commands.NewJujuCommandWithStore(
+		cmdCtx,
+		store,
+		nil,       // quiet?
+		"",        // unknown param
+		"",        // no help hint
+		whitelist, // whitelist
+		true,
+	)
+
+	code := cmd.Main(jujuCmd, cmdCtx, strings.Split(cmdAndArgs, " "))
+
+	if code != 0 {
+		cmdFinishedCh <- fmt.Errorf("cmd failed with code %d", code)
+	} else {
+		cmdFinishedCh <- nil
+	}
+}

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -2,7 +2,6 @@
 
 // Package jujucommands provides functions run juju cmds from a JIMM instance.
 // Each command function is run with its own isolated in-mem store.
-
 package jujucommands
 
 import (
@@ -48,7 +47,6 @@ type outputLine struct {
 //
 // The OutputLine channel is closed once all output from the command has finished an the error has been captured.
 func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) (<-chan outputLine, error) {
-	// memStore := jujuclient.NewEmbeddedMemStore()
 	cmdReader, cmdWriter := io.Pipe()
 
 	cmdCtx, err := cmd.DefaultContext()

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -120,17 +120,7 @@ func runCmd(
 		"",        // no help hint
 		whitelist, // whitelist
 		// We set embedded false because some commands can targets either a controller or client.
-		// I.e.,:
-		// SetFlags initializes the flags supported by the command.
-		// func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
-		// 	c.CommandBase.SetFlags(f)
-		// 	// Embedded commands do not use the --client or --controller options.
-		// 	if !c.Embedded {
-		// 		f.BoolVar(&c.Client, "client", false, "Client operation")
-		// 		f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")
-		// 		f.StringVar(&c.ControllerName, "controller", "", "")
-		// 	}
-		// }
+		// See: https://github.com/juju/juju/blob/1abcb8c5f1f187fd1443e12d6324a47780b43740/cmd/modelcmd/controller.go#L451
 		// And whilst we are "technically" embedding the CLI, without setting this to false,
 		// You must run without --client/--controller and it defaults to updating the client
 		// in update-public-clouds. So, we set it false to allow us to explicitly set

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -119,7 +119,23 @@ func runCmd(
 		"",        // unknown param
 		"",        // no help hint
 		whitelist, // whitelist
-		true,
+		// We set embedded false because some commands can targets either a controller or client.
+		// I.e.,:
+		// SetFlags initializes the flags supported by the command.
+		// func (c *OptionalControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+		// 	c.CommandBase.SetFlags(f)
+		// 	// Embedded commands do not use the --client or --controller options.
+		// 	if !c.Embedded {
+		// 		f.BoolVar(&c.Client, "client", false, "Client operation")
+		// 		f.StringVar(&c.ControllerName, "c", "", "Controller to operate in")
+		// 		f.StringVar(&c.ControllerName, "controller", "", "")
+		// 	}
+		// }
+		// And whilst we are "technically" embedding the CLI, without setting this to false,
+		// You must run without --client/--controller and it defaults to updating the client
+		// in update-public-clouds. So, we set it false to allow us to explicitly set
+		// "--client" and not have it ignored.
+		false,
 	)
 
 	code := cmd.Main(jujuCmd, cmdCtx, strings.Split(cmdAndArgs, " "))

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Canonical.
+
+package jujucommands_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/jujucommands"
+)
+
+type jujucommandsSuite struct{}
+
+func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever(c *qt.C) {
+	outputCh, err := jujucommands.RunCmdWithOutputRetriever(jujuclient.NewEmbeddedMemStore(), "help")
+	c.Assert(err, qt.IsNil)
+
+	// Use a builder to collect streamed output & test entire string.
+	var b strings.Builder
+
+	for out := range outputCh {
+		c.Assert(out.Err, qt.IsNil)
+		b.WriteString(out.Line + "\n")
+	}
+
+	expected := `Juju provides easy, intelligent application orchestration on top of Kubernetes,
+cloud infrastructure providers such as Amazon, Google, Microsoft, Openstack,
+MAAS (and more!), or even your local machine via LXD.
+
+See https://juju.is for getting started tutorials and additional documentation.
+
+Starter commands:
+
+    bootstrap           Initializes a cloud environment.
+    add-model           Adds a workload model.
+    deploy              Deploys a new application.
+    status              Displays the current status of Juju, applications, and units.
+    add-unit            Adds extra units of a deployed application.
+    integrate           Adds an integration between two applications.
+    expose              Makes an application publicly available over the network.
+    models              Lists models a user can access on a controller.
+    controllers         Lists all controllers.
+    whoami              Display the current controller, model and logged in user name. 
+    switch              Selects or identifies the current controller and model.
+    add-k8s             Adds a k8s endpoint and credential to Juju.
+    add-cloud           Adds a user-defined cloud to Juju.
+    add-credential      Adds or replaces credentials for a cloud.
+
+Interactive mode:
+
+When run without arguments, Juju will enter an interactive shell which can be
+used to run any Juju command directly.
+
+Help commands:
+    
+    juju help           This help page.
+    juju help <command> Show help for the specified command.
+
+For the full list of supported commands run: 
+    
+    juju help commands
+`
+
+	c.Assert(b.String(), qt.Equals, expected)
+}
+
+func TestJujucommandsSuite(t *testing.T) {
+	qtsuite.Run(qt.New(t), &jujucommandsSuite{})
+}


### PR DESCRIPTION
## Description
This PR brings in the support to run juju cmds. The new package will contain commands in their own respective files, i.e., `bootstrap.go` The commands will use `runCmdWithOutputRetriever` which returns a channel callers can read from and it is closed once the command completes. It guarantees two conditions:
1. All output has been read from the command.
2. The command has finished.
Should the command error, the final `outputLine` contains an error with the code returned. We could capture the previous line and encapsulate this into the error (as the last line [I think?] is always the error). But for now, I think this should suffice. 
  
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
