### PR TITLE
chore: allow PrepareModelMigration to be called multiple times

### DIFF
--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -66,11 +66,11 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 		return errors.E(op, "missing uuid", errors.CodeBadRequest)
 	}
 
+	lockingClause := clause.Locking{Strength: "UPDATE"}
 	if noWait {
-		db = db.Clauses(clause.Locking{Strength: "UPDATE", Options: "NOWAIT"})
-	} else {
-		db = db.Clauses(clause.Locking{Strength: "UPDATE"})
+		lockingClause.Options = "NOWAIT"
 	}
+	db = db.Clauses(lockingClause)
 	if err := db.First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -15,10 +15,8 @@ import (
 
 // AddOrUpdateIncomingModelMigration stores information about an incoming model migration
 // if it does not already exist, or updates it if it does.
-// It must be run within a transaction as it will lock the existing row for updates
-// if the model migration already exists.
 func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.AddIncomingModelMigration")
+	const op = errors.Op("db.AddOrUpdateIncomingModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
 	}
@@ -27,25 +25,29 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
-	lookup := dbmodel.IncomingModelMigration{
-		ModelUUID: modelMigration.ModelUUID,
-	}
-	// Set noWait to true to ensure that if the row is locked by another transaction,
-	// we will return an error immediately instead of waiting.
-	err = d.GetIncomingModelMigrationWithLock(ctx, &lookup, true)
-	if err == nil {
-		// If the model migration already exists, update it.
-		modelMigration.ID = lookup.ID
-	} else if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return errors.E(op, err)
-	}
+	err = d.Transaction(func(d *Database) error {
+		lookup := dbmodel.IncomingModelMigration{
+			ModelUUID: modelMigration.ModelUUID,
+		}
+		// Set noWait to true to ensure that if the row is locked by another transaction,
+		// we will return an error immediately instead of waiting.
+		err = d.GetIncomingModelMigrationWithLock(ctx, &lookup, true)
+		if err == nil {
+			// If the model migration already exists, update it.
+			modelMigration.ID = lookup.ID
+		} else if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
+			return errors.E(op, err)
+		}
 
-	db := d.DB.WithContext(ctx)
+		db := d.DB.WithContext(ctx)
 
-	if err := db.Save(modelMigration).Error; err != nil {
-		return errors.E(op, dbError(err))
-	}
-	return nil
+		if err := db.Save(modelMigration).Error; err != nil {
+			return errors.E(op, dbError(err))
+		}
+
+		return nil
+	})
+	return err
 }
 
 // GetIncomingMigrationWithLock retrieves an incoming model migration locking the row for updates.

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"time"
 
+	"gorm.io/gorm/clause"
+
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
-// AddIncomingModelMigration stores information about an incoming model migration.
-//   - returns an error with code errors.CodeAlreadyExists if
-//     a migration row with the same model UUID already exists.
-func (d *Database) AddIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
+// AddOrUpdateIncomingModelMigration stores information about an incoming model migration
+// if it does not already exist, or updates it if it does.
+// It must be run within a transaction as it will lock the existing row for updates
+// if the model migration already exists.
+func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = errors.Op("db.AddIncomingModelMigration")
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -24,10 +27,56 @@ func (d *Database) AddIncomingModelMigration(ctx context.Context, modelMigration
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
+	lookup := dbmodel.IncomingModelMigration{
+		ModelUUID: modelMigration.ModelUUID,
+	}
+	// Set noWait to true to ensure that if the row is locked by another transaction,
+	// we will return an error immediately instead of waiting.
+	err = d.GetIncomingModelMigrationWithLock(ctx, &lookup, true)
+	if err == nil {
+		// If the model migration already exists, update it.
+		modelMigration.ID = lookup.ID
+	} else if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
+		return errors.E(op, err)
+	}
+
 	db := d.DB.WithContext(ctx)
 
-	if err := db.Create(modelMigration).Error; err != nil {
+	if err := db.Save(modelMigration).Error; err != nil {
 		return errors.E(op, dbError(err))
+	}
+	return nil
+}
+
+// GetIncomingMigrationWithLock retrieves an incoming model migration locking the row for updates.
+// This must be run within a transaction for the lock to be effective.
+// if `noWait` is true, the function will return an error if the lock cannot be acquired immediately.
+func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration, noWait bool) (err error) {
+	const op = errors.Op("db.GetIncomingMigrationWithLock")
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	switch {
+	case modelMigration.ModelUUID.Valid:
+		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
+	default:
+		return errors.E(op, "missing uuid", errors.CodeBadRequest)
+	}
+
+	if noWait {
+		db = db.Clauses(clause.Locking{Strength: "UPDATE", Options: "NOWAIT"})
+	} else {
+		db = db.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	if err := db.First(&modelMigration).Error; err != nil {
+		err = dbError(err)
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.E(op, err, "model migration not found")
+		}
+		return errors.E(op, err)
 	}
 	return nil
 }
@@ -56,7 +105,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(op, err, "model migration not found")
 		}
-		return errors.E(op, dbError(err))
+		return errors.E(op, err)
 	}
 	return nil
 }

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -71,7 +71,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 		lockingClause.Options = "NOWAIT"
 	}
 	db = db.Clauses(lockingClause)
-	if err := db.First(&modelMigration).Error; err != nil {
+	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(op, err, "model migration not found")

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -91,6 +91,9 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	lookup := dbmodel.IncomingModelMigration{ModelUUID: migration.ModelUUID}
 	err := s.Database.GetIncomingModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Equals, nil)
+	c.Assert(lookup.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+	c.Assert(lookup.TargetControllerID, qt.Equals, controller.ID)
+	c.Assert(lookup.UserMapping, qt.DeepEquals, migration.UserMapping)
 
 	// Not found
 	lookup = dbmodel.IncomingModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -180,7 +180,7 @@ func (s *dbSuite) TestGetModelMigrationWithLock_Wait(c *qt.C) {
 	c.Check(err, qt.IsNotNil)
 	c.Check(err, qt.ErrorMatches, ".*could not obtain lock on row.*")
 
-	// Now we should be able to obtain the if we wait
+	// Now we should be able to obtain the lock if we wait
 	err = s.Database.GetIncomingModelMigrationWithLock(context.Background(), &lookup, noWait)
 	c.Check(err, qt.Equals, nil)
 	c.Check(lookup.ModelUUID, qt.DeepEquals, migration.ModelUUID)

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -9,11 +9,12 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
-func (s *dbSuite) TestAddModelMigration(c *qt.C) {
+func (s *dbSuite) setupModelMigrationTest(c *qt.C) dbmodel.Controller {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
@@ -29,13 +30,18 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 		CloudName: cloud.Name,
 	}
 	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+	return controller
+}
+
+func (s *dbSuite) TestAddModelMigration(c *qt.C) {
+	controller := s.setupModelMigrationTest(c)
 
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
 		TargetControllerID: controller.ID,
 		UserMapping:        dbmodel.StringMap{"local": "external"},
 	}
-	err = s.Database.AddIncomingModelMigration(context.Background(), &migration)
+	err := s.Database.AddOrUpdateIncomingModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
 	var dbMigration dbmodel.IncomingModelMigration
@@ -44,28 +50,36 @@ func (s *dbSuite) TestAddModelMigration(c *qt.C) {
 	c.Assert(dbMigration.ModelUUID, qt.DeepEquals, migration.ModelUUID)
 	c.Assert(dbMigration.TargetControllerID, qt.Equals, controller.ID)
 	c.Assert(dbMigration.UserMapping, qt.DeepEquals, migration.UserMapping)
+	c.Assert(dbMigration.UpdatedAt, qt.Not(qt.Equals), time.Time{})
+}
 
-	migration.ID = 0 // Reset ID to ensure it is not reused
-	err = s.Database.AddIncomingModelMigration(context.Background(), &migration)
-	c.Assert(err, qt.Not(qt.IsNil))
+func (s *dbSuite) TestReplaceModelMigration(c *qt.C) {
+	controller := s.setupModelMigrationTest(c)
+
+	migration := dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.StringMap{"local": "external"},
+	}
+	err := s.Database.AddOrUpdateIncomingModelMigration(context.Background(), &migration)
+	c.Assert(err, qt.Equals, nil)
+
+	newUserMapping := dbmodel.StringMap{"local": "new-external"}
+	migration.UserMapping = newUserMapping
+	err = s.Database.AddOrUpdateIncomingModelMigration(context.Background(), &migration)
+	c.Assert(err, qt.Equals, nil)
+
+	// Verify that the migration was updated
+	var dbMigration dbmodel.IncomingModelMigration
+	result := s.Database.DB.Where("model_uuid = ?", migration.ModelUUID).First(&dbMigration)
+	c.Assert(result.Error, qt.Equals, nil)
+	c.Assert(dbMigration.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+	c.Assert(dbMigration.TargetControllerID, qt.Equals, controller.ID)
+	c.Assert(dbMigration.UserMapping, qt.DeepEquals, newUserMapping)
 }
 
 func (s *dbSuite) TestGetModelMigration(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	cloud := dbmodel.Cloud{
-		Name: "test-cloud",
-	}
-	err = s.Database.AddCloud(context.Background(), &cloud)
-	c.Assert(err, qt.IsNil)
-
-	controller := dbmodel.Controller{
-		Name:      "test-controller",
-		UUID:      "00000000-0000-0000-0000-000000000001",
-		CloudName: cloud.Name,
-	}
-	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+	controller := s.setupModelMigrationTest(c)
 
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
@@ -75,7 +89,7 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
 	lookup := dbmodel.IncomingModelMigration{ModelUUID: migration.ModelUUID}
-	err = s.Database.GetIncomingModelMigration(context.Background(), &lookup)
+	err := s.Database.GetIncomingModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Equals, nil)
 
 	// Not found
@@ -87,22 +101,94 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
 }
 
+func (s *dbSuite) TestGetModelMigrationWithLock_NoWait(c *qt.C) {
+	controller := s.setupModelMigrationTest(c)
+
+	migration := dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.StringMap{"local": "external"},
+	}
+	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
+
+	notifyChan := make(chan struct{})
+	noWait := true
+	go func() {
+		// Lock the migration
+		err := s.Database.Transaction(func(d *db.Database) error {
+			lookup := dbmodel.IncomingModelMigration{
+				ModelUUID: migration.ModelUUID,
+			}
+			err := d.GetIncomingModelMigrationWithLock(context.Background(), &lookup, noWait)
+			c.Check(err, qt.Equals, nil)
+			c.Check(lookup.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+			close(notifyChan)
+			<-c.Context().Done()
+			return nil
+		})
+		c.Check(err, qt.IsNil)
+	}()
+
+	lookup := dbmodel.IncomingModelMigration{
+		ModelUUID: migration.ModelUUID,
+	}
+	<-notifyChan // Wait for the migration to be locked
+	err := s.Database.GetIncomingModelMigrationWithLock(context.Background(), &lookup, noWait)
+	c.Check(err, qt.IsNotNil)
+	c.Check(err, qt.ErrorMatches, ".*could not obtain lock on row.*")
+}
+
+func (s *dbSuite) TestGetModelMigrationWithLock_Wait(c *qt.C) {
+	controller := s.setupModelMigrationTest(c)
+
+	migration := dbmodel.IncomingModelMigration{
+		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
+		TargetControllerID: controller.ID,
+		UserMapping:        dbmodel.StringMap{"local": "external"},
+	}
+	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
+
+	notifyChan := make(chan struct{})
+	done := make(chan struct{})
+	noWait := false
+	go func() {
+		// Lock the migration
+		err := s.Database.Transaction(func(d *db.Database) error {
+			lookup := dbmodel.IncomingModelMigration{
+				ModelUUID: migration.ModelUUID,
+			}
+			err := d.GetIncomingModelMigrationWithLock(context.Background(), &lookup, noWait)
+			c.Check(err, qt.Equals, nil)
+			c.Check(lookup.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+			close(notifyChan)
+			// Sleep to simulate holding the lock, since we can't tell
+			// when the main thread is blocked on the lock.
+			<-time.After(1 * time.Second)
+			return nil
+		})
+		c.Check(err, qt.IsNil)
+		close(done)
+	}()
+
+	lookup := dbmodel.IncomingModelMigration{
+		ModelUUID: migration.ModelUUID,
+	}
+	<-notifyChan // Wait for the migration to be locked
+
+	// Check that we cannot obtain the lock immediately
+	err := s.Database.GetIncomingModelMigrationWithLock(context.Background(), &lookup, true)
+	c.Check(err, qt.IsNotNil)
+	c.Check(err, qt.ErrorMatches, ".*could not obtain lock on row.*")
+
+	// Now we should be able to obtain the if we wait
+	err = s.Database.GetIncomingModelMigrationWithLock(context.Background(), &lookup, noWait)
+	c.Check(err, qt.Equals, nil)
+	c.Check(lookup.ModelUUID, qt.DeepEquals, migration.ModelUUID)
+	<-done // Wait for the goroutine to finish
+}
+
 func (s *dbSuite) TestGetModelMigrationsCreatedBefore(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	cloud := dbmodel.Cloud{
-		Name: "test-cloud",
-	}
-	err = s.Database.AddCloud(context.Background(), &cloud)
-	c.Assert(err, qt.IsNil)
-
-	controller := dbmodel.Controller{
-		Name:      "test-controller",
-		UUID:      "00000000-0000-0000-0000-000000000001",
-		CloudName: cloud.Name,
-	}
-	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+	controller := s.setupModelMigrationTest(c)
 
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
@@ -122,21 +208,7 @@ func (s *dbSuite) TestGetModelMigrationsCreatedBefore(c *qt.C) {
 }
 
 func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
-	err := s.Database.Migrate(context.Background())
-	c.Assert(err, qt.Equals, nil)
-
-	cloud := dbmodel.Cloud{
-		Name: "test-cloud",
-	}
-	err = s.Database.AddCloud(context.Background(), &cloud)
-	c.Assert(err, qt.IsNil)
-
-	controller := dbmodel.Controller{
-		Name:      "test-controller",
-		UUID:      "00000000-0000-0000-0000-000000000001",
-		CloudName: cloud.Name,
-	}
-	c.Assert(s.Database.DB.Create(&controller).Error, qt.IsNil)
+	controller := s.setupModelMigrationTest(c)
 
 	migration := dbmodel.IncomingModelMigration{
 		ModelUUID:          sql.NullString{String: "00000001-0000-0000-0000-000000000001", Valid: true},
@@ -145,7 +217,7 @@ func (s *dbSuite) TestDeleteModelMigration(c *qt.C) {
 	}
 	c.Assert(s.Database.DB.Create(&migration).Error, qt.IsNil)
 
-	err = s.Database.DeleteIncomingModelMigration(context.Background(), &migration)
+	err := s.Database.DeleteIncomingModelMigration(context.Background(), &migration)
 	c.Assert(err, qt.Equals, nil)
 
 	var dbMigration dbmodel.IncomingModelMigration

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -15,6 +15,7 @@ type IncomingModelMigration struct {
 	// Note this doesn't use the standard gorm.Model to avoid soft-deletes.
 	ID        uint `gorm:"primarykey"`
 	CreatedAt time.Time
+	UpdatedAt time.Time
 
 	// ModelUUID is the UUID of the incoming model.
 	ModelUUID sql.NullString

--- a/internal/dbmodel/sql/postgres/031_add_updated_at_incoming_migrations.up.sql
+++ b/internal/dbmodel/sql/postgres/031_add_updated_at_incoming_migrations.up.sql
@@ -1,0 +1,4 @@
+-- Add an updated_at column to the incoming_model_migrations table
+
+ALTER TABLE incoming_model_migrations
+    ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // The group package provides business logic for handling group related methods..
 package group
@@ -96,12 +96,12 @@ func (j *groupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 	}
 
 	err := j.store.Transaction(func(d *db.Database) error {
-		err := j.store.GetGroup(ctx, group)
+		err := d.GetGroup(ctx, group)
 		if err != nil {
 			return err
 		}
 
-		if err := j.store.UpdateGroupName(ctx, group.UUID, newName); err != nil {
+		if err := d.UpdateGroupName(ctx, group.UUID, newName); err != nil {
 			return err
 		}
 		return nil

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -287,8 +287,8 @@ func (j *JujuManager) PrepareModelMigration(
 			return err
 		}
 
-		// Verify the model doesn't exist (implies a migration is in progress
-		// or completed) - it could also mean the model failed to be removed
+		// Verify the model doesn't exist - if it does that means a migration is
+		// in progress or completed or it could also mean the model failed to be removed
 		// during migration ABORT but that problem should be dealt with separately.
 		model := &dbmodel.Model{
 			UUID: sql.NullString{String: modelUUID, Valid: true},

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -283,7 +283,7 @@ func (j *JujuManager) PrepareModelMigration(
 
 	err := j.Database.Transaction(func(d *db.Database) error {
 		ctl := dbmodel.Controller{Name: targetControllerName}
-		if err := j.Database.GetController(ctx, &ctl); err != nil {
+		if err := d.GetController(ctx, &ctl); err != nil {
 			return err
 		}
 
@@ -293,14 +293,14 @@ func (j *JujuManager) PrepareModelMigration(
 		model := &dbmodel.Model{
 			UUID: sql.NullString{String: modelUUID, Valid: true},
 		}
-		err := j.Database.GetModel(ctx, model)
+		err := d.GetModel(ctx, model)
 		if err == nil {
 			return errors.E(op, "model migration for the specified model is already in progress/completed")
 		} else if errors.ErrorCode(err) != errors.CodeNotFound {
 			return err
 		}
 
-		if err := j.Database.AddOrUpdateIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
+		if err := d.AddOrUpdateIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
 			ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
 			TargetControllerID: ctl.ID,
 			UserMapping:        dbmodel.StringMap(userMapping),

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -287,7 +287,20 @@ func (j *JujuManager) PrepareModelMigration(
 			return err
 		}
 
-		if err := j.Database.AddIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
+		// Verify the model doesn't exist (implies a migration is in progress
+		// or completed) - it could also mean the model failed to be removed
+		// during migration ABORT but that problem should be dealt with separately.
+		model := &dbmodel.Model{
+			UUID: sql.NullString{String: modelUUID, Valid: true},
+		}
+		err := j.Database.GetModel(ctx, model)
+		if err == nil {
+			return errors.E(op, "model migration for the specified model is already in progress/completed")
+		} else if errors.ErrorCode(err) != errors.CodeNotFound {
+			return err
+		}
+
+		if err := j.Database.AddOrUpdateIncomingModelMigration(ctx, &dbmodel.IncomingModelMigration{
 			ModelUUID:          sql.NullString{String: modelUUID, Valid: true},
 			TargetControllerID: ctl.ID,
 			UserMapping:        dbmodel.StringMap(userMapping),

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -892,7 +892,7 @@ func TestPrepareMigration_MigrationLocked(t *testing.T) {
 
 	<-notifyChan // Wait for the migration to be locked
 	_, err = j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
-	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, `.*could not obtain lock on row.*`)
 }
 
 func TestPrepareMigration_MultipleCalls(t *testing.T) {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"gorm.io/gorm/clause"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -803,4 +804,121 @@ func TestPrepareModelMigration_Success(t *testing.T) {
 	c.Assert(incomingMigration.ModelUUID.String, qt.Equals, fakeModelUUID)
 	c.Assert(incomingMigration.TargetController.UUID, qt.Equals, targetController.UUID)
 	c.Assert(incomingMigration.UserMapping, qt.DeepEquals, dbmodel.StringMap(userMapping))
+}
+
+const prepareMigrationModelExistsEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+  - owner: alice@canonical.com
+    name: cred-1
+    cloud: test-cloud
+controllers:
+- name: myController
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+- name: test-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  owner: alice@canonical.com
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  controller: myController
+`
+
+func TestPrepareMigration_ModelExists(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	store := jimmtest.NewInMemoryCredentialStore()
+	j := newTestJujuManager(c, &parameters{
+		CredentialStore: store,
+	})
+
+	env := jimmtest.ParseEnvironment(c, prepareMigrationModelExistsEnv)
+	env.PopulateDB(c, j.Database)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	fakeModelUUID := env.Models[0].UUID
+	userMapping := map[string]string{"alice": "alice@canonical.com"}
+	targetController := env.Controllers[0].DBObject(c, j.Database)
+
+	_, err := j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
+	c.Assert(err, qt.IsNotNil)
+}
+
+func TestPrepareMigration_MigrationLocked(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	store := jimmtest.NewInMemoryCredentialStore()
+	j := newTestJujuManager(c, &parameters{
+		CredentialStore: store,
+	})
+
+	env := jimmtest.ParseEnvironment(c, prepareModelMigrationTestEnv)
+	env.PopulateDB(c, j.Database)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	fakeModelUUID := "d9a0bd29-a76e-451f-a186-7216cac77e29"
+	userMapping := map[string]string{"alice": "alice@canonical.com"}
+	targetController := env.Controllers[0].DBObject(c, j.Database)
+
+	// First call to PrepareModelMigration should succeed
+	_, err := j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
+	c.Assert(err, qt.IsNil)
+
+	notifyChan := make(chan struct{})
+	go func() {
+		// Lock the migration
+		err := j.Database.Transaction(func(d *db.Database) error {
+			db := d.DB
+			db = db.Clauses(clause.Locking{Strength: "UPDATE"})
+			mig := &dbmodel.IncomingModelMigration{ModelUUID: sql.NullString{String: fakeModelUUID, Valid: true}}
+			err := db.First(mig).Error
+			c.Check(err, qt.IsNil)
+			close(notifyChan)
+			<-ctx.Done()
+			return nil
+		})
+		c.Check(err, qt.IsNil)
+	}()
+
+	<-notifyChan // Wait for the migration to be locked
+	_, err = j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
+	c.Assert(err, qt.IsNotNil)
+}
+
+func TestPrepareMigration_MultipleCalls(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	store := jimmtest.NewInMemoryCredentialStore()
+	j := newTestJujuManager(c, &parameters{
+		CredentialStore: store,
+	})
+
+	env := jimmtest.ParseEnvironment(c, prepareModelMigrationTestEnv)
+	env.PopulateDB(c, j.Database)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	fakeModelUUID := "d9a0bd29-a76e-451f-a186-7216cac77e29"
+	userMapping := map[string]string{"alice": "alice@canonical.com"}
+	targetController := env.Controllers[0].DBObject(c, j.Database)
+
+	// First call to PrepareModelMigration should succeed
+	_, err := j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
+	c.Assert(err, qt.IsNil)
+
+	// Second call with an updated mapping should succeed
+	userMapping["bob"] = "alice@canonical.com"
+	_, err = j.PrepareModelMigration(ctx, user, fakeModelUUID, targetController.Name, userMapping)
+	c.Assert(err, qt.IsNil)
 }

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -420,26 +420,41 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		return errors.E(op, fmt.Errorf("failed to deserialize model description: %w", err))
 	}
 
-	incomingMigration := &dbmodel.IncomingModelMigration{
-		ModelUUID: sql.NullString{
-			String: modelDescription.Tag().Id(),
-			Valid:  true,
-		},
-	}
+	var (
+		model             *dbmodel.Model
+		offers            []*dbmodel.ApplicationOffer
+		incomingMigration *dbmodel.IncomingModelMigration
+	)
 
-	err = j.Database.GetIncomingModelMigration(ctx, incomingMigration)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to add incoming model migration: %w", err))
-	}
+	// Start a transaction to acquire the incoming model migration record with a
+	// lock to prevent it from being modified while we are importing the model.
+	// Then import the model and app offers into JIMM's state - the existence
+	// of the model implies that the migration record can no longer be modified.
+	err = j.Database.Transaction(func(d *db.Database) error {
+		incomingMigration = &dbmodel.IncomingModelMigration{
+			ModelUUID: sql.NullString{String: modelDescription.Tag().Id(), Valid: true},
+		}
 
-	err = j.modifyModelDescription(modelDescription, incomingMigration.UserMapping)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
-	}
+		// Set noWait to false to allow the transaction to wait for the lock.
+		noWait := false
+		err = j.Database.GetIncomingModelMigrationWithLock(ctx, incomingMigration, noWait)
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to get incoming model migration: %w", err))
+		}
 
-	model, offers, err := j.importFromDescription(ctx, incomingMigration.TargetController.ID, modelDescription)
+		err = j.modifyModelDescription(modelDescription, incomingMigration.UserMapping)
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
+		}
+
+		model, offers, err = j.importFromDescription(ctx, incomingMigration.TargetController.ID, modelDescription)
+		if err != nil {
+			return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+		}
+		return nil
+	})
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+		return err
 	}
 
 	// Pass the controller tag as the controller details
@@ -509,50 +524,44 @@ func (j *JujuManager) importFromDescription(ctx context.Context, targetControlle
 	var importedModel *dbmodel.Model
 	var importedOffers []*dbmodel.ApplicationOffer
 
-	err = j.Database.Transaction(func(db *db.Database) error {
-		model := dbmodel.Model{
-			UUID: sql.NullString{
-				String: modelUUIDStr,
-				Valid:  true,
-			},
-			Name:              modelNameStr,
-			OwnerIdentityName: description.Owner().Id(),
-			ControllerID:      targetControllerID,
-			CloudCredentialID: cloudCredential.ID,
-			CloudRegionID:     region.ID,
-			MigrationMode:     state.MigrationModeImporting,
-		}
-		err = db.AddModel(ctx, &model)
-		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
-		}
-		importedModel = &model
-
-		for _, app := range description.Applications() {
-			for _, offer := range app.Offers() {
-				// construct the offer URL with the same logic as Juju (modelOwner, modelName, offerName, <blank-controller-name>)
-				offerURL := jujucrossmodel.MakeURL(description.Owner().Id(), modelNameStr, offer.OfferName(), "")
-
-				dbOffer := dbmodel.ApplicationOffer{
-					UUID:    offer.OfferUUID(),
-					Name:    offer.OfferName(),
-					URL:     offerURL,
-					ModelID: model.ID,
-				}
-				if err := db.AddApplicationOffer(ctx, &dbOffer); err != nil {
-					if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-						return fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
-					}
-					return err
-				}
-
-				importedOffers = append(importedOffers, &dbOffer)
-			}
-		}
-		return nil
-	})
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: modelUUIDStr,
+			Valid:  true,
+		},
+		Name:              modelNameStr,
+		OwnerIdentityName: description.Owner().Id(),
+		ControllerID:      targetControllerID,
+		CloudCredentialID: cloudCredential.ID,
+		CloudRegionID:     region.ID,
+		MigrationMode:     state.MigrationModeImporting,
+	}
+	err = j.Database.AddModel(ctx, &model)
 	if err != nil {
-		return nil, nil, errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+		return nil, nil, errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
+	}
+	importedModel = &model
+
+	for _, app := range description.Applications() {
+		for _, offer := range app.Offers() {
+			// construct the offer URL with the same logic as Juju (modelOwner, modelName, offerName, <blank-controller-name>)
+			offerURL := jujucrossmodel.MakeURL(description.Owner().Id(), modelNameStr, offer.OfferName(), "")
+
+			dbOffer := dbmodel.ApplicationOffer{
+				UUID:    offer.OfferUUID(),
+				Name:    offer.OfferName(),
+				URL:     offerURL,
+				ModelID: model.ID,
+			}
+			if err := j.Database.AddApplicationOffer(ctx, &dbOffer); err != nil {
+				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
+					return nil, nil, fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
+				}
+				return nil, nil, errors.E(op, fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err))
+			}
+
+			importedOffers = append(importedOffers, &dbOffer)
+		}
 	}
 
 	return importedModel, importedOffers, nil

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -252,7 +252,7 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 
 	newOwnerTag := names.NewUserTag(newOwner)
 	model.Owner = newOwnerTag
-	err := j.modifyModelDescription(model.ModelDescription, userMapping)
+	err := modifyModelDescription(model.ModelDescription, userMapping)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to modify model description: %w", err))
 	}
@@ -261,7 +261,7 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 
 // modifyModelDescription modifies the model description to replace local user references
 // with their external mapping for both the model owner and the cloud credential owner.
-func (j *JujuManager) modifyModelDescription(modelDescription description.Model, userMapping dbmodel.StringMap) error {
+func modifyModelDescription(modelDescription description.Model, userMapping dbmodel.StringMap) error {
 	// change the owner of the model description if it is a local user
 	if modelDescription.Owner().IsLocal() {
 		// If the owner is a local user, we replace it with the external mapping.
@@ -437,17 +437,17 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 
 		// Set noWait to false to allow the transaction to wait for the lock.
 		noWait := false
-		err = j.Database.GetIncomingModelMigrationWithLock(ctx, incomingMigration, noWait)
+		err = d.GetIncomingModelMigrationWithLock(ctx, incomingMigration, noWait)
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to get incoming model migration: %w", err))
 		}
 
-		err = j.modifyModelDescription(modelDescription, incomingMigration.UserMapping)
+		err = modifyModelDescription(modelDescription, incomingMigration.UserMapping)
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
 		}
 
-		model, offers, err = j.importFromDescription(ctx, incomingMigration.TargetController.ID, modelDescription)
+		model, offers, err = importFromDescription(ctx, d, incomingMigration.TargetController.ID, modelDescription)
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
 		}
@@ -490,7 +490,7 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 // and model description and sets the migration mode to importing.
 // Application offers are created for any offers in the model description.
 // It also ensures that the cloud credential and region are present in the database.
-func (j *JujuManager) importFromDescription(ctx context.Context, targetControllerID uint, description description.Model) (*dbmodel.Model, []*dbmodel.ApplicationOffer, error) {
+func importFromDescription(ctx context.Context, tx *db.Database, targetControllerID uint, description description.Model) (*dbmodel.Model, []*dbmodel.ApplicationOffer, error) {
 	op := errors.Op("jimm.importFromDescription")
 
 	modelNameStr, ok := description.Config()[config.NameKey].(string)
@@ -512,11 +512,11 @@ func (j *JujuManager) importFromDescription(ctx context.Context, targetControlle
 		Name:              description.CloudCredential().Name(),
 	}
 
-	err := j.Database.GetCloudCredential(ctx, cloudCredential)
+	err := tx.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
 		return nil, nil, errors.E(op, err)
 	}
-	region, err := j.Database.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
+	region, err := tx.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
 	if err != nil {
 		return nil, nil, errors.E(op, err)
 	}
@@ -536,7 +536,7 @@ func (j *JujuManager) importFromDescription(ctx context.Context, targetControlle
 		CloudRegionID:     region.ID,
 		MigrationMode:     state.MigrationModeImporting,
 	}
-	err = j.Database.AddModel(ctx, &model)
+	err = tx.AddModel(ctx, &model)
 	if err != nil {
 		return nil, nil, errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
 	}
@@ -553,7 +553,7 @@ func (j *JujuManager) importFromDescription(ctx context.Context, targetControlle
 				URL:     offerURL,
 				ModelID: model.ID,
 			}
-			if err := j.Database.AddApplicationOffer(ctx, &dbOffer); err != nil {
+			if err := tx.AddApplicationOffer(ctx, &dbOffer); err != nil {
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 					return nil, nil, fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
 				}

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -55,7 +55,7 @@ func (s *migrationHTTPProxySuite) SetUpTest(c *gc.C) {
 		ModelUUID:          sql.NullString{String: incomingModelUUID, Valid: true},
 		UserMapping:        map[string]string{"bob": "alice@canonical.com"},
 	}
-	err := s.JIMM.Database.AddIncomingModelMigration(ctx, incomingModel)
+	err := s.JIMM.Database.AddOrUpdateIncomingModelMigration(ctx, incomingModel)
 	c.Assert(err, gc.IsNil)
 	s.incomingModel = incomingModel
 

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -583,7 +583,7 @@ func (im *IncomingMigration) DBObject(c Tester, db *db.Database) dbmodel.Incomin
 		im.dbo.UserMapping[im.UserMapping[um].LocalUser] = im.UserMapping[um].ExternalUserName
 	}
 
-	err := db.AddIncomingModelMigration(context.Background(), &im.dbo)
+	err := db.AddOrUpdateIncomingModelMigration(context.Background(), &im.dbo)
 	if err != nil {
 		c.Fatalf("err is not nil: %s", err)
 	}


### PR DESCRIPTION
## Description
Migrating a model to JAAS requires a client to call PrepareModelMigration first. This change makes it possible to call PrepareModelMigration multiple times and allows the initial user mapping or backing controller to change. JIMM will ensure that if the model migration has progressed up to a certain point that the PrepareModelMigration will return an error instead to ensure the data is consistent during the migration process.

Fixes [JUJU-8249](https://warthogs.atlassian.net/browse/JUJU-8249)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8249]: https://warthogs.atlassian.net/browse/JUJU-8249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ