### PR TITLE
feat(model deletion): delete a model when not-found calling `ModelInfo` or `ModelStatus`

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -460,7 +460,6 @@ func New(p Parameters) (*JIMM, error) {
 	j.permissionManager = permissionManager
 
 	j.jujuAuthFactory = jujuauth.NewFactory(j.Database, j.JWTService, permissionManager)
-
 	jujuManager, err := juju.NewJujuManager(
 		j.Database,
 		j.OpenFGAClient,

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -210,7 +210,7 @@ type API interface {
 }
 
 // PermissionManager provides a way to manage permissions within JIMM.
-type PermissionChecker interface {
+type PermissionManager interface {
 	// GetUserCloudAccess returns the user's level of access to a cloud.
 	GetUserCloudAccess(ctx context.Context, user *openfga.User, cloud names.CloudTag) (string, error)
 	// GetUserModelAccess returns the user's level of access to a model.

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -20,7 +20,7 @@ type JujuManager struct {
 	Database                *db.Database
 	OpenFGAClient           *openfga.OFGAClient
 	CredentialStore         credentials.CredentialStore
-	permissionManager       PermissionChecker
+	permissionManager       PermissionManager
 	resourceTag             names.ControllerTag
 	ReservedCloudNames      []string
 	Dialer                  Dialer
@@ -34,7 +34,7 @@ func NewJujuManager(
 	store *db.Database,
 	authSvc *openfga.OFGAClient,
 	credentialStore credentials.CredentialStore,
-	permissionManager PermissionChecker,
+	permissionManager PermissionManager,
 	resourceTag names.ControllerTag,
 	reservedCloudNames []string,
 	dialer Dialer,

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -265,6 +265,15 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 		UUID: mt.Id(),
 	}
 	if err := api.ModelInfo(ctx, mi); err != nil {
+		// If the model is not found or code not authorized on the backing controller then
+		// we delete the model from JIMM.
+		// Juju returns CodeAuthorized when the model is not found for this facade.
+		if errors.ErrorCode(err) == errors.CodeNotFound || errors.ErrorCode(err) == errors.CodeUnauthorized {
+			errDelete := j.Database.DeleteModel(ctx, &m)
+			if errDelete != nil {
+				return nil, errors.E(op, errDelete)
+			}
+		}
 		return nil, errors.E(op, err)
 	}
 
@@ -435,7 +444,24 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		ms.OwnerTag = m.Owner.Tag().String()
 		ms.ModelTag = mt.String()
-		return api.ModelStatus(ctx, &ms)
+		err := api.ModelStatus(ctx, &ms)
+		if err != nil {
+			// If the model is not found on the backing controller then
+			// we delete the model from JIMM.
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				errDelete := j.Database.DeleteModel(ctx, &dbmodel.Model{
+					UUID: sql.NullString{
+						String: mt.Id(),
+						Valid:  true,
+					},
+				})
+				if errDelete != nil {
+					return errDelete
+				}
+			}
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, errors.E(op, err)

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -269,7 +269,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 		// we delete the model from JIMM.
 		// Juju returns CodeAuthorized when the model is not found for this facade.
 		if errors.ErrorCode(err) == errors.CodeNotFound || errors.ErrorCode(err) == errors.CodeUnauthorized {
-			errDelete := j.Database.DeleteModel(ctx, &m)
+			errDelete := j.deleteModel(ctx, mt)
 			if errDelete != nil {
 				return nil, errors.E(op, errDelete)
 			}
@@ -449,12 +449,7 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 			// If the model is not found on the backing controller then
 			// we delete the model from JIMM.
 			if errors.ErrorCode(err) == errors.CodeNotFound {
-				errDelete := j.Database.DeleteModel(ctx, &dbmodel.Model{
-					UUID: sql.NullString{
-						String: mt.Id(),
-						Valid:  true,
-					},
-				})
+				errDelete := j.deleteModel(ctx, mt)
 				if errDelete != nil {
 					return errDelete
 				}
@@ -467,6 +462,27 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 		return nil, errors.E(op, err)
 	}
 	return &ms, nil
+}
+
+// deleteModel deletes the model with the given ModelTag from JIMM's database and
+// clean the openfga tuples related to the model.
+func (j *JujuManager) deleteModel(ctx context.Context, mt names.ModelTag) error {
+	err := j.Database.DeleteModel(ctx, &dbmodel.Model{
+		UUID: sql.NullString{
+			String: mt.Id(),
+			Valid:  true,
+		},
+	})
+	if err != nil {
+		zapctx.Error(ctx, "failed to delete model from database", zap.String("model", mt.Id()), zap.Error(err))
+		return err
+	}
+	err = j.OpenFGAClient.RemoveModel(ctx, mt)
+	if err != nil {
+		zapctx.Error(ctx, "failed to remove model from OpenFGA", zap.String("model", mt.Id()), zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // ForEachUserModel calls the given function once for each model that the

--- a/internal/jimm/juju/model_cleanup.go
+++ b/internal/jimm/juju/model_cleanup.go
@@ -16,8 +16,7 @@ import (
 )
 
 // CleanupNotFoundModels loops over models, contacting the respective controller.
-// And deleting the model from our database if the error is `NotFound` which means the model was successfully deleted.
-// Before we were cleaning up models in a dying state, but this is not enough if people delete models directly from the controller.
+// And deleting the model from our database and openfga if the error is `NotFound` which means the model was successfully deleted.
 func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) (err error) {
 	const op = errors.Op("jimm.CleanupNotFoundModels")
 	zapctx.Info(ctx, string(op))
@@ -37,7 +36,7 @@ func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) (err error) {
 		if err := api.ModelInfo(ctx, &jujuparams.ModelInfo{UUID: m.UUID.String}); err != nil {
 			// Some versions of juju return unauthorized for models that cannot be found.
 			if errors.ErrorCode(err) == errors.CodeNotFound || errors.ErrorCode(err) == errors.CodeUnauthorized {
-				if err := j.Database.DeleteModel(ctx, m); err != nil {
+				if err := j.deleteModel(ctx, m.ResourceTag()); err != nil {
 					zapctx.Error(ctx, fmt.Sprintf("cannot delete model %s: %s\n", m.UUID.String, err))
 				} else {
 					return nil

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1679,6 +1679,64 @@ func TestModelInfo(t *testing.T) {
 	}
 }
 
+func TestModelInfoNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				ModelInfo_: func(_ context.Context, mi *jujuparams.ModelInfo) error {
+					return errors.E(errors.CodeNotFound, "model not found")
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, modelInfoTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+	dbUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(dbUser, j.OpenFGAClient)
+
+	_, err = j.ModelInfo(context.Background(), user, names.NewModelTag("00000002-0000-0000-0000-000000000001"))
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Check the model is deleted as a consequence of the error
+	model := env.Models[0].DBObject(c, j.Database)
+	err = j.Database.GetModel(context.Background(), &model)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}
+
+func TestModelStatusNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				ModelStatus_: func(_ context.Context, ms *jujuparams.ModelStatus) error {
+					return errors.E(errors.CodeNotFound, "model not found")
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, modelInfoTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+	dbUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(dbUser, j.OpenFGAClient)
+
+	_, err = j.ModelStatus(context.Background(), user, names.NewModelTag("00000002-0000-0000-0000-000000000001"))
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Check the model is deleted as a consequence of the error
+	model := env.Models[0].DBObject(c, j.Database)
+	err = j.Database.GetModel(context.Background(), &model)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}
+
 const modelStatusTestEnv = `clouds:
 - name: test-cloud
   type: test-provider

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1698,14 +1698,28 @@ func TestModelInfoNotFound(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	user := openfga.NewUser(dbUser, j.OpenFGAClient)
+	mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
 
-	_, err = j.ModelInfo(context.Background(), user, names.NewModelTag("00000002-0000-0000-0000-000000000001"))
+	ok, err := user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+
+	_, err = j.ModelInfo(context.Background(), user, mt)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
 	// Check the model is deleted as a consequence of the error
 	model := env.Models[0].DBObject(c, j.Database)
 	err = j.Database.GetModel(context.Background(), &model)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Check the openfga tuple is deleted as a consequence of the error
+	ok, err = user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsFalse)
+
+	_, err = j.ModelInfo(context.Background(), user, mt)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
 }
 
 func TestModelStatusNotFound(t *testing.T) {
@@ -1728,12 +1742,26 @@ func TestModelStatusNotFound(t *testing.T) {
 
 	user := openfga.NewUser(dbUser, j.OpenFGAClient)
 
-	_, err = j.ModelStatus(context.Background(), user, names.NewModelTag("00000002-0000-0000-0000-000000000001"))
+	mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
+
+	ok, err := user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+
+	_, err = j.ModelStatus(context.Background(), user, mt)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
 	// Check the model is deleted as a consequence of the error
 	model := env.Models[0].DBObject(c, j.Database)
 	err = j.Database.GetModel(context.Background(), &model)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// Check the openfga tuple is deleted as a consequence of the error
+	ok, err = user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsFalse)
+
+	_, err = j.ModelStatus(context.Background(), user, mt)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 

--- a/internal/jujuapi/modelmanager_test.go
+++ b/internal/jujuapi/modelmanager_test.go
@@ -1069,8 +1069,6 @@ func (s *modelManagerSuite) TestModifyModelAccessErrors(c *gc.C) {
 var zeroDuration = time.Duration(0)
 
 func (s *modelManagerSuite) TestDestroyModel(c *gc.C) {
-	ctx := context.Background()
-
 	conn := s.open(c, nil, "bob")
 	defer conn.Close()
 
@@ -1085,10 +1083,6 @@ func (s *modelManagerSuite) TestDestroyModel(c *gc.C) {
 	c.Assert(mis, gc.HasLen, 1)
 	c.Assert(mis[0].Error, gc.Equals, (*jujuparams.Error)(nil))
 	c.Assert(mis[0].Result.Life, gc.Equals, life.Dying)
-
-	// Kill the model.
-	err = s.JIMM.Database.DeleteModel(ctx, s.Model)
-	c.Assert(err, gc.Equals, nil)
 
 	// Make sure it's not an error if you destroy a model that't not there.
 	err = client.DestroyModel(s.Model.ResourceTag(), nil, nil, nil, &zeroDuration)


### PR DESCRIPTION
## Description

Previously, when deleting a model via the facade, we only marked it as deleted in JIMM and invoked Juju for deletion, but kept the model in the JIMM database until the cleanup routine ran. If ModelInfo was called during this window, JIMM would forward the request to Juju, which might return "not found" (satisfying Terraform's wait-for-delete), even though JIMM still retained the model. Attempting to re-create a model with the same name before JIMM's cleanup completed would result in an "already-exists" error. This change ensures that JIMM state is fully cleaned up before allowing model recreation.

> ModelInfo and ModelStatus are slightly different. ModelInfo convert `not-found` errors into `unauthorized` (9 years-old commit) https://github.com/juju/juju/blob/3.6/apiserver/facades/client/modelmanager/modelmanager.go#L905. ModelStatus returns a not-found.

FYI: the Juju CLI uses the ModelStatus facade to wait for not found. I need to update my terraform PR to have the same behavior

# QA

`juju add-model test`

`juju destroy-model test` 

(quickly)
`juju add-model test`

Before it was failing with `already-exists` now it doesn't
