### PR TITLE
feat: bootstrap start facade

### DIFF
--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -68,4 +69,16 @@ func (b *bootstrapManager) GetBootstrapStatusAndLogs(ctx context.Context, _ *ope
 		Logs:      loggies,
 		Watermark: newOffset,
 	}, nil
+}
+
+// StartBootstrap starts a bootstrap job with the provided parameters.
+func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
+	const op = errors.Op("jimm.StartBootstrap")
+
+	err := params.validate()
+	if err != nil {
+		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))
+	}
+
+	return "", errors.E(op, "not implemented")
 }

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Canonical.
+
+package bootstrap
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+// BootstrapParams defines the parameters required for bootstrapping a JIMM controller.
+type BootstrapParams struct {
+	ControllerName string
+	CloudName      string
+	CloudRegion    string
+	AgentVersion   string
+	TimeoutSeconds int
+}
+
+// Validate checks if the BootstrapParams are valid.
+func (p BootstrapParams) validate() error {
+	var msgs []string
+	if p.ControllerName == "" {
+		msgs = append(msgs, "controller name cannot be empty")
+	}
+	if p.CloudName == "" {
+		msgs = append(msgs, "cloud name cannot be empty")
+	}
+	if p.CloudRegion == "" {
+		msgs = append(msgs, "cloud region cannot be empty")
+	}
+	if p.AgentVersion == "" {
+		msgs = append(msgs, "agent version cannot be empty")
+	}
+	if msgs != nil {
+		return errors.E(fmt.Sprintf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n")))
+	}
+	return nil
+}

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Canonical.
+
+package bootstrap
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestValidateBootstrapParams_AllValid(t *testing.T) {
+	c := qt.New(t)
+	params := BootstrapParams{
+		ControllerName: "ctrl",
+		CloudName:      "cloud",
+		CloudRegion:    "region",
+		AgentVersion:   "1.2.3",
+		TimeoutSeconds: 60,
+	}
+	c.Assert(params.validate(), qt.IsNil)
+}
+
+func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		params BootstrapParams
+		want   []string
+	}{
+		{
+			name:   "all empty",
+			params: BootstrapParams{},
+			want: []string{
+				"controller name cannot be empty",
+				"cloud name cannot be empty",
+				"cloud region cannot be empty",
+				"agent version cannot be empty",
+			},
+		},
+		{
+			name: "missing controller name",
+			params: BootstrapParams{
+				CloudName:    "cloud",
+				CloudRegion:  "region",
+				AgentVersion: "1.2.3",
+			},
+			want: []string{"controller name cannot be empty"},
+		},
+		{
+			name: "missing cloud name",
+			params: BootstrapParams{
+				ControllerName: "ctrl",
+				CloudRegion:    "region",
+				AgentVersion:   "1.2.3",
+			},
+			want: []string{"cloud name cannot be empty"},
+		},
+		{
+			name: "missing cloud region",
+			params: BootstrapParams{
+				ControllerName: "ctrl",
+				CloudName:      "cloud",
+				AgentVersion:   "1.2.3",
+			},
+			want: []string{"cloud region cannot be empty"},
+		},
+		{
+			name: "missing agent version",
+			params: BootstrapParams{
+				ControllerName: "ctrl",
+				CloudName:      "cloud",
+				CloudRegion:    "region",
+			},
+			want: []string{"agent version cannot be empty"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			err := tt.params.validate()
+			c.Assert(err, qt.Not(qt.IsNil))
+			for _, wantMsg := range tt.want {
+				c.Assert(err, qt.ErrorMatches, "(?s).*"+wantMsg+".*")
+			}
+		})
+	}
+}

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -306,6 +306,8 @@ type JujuManager interface {
 type BootstrapManager interface {
 	// GetBootstrapStatusAndLogs retrieves the status and logs of a bootstrap job.
 	GetBootstrapStatusAndLogs(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error)
+	// StartBootstrap starts a bootstrap job and returns the job ID.
+	StartBootstrap(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
 }
 
 // Parameters holds the services and static fields passed to the jimm.New() constructor.

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/bootstrap"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
@@ -62,6 +63,8 @@ func init() {
 		migrateModel := rpc.Method(r.MigrateModel)
 		version := rpc.Method(r.Version)
 		prepareModelMigration := rpc.Method(r.PrepareModelMigration)
+		bootstrapStatus := rpc.Method(r.BootstrapStatus)
+		bootstrapStart := rpc.Method(r.BootstrapStart)
 
 		// JIMM Generic RPC
 		r.AddMethod("JIMM", 4, "AddController", addControllerMethod)
@@ -101,7 +104,8 @@ func init() {
 		// JIMM Model Migrations
 		r.AddMethod("JIMM", 4, "PrepareModelMigration", prepareModelMigration)
 		// JIMM Bootstrap
-		r.AddMethod("JIMM", 4, "BootstrapStatus", rpc.Method(r.BootstrapStatus))
+		r.AddMethod("JIMM", 4, "BootstrapStatus", bootstrapStatus)
+		r.AddMethod("JIMM", 4, "BootstrapStart", bootstrapStart)
 
 		return []int{4}
 	}
@@ -577,4 +581,29 @@ func (r *controllerRoot) BootstrapStatus(ctx context.Context, req apiparams.Boot
 	}
 
 	return r.jimm.BootstrapManager().GetBootstrapStatusAndLogs(ctx, r.user, jobId, req.Watermark)
+}
+
+// BootstrapStart starts a bootstrap job.
+func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.BootstrapStartParams) (apiparams.BootstrapStartResponse, error) {
+	const op = errors.Op("jujuapi.BootstrapStart")
+
+	if !r.user.JimmAdmin {
+		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	params := bootstrap.BootstrapParams{
+		ControllerName: req.ControllerName,
+		CloudName:      req.CloudName,
+		CloudRegion:    req.RegionName,
+		AgentVersion:   req.Flags.AgentVersion,
+		TimeoutSeconds: req.Flags.Timeout,
+	}
+
+	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)
+	if err != nil {
+		return apiparams.BootstrapStartResponse{}, errors.E(op, fmt.Errorf("failed to start bootstrap job: %v", err))
+	}
+	return apiparams.BootstrapStartResponse{
+		JobID: jobID,
+	}, nil
 }

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
+	"github.com/canonical/jimm/v3/internal/jimm/bootstrap"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
@@ -22,7 +23,7 @@ type jimmUnitTestSuite struct{}
 
 var _ = gc.Suite(&jimmUnitTestSuite{})
 
-func (s *jimmSuite) TestPrepareModelMigration_UnauthorizedUser(c *gc.C) {
+func (s *jimmUnitTestSuite) TestPrepareModelMigration_UnauthorizedUser(c *gc.C) {
 	ctx := context.Background()
 	jimm := &jimmtest.JIMM{
 		JujuManager_: func() jimm.JujuManager {
@@ -36,7 +37,7 @@ func (s *jimmSuite) TestPrepareModelMigration_UnauthorizedUser(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "unauthorized")
 }
 
-func (s *jimmSuite) TestPrepareModelMigration_InvalidModelTag(c *gc.C) {
+func (s *jimmUnitTestSuite) TestPrepareModelMigration_InvalidModelTag(c *gc.C) {
 	ctx := context.Background()
 
 	jimm := &jimmtest.JIMM{
@@ -53,7 +54,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidModelTag(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "invalid model tag")
 }
 
-func (s *jimmSuite) TestPrepareModelMigration_InvalidControllerName(c *gc.C) {
+func (s *jimmUnitTestSuite) TestPrepareModelMigration_InvalidControllerName(c *gc.C) {
 	ctx := context.Background()
 
 	jimm := &jimmtest.JIMM{
@@ -71,7 +72,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidControllerName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "invalid controller name")
 }
 
-func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
+func (s *jimmUnitTestSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	ctx := context.Background()
 
 	jimm := &jimmtest.JIMM{
@@ -106,7 +107,7 @@ func (s *jimmSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `--badwolf--@canonical.com is not a valid external user name`)
 }
 
-func (s *jimmSuite) TestBootstrapStatus(c *gc.C) {
+func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 	ctx := context.Background()
 	uuidGenerated := uuid.New()
 	jimm := &jimmtest.JIMM{
@@ -148,5 +149,50 @@ func (s *jimmSuite) TestBootstrapStatus(c *gc.C) {
 		JobID:     uuidGenerated.String(),
 		Watermark: 0,
 	})
+	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeUnauthorized)
+}
+
+func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
+	ctx := context.Background()
+	var startBootstrapErr error
+
+	jimm := &jimmtest.JIMM{
+		BootstapManager_: func() jimm.BootstrapManager {
+			return &mocks.BootstapManager{
+				StartBootstrap_: func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
+					if startBootstrapErr != nil {
+						return "", startBootstrapErr
+					}
+					return uuid.New().String(), nil
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	params := params.BootstrapStartParams{
+		ControllerName: "controller",
+		CloudName:      "cloud",
+		RegionName:     "region",
+		Flags: params.BootstrapFlags{
+			AgentVersion: "1.0.0",
+			Timeout:      3600,
+		},
+	}
+
+	response, err := root.BootstrapStart(ctx, params)
+	c.Assert(err, gc.IsNil)
+	c.Assert(response.JobID, gc.Not(gc.Equals), "")
+
+	// Test start bootstrap fails
+	startBootstrapErr = errors.E("foo")
+	_, err = root.BootstrapStart(ctx, params)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err.Error(), gc.Matches, "failed to start bootstrap job: foo")
+
+	startBootstrapErr = nil
+	// Test unauthorized user
+	root = newTestControllerRoot(jimm, "alice@canonical.com", false)
+	_, err = root.BootstrapStart(ctx, params)
 	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeUnauthorized)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
@@ -8,12 +8,14 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/bootstrap"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 type BootstapManager struct {
 	GetBootstrapStatusAndLogs_ func(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error)
+	StartBootstrap_            func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
 }
 
 func (b *BootstapManager) GetBootstrapStatusAndLogs(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error) {
@@ -21,4 +23,11 @@ func (b *BootstapManager) GetBootstrapStatusAndLogs(ctx context.Context, user *o
 		return params.BootstrapStatusResponse{}, errors.E(errors.CodeNotImplemented)
 	}
 	return b.GetBootstrapStatusAndLogs_(ctx, user, jobId, offset)
+}
+
+func (b *BootstapManager) StartBootstrap(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
+	if b.StartBootstrap_ == nil {
+		return "", errors.E(errors.CodeNotImplemented)
+	}
+	return b.StartBootstrap_(ctx, user, params)
 }

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -594,22 +594,28 @@ type BootstrapStatusResponse struct {
 // BootstrapFlags holds the flags that can be used
 // when bootstrapping a new controller.
 type BootstrapFlags struct {
+	// The agent version to use for the bootstrap.
 	AgentVersion string `json:"agent-version,omitempty"`
-	Timeout      string `json:"timeout,omitempty"`
+	// The timeout in seconds for the bootstrap.
+	Timeout int `json:"timeout,omitempty"`
 }
 
 // BootstrapStartParams holds parameters for starting
 // a controller bootstrap job.
-type BoostrapStartParams struct {
-	CloudName      string         `json:"cloud-name"`
-	RegionName     string         `json:"region-name"`
-	ControllerName string         `json:"controller-name"`
-	Flags          BootstrapFlags `json:"flags"`
+type BootstrapStartParams struct {
+	// CloudName specifies the target cloud for the controller.
+	CloudName string `json:"cloud-name"`
+	// RegionName specifies the target region for the controller.
+	RegionName string `json:"region-name"`
+	// ControllerName specifies the name of the controller as recorded in JIMM.
+	ControllerName string `json:"controller-name"`
+	// Flags hold modifiers for the bootstrap job.
+	Flags BootstrapFlags `json:"flags"`
 }
 
 // BootstrapStartResponse holds the response for starting
 // a controller bootstrap job.
 type BootstrapStartResponse struct {
+	// JobID is the ID of the bootstrap job that was started.
 	JobID string `json:"job-id"`
-	Error string `json:"error,omitempty"`
 }

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -590,3 +590,26 @@ type BootstrapStatusResponse struct {
 	// Error is the error message if the bootstrap job failed.
 	Error string `json:"error,omitempty"`
 }
+
+// BootstrapFlags holds the flags that can be used
+// when bootstrapping a new controller.
+type BootstrapFlags struct {
+	AgentVersion string `json:"agent-version,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
+}
+
+// BootstrapStartParams holds parameters for starting
+// a controller bootstrap job.
+type BoostrapStartParams struct {
+	CloudName      string         `json:"cloud-name"`
+	RegionName     string         `json:"region-name"`
+	ControllerName string         `json:"controller-name"`
+	Flags          BootstrapFlags `json:"flags"`
+}
+
+// BootstrapStartResponse holds the response for starting
+// a controller bootstrap job.
+type BootstrapStartResponse struct {
+	JobID string `json:"job-id"`
+	Error string `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Description
This PR adds a new facade method to JIMM called `bootstrapStart` for starting a bootstrap job.

There are a few things that are worth discussing that I'll bring up offline, mainly:
- The use of error fields in our RPC structs. We don't need to put error fields in the return types.
- What type we return from the `internal/jimm` layer.
- Where we run validation.

Fixes [JUJU-8149](https://warthogs.atlassian.net/browse/JUJU-8149)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8149]: https://warthogs.atlassian.net/browse/JUJU-8149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ