### PR TITLE
test: fix flakey test TestModelAccessWatcher

### DIFF
--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -3,6 +3,8 @@
 package jujuapi
 
 import (
+	"sync"
+
 	jujuparams "github.com/juju/juju/rpc/params"
 
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -30,8 +32,12 @@ func ModelAccessWatcherMatch(w *modelAccessWatcher, model string) bool {
 	return w.match(model)
 }
 
-func RunModelAccessWatcher(w *modelAccessWatcher) {
-	go w.loop()
+func RunModelAccessWatcher(w *modelAccessWatcher, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.loop()
+	}()
 }
 
 type ControllerRoot = controllerRoot

--- a/internal/jujuapi/modelsummarywatcher_test.go
+++ b/internal/jujuapi/modelsummarywatcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi_test
 
@@ -55,18 +55,20 @@ func (s *modelSummaryWatcherSuite) TestModelSummaryWatcher(c *gc.C) {
 func (s *modelSummaryWatcherSuite) TestModelAccessWatcher(c *gc.C) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
 	modelGetter := &testModelGetter{
 		calledChan: make(chan bool, 1),
 	}
 
 	watcher := jujuapi.NewModelAccessWatcher(ctx, 100*time.Millisecond, modelGetter.getModels)
-	jujuapi.RunModelAccessWatcher(watcher)
+	wg := sync.WaitGroup{}
+	jujuapi.RunModelAccessWatcher(watcher, &wg)
 
 	select {
 	case <-modelGetter.calledChan:
 	case <-time.After(200 * time.Millisecond):
-		c.Fatalf("timed oud")
+		c.Fatalf("timed out")
 	}
 
 	match := jujuapi.ModelAccessWatcherMatch(watcher, "model1")
@@ -77,8 +79,14 @@ func (s *modelSummaryWatcherSuite) TestModelAccessWatcher(c *gc.C) {
 	select {
 	case <-modelGetter.calledChan:
 	case <-time.After(200 * time.Millisecond):
-		c.Fatalf("timed oud")
+		c.Fatalf("timed out")
 	}
+
+	// Once the modelGetter has been called, the watcher should have the models.
+	// We then cancel the watcher and call Wait() as way of synchronising the test
+	// to ensure the watcher has processed the models.
+	cancelFunc()
+	wg.Wait()
 
 	match = jujuapi.ModelAccessWatcherMatch(watcher, "model1")
 	c.Assert(match, jc.IsTrue)
@@ -89,8 +97,8 @@ func (s *modelSummaryWatcherSuite) TestModelAccessWatcher(c *gc.C) {
 	match = jujuapi.ModelAccessWatcherMatch(watcher, "model3")
 	c.Assert(match, jc.IsFalse)
 
-	cancelFunc()
-
+	// Now with the watcher stopped, we set new models and
+	// check that the previous models are still matched.
 	modelGetter.setModels([]string{"model1", "model3"})
 
 	<-time.After(200 * time.Millisecond)


### PR DESCRIPTION
## Description
This PR fixes the flakey test TestModelSummaryWatcher which would sometimes fail with,
```go
modelsummarywatcher_test.go:84:
    c.Assert(match, jc.IsTrue)
... obtained bool = false
```
The issue is a race in the model access watcher's `match` and `do` methods copied below,
```go
func (w *modelAccessWatcher) match(model string) bool {
	w.mu.RLock()
	defer w.mu.RUnlock()
	access, ok := w.models[model]
	if !ok {
		return false
	}
	return access
}
```
vs 
```go
func (w *modelAccessWatcher) do() error {
	modelUUIDList, err := w.modelGetterFunc(w.ctx)
	if err != nil {
		return err
	}

	models := make(map[string]bool)
	for _, modelUUID := range modelUUIDList {
		models[modelUUID] = true
	}

	w.mu.Lock()
	defer w.mu.Unlock()
	w.models = models

	return nil
}
```
In our test, we wait until `modelGetterFunc()` has been called and then immediately check if `w.models` has the expected values by calling `match()` but as you can see from the above, it's possible that `do()` hasn't yet reached `w.mu.Lock()` to lock the mutex that `match` is also attempting to lock. 

One fix for this I initially attempted was to move the `w.mu.Lock()` in the `do()` function to the top. That ensures that when `modelGetterFunc()` has been called, the mutex is already locked for updates to the model map. But if we look at the real implementation, the `modelGetterFunc()` func uses our DB to get all models which means we'll end up holding this lock a lot longer than we need to.

The alternative approach I came up with is to adjust the test in such a way that we can ensure `do()` is finished before we check for matches in the model map. We can do that by waiting until the `modelAccessWatcher` object's loop() method is done before checking. That can all be handled within test code.

Fixes [JUJU-8341](https://warthogs.atlassian.net/browse/JUJU-8341)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Before the fix the following showed frequent failures,
```
go test -c ./internal/jujuapi/ -race
stress ./jujuapi.test -check.f=modelSummaryWatcherSuite.TestModelAccessWatcher
```
After the fix the above showed no failures.

[JUJU-8341]: https://warthogs.atlassian.net/browse/JUJU-8341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ