### PR TITLE
feat: validate migration users backend

### DIFF
--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -26,6 +26,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
 const TIMEOUT_PENDING_MIGRATION = 24 * time.Hour
@@ -212,6 +213,9 @@ func (j *JujuManager) validateUserMapping(modelDescription description.Model, us
 
 	modelUsers := modelDescription.Users()
 	for _, user := range modelUsers {
+		if user.Name().Id() == ofganames.EveryoneUser {
+			continue
+		}
 		if _, ok := userMapping[user.Name().Id()]; !ok {
 			missingUserMessages = append(missingUserMessages, fmt.Sprintf("expected user %q who has %s access to the model", user.Name().Id(), user.Access()))
 		}
@@ -221,6 +225,9 @@ func (j *JujuManager) validateUserMapping(modelDescription description.Model, us
 	for _, app := range apps {
 		for _, offer := range app.Offers() {
 			for user, access := range offer.ACL() {
+				if user == ofganames.EveryoneUser {
+					continue
+				}
 				if _, ok := userMapping[user]; !ok {
 					missingUserMessages = append(missingUserMessages, fmt.Sprintf("expected user %q who has %s access to offer %q", user, access, offer.OfferName()))
 				}

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	goerr "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/juju/description/v9"
@@ -165,7 +166,10 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
 	}
 
-	// TODO(Kian): Validate user mapping contains all local users in the model description.
+	err = j.validateUserMapping(model.ModelDescription, incomingModel.UserMapping)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to validate user mapping: %w", err))
+	}
 
 	err = j.modifyMigrationInfo(&model, incomingModel.UserMapping)
 	if err != nil {
@@ -197,6 +201,34 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 	err = api.Prechecks(model)
 	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to run pre-checks for migration: %w", err))
+	}
+	return nil
+}
+
+// validateUserMapping checks that the provided user mapping contains all the users
+// that either have access to the model or have access to any application offers in the model.
+func (j *JujuManager) validateUserMapping(modelDescription description.Model, userMapping dbmodel.StringMap) error {
+	var missingUserMessages []string
+
+	modelUsers := modelDescription.Users()
+	for _, user := range modelUsers {
+		if _, ok := userMapping[user.Name().Id()]; !ok {
+			missingUserMessages = append(missingUserMessages, fmt.Sprintf("expected user %q who has %s access to the model", user.Name().Id(), user.Access()))
+		}
+	}
+
+	apps := modelDescription.Applications()
+	for _, app := range apps {
+		for _, offer := range app.Offers() {
+			for user, access := range offer.ACL() {
+				if _, ok := userMapping[user]; !ok {
+					missingUserMessages = append(missingUserMessages, fmt.Sprintf("expected user %q who has %s access to offer %q", user, access, offer.OfferName()))
+				}
+			}
+		}
+	}
+	if len(missingUserMessages) > 0 {
+		return fmt.Errorf("user mapping is missing the following users:\n%s\n", strings.Join(missingUserMessages, "\n"))
 	}
 	return nil
 }

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -283,6 +283,9 @@ func (j *JujuManager) modifyMigrationInfo(model *migration.ModelInfo, userMappin
 		// This is to ensure that the migration does not proceed with an invalid owner.
 		return errors.E(fmt.Errorf("no external user mapping found for local user %q", model.Owner.Id()))
 	}
+	if !names.IsValidUser(newOwner) {
+		return errors.E(fmt.Errorf("invalid external user mapping %q for local user %q", newOwner, model.Owner.Id()))
+	}
 
 	newOwnerTag := names.NewUserTag(newOwner)
 	model.Owner = newOwnerTag

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -224,6 +224,59 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }
 
+func TestPreChecks_NoUsersWithAccess(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	api := &jimmtest.API{
+		Prechecks_: func(mi migration.ModelInfo) error {
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+
+	// Below is a simple model description with no users that have access.
+	descriptionArgs := description.ModelArgs{
+		AgentVersion: "3.2.1",
+		Owner:        names.NewUserTag("bob"),
+		Type:         description.IAAS,
+		Cloud:        "test",
+		Config: map[string]interface{}{
+			"uuid": migratingModelUUID,
+			"name": "test-model",
+		},
+		CloudRegion: "test-region",
+	}
+	modelDescription := description.NewModel(descriptionArgs)
+
+	modelDescription.SetCloudCredential(description.CloudCredentialArgs{
+		Owner: names.NewUserTag("bob"),
+		Name:  "test-cred",
+		Cloud: names.NewCloudTag("test"),
+	})
+	modelInfo := migration.ModelInfo{
+		UUID:                   migratingModelUUID,
+		Owner:                  names.NewUserTag("bob"),
+		Name:                   "test-model",
+		AgentVersion:           version.MustParse("3.2.1"),
+		ControllerAgentVersion: version.MustParse("3.2.1"),
+		ModelDescription:       modelDescription,
+	}
+	err := j.Prechecks(ctx, user, modelInfo)
+	c.Assert(err, qt.IsNil)
+}
+
 func TestPreChecks_ValidatesUserMapping(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -224,7 +224,7 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }
 
-func TestPreChecks_ValidateUserMapping(t *testing.T) {
+func TestPreChecks_ValidatesUserMapping(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
@@ -285,6 +285,55 @@ func modelInfoWithUnmappedUsers() migration.ModelInfo {
 		ModelDescription:       modelDescription,
 	}
 	return modelInfo
+}
+
+func TestPreChecks_SkipsEveryoneUser(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	api := &jimmtest.API{
+		Prechecks_: func(mi migration.ModelInfo) error {
+			return nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: api,
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo(modelDescriptionArgs{
+		Owner:               "bob",
+		ModelName:           "test-model",
+		CloudName:           "test",
+		CloudCredentialName: "test-cred",
+		CloudRegionName:     "test-region",
+	})
+	everyoneUserArgs := description.UserArgs{
+		Name:   names.NewUserTag("everyone@external"),
+		Access: "read",
+	}
+	model.ModelDescription.AddUser(everyoneUserArgs)
+
+	appArgs := description.ApplicationArgs{}
+	app := model.ModelDescription.AddApplication(appArgs)
+
+	// Add an offer with an ACL for the everyone@external user.
+	offerArgs := description.ApplicationOfferArgs{
+		OfferName: "test-offer",
+		ACL:       map[string]string{"everyone@external": "read"},
+	}
+	app.AddOffer(offerArgs)
+
+	err := j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.IsNil)
 }
 
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -224,6 +224,69 @@ func TestControllerDetailsForIncomingModel(t *testing.T) {
 	c.Assert(controllerDetails.Credentials.AdminPassword, qt.Equals, "test-password")
 }
 
+func TestPreChecks_ValidateUserMapping(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	err := j.Prechecks(ctx, user, modelInfoWithUnmappedUsers())
+	c.Assert(err, qt.ErrorMatches, `(?ms).*^expected user \"jane\" who has admin access to the model$.*`)
+	c.Assert(err, qt.ErrorMatches, `(?ms).*^expected user \"jack\" who has admin access to offer "test-offer"$.*`)
+}
+
+func modelInfoWithUnmappedUsers() migration.ModelInfo {
+	descriptionArgs := description.ModelArgs{
+		AgentVersion: "3.2.1",
+		Owner:        names.NewUserTag("bob"),
+		Type:         description.IAAS,
+		Cloud:        "test",
+		Config: map[string]interface{}{
+			"uuid": migratingModelUUID,
+			"name": "test-model",
+		},
+		CloudRegion: "test-region",
+	}
+	modelDescription := description.NewModel(descriptionArgs)
+
+	// Add a user with admin access that is not mapped.
+	userArgs := description.UserArgs{
+		Name:        names.NewUserTag("jane"),
+		DisplayName: "jane",
+		Access:      "admin",
+	}
+	modelDescription.AddUser(userArgs)
+	modelDescription.SetCloudCredential(description.CloudCredentialArgs{
+		Owner: names.NewUserTag("bob"),
+		Name:  "test-cred",
+		Cloud: names.NewCloudTag("test"),
+	})
+	appArgs := description.ApplicationArgs{}
+	app := modelDescription.AddApplication(appArgs)
+
+	// Add an offer with an ACL for a user that is not mapped.
+	offerArgs := description.ApplicationOfferArgs{
+		OfferName: "test-offer",
+		ACL:       map[string]string{"jack": "admin"},
+	}
+	app.AddOffer(offerArgs)
+	modelInfo := migration.ModelInfo{
+		UUID:                   migratingModelUUID,
+		Owner:                  names.NewUserTag("bob"),
+		Name:                   "test-model",
+		AgentVersion:           version.MustParse("3.2.1"),
+		ControllerAgentVersion: version.MustParse("3.2.1"),
+		ModelDescription:       modelDescription,
+	}
+	return modelInfo
+}
+
 func TestPrechecks_ModifiesModelDescription(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -469,7 +469,35 @@ func TestPrechecks_MissingUserMapping(t *testing.T) {
 		CloudRegionName:     "test-region",
 	})
 	err := j.Prechecks(ctx, user, model)
-	c.Assert(err, qt.ErrorMatches, `.*no external user mapping found for local user "not-found-user"`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*user mapping is missing the following users.*`)
+}
+
+func TestPrechecks_InvalidOwner(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	incomingModel := env.IncomingMigrations[0].DBObject(c, j.Database)
+	incomingModel.UserMapping["bob"] = ""
+	err := j.Database.AddOrUpdateIncomingModelMigration(ctx, &incomingModel)
+	c.Assert(err, qt.IsNil)
+
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, nil)
+
+	model := newMigrationInfo(modelDescriptionArgs{
+		Owner:               "bob",
+		ModelName:           "test-model",
+		CloudName:           "test",
+		CloudCredentialName: "test-cred",
+		CloudRegionName:     "test-region",
+	})
+	err = j.Prechecks(ctx, user, model)
+	c.Assert(err, qt.ErrorMatches, `.*invalid external user mapping "" for local user "bob"`)
 }
 
 func TestPrechecks_NoIncomingModelMigration(t *testing.T) {

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -555,6 +555,12 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 			return resp, errors.E(op, fmt.Sprintf("%s is not a valid local user name", local))
 		}
 
+		if external == "" {
+			// The external user can be empty meaning that we are
+			// intentionally skipping the mapping for this local user.
+			continue
+		}
+
 		if !names.IsValidUser(external) || !strings.Contains(external, "@") {
 			return resp, errors.E(op, fmt.Sprintf("%s is not a valid external user name", external))
 		}

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -72,6 +72,29 @@ func (s *jimmUnitTestSuite) TestPrepareModelMigration_InvalidControllerName(c *g
 	c.Assert(err, gc.ErrorMatches, "invalid controller name")
 }
 
+func (s *jimmUnitTestSuite) TestPrepareModelMigration_EmptyExternalUser(c *gc.C) {
+	ctx := context.Background()
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jimm.JujuManager {
+			return &mocks.JujuManager{
+				PrepareModelMigration_: func(ctx context.Context, user *openfga.User, modelUUID, targetControllerName string, userMapping map[string]string) (string, error) {
+					return "foo", nil
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	_, err := root.PrepareModelMigration(ctx, apiparams.PrepareModelMigrationRequest{
+		ModelTag:              names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
+		BackingControllerName: "test-controller",
+		UserMapping:           map[string]string{"alice": "alice@canonical.com", "skipped-local-user": ""},
+	})
+
+	c.Assert(err, gc.IsNil)
+}
+
 func (s *jimmUnitTestSuite) TestPrepareModelMigration_InvalidUserMapping(c *gc.C) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description
This PR builds on #1664 and adds validation of the user mapping on the server side. We check that all users who have access to the model or have access to application-offers in the model are included in the user mapping.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests