### PR TITLE
chore: quality of life fixes

### DIFF
--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -40,6 +40,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewListPermissionsCommand())
 	jaasCmd.Register(cmd.NewListRolesCommand())
 	jaasCmd.Register(cmd.NewMigrateModelCommand())
+	jaasCmd.Register(cmd.NewMigrateInternalModelCommand())
 	jaasCmd.Register(cmd.NewModelStatusCommand())
 	jaasCmd.Register(cmd.NewPurgeLogsCommand())
 	jaasCmd.Register(cmd.NewRegisterControllerCommand())

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -120,8 +121,12 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 
 	insecureSecretStorage := false
-	if _, ok := os.LookupEnv("INSECURE_SECRET_STORAGE"); ok {
-		insecureSecretStorage = true
+	insecureSecretStorage, err = strconv.ParseBool(os.Getenv("INSECURE_SECRET_STORAGE"))
+	if err != nil {
+		return fmt.Errorf("failed to parse INSECURE_SECRET_STORAGE env var: %v", err)
+	}
+	if insecureSecretStorage {
+		zapctx.Warn(ctx, "insecure secret storage is enabled, this is not recommended for production use")
 	}
 
 	secureSessionCookies := false

--- a/docker-compose.common.yaml
+++ b/docker-compose.common.yaml
@@ -11,13 +11,15 @@ services:
       # Not needed for local test (yet).
       # BAKERY_AGENT_FILE: ""
       JIMM_ADMINS: "jimm-test@canonical.com"
-      # Note: You can comment out the Vault ENV vars below and instead use INSECURE_SECRET_STORAGE to place secrets in Postgres.
+      # Note: You can set an env var INSECURE_SECRET_STORAGE to 'true' to place secrets in Postgres.
+      # Useful for testing scenarios where you don't want to use Vault. In our Docker Compose Vault
+      # runs in dev mode so secrets are only ever stored in memory and lost when the container is stopped.
       VAULT_ADDR: "http://vault:8200"
       VAULT_PATH: "/jimm-kv/"
       VAULT_ROLE_ID: test-role-id
       VAULT_ROLE_SECRET_ID: test-secret-id
       # Note: By default we should use Vault as that is the primary means of secret storage.
-      # INSECURE_SECRET_STORAGE: "enabled"
+      INSECURE_SECRET_STORAGE: ${INSECURE_SECRET_STORAGE:-false}
       # JIMM_DASHBOARD_LOCATION: ""
       JIMM_DNS_NAME: "jimm.localhost"
       JIMM_LISTEN_ADDR: "0.0.0.0:80"

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -45,11 +45,13 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 
 	db := d.DB.WithContext(ctx)
 
-	if controller.UUID != "" {
+	switch {
+	case controller.UUID != "":
 		db = db.Where("uuid = ?", controller.UUID)
-	}
-	if controller.Name != "" {
+	case controller.Name != "":
 		db = db.Where("name = ?", controller.Name)
+	default:
+		return errors.E(op, errors.CodeBadRequest, "controller UUID or name must be provided")
 	}
 	db = db.Preload("CloudRegions").Preload("CloudRegions.CloudRegion").Preload("CloudRegions.CloudRegion.Cloud")
 	if err := db.First(&controller).Error; err != nil {

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -60,6 +60,9 @@ func (s *dbSuite) TestGetController(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
+	err = s.Database.GetController(context.Background(), &dbmodel.Controller{})
+	c.Assert(err, qt.ErrorMatches, `controller UUID or name must be provided`)
+
 	cloud := dbmodel.Cloud{
 		Name: "test-cloud",
 	}

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -201,7 +202,10 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 	ctx := context.Background()
 	err := db.GetController(ctx, &dbController)
 	if err != nil {
-		return jujuparams.MigrationTargetInfo{}, 0, err
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return jujuparams.MigrationTargetInfo{}, 0, err
+		}
+		return jujuparams.MigrationTargetInfo{}, 0, errors.E(err, fmt.Errorf("failed to get controller with name %q", controllerName))
 	}
 	adminUser, adminPass, err := credStore.GetControllerCredentials(ctx, controllerName)
 	if err != nil {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -652,6 +652,11 @@ func TestInitiateInternalMigration(t *testing.T) {
 		user:        "alice@canonical.com",
 		migrateInfo: params.MigrateModelInfo{TargetModelNameOrUUID: "alice@canonical.com/model-1", TargetController: "myController"},
 	}, {
+		about:         "empty controller name",
+		user:          "alice@canonical.com",
+		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "alice@canonical.com/model-1", TargetController: ""},
+		expectedError: `failed to get controller with name ""`,
+	}, {
 		about:         "model doesn't exist",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "00000002-0000-0000-0000-000000000002", TargetController: "myController"},

--- a/local/jimm/qa-lxd-multipass.sh
+++ b/local/jimm/qa-lxd-multipass.sh
@@ -39,7 +39,7 @@ multipass exec $VM_NAME -- bash <<- 'EOF'
 EOF
 
 echo "Setting up JIMM"
-multipass exec --working-directory /home/ubuntu/jimm $VM_NAME -- bash <<- 'EOF'
+multipass exec --working-directory /home/ubuntu/jimm "$VM_NAME" -- bash <<- EOF
     make certs
 
     # Re-copy and update certs (workaround to keep the same generated certs but simply update the VM's certs only)
@@ -49,6 +49,7 @@ multipass exec --working-directory /home/ubuntu/jimm $VM_NAME -- bash <<- 'EOF'
     make version/commit.txt
     make version/version.txt
 
+    export INSECURE_SECRET_STORAGE=${INSECURE_SECRET_STORAGE}
     # TODO(ale8k): Have docker cache images somewhere that can be shared, the compose takes forever otherwise.
     docker compose --profile dev up --wait -d
 EOF

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
       ln -sf jaas bin/juju-list-roles
       ln -sf jaas bin/juju-list-service-account-credentials
       ln -sf jaas bin/juju-migrate
+      ln -sf jaas bin/juju-migrate-internal
       ln -sf jaas bin/juju-model-status
       ln -sf jaas bin/juju-permissions
       ln -sf jaas bin/juju-purge-audit-logs


### PR DESCRIPTION
## Description

This PR contains several small and unrelated quality of life changes/fixes that I found while working through internal model migration testing with the web team.

The first two are related to Vault. When the vault container restarts, all secrets it contained are lost. This can result in confusing scenarios because the Postgres container keeps data until the container is removed. While testing this can lead to tricky issues where Postgres is aware of a controller, but the controller's admin user/password are missing from Vault. Unfortunately there is no good fix for this as we run Vault in "dev" mode for testing and this always stores data in-memory only. To offer an alternative the two changes below make it easier to set the `INSECURE_SECRET_STORAGE` variable to use Postgres for secrets.
- Parse INSECURE_SECRET_STORAGE as a boolean rather than accepting the value to simply be set.
- Explain in the docker compose how to set the INSECURE_SECRET_STORAGE env var.

The next change was spotted due to some missing validation. In the db method `GetController`, if the controller name was empty, `GetController` would return the first controller found. This can lead to unexpected scenarios and has been changed to make the controller name/UUID required.
- Change behavior of the `GetController` db method to require a controller name/uuid.

Finally, this change was simple but important. The `migrate-internal` command was not registered in the jaas plugin's `main.go` file and therefore wasn't available.
- Ensure the migrate-internal command is present in the jaas plugin.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
