### PR TITLE
chore: add bootstrap start api types

### DIFF
--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -580,3 +580,26 @@ type BootstrapStatusResponse struct {
 	// Error is the error message if the bootstrap job failed.
 	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 }
+
+// BootstrapFlags holds the flags that can be used
+// when bootstrapping a new controller.
+type BootstrapFlags struct {
+	AgentVersion string `json:"agent-version,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
+}
+
+// BootstrapStartParams holds parameters for starting
+// a controller bootstrap job.
+type BoostrapStartParams struct {
+	CloudName      string         `json:"cloud-name"`
+	RegionName     string         `json:"region-name"`
+	ControllerName string         `json:"controller-name"`
+	Flags          BootstrapFlags `json:"flags"`
+}
+
+// BootstrapStartResponse holds the response for starting
+// a controller bootstrap job.
+type BootstrapStartResponse struct {
+	JobID string `json:"job-id"`
+	Error string `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Description
This PR adds new API types for starting a controller bootstrap job.

Note that the file `pkg/api/params/params.go` file contains structs where some include both `yaml` and `json` tags while others only include a `json` tag. I believe only the JSON tags are necessary because Juju RPC only works by unmarshalling JSON, it doesn't offer support for yaml and the yaml tags were added unnecessarily.