### PR TITLE
chore: improve retrieval of error codes

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -57,6 +57,11 @@ func (e *Error) ErrorCode() string {
 	return string(e.Code)
 }
 
+// ErrorInfo returns the value of this error's Info.
+func (e *Error) ErrorInfo() map[string]any {
+	return e.Info
+}
+
 // E constructs errors for use throughout the JIMM application. An error
 // is constructed by processing the given arguments. The meaning of the
 // arguments is as follows:
@@ -73,6 +78,7 @@ func E(args ...interface{}) error {
 		panic("call to errors.E with no arguments")
 	}
 	var setCode bool
+	var setInfo bool
 	var e Error
 	for _, arg := range args {
 		switch v := arg.(type) {
@@ -86,6 +92,7 @@ func E(args ...interface{}) error {
 		case string:
 			e.Message = v
 		case map[string]any:
+			setInfo = true
 			e.Info = v
 		default:
 			zapctx.Default.DPanic("unknown type passed to errors.E", zap.String("type", fmt.Sprintf("%T", arg)), zap.Any("value", arg))
@@ -95,12 +102,20 @@ func E(args ...interface{}) error {
 	if setCode {
 		return &e
 	}
-	// the caller didn't explicitly set the code for this error, attempt
-	// to copy the code from the wrapped error. The interface used to
-	// extract error codes is compatible with both the Error type and juju
+
+	// If the caller didn't explicitly set the code/info for this error, attempt
+	// to copy the code/info from the wrapped error. The interface used to
+	// extract the details is compatible with both the Error type and juju
 	// API Error types.
-	if ec, ok := e.Err.(interface{ ErrorCode() string }); ok {
-		e.Code = Code(ec.ErrorCode())
+	if !setCode {
+		if ec, ok := e.Err.(interface{ ErrorCode() string }); ok {
+			e.Code = Code(ec.ErrorCode())
+		}
+	}
+	if !setInfo {
+		if ei, ok := e.Err.(interface{ ErrorInfo() map[string]any }); ok {
+			e.Info = ei.ErrorInfo()
+		}
 	}
 	return &e
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -4,6 +4,7 @@
 package errors
 
 import (
+	stderr "errors"
 	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -138,18 +139,18 @@ const (
 
 // ErrorCode returns the error code from the given error.
 func ErrorCode(err error) Code {
-	e, ok := err.(*Error)
-	if !ok {
-		return ""
+	var errCode interface{ ErrorCode() string }
+	if stderr.As(err, &errCode) {
+		return Code(errCode.ErrorCode())
 	}
-	return e.Code
+	return ""
 }
 
 // ErrorInfo returns additional information about the error.
 func ErrorInfo(err error) map[string]any {
-	e, ok := err.(*Error)
-	if !ok {
-		return nil
+	var errInfo interface{ ErrorInfo() map[string]any }
+	if stderr.As(err, &errInfo) {
+		return errInfo.ErrorInfo()
 	}
-	return e.Info
+	return nil
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -3,9 +3,11 @@
 package errors_test
 
 import (
+	"fmt"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/rpc"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 )
@@ -50,4 +52,19 @@ func TestEWithInfo(t *testing.T) {
 	err = errors.E("plain-error")
 	c.Check(err, qt.ErrorMatches, `plain-error`)
 	c.Check(errors.ErrorInfo(err), qt.DeepEquals, map[string]any(nil))
+}
+
+func TestErrorCodeWithJujuRPC(t *testing.T) {
+	c := qt.New(t)
+
+	err := rpc.RequestError{
+		Code: "my-code",
+		Info: map[string]any{"key": "value"},
+	}
+	c.Check(string(errors.ErrorCode(&err)), qt.Equals, "my-code")
+	c.Check(errors.ErrorInfo(&err), qt.DeepEquals, map[string]any{"key": "value"})
+
+	wrappedErr := fmt.Errorf("wrapped: %w", &err)
+	c.Check(string(errors.ErrorCode(wrappedErr)), qt.Equals, "my-code")
+	c.Check(errors.ErrorInfo(wrappedErr), qt.DeepEquals, map[string]any{"key": "value"})
 }

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/juju/juju/rpc"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
@@ -20,10 +19,10 @@ import (
 // unsupportedLogin returns an appropriate error for login attempts using
 // old version of the Admin facade.
 func unsupportedLogin() error {
-	return &rpc.RequestError{
-		Code:    jujuparams.CodeNotSupported,
-		Message: "JIMM does not support login from old clients",
-	}
+	return errors.E(
+		errors.CodeNotSupported,
+		"JIMM does not support login from old clients",
+	)
 }
 
 // unsupportedLoginWithInfo is a version of unsupportedLogin that logs the


### PR DESCRIPTION
## Description
This PR improves our internal error package, specifically the `ErrorCode` and `ErrorInfo` functions. Instead of doing a typecast to our internal type, use the standard "errors" package to check if the error (or an underlying error) implements `ErrorCode`/`ErrorInfo`. 

I've made this change because I noticed in `internal/jujuapi/admin.go` in `unsupportedLogin()` that we return an `rpc.RequestError` object as an error which implements error code and info but when this gets converted to a Juju error, our `ErrorCode` and `ErrorInfo` functions failed to correctly extract the code/info.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
