### PR TITLE
feat: run commands via os.exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cjlapao/common-go v0.0.39 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/creack/pty v1.1.18 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
@@ -339,15 +339,15 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
+require mvdan.cc/sh/v3 v3.12.0
+
 require (
 	cloud.google.com/go/auth v0.16.2 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/juju/packaging/v4 v4.0.0 // indirect
-	github.com/juju/terms-client/v2 v2.0.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,14 +176,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
-github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
-github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
-github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cjlapao/common-go v0.0.39 h1:bAAUrj2B9v0kMzbAOhzjSmiyDy+rd56r2sy7oEiQLlA=
 github.com/cjlapao/common-go v0.0.39/go.mod h1:M3dzazLjTjEtZJbbxoA5ZDiGCiHmpwqW9l4UWaddwOA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -205,8 +199,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -316,6 +310,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4Bx7ia+JlgcnOao=
 github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
@@ -704,8 +700,6 @@ github.com/juju/rpcreflect v1.2.0/go.mod h1:yWSyMkWOwQGqUVxvboHn1c3CuCQrQ5LgV//8
 github.com/juju/schema v1.0.0/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/schema v1.2.0 h1:+XywM0pYzuhGebQiK1aR4Bj7Q7nLV5MihcOgq6dLLxs=
 github.com/juju/schema v1.2.0/go.mod h1:VdljuJLc45loM79LYm4yKKmPJwK1bPKRekvMVlfywU0=
-github.com/juju/terms-client/v2 v2.0.0 h1:8DGcK9JW5Q7gmuvTzB2qIXsa/KY70jWM54rtGFAmyak=
-github.com/juju/terms-client/v2 v2.0.0/go.mod h1:ezOEZrFZZ0c9Kc0xeHH7SCmniWPkjuxiAm82wwg+fpE=
 github.com/juju/testing v0.0.0-20180402130637-44801989f0f7/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20180517134105-72703b1e95eb/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/juju/testing v0.0.0-20190723135506-ce30eb24acd2/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
@@ -1351,7 +1345,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1655,6 +1648,8 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
 launchpad.net/xmlpath v0.0.0-20130614043138-000000000004/go.mod h1:vqyExLOM3qBx7mvYRkoxjSCF945s0mbe7YynlKYXtsA=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/jujucommands/export_test.go
+++ b/internal/jujucommands/export_test.go
@@ -4,4 +4,5 @@ package jujucommands
 
 var (
 	RunJujuCmd = runJujuCmd
+	CmdPrefix  = &cmdPrefix
 )

--- a/internal/jujucommands/export_test.go
+++ b/internal/jujucommands/export_test.go
@@ -3,5 +3,5 @@
 package jujucommands
 
 var (
-	RunCmdWithOutputRetriever = runCmdWithOutputRetriever
+	RunJujuCmd = runJujuCmd
 )

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -19,22 +19,21 @@ type outputLine struct {
 	Err  error
 }
 
+var (
+	cmdPrefix = "juju"
+)
+
 // runJujuCmd runs a juju command with the given command string and JUJU_DATA directory.
 // It returns a channel that will receive output lines from the command's stdout and stderr.
 // The command is run in a separate goroutine, and the context can be used to cancel the command.
 func runJujuCmd(ctx context.Context, cmdStr, jujuDataDir string) (<-chan outputLine, error) {
-	env := func(key string) string {
-		if key == "JUJU_DATA" {
-			return jujuDataDir
-		}
-		return ""
-	}
-	args, err := shell.Fields(cmdStr, env)
+	args, err := shell.Fields(cmdStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse command: %w", err)
 	}
 
-	cmd := exec.Command("juju", args...)
+	cmd := exec.Command(cmdPrefix, args...)
+	cmd.Env = append(cmd.Env, "JUJU_DATA="+jujuDataDir)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/mitchellh/go-linereader"
-	"mvdan.cc/sh/v3/shell"
 )
 
 type outputLine struct {
@@ -26,13 +25,8 @@ var (
 // runJujuCmd runs a juju command with the given command string and JUJU_DATA directory.
 // It returns a channel that will receive output lines from the command's stdout and stderr.
 // The command is run in a separate goroutine, and the context can be used to cancel the command.
-func runJujuCmd(ctx context.Context, cmdStr, jujuDataDir string) (<-chan outputLine, error) {
-	args, err := shell.Fields(cmdStr, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse command: %w", err)
-	}
-
-	cmd := exec.Command(cmdPrefix, args...)
+func runJujuCmd(ctx context.Context, args []string, jujuDataDir string) (<-chan outputLine, error) {
+	cmd := exec.CommandContext(ctx, cmdPrefix, args...)
 	cmd.Env = append(cmd.Env, "JUJU_DATA="+jujuDataDir)
 
 	stdOut, err := cmd.StdoutPipe()
@@ -50,11 +44,6 @@ func runJujuCmd(ctx context.Context, cmdStr, jujuDataDir string) (<-chan outputL
 	}
 
 	outputCh := make(chan outputLine, 10) // buffered to avoid blocking
-
-	go func() {
-		<-ctx.Done()
-		_ = cmd.Process.Kill()
-	}()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -82,6 +71,7 @@ func runJujuCmd(ctx context.Context, cmdStr, jujuDataDir string) (<-chan outputL
 		if err := cmd.Wait(); err != nil {
 			outputCh <- outputLine{Err: err}
 		}
+
 		close(outputCh)
 	}()
 

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -5,18 +5,13 @@
 package jujucommands
 
 import (
+	"context"
 	"fmt"
-	"io"
-	"strings"
+	"os/exec"
+	"sync"
 
-	"github.com/juju/cmd/v3"
-	"github.com/juju/juju/cmd/juju/commands"
-	"github.com/juju/juju/jujuclient"
 	"github.com/mitchellh/go-linereader"
-)
-
-var (
-	whitelist = []string{"help", "bootstrap"}
+	"mvdan.cc/sh/v3/shell"
 )
 
 type outputLine struct {
@@ -24,108 +19,72 @@ type outputLine struct {
 	Err  error
 }
 
-// runCmdWithOutputRetriever runs the command given by cmdAndArgs using the provided jujuclient.ClientStore.
-// It returns a channel that streams OutputLine values for each line of command output and any final error.
-//
-// Upon receiving an error in an OutputLine, the line previously streamed is guaranteed to be the error line written by
-// the command.
-// I.e., if you run: "help -b"
-// You will get:
-//
-//	Output line: ERROR option provided but not defined: -b // The error line from juju (Which is a none-erroneous OutputLine)
-//	Command finished with error: cmd failed with code 2 // The command error code line (Contains an error in the OutputLine)
-//
-// Consumers are expected to simply read from the OutputLine channel and check for an error like so:
-//
-//	for out := range outputCh {
-//		if out.Err != nil {
-//			fmt.Println("Command finished with error:", out.Err)
-//			break
-//		}
-//		fmt.Println("Output line:", out.Line)
-//	}
-//
-// The OutputLine channel is closed once all output from the command has finished an the error has been captured.
-//
-// Lines returned are returned with no newlines.
-func runCmdWithOutputRetriever(store jujuclient.ClientStore, cmdAndArgs string) (<-chan outputLine, error) {
-	cmdReader, cmdWriter := io.Pipe()
-
-	cmdCtx, err := cmd.DefaultContext()
+// runJujuCmd runs a juju command with the given command string and JUJU_DATA directory.
+// It returns a channel that will receive output lines from the command's stdout and stderr.
+// The command is run in a separate goroutine, and the context can be used to cancel the command.
+func runJujuCmd(ctx context.Context, cmdStr, jujuDataDir string) (<-chan outputLine, error) {
+	env := func(key string) string {
+		if key == "JUJU_DATA" {
+			return jujuDataDir
+		}
+		return ""
+	}
+	args, err := shell.Fields(cmdStr, env)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse command: %w", err)
 	}
 
-	cmdCtx.Stderr = cmdWriter
-	cmdCtx.Stdout = cmdWriter
+	cmd := exec.Command("juju", args...)
 
-	outputCh := make(chan outputLine)
-	// We buffer cmdFinishedCh (capacity 1) to avoid deadlock.
-	// runCmd defers cmdWriter.Close(), which only runs after runCmd finishes.
-	// If cmdFinishedCh were unbuffered, sending the final error would block
-	// (since no goroutine is receiving yet), which prevents runCmd from finishing.
-	// This means cmdWriter.Close() never runs, so the reader never gets EOF and hangs.
-	// With a buffered channel, the send doesn't block, allowing runCmd to finish,
-	// the writer to close, and the reader to eventually see EOF and exit.
-	//
-	// This is safe because we only send once, after the command finishes.
-	// Alternatively, we could manually close cmdWriter right after the command.
-	cmdFinishedCh := make(chan int, 1)
+	stdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stdout: %w", err)
+	}
+
+	stdErr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stderr: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start command: %w", err)
+	}
+
+	outputCh := make(chan outputLine, 10) // buffered to avoid blocking
 
 	go func() {
-		// Read cmdoutput.
-		lr := linereader.New(cmdReader)
-		for line := range lr.Ch {
-			outputCh <- outputLine{Line: line}
-		}
+		<-ctx.Done()
+		_ = cmd.Process.Kill()
+	}()
 
-		// Wait for cmd to finish.
-		code := <-cmdFinishedCh
-		if code != 0 {
-			outputCh <- outputLine{Err: fmt.Errorf("cmd failed with code: %d", code)}
-		}
+	var wg sync.WaitGroup
+	wg.Add(2)
 
+	readLines := func(r *linereader.Reader) {
+		defer wg.Done()
+		for line := range r.Ch {
+			select {
+			case outputCh <- outputLine{Line: line}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	go readLines(linereader.New(stdOut))
+	go readLines(linereader.New(stdErr))
+
+	go func() {
+		// We wait for readers to finished in the case the command exits but
+		// the readers are still processing output. Small chance this could happen,
+		// but this protects us.
+		wg.Wait()
+
+		if err := cmd.Wait(); err != nil {
+			outputCh <- outputLine{Err: err}
+		}
 		close(outputCh)
 	}()
-	go runCmd(cmdCtx, cmdWriter, store, cmdFinishedCh, cmdAndArgs)
 
 	return outputCh, nil
-}
-
-// runCmd executes a Juju command using the provided context, client store, and command arguments.
-// It writes command output to the given io.PipeWriter and signals completion or error via cmdFinishedCh.
-// The function splits cmdAndArgs into arguments, constructs a Juju command, and runs it.
-// On non-zero exit code, it sends an error to cmdFinishedCh; otherwise, it signals successful completion.
-//
-// Note, the cmdAndArgs argument expects a fully-qualified command string. I.e.,
-//
-//	"bootstrap lxd a --add-model=\"my-initial-model\""
-func runCmd(
-	cmdCtx *cmd.Context,
-	cmdWriter *io.PipeWriter,
-	store jujuclient.ClientStore,
-	cmdFinishedCh chan<- int,
-	cmdAndArgs string,
-) {
-	defer cmdWriter.Close()
-
-	jujuCmd := commands.NewJujuCommandWithStore(
-		cmdCtx,
-		store,
-		nil,       // quiet?
-		"",        // unknown param
-		"",        // no help hint
-		whitelist, // whitelist
-		// We set embedded false because some commands can targets either a controller or client.
-		// See: https://github.com/juju/juju/blob/1abcb8c5f1f187fd1443e12d6324a47780b43740/cmd/modelcmd/controller.go#L451
-		// And whilst we are "technically" embedding the CLI, without setting this to false,
-		// You must run without --client/--controller and it defaults to updating the client
-		// in update-public-clouds. So, we set it false to allow us to explicitly set
-		// "--client" and not have it ignored.
-		false,
-	)
-
-	code := cmd.Main(jujuCmd, cmdCtx, strings.Split(cmdAndArgs, " "))
-
-	cmdFinishedCh <- code
 }

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -17,7 +17,8 @@ type jujucommandsSuite struct{}
 func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever(c *qt.C) {
 	testCtx := c.Context()
 	dir := c.TempDir()
-	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"help"}, dir)
+	c.Patch(jujucommands.CmdPrefix, "echo")
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"i am an output"}, dir)
 	c.Assert(err, qt.IsNil)
 
 	// Use a builder to collect streamed output & test entire string.
@@ -25,46 +26,10 @@ func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever(c *qt.C) {
 
 	for out := range outputCh {
 		c.Assert(out.Err, qt.IsNil)
-		b.WriteString(out.Line + "\n")
+		b.WriteString(out.Line)
 	}
 
-	expected := `Juju provides easy, intelligent application orchestration on top of Kubernetes,
-cloud infrastructure providers such as Amazon, Google, Microsoft, Openstack,
-MAAS (and more!), or even your local machine via LXD.
-
-See https://juju.is for getting started tutorials and additional documentation.
-
-Starter commands:
-
-    bootstrap           Initializes a cloud environment.
-    add-model           Adds a workload model.
-    deploy              Deploys a new application.
-    status              Displays the current status of Juju, applications, and units.
-    add-unit            Adds extra units of a deployed application.
-    integrate           Adds an integration between two applications.
-    expose              Makes an application publicly available over the network.
-    models              Lists models a user can access on a controller.
-    controllers         Lists all controllers.
-    whoami              Display the current controller, model and logged in user name. 
-    switch              Selects or identifies the current controller and model.
-    add-k8s             Adds a k8s endpoint and credential to Juju.
-    add-cloud           Adds a user-defined cloud to Juju.
-    add-credential      Adds or replaces credentials for a cloud.
-
-Interactive mode:
-
-When run without arguments, Juju will enter an interactive shell which can be
-used to run any Juju command directly.
-
-Help commands:
-    
-    juju help           This help page.
-    juju help <command> Show help for the specified command.
-
-For the full list of supported commands run: 
-    
-    juju help commands
-`
+	expected := `i am an output`
 
 	c.Assert(b.String(), qt.Equals, expected)
 }
@@ -72,27 +37,29 @@ For the full list of supported commands run:
 func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
 	testCtx := c.Context()
 	dir := c.TempDir()
-	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"help", "-blahhhhh"}, dir)
+	c.Patch(jujucommands.CmdPrefix, "ls")
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"-idontexist"}, dir)
 	c.Assert(err, qt.IsNil)
 
-	lines := make([]string, 0)
-	errs := make([]error, 0)
+	// The assertion for this test works such that we know we're going to receive 2 lines exactly.
+	// The first line is a human readable error message, which we'll simply display to the user.
+	// And contains no populated error field in out OutputLine struct.
+	//
+	// The second line is an actual error message from the command including the exit code.
+	// It contains no line and just an error field in the OutputLine struct.
+	var outputErr error
+	var outputLineJustBeforeTheError string
 
 	for out := range outputCh {
-		lines = append(lines, out.Line)
 		if out.Err != nil {
-			errs = append(errs, out.Err)
+			outputErr = out.Err
+			continue
 		}
+		outputLineJustBeforeTheError = out.Line
 	}
 
-	// 0 holds the error line
-	// 1 is the exit status (but we're just filtering them into two slices to see
-	// that the output from errors is how we expect, i.e., the line before is the actual
-	// error message).
-	c.Assert(len(lines), qt.Equals, 2)
-	c.Assert(lines[0], qt.Equals, "ERROR option provided but not defined: -b")
-	c.Assert(len(errs), qt.Equals, 1)
-	c.Assert(errs[0].Error(), qt.Equals, "exit status 2")
+	c.Assert(outputLineJustBeforeTheError, qt.Equals, "Try 'ls --help' for more information.")
+	c.Assert(outputErr, qt.ErrorMatches, "exit status 2")
 }
 
 func (s *jujucommandsSuite) TestEnvironmentIsCorrectlySet(c *qt.C) {

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -68,6 +68,48 @@ For the full list of supported commands run:
 	c.Assert(b.String(), qt.Equals, expected)
 }
 
+func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
+	testCtx := c.Context()
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, "help -blahhhhh", "")
+	c.Assert(err, qt.IsNil)
+
+	lines := make([]string, 0)
+	errs := make([]error, 0)
+
+	for out := range outputCh {
+		lines = append(lines, out.Line)
+		if out.Err != nil {
+			errs = append(errs, out.Err)
+		}
+	}
+
+	// 0 holds the error line
+	// 1 is the exist status (but we're just filtering them into two slices to see
+	// that the output from errors is how we expect, i.e., the line before is the actual
+	// error message).
+	c.Assert(len(lines), qt.Equals, 2)
+	c.Assert(lines[0], qt.Equals, "ERROR option provided but not defined: -b")
+	c.Assert(len(errs), qt.Equals, 1)
+	c.Assert(errs[0].Error(), qt.Equals, "exit status 2")
+}
+
+func (s *jujucommandsSuite) TestEnvironmentIsCorrectlySet(c *qt.C) {
+	testCtx := c.Context()
+	c.Patch(jujucommands.CmdPrefix, "env")
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, "", "testing-data-is-set")
+	c.Assert(err, qt.IsNil)
+
+	// Use a builder to collect streamed output & test entire string.
+	var b strings.Builder
+
+	for out := range outputCh {
+		c.Assert(out.Err, qt.IsNil)
+		b.WriteString(out.Line + "\n")
+	}
+
+	c.Assert(b.String(), qt.Equals, "JUJU_DATA=testing-data-is-set\n")
+}
+
 func TestJujucommandsSuite(t *testing.T) {
 	qtsuite.Run(qt.New(t), &jujucommandsSuite{})
 }

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -16,7 +16,8 @@ type jujucommandsSuite struct{}
 
 func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever(c *qt.C) {
 	testCtx := c.Context()
-	outputCh, err := jujucommands.RunJujuCmd(testCtx, "help", "")
+	dir := c.TempDir()
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"help"}, dir)
 	c.Assert(err, qt.IsNil)
 
 	// Use a builder to collect streamed output & test entire string.
@@ -70,7 +71,8 @@ For the full list of supported commands run:
 
 func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
 	testCtx := c.Context()
-	outputCh, err := jujucommands.RunJujuCmd(testCtx, "help -blahhhhh", "")
+	dir := c.TempDir()
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{"help", "-blahhhhh"}, dir)
 	c.Assert(err, qt.IsNil)
 
 	lines := make([]string, 0)
@@ -84,7 +86,7 @@ func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
 	}
 
 	// 0 holds the error line
-	// 1 is the exist status (but we're just filtering them into two slices to see
+	// 1 is the exit status (but we're just filtering them into two slices to see
 	// that the output from errors is how we expect, i.e., the line before is the actual
 	// error message).
 	c.Assert(len(lines), qt.Equals, 2)
@@ -96,7 +98,7 @@ func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
 func (s *jujucommandsSuite) TestEnvironmentIsCorrectlySet(c *qt.C) {
 	testCtx := c.Context()
 	c.Patch(jujucommands.CmdPrefix, "env")
-	outputCh, err := jujucommands.RunJujuCmd(testCtx, "", "testing-data-is-set")
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, []string{}, "testing-data-is-set")
 	c.Assert(err, qt.IsNil)
 
 	// Use a builder to collect streamed output & test entire string.

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -8,7 +8,6 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
-	"github.com/juju/juju/jujuclient"
 
 	"github.com/canonical/jimm/v3/internal/jujucommands"
 )
@@ -16,7 +15,8 @@ import (
 type jujucommandsSuite struct{}
 
 func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever(c *qt.C) {
-	outputCh, err := jujucommands.RunCmdWithOutputRetriever(jujuclient.NewEmbeddedMemStore(), "help")
+	testCtx := c.Context()
+	outputCh, err := jujucommands.RunJujuCmd(testCtx, "help", "")
 	c.Assert(err, qt.IsNil)
 
 	// Use a builder to collect streamed output & test entire string.


### PR DESCRIPTION
The function to run commands now uses os.Exec and reads in line exactly like previously. It additionally uses a shell parser to protect us from bad escapes and an environment override to protect us from bad environments.


## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
