### PR TITLE
chore: add offers and permissions during migration import

### DIFF
--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -405,16 +405,6 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 	return nil
 }
 
-// modelMigrationImport is a struct that holds the JujuManager and the model description
-// that is being imported. It is used to encapsulate the logic for importing a model
-// from a serialized description.
-// This helps to keep the import logic and associated methods separate from the JujuManager
-// methods.
-type modelMigrationImport struct {
-	*JujuManager
-	modelDescription description.Model
-}
-
 // Import imports a model from a serialized description.
 //   - Checks the incoming model migration record in the database.
 //   - Modifies the model description to replace local user references with their external mapping for owner and
@@ -430,59 +420,41 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		return errors.E(op, fmt.Errorf("failed to deserialize model description: %w", err))
 	}
 
-	importer := modelMigrationImport{
-		JujuManager:      j,
-		modelDescription: modelDescription,
-	}
-	err = importer.migrationImport(ctx, user)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to import resources: %w", err))
-	}
-	return nil
-}
-
-// migrationImport imports resources from the model description into JIMM's state
-// and adds the necessary permissions for the model and application offers
-// before calling the import method on the target Juju controller.
-// Since `import` is a reserved word in Go, we use `migrationImport`.
-func (mmi *modelMigrationImport) migrationImport(ctx context.Context, user *openfga.User) error {
-	const op = errors.Op("jimm.migrationImport")
-
 	incomingMigration := &dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
-			String: mmi.modelDescription.Tag().Id(),
+			String: modelDescription.Tag().Id(),
 			Valid:  true,
 		},
 	}
 
-	err := mmi.Database.GetIncomingModelMigration(ctx, incomingMigration)
+	err = j.Database.GetIncomingModelMigration(ctx, incomingMigration)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to add incoming model migration: %w", err))
 	}
 
-	err = mmi.modifyModelDescription(mmi.modelDescription, incomingMigration.UserMapping)
+	err = j.modifyModelDescription(modelDescription, incomingMigration.UserMapping)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
 	}
 
-	resources, err := mmi.importFromDescription(ctx, incomingMigration.TargetController.ID, mmi.modelDescription)
+	model, offers, err := j.importFromDescription(ctx, incomingMigration.TargetController.ID, modelDescription)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
 	}
 
-	err = mmi.addResourcePermissions(ctx, user, resources, incomingMigration.TargetController.ResourceTag())
+	err = j.addModelAndOfferPermissions(ctx, user, model, offers)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to add resource permissions: %w", err))
 	}
 
 	// Call the import method on the target controller to import the model.
-	api, err := mmi.dialController(ctx, &incomingMigration.TargetController)
+	api, err := j.dialController(ctx, &incomingMigration.TargetController)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
-	serializedDescrition, err := description.Serialize(mmi.modelDescription)
+	serializedDescrition, err := description.Serialize(modelDescription)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to serialize model description: %w", err))
 	}
@@ -495,31 +467,26 @@ func (mmi *modelMigrationImport) migrationImport(ctx context.Context, user *open
 	return nil
 }
 
-type importedResources struct {
-	model  dbmodel.Model
-	offers []dbmodel.ApplicationOffer
-}
-
 // importFromDescription imports resources into JIMM's state from a model description.
 // It creates a new model record in the database with the given target controller ID
 // and model description and sets the migration mode to importing.
 // Application offers are created for any offers in the model description.
 // It also ensures that the cloud credential and region are present in the database.
-func (mmi *modelMigrationImport) importFromDescription(ctx context.Context, targetControllerID uint, description description.Model) (*importedResources, error) {
+func (j *JujuManager) importFromDescription(ctx context.Context, targetControllerID uint, description description.Model) (*dbmodel.Model, []*dbmodel.ApplicationOffer, error) {
 	op := errors.Op("jimm.importFromDescription")
 
 	modelNameStr, ok := description.Config()[config.NameKey].(string)
 	if !ok {
-		return nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
+		return nil, nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
 	}
 
 	modelUUIDStr, ok := description.Config()[config.UUIDKey].(string)
 	if !ok {
-		return nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+		return nil, nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
 	}
 
 	if description.CloudCredential() == nil {
-		return nil, errors.E(op, fmt.Errorf("model description must contain a cloud credential"))
+		return nil, nil, errors.E(op, fmt.Errorf("model description must contain a cloud credential"))
 	}
 	cloudCredential := &dbmodel.CloudCredential{
 		CloudName:         description.CloudCredential().Cloud(),
@@ -527,18 +494,19 @@ func (mmi *modelMigrationImport) importFromDescription(ctx context.Context, targ
 		Name:              description.CloudCredential().Name(),
 	}
 
-	err := mmi.Database.GetCloudCredential(ctx, cloudCredential)
+	err := j.Database.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, nil, errors.E(op, err)
 	}
-	region, err := mmi.Database.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
+	region, err := j.Database.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, nil, errors.E(op, err)
 	}
 
-	appAndOffers := importedResources{}
+	var importedModel *dbmodel.Model
+	var importedOffers []*dbmodel.ApplicationOffer
 
-	err = mmi.Database.Transaction(func(db *db.Database) error {
+	err = j.Database.Transaction(func(db *db.Database) error {
 		model := dbmodel.Model{
 			UUID: sql.NullString{
 				String: modelUUIDStr,
@@ -555,7 +523,7 @@ func (mmi *modelMigrationImport) importFromDescription(ctx context.Context, targ
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
 		}
-		appAndOffers.model = model
+		importedModel = &model
 
 		for _, app := range description.Applications() {
 			for _, offer := range app.Offers() {
@@ -575,28 +543,30 @@ func (mmi *modelMigrationImport) importFromDescription(ctx context.Context, targ
 					return err
 				}
 
-				appAndOffers.offers = append(appAndOffers.offers, dbOffer)
+				importedOffers = append(importedOffers, &dbOffer)
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+		return nil, nil, errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
 	}
 
-	return &appAndOffers, nil
+	return importedModel, importedOffers, nil
 }
 
-func (mmi *modelMigrationImport) addResourcePermissions(ctx context.Context, user *openfga.User, resources *importedResources, targetControllerTag names.ControllerTag) error {
+// addModelAndOfferPermissions grants the user access to the model
+// and adds the necesary relations between the model and app offers.
+func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *openfga.User, model *dbmodel.Model, offers []*dbmodel.ApplicationOffer) error {
 	const op = errors.Op("jimm.addResourcePermissions")
 
-	modelTag := resources.model.ResourceTag()
-	if err := mmi.addModelPermissions(ctx, user, modelTag, targetControllerTag); err != nil {
+	modelTag := model.ResourceTag()
+	if err := j.addModelPermissions(ctx, user, modelTag, model.Controller.ResourceTag()); err != nil {
 		return errors.E(op, fmt.Errorf("failed to add model permissions: %w", err))
 	}
 
-	for _, offer := range resources.offers {
-		err := mmi.OpenFGAClient.AddModelApplicationOffer(ctx, modelTag, offer.ResourceTag())
+	for _, offer := range offers {
+		err := j.OpenFGAClient.AddModelApplicationOffer(ctx, modelTag, offer.ResourceTag())
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to add application offer permissions: %w", err))
 		}

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/description/v9"
+	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/migration"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/environs/config"
@@ -69,12 +70,16 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 			Valid:  true,
 		},
 	}
-	// Don't return an error if we fail to delete the model from JIMM's state,
-	// as the migration has already been aborted on the target controller.
+	// Don't return an error if we fail to delete the model/permissions from
+	// JIMM's state, the migration has already been aborted on the target controller.
 	// The model will be cleanup eventually by JIMM's cleanup routine.
 	err = j.Database.DeleteModel(ctx, &model)
 	if err != nil {
 		zapctx.Error(ctx, "failed to delete incoming model migration", zap.Error(err), zap.String("modelUUID", modelUUID))
+	}
+	err = j.OpenFGAClient.RemoveModel(ctx, model.ResourceTag())
+	if err != nil {
+		zapctx.Error(ctx, "failed to remove model from OpenFGA", zap.Error(err), zap.String("modelUUID", modelUUID))
 	}
 	return nil
 }
@@ -400,11 +405,22 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 	return nil
 }
 
+// modelMigrationImport is a struct that holds the JujuManager and the model description
+// that is being imported. It is used to encapsulate the logic for importing a model
+// from a serialized description.
+// This helps to keep the import logic and associated methods separate from the JujuManager
+// methods.
+type modelMigrationImport struct {
+	*JujuManager
+	modelDescription description.Model
+}
+
 // Import imports a model from a serialized description.
 //   - Checks the incoming model migration record in the database.
 //   - Modifies the model description to replace local user references with their external mapping for owner and
 //     cloud credential owner.
 //   - Imports the model into JIMM's state.
+//   - Adds permissions for the model and application offers.
 //   - Calls the import method on the target Juju controller to import the model.
 func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized params.SerializedModel) error {
 	const op = errors.Op("jimm.Import")
@@ -413,32 +429,60 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to deserialize model description: %w", err))
 	}
+
+	importer := modelMigrationImport{
+		JujuManager:      j,
+		modelDescription: modelDescription,
+	}
+	err = importer.migrationImport(ctx, user)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to import resources: %w", err))
+	}
+	return nil
+}
+
+// migrationImport imports resources from the model description into JIMM's state
+// and adds the necessary permissions for the model and application offers
+// before calling the import method on the target Juju controller.
+// Since `import` is a reserved word in Go, we use `migrationImport`.
+func (mmi *modelMigrationImport) migrationImport(ctx context.Context, user *openfga.User) error {
+	const op = errors.Op("jimm.migrationImport")
+
 	incomingMigration := &dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
-			String: modelDescription.Tag().Id(),
+			String: mmi.modelDescription.Tag().Id(),
 			Valid:  true,
 		},
 	}
-	err = j.Database.GetIncomingModelMigration(ctx, incomingMigration)
+
+	err := mmi.Database.GetIncomingModelMigration(ctx, incomingMigration)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to add incoming model migration: %w", err))
 	}
-	err = j.modifyModelDescription(modelDescription, incomingMigration.UserMapping)
+
+	err = mmi.modifyModelDescription(mmi.modelDescription, incomingMigration.UserMapping)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
 	}
-	err = j.importModelFromDescription(ctx, incomingMigration.TargetController.ID, modelDescription)
+
+	resources, err := mmi.importFromDescription(ctx, incomingMigration.TargetController.ID, mmi.modelDescription)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
 	}
 
-	api, err := j.dialController(ctx, &incomingMigration.TargetController)
+	err = mmi.addResourcePermissions(ctx, user, resources, incomingMigration.TargetController.ResourceTag())
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to add resource permissions: %w", err))
+	}
+
+	// Call the import method on the target controller to import the model.
+	api, err := mmi.dialController(ctx, &incomingMigration.TargetController)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
-	serializedDescrition, err := description.Serialize(modelDescription)
+	serializedDescrition, err := description.Serialize(mmi.modelDescription)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to serialize model description: %w", err))
 	}
@@ -447,28 +491,35 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		// TODO: handle migration failure in a cleanup routine.
 		return errors.E(op, fmt.Errorf("failed to import model: %w", err))
 	}
+
 	return nil
 }
 
-// importModelFromDescription imports a model into JIMM's state from a model description.
-// It creates a new model record in the database with the given target controller ID and model description
-// and sets the migration mode to importing.
+type importedResources struct {
+	model  dbmodel.Model
+	offers []dbmodel.ApplicationOffer
+}
+
+// importFromDescription imports resources into JIMM's state from a model description.
+// It creates a new model record in the database with the given target controller ID
+// and model description and sets the migration mode to importing.
+// Application offers are created for any offers in the model description.
 // It also ensures that the cloud credential and region are present in the database.
-func (j *JujuManager) importModelFromDescription(ctx context.Context, targetControllerID uint, description description.Model) error {
-	op := errors.Op("jimm.importModelFromDescription")
+func (mmi *modelMigrationImport) importFromDescription(ctx context.Context, targetControllerID uint, description description.Model) (*importedResources, error) {
+	op := errors.Op("jimm.importFromDescription")
+
 	modelNameStr, ok := description.Config()[config.NameKey].(string)
 	if !ok {
-		return errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
+		return nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
 	}
-	// TODO: create the offers in JIMM's state. Card: https://warthogs.atlassian.net/browse/JUJU-8192
 
 	modelUUIDStr, ok := description.Config()[config.UUIDKey].(string)
 	if !ok {
-		return errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+		return nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
 	}
 
 	if description.CloudCredential() == nil {
-		return errors.E(op, fmt.Errorf("model description must contain a cloud credential"))
+		return nil, errors.E(op, fmt.Errorf("model description must contain a cloud credential"))
 	}
 	cloudCredential := &dbmodel.CloudCredential{
 		CloudName:         description.CloudCredential().Cloud(),
@@ -476,28 +527,79 @@ func (j *JujuManager) importModelFromDescription(ctx context.Context, targetCont
 		Name:              description.CloudCredential().Name(),
 	}
 
-	err := j.Database.GetCloudCredential(ctx, cloudCredential)
+	err := mmi.Database.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return errors.E(op, err)
+		return nil, errors.E(op, err)
 	}
-	region, err := j.Database.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
+	region, err := mmi.Database.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
 	if err != nil {
-		return errors.E(op, err)
+		return nil, errors.E(op, err)
 	}
-	err = j.Database.AddModel(ctx, &dbmodel.Model{
-		UUID: sql.NullString{
-			String: modelUUIDStr,
-			Valid:  true,
-		},
-		Name:              modelNameStr,
-		OwnerIdentityName: description.Owner().Id(),
-		ControllerID:      targetControllerID,
-		CloudCredentialID: cloudCredential.ID,
-		CloudRegionID:     region.ID,
-		MigrationMode:     state.MigrationModeImporting,
+
+	appAndOffers := importedResources{}
+
+	err = mmi.Database.Transaction(func(db *db.Database) error {
+		model := dbmodel.Model{
+			UUID: sql.NullString{
+				String: modelUUIDStr,
+				Valid:  true,
+			},
+			Name:              modelNameStr,
+			OwnerIdentityName: description.Owner().Id(),
+			ControllerID:      targetControllerID,
+			CloudCredentialID: cloudCredential.ID,
+			CloudRegionID:     region.ID,
+			MigrationMode:     state.MigrationModeImporting,
+		}
+		err = db.AddModel(ctx, &model)
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
+		}
+		appAndOffers.model = model
+
+		for _, app := range description.Applications() {
+			for _, offer := range app.Offers() {
+				// construct the offer URL with the same logic as Juju (modelOwner, modelName, offerName, <blank-controller-name>)
+				offerURL := jujucrossmodel.MakeURL(description.Owner().Id(), modelNameStr, offer.OfferName(), "")
+
+				dbOffer := dbmodel.ApplicationOffer{
+					UUID:    offer.OfferUUID(),
+					Name:    offer.OfferName(),
+					URL:     offerURL,
+					ModelID: model.ID,
+				}
+				if err := db.AddApplicationOffer(ctx, &dbOffer); err != nil {
+					if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+						return fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
+					}
+					return err
+				}
+
+				appAndOffers.offers = append(appAndOffers.offers, dbOffer)
+			}
+		}
+		return nil
 	})
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
+		return nil, errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+	}
+
+	return &appAndOffers, nil
+}
+
+func (mmi *modelMigrationImport) addResourcePermissions(ctx context.Context, user *openfga.User, resources *importedResources, targetControllerTag names.ControllerTag) error {
+	const op = errors.Op("jimm.addResourcePermissions")
+
+	modelTag := resources.model.ResourceTag()
+	if err := mmi.addModelPermissions(ctx, user, modelTag, targetControllerTag); err != nil {
+		return errors.E(op, fmt.Errorf("failed to add model permissions: %w", err))
+	}
+
+	for _, offer := range resources.offers {
+		err := mmi.OpenFGAClient.AddModelApplicationOffer(ctx, modelTag, offer.ResourceTag())
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to add application offer permissions: %w", err))
+		}
 	}
 	return nil
 }

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -442,7 +442,10 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
 	}
 
-	err = j.addModelAndOfferPermissions(ctx, user, model, offers)
+	// Pass the controller tag as the controller details
+	// are not populated on the model after creation.
+	controllerTag := incomingMigration.TargetController.ResourceTag()
+	err = j.addModelAndOfferPermissions(ctx, user, model, offers, controllerTag)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to add resource permissions: %w", err))
 	}
@@ -557,11 +560,11 @@ func (j *JujuManager) importFromDescription(ctx context.Context, targetControlle
 
 // addModelAndOfferPermissions grants the user access to the model
 // and adds the necesary relations between the model and app offers.
-func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *openfga.User, model *dbmodel.Model, offers []*dbmodel.ApplicationOffer) error {
+func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *openfga.User, model *dbmodel.Model, offers []*dbmodel.ApplicationOffer, ct names.ControllerTag) error {
 	const op = errors.Op("jimm.addResourcePermissions")
 
 	modelTag := model.ResourceTag()
-	if err := j.addModelPermissions(ctx, user, modelTag, model.Controller.ResourceTag()); err != nil {
+	if err := j.addModelPermissions(ctx, user, modelTag, ct); err != nil {
 		return errors.E(op, fmt.Errorf("failed to add model permissions: %w", err))
 	}
 

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	migratingModelUUID = "00000000-0000-0000-0000-000000000001"
+	offerUUID          = "00000012-0000-0000-0000-000000000001"
 )
 
 const testEnvWithIncomingMigration = `clouds:
@@ -94,7 +95,7 @@ func TestAbortMigration_Success(t *testing.T) {
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
-	user := openfga.NewUser(&dbUser, nil)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	err := j.AbortMigration(ctx, user, migratingModelUUID)
 	c.Assert(err, qt.IsNil)
@@ -119,6 +120,14 @@ func TestAbortMigration_Success(t *testing.T) {
 	}
 	err = j.Database.GetModel(ctx, model)
 	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+
+	// Check that permissions for the user have been removed.
+	ok, err := user.IsModelAdmin(ctx, names.NewModelTag(migratingModelUUID))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsFalse)
+	ok, err = user.IsApplicationOfferConsumer(ctx, names.NewApplicationOfferTag(offerUUID))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsFalse)
 }
 
 func TestAbortMigration_MissingIncomingModel(t *testing.T) {
@@ -499,6 +508,14 @@ models:
     access: admin
   - user: bob@canonical.com
     access: write
+application-offers:
+- name: offer-1
+  url: test-offer-url
+  uuid: 00000012-0000-0000-0000-000000000001
+  model-name: model-1
+  model-owner: alice@canonical.com
+  application-name: application-1
+  application-description: app description 1
 users:
 - username: alice@canonical.com
   controller-access: superuser
@@ -790,7 +807,7 @@ func TestImport_Success(t *testing.T) {
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
-	user := openfga.NewUser(&dbUser, nil)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	desc := newModelDescription(modelDescriptionArgs{
 		Owner:               "bob",
@@ -800,8 +817,24 @@ func TestImport_Success(t *testing.T) {
 		CloudRegionName:     "test-region",
 	})
 	desc.SetStatus(description.StatusArgs{Value: "available"})
+	app := desc.AddApplication(description.ApplicationArgs{
+		Tag: names.NewApplicationTag("test-app"),
+	})
+	appOfferUUID := "00000000-0000-0000-0000-000000000001"
+	app.SetStatus(description.StatusArgs{
+		Value: "active",
+	})
+	app.AddOffer(description.ApplicationOfferArgs{
+		OfferUUID:              appOfferUUID,
+		OfferName:              "test-offer",
+		ApplicationName:        "test-app",
+		ApplicationDescription: "some description",
+		Endpoints:              map[string]string{"foo": "bar"},
+		ACL:                    map[string]string{"bob": "write"},
+	})
 	bytes, err := description.Serialize(desc)
 	c.Assert(err, qt.IsNil)
+
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
@@ -817,6 +850,23 @@ func TestImport_Success(t *testing.T) {
 	err = j.Database.GetModel(ctx, m)
 	c.Assert(err, qt.IsNil)
 	c.Assert(m.MigrationMode, qt.Equals, state.MigrationModeImporting)
+
+	// Check that the application is created in the database.
+	appOffer := &dbmodel.ApplicationOffer{
+		ModelID: m.ID,
+		UUID:    appOfferUUID,
+	}
+	err = j.Database.GetApplicationOffer(ctx, appOffer)
+	c.Assert(err, qt.IsNil)
+	c.Assert(appOffer.Name, qt.Equals, "test-offer")
+
+	// Check that the user has access to the model and offer(s).
+	ok, err := user.IsModelAdmin(ctx, m.ResourceTag())
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	ok, err = user.IsApplicationOfferConsumer(ctx, appOffer.ResourceTag())
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
 }
 
 func TestImport_MissingCloudCredentialsFromDescription(t *testing.T) {
@@ -851,7 +901,7 @@ func TestImport_MissingCloudCredentialsFromDescription(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, "^failed to modify model description.*")
+	c.Assert(err, qt.ErrorMatches, ".*failed to modify model description.*")
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{
@@ -894,7 +944,7 @@ func TestImport_UserNotFoundInUserMapping(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, "^failed to modify model description.*")
+	c.Assert(err, qt.ErrorMatches, ".*failed to modify model description.*")
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{
@@ -938,7 +988,7 @@ func TestImport_MissingCloudCredentialFromJIMMState(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, `^failed to import model from description: cloudcredential \S+ not found$`)
+	c.Assert(err, qt.ErrorMatches, `.*failed to import model from description: cloudcredential \S+ not found$`)
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{
@@ -973,7 +1023,7 @@ func TestImport_APIFailure(t *testing.T) {
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
-	user := openfga.NewUser(&dbUser, nil)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	desc := newModelDescription(modelDescriptionArgs{
 		Owner:               "bob",
@@ -988,7 +1038,7 @@ func TestImport_APIFailure(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, `^failed to import model: API failure$`)
+	c.Assert(err, qt.ErrorMatches, `.*failed to import model: API failure$`)
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -287,12 +287,27 @@ func (o *OFGAClient) RemoveControllerModel(ctx context.Context, controller names
 	return o.unsetResourceAccess(ctx, controller, model, ofganames.ControllerRelation)
 }
 
-// RemoveModel removes a model.
+// RemoveModel removes all tuples that contain a model as the target
+// as well as tuples that relate a model to an application offer.
 func (o *OFGAClient) RemoveModel(ctx context.Context, model names.ModelTag) error {
 	if err := o.removeTuples(
 		ctx,
 		Tuple{
 			Target: ofganames.ConvertTag(model),
+		},
+	); err != nil {
+		return errors.E(err)
+	}
+	// Remove the relation between the model and any application offers.
+	offerKind, err := ofganames.BlankKindTag(names.ApplicationOfferTagKind)
+	if err != nil {
+		return errors.E(err)
+	}
+	if err := o.removeTuples(
+		ctx,
+		Tuple{
+			Object: ofganames.ConvertTag(model),
+			Target: offerKind,
 		},
 	); err != nil {
 		return errors.E(err)

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -235,25 +235,40 @@ func (s *openFGATestSuite) TestRemoveModel(c *gc.C) {
 
 	controller := names.NewControllerTag(controllerUUID.String())
 	model := names.NewModelTag(modelUUID.String())
+	appOffer := names.NewApplicationOfferTag("c7af7fc3-5e40-4de7-98f3-a693a83e0a4f")
 
 	err = s.ofgaClient.AddControllerModel(context.Background(), controller, model)
 	c.Assert(err, gc.IsNil)
 
-	tuple := openfga.Tuple{
-		Object:   ofganames.ConvertTag(controller),
-		Relation: "controller",
-		Target:   ofganames.ConvertTag(model),
-	}
-	allowed, err := s.ofgaClient.CheckRelation(context.Background(), tuple, false)
+	err = s.ofgaClient.AddModelApplicationOffer(context.Background(), model, appOffer)
 	c.Assert(err, gc.IsNil)
-	c.Assert(allowed, gc.Equals, true)
+
+	tuples := []openfga.Tuple{
+		{
+			Object:   ofganames.ConvertTag(controller),
+			Relation: "controller",
+			Target:   ofganames.ConvertTag(model),
+		},
+		{
+			Object:   ofganames.ConvertTag(model),
+			Relation: "model",
+			Target:   ofganames.ConvertTag(appOffer),
+		},
+	}
+	for _, tuple := range tuples {
+		allowed, err := s.ofgaClient.CheckRelation(context.Background(), tuple, false)
+		c.Assert(err, gc.IsNil)
+		c.Assert(allowed, gc.Equals, true)
+	}
 
 	err = s.ofgaClient.RemoveModel(context.Background(), model)
 	c.Assert(err, gc.IsNil)
 
-	allowed, err = s.ofgaClient.CheckRelation(context.Background(), tuple, false)
-	c.Assert(err, gc.IsNil)
-	c.Assert(allowed, gc.Equals, false)
+	for _, tuple := range tuples {
+		allowed, err := s.ofgaClient.CheckRelation(context.Background(), tuple, false)
+		c.Assert(err, gc.IsNil)
+		c.Assert(allowed, gc.Equals, false)
+	}
 }
 
 func (s *openFGATestSuite) TestAddModelApplicationOffer(c *gc.C) {

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // The servermon package is used to update statistics used
 // for monitoring the API server.
@@ -153,7 +153,7 @@ func DurationObserver(m *prometheus.HistogramVec, labelValues ...string) func() 
 
 // ErrorCount increases the specified counter if the error is not nil.
 func ErrorCounter(m *prometheus.CounterVec, err *error, labelValues ...string) {
-	if *err == nil {
+	if err == nil || *err == nil {
 		return
 	}
 


### PR DESCRIPTION
## Description
This PR makes a few tweaks to the `Import` step of model migration, namely:
- Creates offers in JIMM's database alongside model creation.
- Adds permissions for the new model owner to the model and adds the correct permissions for any application offers.
- Ensures permissions are removed during `Abort`.

I also refactored the logic in `Import` to encapsulate it, and avoid leaking methods that are specific to the `Import` method to the rest of the Juju manager.

Fixes [JUJU-8192](https://warthogs.atlassian.net/browse/JUJU-8192)

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8192]: https://warthogs.atlassian.net/browse/JUJU-8192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ