### PR TITLE
chore: remove user mappings on model removal

### DIFF
--- a/internal/db/usermapping_test.go
+++ b/internal/db/usermapping_test.go
@@ -12,17 +12,12 @@ import (
 )
 
 func (s *dbSuite) TestAddUserMapping(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
 	ctx := context.Background()
+	env := initTestEnvironment(c, s.Database)
 
-	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	modelUUID := env.model.UUID
 	localUser := "localuser1"
-	identityName := "bob@canonical.com"
-
-	u, err := dbmodel.NewIdentity(identityName)
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+	identityName := env.u.Name
 
 	userMapping := &dbmodel.UserMapping{
 		ModelUUID:        modelUUID,
@@ -30,7 +25,7 @@ func (s *dbSuite) TestAddUserMapping(c *qt.C) {
 		ExternalUserName: identityName,
 	}
 
-	err = s.Database.AddUserMapping(ctx, userMapping)
+	err := s.Database.AddUserMapping(ctx, userMapping)
 	c.Assert(err, qt.IsNil)
 	c.Assert(userMapping.ID, qt.Not(qt.Equals), 0)
 
@@ -40,17 +35,12 @@ func (s *dbSuite) TestAddUserMapping(c *qt.C) {
 }
 
 func (s *dbSuite) TestGetUserMapping(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
 	ctx := context.Background()
+	env := initTestEnvironment(c, s.Database)
 
-	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	modelUUID := env.model.UUID
 	localUser := "localuser1"
-	identityName := "bob@canonical.com"
-
-	u, err := dbmodel.NewIdentity(identityName)
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+	identityName := env.u.Name
 
 	// Insert mapping first
 	userMapping := &dbmodel.UserMapping{
@@ -64,7 +54,7 @@ func (s *dbSuite) TestGetUserMapping(c *qt.C) {
 		ModelUUID: modelUUID,
 		LocalUser: localUser,
 	}
-	err = s.Database.GetUserMapping(ctx, lookup)
+	err := s.Database.GetUserMapping(ctx, lookup)
 	c.Assert(err, qt.IsNil)
 	c.Assert(lookup.ExternalUserName, qt.Equals, identityName)
 	c.Assert(lookup.ModelUUID.String, qt.Equals, modelUUID.String)
@@ -80,17 +70,12 @@ func (s *dbSuite) TestGetUserMapping(c *qt.C) {
 }
 
 func (s *dbSuite) TestDeleteUserMapping(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
 	ctx := context.Background()
+	env := initTestEnvironment(c, s.Database)
 
-	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	modelUUID := env.model.UUID
 	localUser := "localuser1"
-	identityName := "externaluser@canonical.com"
-
-	u, err := dbmodel.NewIdentity(identityName)
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+	identityName := env.u.Name
 
 	userMapping := &dbmodel.UserMapping{
 		ModelUUID:        modelUUID,
@@ -100,7 +85,7 @@ func (s *dbSuite) TestDeleteUserMapping(c *qt.C) {
 	c.Assert(s.Database.AddUserMapping(ctx, userMapping), qt.IsNil)
 
 	// Delete
-	err = s.Database.DeleteUserMapping(ctx, userMapping)
+	err := s.Database.DeleteUserMapping(ctx, userMapping)
 	c.Assert(err, qt.IsNil)
 
 	// Read after delete
@@ -109,17 +94,12 @@ func (s *dbSuite) TestDeleteUserMapping(c *qt.C) {
 }
 
 func (s *dbSuite) TestDeleteUserMappingsByModelUUID(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
 	ctx := context.Background()
+	env := initTestEnvironment(c, s.Database)
 
-	modelUUID := sql.NullString{String: "model-uuid-123", Valid: true}
+	modelUUID := env.model.UUID
 	localUser := "localuser1"
-	identityName := "externaluser@canonical.com"
-
-	u, err := dbmodel.NewIdentity(identityName)
-	c.Assert(err, qt.IsNil)
-	c.Assert(s.Database.DB.Create(&u).Error, qt.IsNil)
+	identityName := env.u.Name
 
 	userMapping := &dbmodel.UserMapping{
 		ModelUUID:        modelUUID,
@@ -135,7 +115,7 @@ func (s *dbSuite) TestDeleteUserMappingsByModelUUID(c *qt.C) {
 	}
 	c.Assert(s.Database.AddUserMapping(ctx, userMapping2), qt.IsNil)
 
-	err = s.Database.DeleteUserMappingsByModelUUID(ctx, modelUUID.String)
+	err := s.Database.DeleteUserMappingsByModelUUID(ctx, modelUUID.String)
 	c.Assert(err, qt.IsNil)
 
 	// Check that both mappings are deleted

--- a/internal/dbmodel/sql/postgres/030_cascade_delete_user_mappings.up.sql
+++ b/internal/dbmodel/sql/postgres/030_cascade_delete_user_mappings.up.sql
@@ -1,0 +1,10 @@
+-- Add foreign key constraint between user mappings and 
+-- models with ON DELETE CASCADE to ensure user mappings
+-- are deleted when the corresponding model is removed.
+
+-- Add a foreign key constraint with ON DELETE CASCADE
+ALTER TABLE user_mappings
+    ADD CONSTRAINT fk_user_mappings_model_uuid
+    FOREIGN KEY (model_uuid)
+    REFERENCES models(uuid)
+    ON DELETE CASCADE;

--- a/internal/dbmodel/usermapping.go
+++ b/internal/dbmodel/usermapping.go
@@ -17,6 +17,7 @@ type UserMapping struct {
 
 	// ModelUUID is the UUID of the model the mapping applies to.
 	ModelUUID sql.NullString
+	Model     Model `gorm:"foreignkey:ModelUUID;references:UUID"`
 
 	// LocalUser is the local user that this mapping applies to.
 	LocalUser string

--- a/internal/dbmodel/usermapping_test.go
+++ b/internal/dbmodel/usermapping_test.go
@@ -18,27 +18,93 @@ func TestUserMappingUniqueConstraint(t *testing.T) {
 	c := qt.New(t)
 	db := gormDB(c)
 
-	u, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.Create(&u).Error, qt.IsNil)
+	cl, cred, ctl, u := initModelEnv(c, db)
 
-	m := dbmodel.UserMapping{
-		ModelUUID: sql.NullString{
+	model := dbmodel.Model{
+		UUID: sql.NullString{
 			String: "00000001-0000-0000-0000-000000000001",
 			Valid:  true,
 		},
+		Owner:           u,
+		Name:            "test-1",
+		Controller:      ctl,
+		CloudRegion:     cl.Regions[0],
+		CloudCredential: cred,
+	}
+	c.Assert(db.Create(&model).Error, qt.IsNil)
+
+	m := dbmodel.UserMapping{
+		ModelUUID:        model.UUID,
 		LocalUser:        "bob",
 		ExternalUserName: u.Name,
 	}
 	c.Assert(db.Create(&m).Error, qt.IsNil)
 
 	m2 := dbmodel.UserMapping{
-		ModelUUID: sql.NullString{
-			String: "00000001-0000-0000-0000-000000000001",
-			Valid:  true,
-		},
+		ModelUUID:        model.UUID,
 		LocalUser:        "bob",
 		ExternalUserName: u.Name,
 	}
 	c.Assert(db.Create(&m2).Error, qt.ErrorMatches, ".*duplicate key value violates unique constraint \"unique_user_mappings_key\".*")
+}
+
+func TestUserMappingModelUUIDNotEmpty(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+
+	cl, cred, ctl, u := initModelEnv(c, db)
+
+	// Create a model without a model UUID,
+	// e.g. we are waiting for Juju to provide us the UUID.
+	model := dbmodel.Model{
+		Owner:           u,
+		Name:            "test-1",
+		Controller:      ctl,
+		CloudRegion:     cl.Regions[0],
+		CloudCredential: cred,
+	}
+	c.Assert(db.Create(&model).Error, qt.IsNil)
+
+	m := dbmodel.UserMapping{
+		ModelUUID:        model.UUID,
+		LocalUser:        "bob",
+		ExternalUserName: u.Name,
+	}
+	c.Assert(db.Create(&m).Error, qt.IsNotNil)
+}
+
+func TestUserMappingIsDeletedWhenModelIsDeleted(t *testing.T) {
+	c := qt.New(t)
+	db := gormDB(c)
+
+	cl, cred, ctl, u := initModelEnv(c, db)
+
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000001",
+			Valid:  true,
+		},
+		Owner:           u,
+		Name:            "test-1",
+		Controller:      ctl,
+		CloudRegion:     cl.Regions[0],
+		CloudCredential: cred,
+	}
+	c.Assert(db.Create(&model).Error, qt.IsNil)
+
+	m := dbmodel.UserMapping{
+		ModelUUID:        model.UUID,
+		LocalUser:        "bob",
+		ExternalUserName: u.Name,
+	}
+	c.Assert(db.Create(&m).Error, qt.IsNil)
+
+	var count int64
+	c.Assert(db.Model(&dbmodel.UserMapping{}).Where("model_uuid = ?", model.UUID).Count(&count).Error, qt.IsNil)
+	c.Assert(count, qt.Equals, int64(1))
+
+	c.Assert(db.Delete(&model).Error, qt.IsNil)
+
+	c.Assert(db.Model(&dbmodel.UserMapping{}).Where("model_uuid = ?", model.UUID).Count(&count).Error, qt.IsNil)
+	c.Assert(count, qt.Equals, int64(0))
 }


### PR DESCRIPTION
## Description
This PR adds a SQL migration updating the user-mapping table (used for mapping local users to external users for models migrated to JAAS) to set a foreign-key reference to the model table, ensuring that we delete all the user-mappings for a model when that model is removed.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests