### PR TITLE
feat: prevent simultaneous changes to migration mode

### DIFF
--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -4,8 +4,10 @@ package db
 
 import (
 	"context"
+	"database/sql"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -73,6 +75,49 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 		return errors.E(op, dbError(err))
 	}
 	return nil
+}
+
+// SetModelMigrating updates the model's migration mode to the provided value.
+// This function will return an error if the model's migration mode is already
+// set to anything besides MigrationModeNone.
+func (d *Database) SetModelMigrating(ctx context.Context, uuid string, migrationMode dbmodel.MigrationMode) (m *dbmodel.Model, err error) {
+	const op = errors.Op("db.SetModelMigrating")
+	if err := d.ready(); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+	err = db.Transaction(func(tx *gorm.DB) error {
+
+		m = &dbmodel.Model{UUID: sql.NullString{String: uuid, Valid: true}}
+		if err := preloadModel("", tx).Clauses(clause.Locking{Strength: "UPDATE"}).First(m).Error; err != nil {
+			return errors.E(op, err)
+		}
+
+		if m.MigrationMode != dbmodel.MigrationModeNone {
+			return errors.E(op, "model is already migrating", errors.CodeBadRequest)
+		}
+
+		m.MigrationMode = migrationMode
+		if err := tx.Save(m).Error; err != nil {
+			return errors.E(op, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		err = dbError(err)
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return nil, errors.E(op, err, "model not found")
+		}
+		return nil, errors.E(op, err)
+	}
+
+	return m, nil
 }
 
 // GetModelsUsingCredential returns all models that use the specified credentials.

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -5,6 +5,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -77,11 +78,12 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 	return nil
 }
 
-// SetModelMigrating updates the model's migration mode to the provided value.
+// SetModelMigrationMode updates the model's migration mode to the provided value.
 // This function will return an error if the model's migration mode is already
-// set to anything besides MigrationModeNone.
-func (d *Database) SetModelMigrating(ctx context.Context, uuid string, migrationMode dbmodel.MigrationMode) (m *dbmodel.Model, err error) {
-	const op = errors.Op("db.SetModelMigrating")
+// set to anything besides MigrationModeNone. Use `UpdateModel` to complete the
+// migration and reset the migration mode to MigrationModeNone.
+func (d *Database) SetModelMigrationMode(ctx context.Context, uuid string, migrationMode dbmodel.MigrationMode) (m *dbmodel.Model, err error) {
+	const op = errors.Op("db.SetModelMigrationMode")
 	if err := d.ready(); err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -92,9 +94,12 @@ func (d *Database) SetModelMigrating(ctx context.Context, uuid string, migration
 
 	db := d.DB.WithContext(ctx)
 	err = db.Transaction(func(tx *gorm.DB) error {
-
 		m = &dbmodel.Model{UUID: sql.NullString{String: uuid, Valid: true}}
 		if err := preloadModel("", tx).Clauses(clause.Locking{Strength: "UPDATE"}).First(m).Error; err != nil {
+			err = dbError(err)
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				return errors.E(op, fmt.Errorf("model with uuid %q does not exist", uuid))
+			}
 			return errors.E(op, err)
 		}
 
@@ -104,17 +109,13 @@ func (d *Database) SetModelMigrating(ctx context.Context, uuid string, migration
 
 		m.MigrationMode = migrationMode
 		if err := tx.Save(m).Error; err != nil {
-			return errors.E(op, err)
+			return errors.E(op, dbError(err))
 		}
 
 		return nil
 	})
 	if err != nil {
-		err = dbError(err)
-		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(op, err, "model not found")
-		}
-		return nil, errors.E(op, err)
+		return nil, err
 	}
 
 	return m, nil

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -767,7 +767,7 @@ func (s *dbSuite) TestCountModelsByController(c *qt.C) {
 	c.Assert(count, qt.Equals, 3)
 }
 
-const testSetModelMigratingEnv = `clouds:
+const testSetModelMigrationModeEnv = `clouds:
 - name: test
   type: test
   regions:
@@ -792,11 +792,11 @@ models:
   controller: test
 `
 
-func (s *dbSuite) TestSetModelMigrating(c *qt.C) {
+func (s *dbSuite) TestSetModelMigrationMode(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
-	env := jimmtest.ParseEnvironment(c, testSetModelMigratingEnv)
+	env := jimmtest.ParseEnvironment(c, testSetModelMigrationModeEnv)
 	env.PopulateDB(c, s.Database)
 
 	model := env.Models[0].DBObject(c, s.Database)
@@ -815,7 +815,7 @@ func (s *dbSuite) TestSetModelMigrating(c *qt.C) {
 	c.Assert(migrationMode, qt.Equals, dbmodel.MigrationModeMigrateInternal)
 }
 
-func (s *dbSuite) TestSetModelMigrating_ModelDoesNotExist(c *qt.C) {
+func (s *dbSuite) TestSetModelMigrationMode_ModelDoesNotExist(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
@@ -823,11 +823,11 @@ func (s *dbSuite) TestSetModelMigrating_ModelDoesNotExist(c *qt.C) {
 	c.Assert(err, qt.ErrorMatches, `model with uuid "fake-uuid" does not exist`)
 }
 
-func (s *dbSuite) TestSetModelMigrating_PreventSetAgain(c *qt.C) {
+func (s *dbSuite) TestSetModelMigrationMode_PreventSetAgain(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
 
-	env := jimmtest.ParseEnvironment(c, testSetModelMigratingEnv)
+	env := jimmtest.ParseEnvironment(c, testSetModelMigrationModeEnv)
 	env.PopulateDB(c, s.Database)
 
 	model := env.Models[0].DBObject(c, s.Database)

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -802,7 +802,7 @@ func (s *dbSuite) TestSetModelMigrating(c *qt.C) {
 	model := env.Models[0].DBObject(c, s.Database)
 	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
 
-	modelWithMigration, err := s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	modelWithMigration, err := s.Database.SetModelMigrationMode(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
 	c.Assert(err, qt.IsNil)
 
 	// Validate the returned struct has the correct migration mode.
@@ -815,6 +815,14 @@ func (s *dbSuite) TestSetModelMigrating(c *qt.C) {
 	c.Assert(migrationMode, qt.Equals, dbmodel.MigrationModeMigrateInternal)
 }
 
+func (s *dbSuite) TestSetModelMigrating_ModelDoesNotExist(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	_, err = s.Database.SetModelMigrationMode(context.Background(), "fake-uuid", dbmodel.MigrationModeMigrateInternal)
+	c.Assert(err, qt.ErrorMatches, `model with uuid "fake-uuid" does not exist`)
+}
+
 func (s *dbSuite) TestSetModelMigrating_PreventSetAgain(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.Equals, nil)
@@ -825,10 +833,10 @@ func (s *dbSuite) TestSetModelMigrating_PreventSetAgain(c *qt.C) {
 	model := env.Models[0].DBObject(c, s.Database)
 	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
 
-	_, err = s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	_, err = s.Database.SetModelMigrationMode(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to set the model to migrating again should return an error.
-	_, err = s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	_, err = s.Database.SetModelMigrationMode(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
 	c.Assert(err, qt.ErrorMatches, `model is already migrating`)
 }

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -766,3 +766,69 @@ func (s *dbSuite) TestCountModelsByController(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(count, qt.Equals, 3)
 }
+
+const testSetModelMigratingEnv = `clouds:
+- name: test
+  type: test
+  regions:
+  - name: test-region
+cloud-credentials:
+- name: test-cred
+  cloud: test
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: test
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test
+  region: test-region
+models:
+- name: test-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  owner: alice@canonical.com
+  cloud: test
+  region: test-region
+  cloud-credential: test-cred
+  controller: test
+`
+
+func (s *dbSuite) TestSetModelMigrating(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	env := jimmtest.ParseEnvironment(c, testSetModelMigratingEnv)
+	env.PopulateDB(c, s.Database)
+
+	model := env.Models[0].DBObject(c, s.Database)
+	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
+
+	modelWithMigration, err := s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	c.Assert(err, qt.IsNil)
+
+	// Validate the returned struct has the correct migration mode.
+	c.Assert(modelWithMigration.MigrationMode, qt.Equals, dbmodel.MigrationModeMigrateInternal)
+
+	// Validate the model in the database has the correct migration mode.
+	var migrationMode dbmodel.MigrationMode
+	err = s.Database.DB.Table("models").Select("migration_mode").Where("uuid = ?", model.UUID).Scan(&migrationMode).Error
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationMode, qt.Equals, dbmodel.MigrationModeMigrateInternal)
+}
+
+func (s *dbSuite) TestSetModelMigrating_PreventSetAgain(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	env := jimmtest.ParseEnvironment(c, testSetModelMigratingEnv)
+	env.PopulateDB(c, s.Database)
+
+	model := env.Models[0].DBObject(c, s.Database)
+	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
+
+	_, err = s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	c.Assert(err, qt.IsNil)
+
+	// Attempt to set the model to migrating again should return an error.
+	_, err = s.Database.SetModelMigrating(context.Background(), model.UUID.String, dbmodel.MigrationModeMigrateInternal)
+	c.Assert(err, qt.ErrorMatches, `model is already migrating`)
+}

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -35,7 +35,7 @@ const (
 
 	// MigrationModeMovingInternal reflects a model that is being moved internally
 	// within JIMM, e.g. from one controller to another.
-	MigrationModeMigrateInternal = MigrationMode("migrate-internal")
+	MigrationModeMigrateInternal = MigrationMode("migrating-internally")
 )
 
 // A Model is a juju model.

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -14,6 +14,30 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
+// MigrationMode specifies where the Model is with respect to migration.
+// The modes mirror Juju's state values with some JIMM-specific additions.
+// We use our own type to avoid introducing a dependency on Juju's state
+// package throughout JIMM's codebase.
+type MigrationMode string
+
+const (
+	// MigrationModeNone is the default mode for a model and reflects
+	// that it isn't involved with a model migration.
+	MigrationModeNone = MigrationMode(state.MigrationMode(""))
+
+	// MigrationModeExporting reflects a model that is in the process of being
+	// exported away from JIMM.
+	MigrationModeExporting = MigrationMode(state.MigrationMode("exporting"))
+
+	// MigrationModeImporting reflects a model that is being imported into a
+	// controller, but is not yet fully active.
+	MigrationModeImporting = MigrationMode(state.MigrationMode("importing"))
+
+	// MigrationModeMovingInternal reflects a model that is being moved internally
+	// within JIMM, e.g. from one controller to another.
+	MigrationModeMigrateInternal = MigrationMode("migrate-internal")
+)
+
 // A Model is a juju model.
 type Model struct {
 	// Note this cannot use the standard gorm.Model as the soft-delete does
@@ -51,10 +75,7 @@ type Model struct {
 	Offers []ApplicationOffer
 
 	// MigrationMode is the migration mode of the model.
-	// In JIMM it can have two values:
-	// - state.MigrationModeNone: the model is not being migrated.
-	// - state.MigrationModeImporting: the model is being migrated to JIMM.
-	MigrationMode state.MigrationMode `gorm:"default:''"`
+	MigrationMode MigrationMode `gorm:"default:''"`
 }
 
 // Tag returns a names.Tag for the model.

--- a/internal/dbmodel/model_test.go
+++ b/internal/dbmodel/model_test.go
@@ -187,7 +187,7 @@ func TestModelSetMigrationModeEnumType(t *testing.T) {
 		UUID: m1.UUID,
 	}
 	c.Assert(db.First(&m).Error, qt.IsNil)
-	c.Check(m.MigrationMode, qt.Equals, state.MigrationModeNone)
+	c.Check(m.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
 
 	// Check that we can set the migration mode to a valid value.
 	m2 := dbmodel.Model{
@@ -201,7 +201,7 @@ func TestModelSetMigrationModeEnumType(t *testing.T) {
 		CloudRegion:     cl1.Regions[0],
 		CloudCredential: cred1,
 		Life:            state.Alive.String(),
-		MigrationMode:   state.MigrationModeNone,
+		MigrationMode:   dbmodel.MigrationModeNone,
 	}
 	c.Assert(db.Create(&m2).Error, qt.IsNil)
 

--- a/internal/dbmodel/sql/postgres/032_add_migrate_internal_to_migration_mode.up.sql
+++ b/internal/dbmodel/sql/postgres/032_add_migrate_internal_to_migration_mode.up.sql
@@ -1,3 +1,3 @@
--- Add 'migrate-internal' value to migration_mode_type enum.
+-- Add internal migration value to migration_mode_type enum.
 
-ALTER TYPE migration_mode_type ADD VALUE 'migrate-internal';
+ALTER TYPE migration_mode_type ADD VALUE 'migrating-internally';

--- a/internal/dbmodel/sql/postgres/032_add_migrate_internal_to_migration_mode.up.sql
+++ b/internal/dbmodel/sql/postgres/032_add_migrate_internal_to_migration_mode.up.sql
@@ -1,0 +1,3 @@
+-- Add 'migrate-internal' value to migration_mode_type enum.
+
+ALTER TYPE migration_mode_type ADD VALUE 'migrate-internal';

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -656,12 +656,18 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	return nil
 }
 
-// InitiateMigration triggers the migration of the specified model to a target controller.
-// externalMigration indicates whether this model is moving to a controller managed by
-// JIMM or not.
+// InitiateMigration triggers the migration of the specified model to a controller
+// that is not managed by JIMM.
 func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
-	const op = errors.Op("jimm.InitiateMigration")
+	internalMigration := false
+	return j.initiateMigration(ctx, user, spec, internalMigration)
+}
 
+// initiateMigration is the internal implementation for model migration.
+// It is used for both internal migrations (migrating a model to another
+// controller managed by JIMM) and migrations away from JIMM.
+func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec, internalMigration bool) (jujuparams.InitiateMigrationResult, error) {
+	const op = errors.Op("jimm.initiateMigration")
 	result := jujuparams.InitiateMigrationResult{
 		ModelTag: spec.ModelTag,
 	}
@@ -695,15 +701,27 @@ func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User,
 		}
 	}
 
-	model := dbmodel.Model{}
-	model.SetTag(mt)
-	err = j.Database.GetModel(ctx, &model)
+	migrationMode := dbmodel.MigrationModeExporting
+	if internalMigration {
+		migrationMode = dbmodel.MigrationModeMigrateInternal
+	}
+	model, err := j.Database.SetModelMigrating(ctx, mt.Id(), migrationMode)
 	if err != nil {
-		return result, errors.E(op, "failed to retrieve the model from the database", err)
+		return result, errors.E(op, fmt.Errorf("failed to set model as migrating: %v", err))
+	}
+
+	// Until we have better handling for partial failures we try to revert
+	// the model migration mode if we fail after this to avoid inconsistenties.
+	rollbackMigrationMode := func() {
+		model.MigrationMode = dbmodel.MigrationModeNone
+		if updateErr := j.Database.UpdateModel(ctx, model); updateErr != nil {
+			zapctx.Error(ctx, "failed to revert model migration mode after failure initiating migration", zap.Error(updateErr))
+		}
 	}
 
 	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
+		rollbackMigrationMode()
 		return result, errors.E(op, "failed to dial the controller", err)
 	}
 
@@ -721,8 +739,10 @@ func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User,
 		TargetMacaroons:       targetMacaroons,
 	})
 	if err != nil {
+		rollbackMigrationMode()
 		return result, errors.E(op, err)
 	}
+
 	return result, nil
 }
 

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -705,7 +705,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	if internalMigration {
 		migrationMode = dbmodel.MigrationModeMigrateInternal
 	}
-	model, err := j.Database.SetModelMigrating(ctx, mt.Id(), migrationMode)
+	model, err := j.Database.SetModelMigrationMode(ctx, mt.Id(), migrationMode)
 	if err != nil {
 		return result, errors.E(op, fmt.Errorf("failed to set model as migrating: %v", err))
 	}

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1461,6 +1461,16 @@ func TestInitiateMigration(t *testing.T) {
 			} else {
 				c.Assert(err, qt.ErrorMatches, test.expectedError)
 			}
+			model := dbmodel.Model{
+				UUID: sql.NullString{String: mt1.Id(), Valid: true},
+			}
+			err = j.Database.GetModel(context.Background(), &model)
+			c.Assert(err, qt.IsNil)
+			if test.expectedError == "" {
+				c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeExporting)
+			} else {
+				c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
+			}
 		})
 	}
 }

--- a/internal/jimm/juju/export_test.go
+++ b/internal/jimm/juju/export_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	NewControllerClient = &newControllerClient
-	FillMigrationTarget = fillMigrationTarget
-	InitiateMigration   = &initiateMigration
+	NewControllerClient       = &newControllerClient
+	FillMigrationTarget       = fillMigrationTarget
+	InitiateInternalMigration = &initiateInternalMigration
 )
 
 func NewWatcherWithControllerUnavailableChan(db *db.Database, dialer Dialer, pubsub Publisher, testChannel chan error) *Watcher {

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -23,7 +23,8 @@ import (
 )
 
 var (
-	initiateMigration = func(ctx context.Context, j *JujuManager, user *openfga.User, spec jujuparams.MigrationSpec, internalMigration bool) (jujuparams.InitiateMigrationResult, error) {
+	initiateInternalMigration = func(ctx context.Context, j *JujuManager, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
+		internalMigration := true
 		return j.initiateMigration(ctx, user, spec, internalMigration)
 	}
 )
@@ -267,8 +268,7 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 		return jujuparams.InitiateMigrationResult{}, errors.E(op, err)
 	}
 	spec := jujuparams.MigrationSpec{ModelTag: model.ResourceTag().String(), TargetInfo: migrationTarget}
-	internalMigration := true
-	result, err := initiateMigration(ctx, j, user, spec, internalMigration)
+	result, err := initiateInternalMigration(ctx, j, user, spec)
 	if err != nil {
 		return result, errors.E(op, err)
 	}

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	initiateMigration = func(ctx context.Context, j *JujuManager, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
-		return j.InitiateMigration(ctx, user, spec)
+	initiateMigration = func(ctx context.Context, j *JujuManager, user *openfga.User, spec jujuparams.MigrationSpec, internalMigration bool) (jujuparams.InitiateMigrationResult, error) {
+		return j.initiateMigration(ctx, user, spec, internalMigration)
 	}
 )
 
@@ -267,7 +267,8 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 		return jujuparams.InitiateMigrationResult{}, errors.E(op, err)
 	}
 	spec := jujuparams.MigrationSpec{ModelTag: model.ResourceTag().String(), TargetInfo: migrationTarget}
-	result, err := initiateMigration(ctx, j, user, spec)
+	internalMigration := true
+	result, err := initiateMigration(ctx, j, user, spec, internalMigration)
 	if err != nil {
 		return result, errors.E(op, err)
 	}

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -684,7 +684,7 @@ func TestInitiateInternalMigration(t *testing.T) {
 	}}
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			c.Patch(juju.InitiateMigration, func(ctx context.Context, j *juju.JujuManager, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
+			c.Patch(juju.InitiateInternalMigration, func(ctx context.Context, j *juju.JujuManager, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
 				return jujuparams.InitiateMigrationResult{}, nil
 			})
 			store := jimmtest.NewInMemoryCredentialStore()

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -434,7 +434,7 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 		if err != nil {
 			return errors.E(op, fmt.Errorf("failed to get model %q: %w", modelTag.Id(), err))
 		}
-		model.MigrationMode = state.MigrationModeNone
+		model.MigrationMode = dbmodel.MigrationModeNone
 		model.Life = state.Alive.String()
 
 		err = db.UpdateModel(ctx, &model)
@@ -583,7 +583,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 		ControllerID:      targetControllerID,
 		CloudCredentialID: cloudCredential.ID,
 		CloudRegionID:     region.ID,
-		MigrationMode:     state.MigrationModeImporting,
+		MigrationMode:     dbmodel.MigrationModeImporting,
 	}
 	err = tx.AddModel(ctx, &model)
 	if err != nil {

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -789,7 +789,7 @@ func TestActivate_Success(t *testing.T) {
 	}
 	err = j.Database.GetModel(ctx, model)
 	c.Assert(err, qt.IsNil)
-	c.Assert(model.MigrationMode, qt.Equals, state.MigrationModeNone)
+	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
 	c.Assert(model.Life, qt.Equals, state.Alive.String())
 }
 
@@ -1055,7 +1055,7 @@ func TestImport_Success(t *testing.T) {
 	}
 	err = j.Database.GetModel(ctx, m)
 	c.Assert(err, qt.IsNil)
-	c.Assert(m.MigrationMode, qt.Equals, state.MigrationModeImporting)
+	c.Assert(m.MigrationMode, qt.Equals, dbmodel.MigrationModeImporting)
 
 	// Check that the application is created in the database.
 	appOffer := &dbmodel.ApplicationOffer{
@@ -1255,7 +1255,7 @@ func TestImport_APIFailure(t *testing.T) {
 	}
 	err = j.Database.GetModel(ctx, m)
 	c.Assert(err, qt.IsNil)
-	c.Assert(m.MigrationMode, qt.Equals, state.MigrationModeImporting)
+	c.Assert(m.MigrationMode, qt.Equals, dbmodel.MigrationModeImporting)
 }
 
 // environment for testing cleanup of partial model migrations.

--- a/internal/jimm/juju/model_cleanup.go
+++ b/internal/jimm/juju/model_cleanup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -25,7 +24,7 @@ func (j *JujuManager) CleanupNotFoundModels(ctx context.Context) (err error) {
 
 	err = j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
 		// we don't want to delete models that are in the process of being migrated.
-		if m.MigrationMode != state.MigrationModeNone {
+		if m.MigrationMode != dbmodel.MigrationModeNone {
 			return nil
 		}
 		api, err := j.dialController(ctx, &m.Controller)

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -11,7 +11,6 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
 	"sigs.k8s.io/yaml"
 
@@ -478,7 +477,7 @@ type Model struct {
 	Type          string                   `json:"type"`
 	DefaultSeries string                   `json:"default-series"`
 	Life          string                   `json:"life"`
-	MigrationMode state.MigrationMode      `json:"migration-mode"`
+	MigrationMode dbmodel.MigrationMode    `json:"migration-mode"`
 	Status        jujuparams.EntityStatus  `json:"status"`
 	SLA           *jujuparams.ModelSLAInfo `json:"sla"`
 	AgentVersion  string                   `json:"agent-version"`


### PR DESCRIPTION
## Description
This PR lays some groundwork for a follow-up change to make the completion of an internal model migration automatic.
Specifically, this PR does the following:
- Adds a DB method called `SetModelMigrating` that locks the DB row for the model and updates its migration mode ensuring that if a model is already undergoing a migration this cannot be set again.
- Remove the use of `"github.com/juju/juju/state"` for the migrationMode field and create our own.
- Add a new migration mode called "migrate-internal"

Partially fixes [JUJU-7481](https://warthogs.atlassian.net/browse/JUJU-7481)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-7481]: https://warthogs.atlassian.net/browse/JUJU-7481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ