### PR TITLE
feat: redirect agents to backing controller

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -24,6 +24,10 @@ type Error struct {
 	// Message is a human-readable error description.
 	Message string
 
+	// Info is additional information about the error
+	// that clients need to use.
+	Info map[string]any
+
 	// Err contains the underlying error, if there is one.
 	Err error
 }
@@ -80,6 +84,8 @@ func E(args ...interface{}) error {
 			e.Err = v
 		case string:
 			e.Message = v
+		case map[string]any:
+			e.Info = v
 		default:
 			zapctx.Default.DPanic("unknown type passed to errors.E", zap.String("type", fmt.Sprintf("%T", arg)), zap.Any("value", arg))
 			return fmt.Errorf("unknown type (%T) passed to errors.E", arg)
@@ -137,4 +143,13 @@ func ErrorCode(err error) Code {
 		return ""
 	}
 	return e.Code
+}
+
+// ErrorInfo returns additional information about the error.
+func ErrorInfo(err error) map[string]any {
+	e, ok := err.(*Error)
+	if !ok {
+		return nil
+	}
+	return e.Info
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package errors_test
 
@@ -34,4 +34,20 @@ func TestE(t *testing.T) {
 	err = errors.E(errors.Op("test.op2"), err)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
+}
+
+func TestEWithInfo(t *testing.T) {
+	c := qt.New(t)
+
+	code := errors.Code("test code")
+	info := map[string]any{"key": "value"}
+	err := errors.E(errors.Op("test.op"), code, "an error happened", info)
+	c.Check(err, qt.ErrorMatches, `an error happened`)
+	c.Check(errors.ErrorCode(err), qt.Equals, code)
+	c.Check(err.(*errors.Error).Info, qt.DeepEquals, info)
+	c.Check(errors.ErrorInfo(err), qt.DeepEquals, info)
+
+	err = errors.E("plain-error")
+	c.Check(err, qt.ErrorMatches, `plain-error`)
+	c.Check(errors.ErrorInfo(err), qt.DeepEquals, map[string]any(nil))
 }

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -1,4 +1,5 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
+
 package jimmhttp_test
 
 import (
@@ -81,6 +82,7 @@ func TestWellknownAPIJWKSJSONHandles404(t *testing.T) {
 	c.Assert(b, qt.JSONEquals, map[string]any{
 		"Code":    errors.CodeNotFound,
 		"Err":     nil,
+		"Info":    nil,
 		"Message": "JWKS does not exist yet",
 		"Op":      "wellknownapi.JWKS",
 	})
@@ -110,6 +112,7 @@ func TestWellknownAPIJWKSJSONHandles500(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusInternalServerError)
 	c.Assert(b, qt.JSONEquals, map[string]any{
 		"Code":    errors.CodeJWKSRetrievalFailed,
+		"Info":    nil,
 		"Err":     nil,
 		"Message": "something went wrong...",
 		"Op":      "wellknownapi.JWKS",

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -174,10 +174,12 @@ func modelInfoFromPath(path string) (uuid string, finalPath string, err error) {
 // We act as a proxier, handling auth on requests before forwarding the
 // requests to the appropriate Juju controller.
 func (s apiModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn) {
+	redirectInfo := redirectInfoAdapter{jimm: s.jimm}
 	jwtGenerator := s.jimm.NewJujuAuthenticator()
 	connectionFunc := controllerConnectionFunc(s, &jwtGenerator)
-	zapctx.Debug(ctx, "Starting proxier")
 	auditLogger := s.jimm.AuditLogManager().AddAuditLogEntry
+
+	zapctx.Debug(ctx, "Starting proxier")
 	proxyHelpers := rpcproxy.ProxyHelpers{
 		ConnClient:              clientConn,
 		TokenGen:                &jwtGenerator,
@@ -186,6 +188,7 @@ func (s apiModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn
 		LoginService:            s.jimm.LoginManager(),
 		AuthenticatedIdentityID: auth.SessionIdentityFromContext(ctx),
 		SSHKeyManager:           s.jimm.SSHKeyManager(),
+		RedirectInfo:            redirectInfo,
 	}
 	if err := rpcproxy.ProxySockets(ctx, proxyHelpers); err != nil {
 		zapctx.Error(ctx, "failed to start jimm model proxy", zap.Error(err))
@@ -230,6 +233,34 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 			ModelUUID:      uuid,
 		}, nil
 	}
+}
+
+// redirectInfoAdapter provides an implementation of rpcproxy.RedirectInfo
+// for retrieving the controller details needed for redirecting requests.
+type redirectInfoAdapter struct {
+	jimm *jimm.JIMM
+}
+
+// GetRedirectInfo implements rpcproxy.RedirectInfo.
+// It extracts the model UUID from the request context and retrieves the
+// controller details from JIMM's JujuManager.
+// It returns the controller's addresses and CA certificate.
+func (r redirectInfoAdapter) GetRedirectInfo(ctx context.Context) (rpcproxy.ControllerDetails, error) {
+	path := jimmhttp.PathElementFromContext(ctx)
+	uuid, _, err := modelInfoFromPath(path)
+	if err != nil {
+		zapctx.Error(ctx, "error parsing path", zap.Error(err))
+		return rpcproxy.ControllerDetails{}, err
+	}
+	model, err := r.jimm.JujuManager().GetModel(ctx, uuid)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get model", zap.String("uuid", uuid), zap.Error(err))
+		return rpcproxy.ControllerDetails{}, err
+	}
+	return rpcproxy.ControllerDetails{
+		Servers: model.Controller.Addresses,
+		CACert:  model.Controller.CACertificate,
+	}, nil
 }
 
 // Use a 64k frame size for the websockets while we need to deal

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -258,8 +258,8 @@ func (r redirectInfoAdapter) GetRedirectInfo(ctx context.Context) (rpcproxy.Cont
 		return rpcproxy.ControllerDetails{}, err
 	}
 	return rpcproxy.ControllerDetails{
-		Servers: model.Controller.Addresses,
-		CACert:  model.Controller.CACertificate,
+		Addresses: model.Controller.Addresses,
+		CACert:    model.Controller.CACertificate,
 	}, nil
 }
 

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/juju/errors"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/client/keymanager"
@@ -221,6 +222,44 @@ func (s *apiProxySuite) TestSessionTokenLoginProvider(c *gc.C) {
 	c.Check(err, gc.Equals, nil)
 	outputNoNewLine := strings.ReplaceAll(output.String(), "\n", "")
 	c.Check(outputNoNewLine, gc.Matches, `Please visit .* and enter code.*`)
+}
+
+// TestAgentLoginReturnsRedirect verifies that the agent login returns a redirect error
+// when trying to connect to the model proxy. We don't use the helper methods
+// for opening the connection because we want to test authenticating as an agent.
+func (s *apiProxySuite) TestAgentLoginReturnsRedirect(c *gc.C) {
+	u, err := url.Parse(s.HTTP.URL)
+	c.Assert(err, gc.Equals, nil)
+
+	info := api.Info{
+		Tag:      names.NewUnitTag("ubuntu/1"),
+		ModelTag: s.Model.ResourceTag(),
+		Addrs:    []string{u.Host},
+	}
+	dialOpts := api.DialOpts{
+		InsecureSkipVerify: true,
+	}
+	_, err = api.Open(&info, dialOpts)
+	c.Assert(err, gc.NotNil)
+	_, ok := errors.Cause(err).(*api.RedirectError)
+	c.Check(ok, gc.Equals, true)
+}
+
+func (s *apiProxySuite) TestAgentLoginModelDoesNotExist(c *gc.C) {
+	u, err := url.Parse(s.HTTP.URL)
+	c.Assert(err, gc.Equals, nil)
+
+	info := api.Info{
+		Tag:      names.NewUnitTag("ubuntu/1"),
+		ModelTag: names.NewModelTag("00000000-0000-0000-0000-000000000000"),
+		Addrs:    []string{u.Host},
+	}
+	dialOpts := api.DialOpts{
+		InsecureSkipVerify: true,
+	}
+	_, err = api.Open(&info, dialOpts)
+	c.Assert(err, gc.NotNil)
+	c.Check(err.Error(), gc.Matches, `model not found.*`)
 }
 
 type logger struct{}

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -241,8 +241,13 @@ func (s *apiProxySuite) TestAgentLoginReturnsRedirect(c *gc.C) {
 	}
 	_, err = api.Open(&info, dialOpts)
 	c.Assert(err, gc.NotNil)
-	_, ok := errors.Cause(err).(*api.RedirectError)
+	redirectErr, ok := errors.Cause(err).(*api.RedirectError)
 	c.Check(ok, gc.Equals, true)
+	c.Assert(redirectErr.Servers, gc.HasLen, 1)
+	servers := redirectErr.Servers[0].HostPorts().Strings()
+	c.Assert(servers, gc.HasLen, 1)
+	c.Check(servers[0], gc.Matches, "localhost:[0-9]+")
+	c.Check(len(redirectErr.CACert), gc.Not(gc.Equals), 0)
 }
 
 func (s *apiProxySuite) TestAgentLoginModelDoesNotExist(c *gc.C) {

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -39,16 +39,16 @@ const (
 // ControllerDetails holds information about the controller
 // that is being proxied to.
 type ControllerDetails struct {
-	Servers [][]jujuparams.HostPort
-	CACert  string
+	Addresses [][]jujuparams.HostPort
+	CACert    string
 }
 
-// RedirectInfo provides information about the controller
+// RedirectInfoGetter provides information about the controller
 // that is being proxied to.T his information is useful
 // when we need to redirect a client to that controller
 // instead of proxying the request. This is the case during
 // model migration when receiving requests from agents.
-type RedirectInfo interface {
+type RedirectInfoGetter interface {
 	GetRedirectInfo(ctx context.Context) (ControllerDetails, error)
 }
 
@@ -116,7 +116,7 @@ type ProxyHelpers struct {
 	AuditLog                func(*dbmodel.AuditLogEntry)
 	LoginService            LoginService
 	AuthenticatedIdentityID string
-	RedirectInfo            RedirectInfo
+	RedirectInfo            RedirectInfoGetter
 }
 
 // ProxySockets will proxy requests from a client connection through to a controller
@@ -299,7 +299,7 @@ type modelProxy struct {
 	modelUUID               string
 	conversationId          string
 	authenticatedIdentityID string
-	redirectInfo            RedirectInfo
+	redirectInfo            RedirectInfoGetter
 
 	deviceOAuthResponse *oauth2.DeviceAuthResponse
 }
@@ -825,7 +825,7 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 		// This is a legacy login request from an agent.
 		// We return a redirect to the backing Juju controller.
 		info := jujuparams.RedirectErrorInfo{
-			Servers: redirectInfo.Servers,
+			Servers: redirectInfo.Addresses,
 			CACert:  redirectInfo.CACert,
 		}.AsMap()
 		errRedirect := errors.E(
@@ -834,7 +834,7 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 			info,
 		)
 
-		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Servers))
+		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Addresses))
 		return nil, errRedirect
 	default:
 		return nil, fmt.Errorf("unsupported login request for tag %s", tag)

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/rpc/params"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -34,6 +35,22 @@ import (
 const (
 	accessRequiredErrorCode = "access required"
 )
+
+// ControllerDetails holds information about the controller
+// that is being proxied to.
+type ControllerDetails struct {
+	Servers [][]jujuparams.HostPort
+	CACert  string
+}
+
+// RedirectInfo provides information about the controller
+// that is being proxied to.T his information is useful
+// when we need to redirect a client to that controller
+// instead of proxying the request. This is the case during
+// model migration when receiving requests from agents.
+type RedirectInfo interface {
+	GetRedirectInfo(ctx context.Context) (ControllerDetails, error)
+}
 
 // SSHKeyManager is an interface for managing SSH keys.
 type SSHKeyManager interface {
@@ -99,6 +116,7 @@ type ProxyHelpers struct {
 	AuditLog                func(*dbmodel.AuditLogEntry)
 	LoginService            LoginService
 	AuthenticatedIdentityID string
+	RedirectInfo            RedirectInfo
 }
 
 // ProxySockets will proxy requests from a client connection through to a controller
@@ -122,6 +140,10 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 		zapctx.Error(ctx, "Missing ssh key manager function")
 		return errors.E(op, "Missing ssh key manager function")
 	}
+	if helpers.RedirectInfo == nil {
+		zapctx.Error(ctx, "Missing redirect info function")
+		return errors.E(op, "Missing redirect info function")
+	}
 	errChan := make(chan error, 2)
 	msgInFlight := inflightMsgs{messages: make(map[uint64]*message)}
 	client := writeLockConn{conn: helpers.ConnClient}
@@ -137,6 +159,7 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 			sshKeyManager:           helpers.SSHKeyManager,
 			loginService:            helpers.LoginService,
 			authenticatedIdentityID: helpers.AuthenticatedIdentityID,
+			redirectInfo:            helpers.RedirectInfo,
 		},
 		errChan:              errChan,
 		createControllerConn: helpers.ConnectController,
@@ -276,6 +299,7 @@ type modelProxy struct {
 	modelUUID               string
 	conversationId          string
 	authenticatedIdentityID string
+	redirectInfo            RedirectInfo
 
 	deviceOAuthResponse *oauth2.DeviceAuthResponse
 }
@@ -379,6 +403,12 @@ func (p *clientProxy) start(ctx context.Context) error {
 			}
 			return nil
 		}
+		// TODO: In some scenarios we don't need to ever dial the controller.
+		// For example, if the client is only sending requests that are handled by JIMM
+		// itself, like SSH key management or scenarios where JIMM returns a redirect.
+		// But we currently need `makeControllerConnection` to set the model UUID and name
+		// so that we can generate JWTs when messages DO need to be forwarded.
+		// Refactor this to be avoid dialling the controller if we don't need to.
 		err := p.makeControllerConnection(ctx)
 		if err != nil {
 			zapctx.Error(ctx, "error connecting to controller", zap.Error(err))
@@ -631,6 +661,7 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 func createErrResponse(err error, req *message) *message {
 	errMsg := new(message)
 	errMsg.RequestID = req.RequestID
+	errMsg.ErrorInfo = errors.ErrorInfo(err)
 	errMsg.Error = err.Error()
 	errMsg.ErrorCode = string(errors.ErrorCode(err))
 	return errMsg
@@ -744,36 +775,70 @@ func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clie
 
 		return controllerLoginMessageFnc(user)
 	case "Login":
-		controllerMessage, err := p.handleAnonymousLogin(msg)
-		if err != nil {
-			return errorFnc(err)
-		}
-		return nil, controllerMessage, nil
+		controllerMessage, err := p.handleLegacyLogin(ctx, msg)
+		return nil, controllerMessage, err
 	default:
 		return nil, nil, nil
 	}
 }
 
-// handleAnonymousLogin checks for the presence of an anonymous login request
-// and returns the message to be sent to the controller.
-// If the request is not an anonymous login request, it returns an error
-// indicating that JIMM does not support login from old clients.
-func (p *clientProxy) handleAnonymousLogin(msg *message) (*message, error) {
+// handleLegacyLogin handles old style username+password/macaroon login
+// requests and decides what to do based on the client's auth tag.
+//
+// If the request is an "anonymous login" request (i.e., the auth tag is
+// api.AnonymousUsername), it sets the anonymousLogin flag to true and returns
+// the message verbatim to the controller, allowing it to handle the login.
+// This supports login from a Juju controller during model migration.
+//
+// If the auth tag is a non-user entity e.g. a machine/unit then we return
+// a redirect to the backing Juju controller. This is also used for model migrations
+// but specifically for directing agents to speak to the backing Juju controller.
+//
+// Legacy login requests from users (i.e., those with a user tag) are not supported
+// in JIMM and will return an error.
+func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*message, error) {
 	var request params.LoginRequest
 	err := json.Unmarshal(msg.Params, &request)
 	if err != nil {
 		return nil, err
 	}
-	user, err := names.ParseUserTag(request.AuthTag)
+	tag, err := names.ParseTag(request.AuthTag)
 	if err != nil {
 		return nil, fmt.Errorf("invalid user tag: %v", err)
 	}
-	if user.Id() == api.AnonymousUsername {
-		p.anonymousLogin = true
-		// return the client's login message verbatim to the controller.
-		return msg, nil
+	switch tag := tag.(type) {
+	case names.UserTag:
+		if tag.Id() == api.AnonymousUsername {
+			p.anonymousLogin = true
+			// return the client's login message verbatim to the controller.
+			return msg, nil
+		}
+		return nil, errors.E("JIMM does not support login from old clients", errors.CodeNotSupported)
+	case names.ModelTag, names.MachineTag, names.UnitTag:
+		zapctx.Debug(ctx, "Legacy login request from agent", zap.String("tag", tag.String()))
+
+		redirectInfo, err := p.redirectInfo.GetRedirectInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get redirect info: %w", err)
+		}
+
+		// This is a legacy login request from an agent.
+		// We return a redirect to the backing Juju controller.
+		info := jujuparams.RedirectErrorInfo{
+			Servers: redirectInfo.Servers,
+			CACert:  redirectInfo.CACert,
+		}.AsMap()
+		errRedirect := errors.E(
+			errors.CodeRedirect,
+			"redirection to alternative server required",
+			info,
+		)
+
+		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Servers))
+		return nil, errRedirect
+	default:
+		return nil, fmt.Errorf("unsupported login request for tag %s", tag)
 	}
-	return nil, errors.E("JIMM does not support login from old clients", errors.CodeNotSupported)
 }
 
 // handleKeyManagerFacade processes the key manager facade call.

--- a/internal/rpcproxy/rpcproxy_test.go
+++ b/internal/rpcproxy/rpcproxy_test.go
@@ -58,6 +58,7 @@ func TestProxySockets(t *testing.T) {
 		}
 		auditLogger := func(ale *dbmodel.AuditLogEntry) {}
 		proxyHelpers := rpcproxy.ProxyHelpers{
+			RedirectInfo:      &mockRedirectInfo{},
 			ConnClient:        connClient,
 			TokenGen:          &testTokenGen,
 			ConnectController: f,
@@ -91,6 +92,8 @@ func TestProxySockets(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		c.Logf("took too long to read response")
 		c.FailNow()
+	case err := <-errChan:
+		c.Fatal(err)
 	}
 	c.Assert(resp.Response, qt.DeepEquals, msg.Params)
 	ws.Close()
@@ -118,6 +121,7 @@ func TestProxySocketsControllerConnectionFails(t *testing.T) {
 		}
 		auditLogger := func(ale *dbmodel.AuditLogEntry) {}
 		proxyHelpers := rpcproxy.ProxyHelpers{
+			RedirectInfo:      &mockRedirectInfo{},
 			ConnClient:        connClient,
 			TokenGen:          &testTokenGen,
 			ConnectController: f,
@@ -151,12 +155,18 @@ func TestProxySocketsControllerConnectionFails(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		c.Logf("took too long to read response")
 		c.FailNow()
+	case err := <-errChan:
+		c.Fatal(err)
 	}
 	c.Assert(resp.Response, qt.DeepEquals, msg.Params)
 
 	// Now close the connection to the controller and ensure the model proxy is cleaned up.
 	connController.Close()
-	<-errChan // Ensure go routines are cleaned up
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatalf("model proxy did not return in time")
+	case <-errChan: // Ensure go routines are cleaned up
+	}
 }
 
 func TestCancelProxySockets(t *testing.T) {
@@ -178,6 +188,7 @@ func TestCancelProxySockets(t *testing.T) {
 		}
 		auditLogger := func(ale *dbmodel.AuditLogEntry) {}
 		proxyHelpers := rpcproxy.ProxyHelpers{
+			RedirectInfo:      &mockRedirectInfo{},
 			ConnClient:        connClient,
 			TokenGen:          &testTokenGen,
 			ConnectController: f,
@@ -196,7 +207,11 @@ func TestCancelProxySockets(t *testing.T) {
 	ws := srvJIMM.Dialer.DialWebsocket(c, srvJIMM.URL)
 	defer ws.Close()
 	cancel()
-	<-errChan
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatalf("model proxy did not return in time")
+	case <-errChan: // Ensure go routines are cleaned up
+	}
 }
 
 func TestProxySocketsAuditLogs(t *testing.T) {
@@ -220,6 +235,7 @@ func TestProxySocketsAuditLogs(t *testing.T) {
 		}
 		auditLogger := func(ale *dbmodel.AuditLogEntry) { auditLogs = append(auditLogs, ale) }
 		proxyHelpers := rpcproxy.ProxyHelpers{
+			RedirectInfo:      &mockRedirectInfo{},
 			ConnClient:        connClient,
 			TokenGen:          &testTokenGen,
 			ConnectController: f,
@@ -246,7 +262,13 @@ func TestProxySocketsAuditLogs(t *testing.T) {
 	err = ws.ReadJSON(&resp)
 	c.Assert(err, qt.IsNil)
 	ws.Close()
-	<-errChan // Ensure go routines are cleaned up
+
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatalf("model proxy did not return in time")
+	case <-errChan: // Ensure go routines are cleaned up
+	}
+
 	c.Assert(auditLogs, qt.HasLen, 2)
 	expectedEvents := []*dbmodel.AuditLogEntry{{
 		ID:             auditLogs[0].ID,
@@ -279,7 +301,6 @@ func TestProxySocketsAuditLogs(t *testing.T) {
 	},
 	}
 	c.Assert(auditLogs, qt.DeepEquals, expectedEvents)
-
 }
 
 // TestProxySocketsSSHKeys verifies that the
@@ -306,6 +327,7 @@ func TestProxySocketsSSHKeys(t *testing.T) {
 			}, nil
 		}
 		proxyHelpers := rpcproxy.ProxyHelpers{
+			RedirectInfo:      &mockRedirectInfo{},
 			ConnClient:        connClient,
 			TokenGen:          &testTokenGen,
 			ConnectController: connectControllerF,
@@ -422,7 +444,11 @@ func TestProxySocketsSSHKeys(t *testing.T) {
 		})
 	}
 	ws.Close()
-	<-errChan // Ensure go routines are cleaned up
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatalf("model proxy did not return in time")
+	case <-errChan: // Ensure go routines are cleaned up
+	}
 }
 
 func mustMarshal(data any) []byte {

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -205,6 +205,66 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Params:    []byte(`{"auth-tag":"user-jujuanonymous"}`),
 		},
 	}, {
+		about: "login as unit agent returns redirect",
+		messageToSend: rpcproxy.Message{
+			RequestID: 1,
+			Type:      "Admin",
+			Version:   3,
+			Request:   "Login",
+			Params:    []byte(`{"auth-tag":"unit-charm/1"}`),
+		},
+		expectedClientResponse: &rpcproxy.Message{
+			RequestID: 1,
+			Error:     "redirection to alternative server required",
+			ErrorCode: "redirection required",
+			ErrorInfo: expectedRedirectInfo(),
+		},
+	}, {
+		about: "login as machine agent returns redirect",
+		messageToSend: rpcproxy.Message{
+			RequestID: 1,
+			Type:      "Admin",
+			Version:   3,
+			Request:   "Login",
+			Params:    []byte(`{"auth-tag":"machine-1"}`),
+		},
+		expectedClientResponse: &rpcproxy.Message{
+			RequestID: 1,
+			Error:     "redirection to alternative server required",
+			ErrorCode: "redirection required",
+			ErrorInfo: expectedRedirectInfo(),
+		},
+	}, {
+		about: "login as model agent returns redirect",
+		messageToSend: rpcproxy.Message{
+			RequestID: 1,
+			Type:      "Admin",
+			Version:   3,
+			Request:   "Login",
+			Params:    []byte(`{"auth-tag":"model-f25de75d-5460-442f-a320-8584f8f985d7"}`),
+		},
+		expectedClientResponse: &rpcproxy.Message{
+			RequestID: 1,
+			Error:     "redirection to alternative server required",
+			ErrorCode: "redirection required",
+			ErrorInfo: expectedRedirectInfo(),
+		},
+	}, {
+		about: "login as agent with invalid tag returns error",
+		messageToSend: rpcproxy.Message{
+			RequestID: 1,
+			Type:      "Admin",
+			Version:   3,
+			Request:   "Login",
+			Params:    []byte(`{"auth-tag":"model-invalid"}`),
+		},
+		expectedClientResponse: &rpcproxy.Message{
+			RequestID: 1,
+			Error:     `invalid user tag: "model-invalid" is not a valid model tag`,
+			ErrorCode: "",
+			ErrorInfo: nil,
+		},
+	}, {
 		about: "any other message - gets forwarded directly to the controller",
 		messageToSend: rpcproxy.Message{
 			RequestID: 1,
@@ -295,6 +355,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 				LoginService:            loginSvc,
 				AuthenticatedIdentityID: test.authenticateEntityID,
 				SSHKeyManager:           &mocks.SSHKeyManager{},
+				RedirectInfo:            &mockRedirectInfo{},
 			}
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -466,4 +527,35 @@ func (m *mockTokenGenerator) GetUser() names.UserTag {
 	defer m.mu.RUnlock()
 
 	return m.ut
+}
+
+type mockRedirectInfo struct{}
+
+func (m *mockRedirectInfo) GetRedirectInfo(_ context.Context) (rpcproxy.ControllerDetails, error) {
+	return rpcproxy.ControllerDetails{
+		Servers: [][]params.HostPort{{{
+			Address: params.Address{
+				Value: "controller-1",
+				Type:  "ipv4",
+			},
+			Port: 17070,
+		}}},
+		CACert: "test-ca-cert",
+	}, nil
+}
+
+func expectedRedirectInfo() map[string]interface{} {
+	return map[string]interface{}{
+		"servers": []any{
+			[]any{
+				map[string]any{
+					"port":  float64(17070),
+					"scope": string(""),
+					"type":  string("ipv4"),
+					"value": string("controller-1"),
+				},
+			},
+		},
+		"ca-cert": "test-ca-cert",
+	}
 }

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -533,7 +533,7 @@ type mockRedirectInfo struct{}
 
 func (m *mockRedirectInfo) GetRedirectInfo(_ context.Context) (rpcproxy.ControllerDetails, error) {
 	return rpcproxy.ControllerDetails{
-		Servers: [][]params.HostPort{{{
+		Addresses: [][]params.HostPort{{{
 			Address: params.Address{
 				Value: "controller-1",
 				Type:  "ipv4",


### PR DESCRIPTION
## Description
This change is in support of model migration. During model migration, agents connect to the new controller to validate they will work after migration has completed. JIMM should not be the address for Juju agents, they should point to the backing controller but the migration flow needs to go through JIMM for it to modify things like the model owner. To handle this, when an agent is trying to login to JIMM we return a redirect to the backing controller.

Both integration and unit tests have been added and JIMM's errors package has also been modified to support all the error fields that are used in Juju's RPC error handling/

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests