### PR TITLE
chore: filter sarif file before upload

### DIFF
--- a/.github/workflows/security-scan-weekly.yaml
+++ b/.github/workflows/security-scan-weekly.yaml
@@ -53,11 +53,25 @@ jobs:
         with:
           name: govuln-security-scan-results
           path: 'govuln-results.sarif'
+      
+      # Filter the SARIF to exclude rules that cause
+      # a large threadflow count and prevent the file
+      # from being uploaded to the Security tab.
+      # See https://github.com/github/codeql-action/issues/1245
+      - name: filter-sarif
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -go.mod:GO-2024-3010
+            -go.mod:GO-2024-3040
+            -go.mod:GO-2024-3175
+          input: 'govuln-results.sarif'
+          output: 'govuln-results-filtered.sarif'
   
       - name: Upload govuln scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'govuln-results.sarif'
+          sarif_file: 'govuln-results-filtered.sarif'
       
       #############
       # KEV Check #


### PR DESCRIPTION
## Description
This PR fixes an error in our security scan workflow (see [here](https://github.com/canonical/jimm/actions/runs/16406018295/job/46352110073)) that was raising the error `rejecting SARIF, as there are more threadflow steps per result than allowed (11454 > 10000)`.

https://github.com/github/codeql-action/issues/1245 briefly explains that this is due to limitations with Github's sarif analyzer and offers a workaround to ignore rules that have a high threadflow. 
The linked issue suggests running the following `jq` query to see which rules are causing a high step count.
```
$ cat govuln-results.sarif | jq -rc '.runs[].results[] | {rule: .ruleId, file: .locations[0].physicalLocation.artifactLocation.uri, codeFlowsCount: (.codeFlows | length), threadFlowStepsCount: (.codeFlows | reduce .[]? as $item (0;  . + ($item.threadFlows[0].locations | length)))}' | jq -s -c 'sort_by(.threadFlowStepsCount) | .[]'
{"rule":"GO-2025-3533","file":"go.mod","codeFlowsCount":0,"threadFlowStepsCount":0}
{"rule":"GO-2025-3553","file":"go.mod","codeFlowsCount":0,"threadFlowStepsCount":0}
{"rule":"GO-2024-3010","file":"go.mod","codeFlowsCount":3013,"threadFlowStepsCount":11454}
{"rule":"GO-2024-3040","file":"go.mod","codeFlowsCount":3013,"threadFlowStepsCount":11454}
{"rule":"GO-2024-3175","file":"go.mod","codeFlowsCount":3013,"threadFlowStepsCount":11454}
```
Where we can see that 3 vulnerabilities have a count over 10 000. If you look up these issues, you can see they are all Juju related i.e. https://pkg.go.dev/vuln/GO-2024-3010. It seems we are already on a fixed Juju version but likely because Juju's go.mod doesn't yet follow standard versioning, the error is still surfaced.

A workaround for this issue is also mentioned in the linked issue - we can filter the sarif file before uploading it. We filter out the 3 rules causing the problem (which are false-positives now as explained above) and we should be good to go.

The filter-sarif workflow used is offered by Github so is safe to use and it's is just a Python script so I tested it locally and the filtering worked as expected (it also reduced the original sarif file from 80MB->7.4Kb).

Fixes [JUJU-8271](https://warthogs.atlassian.net/browse/JUJU-8271)

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8271]: https://warthogs.atlassian.net/browse/JUJU-8271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ