### PR TITLE
feat(delete-model): delete model by uuid

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -113,7 +113,7 @@ func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err e
 	return nil
 }
 
-// DeleteModel removes the model information from the database.
+// DeleteModel removes the model information from the database. It supports deletion by ID or UUID.
 func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err error) {
 	const op = errors.Op("db.DeleteModel")
 	if err := d.ready(); err != nil {
@@ -123,9 +123,17 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
-
 	db := d.DB.WithContext(ctx)
-	if err := db.Delete(model, model.ID).Error; err != nil {
+	switch {
+	case model.UUID.Valid:
+		db = db.Where("uuid = ?", model.UUID.String)
+	case model.ID != 0:
+		db = db.Where("id = ?", model.ID)
+	default:
+		return errors.E(op, "missing id or uuid", errors.CodeBadRequest)
+	}
+
+	if err := db.Delete(model).Error; err != nil {
 		return errors.E(op, dbError(err))
 	}
 	return nil

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -292,18 +292,82 @@ func (s *dbSuite) TestDeleteModel(c *qt.C) {
 		Life:              state.Alive.String(),
 	}
 
-	// model does not exist
-	err = s.Database.DeleteModel(context.Background(), &model)
-	c.Assert(err, qt.IsNil)
-
 	err = s.Database.AddModel(context.Background(), &model)
 	c.Assert(err, qt.Equals, nil)
 
-	model.UUID = sql.NullString{
-		String: "00000001-0000-0000-0000-0000-000000000001",
-		Valid:  true,
-	}
 	err = s.Database.DeleteModel(context.Background(), &model)
+	c.Assert(err, qt.Equals, nil)
+
+	var dbModel dbmodel.Model
+	result := s.Database.DB.Where("uuid = ?", model.UUID).First(&dbModel)
+	c.Assert(result.Error, qt.Equals, gorm.ErrRecordNotFound)
+
+	// model should not be found in the database but no error is returned.
+	err = s.Database.DeleteModel(context.Background(), &model)
+	c.Assert(err, qt.Equals, nil)
+}
+
+func (s *dbSuite) TestDeleteModelNotValid(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	err = s.Database.DeleteModel(context.Background(), &dbmodel.Model{})
+	c.Assert(err, qt.ErrorMatches, "^missing id or uuid$")
+}
+
+func (s *dbSuite) TestDeleteModelByModelUUID(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	i, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(i).Error, qt.IsNil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+		Type: "test-provider",
+		Regions: []dbmodel.CloudRegion{{
+			Name: "test-region",
+		}},
+	}
+	c.Assert(s.Database.DB.Create(&cloud).Error, qt.IsNil)
+
+	cred := dbmodel.CloudCredential{
+		Name:     "test-cred",
+		Cloud:    cloud,
+		Owner:    *i,
+		AuthType: "empty",
+	}
+	c.Assert(s.Database.DB.Create(&cred).Error, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:        "test-controller",
+		UUID:        "00000000-0000-0000-0000-0000-0000000000001",
+		CloudName:   "test-cloud",
+		CloudRegion: "test-region",
+	}
+	err = s.Database.AddController(context.Background(), &controller)
+	c.Assert(err, qt.Equals, nil)
+
+	model := dbmodel.Model{
+		Name:              "test-model-1",
+		OwnerIdentityName: i.Name,
+		ControllerID:      controller.ID,
+		Controller:        controller,
+		CloudRegionID:     cloud.Regions[0].ID,
+		CloudCredentialID: cred.ID,
+		Life:              state.Alive.String(),
+	}
+
+	err = s.Database.AddModel(context.Background(), &model)
+	c.Assert(err, qt.Equals, nil)
+	modelToDelete := dbmodel.Model{
+		UUID: sql.NullString{
+			Valid:  true,
+			String: model.UUID.String,
+		},
+	}
+	err = s.Database.DeleteModel(context.Background(), &modelToDelete)
 	c.Assert(err, qt.Equals, nil)
 
 	var dbModel dbmodel.Model

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -72,14 +72,6 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 	// Don't return an error if we fail to delete the model from JIMM's state,
 	// as the migration has already been aborted on the target controller.
 	// The model will be cleanup eventually by JIMM's cleanup routine.
-	err = j.Database.GetModel(ctx, &model)
-	if err != nil {
-		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil
-		}
-		zapctx.Error(ctx, "failed to get model for abort migration", zap.Error(err), zap.String("modelUUID", modelUUID))
-		return nil
-	}
 	err = j.Database.DeleteModel(ctx, &model)
 	if err != nil {
 		zapctx.Error(ctx, "failed to delete incoming model migration", zap.Error(err), zap.String("modelUUID", modelUUID))
@@ -535,13 +527,6 @@ func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migratio
 				String: migration.ModelUUID.String,
 				Valid:  true,
 			},
-		}
-		err = j.Database.GetModel(ctx, &model)
-		if err != nil {
-			if errors.ErrorCode(err) == errors.CodeNotFound {
-				return nil
-			}
-			return errors.E(op, err)
 		}
 		err = j.Database.DeleteModel(ctx, &model)
 		if err != nil {

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -358,8 +358,6 @@ func (s *JIMMSuite) DestroyModelAndDeleteFromDatabase(c *gc.C, modelTag names.Mo
 			Valid:  true,
 		},
 	}
-	err = s.JIMM.Database.GetModel(context.Background(), model)
-	c.Assert(err, gc.Equals, nil)
 	err = s.JIMM.Database.DeleteModel(context.Background(), model)
 	c.Assert(err, gc.Equals, nil)
 }


### PR DESCRIPTION
In this PR we add the ability to delete models by UUID.
Before we needed to GetModel first to be able to delete it via its primary key (`ID`).