### PR TITLE
fix: replace usages of ScanRows to avoid O(n) queries

### DIFF
--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -105,22 +105,14 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 		db = db.Offset(filter.Offset)
 	}
 
-	rows, err := db.Rows()
-	if err != nil {
-		return errors.E(op, err)
+	var ales []dbmodel.AuditLogEntry
+	if err := db.Find(&ales).Error; err != nil {
+		return errors.E(op, dbError(err))
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var ale dbmodel.AuditLogEntry
-		if err := db.ScanRows(rows, &ale); err != nil {
-			return errors.E(op, err)
-		}
-		if err := f(&ale); err != nil {
+	for _, a := range ales {
+		if err := f(&a); err != nil {
 			return err
 		}
-	}
-	if rows.Err() != nil {
-		return errors.E(op, rows.Err())
 	}
 	return nil
 }

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2024 Canonical.
 
 package db
 
@@ -105,14 +105,22 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 		db = db.Offset(filter.Offset)
 	}
 
-	var ales []dbmodel.AuditLogEntry
-	if err := db.Find(&ales).Error; err != nil {
-		return errors.E(op, dbError(err))
+	rows, err := db.Rows()
+	if err != nil {
+		return errors.E(op, err)
 	}
-	for _, a := range ales {
-		if err := f(&a); err != nil {
+	defer rows.Close()
+	for rows.Next() {
+		var ale dbmodel.AuditLogEntry
+		if err := db.ScanRows(rows, &ale); err != nil {
+			return errors.E(op, err)
+		}
+		if err := f(&ale); err != nil {
 			return err
 		}
+	}
+	if rows.Err() != nil {
+		return errors.E(op, rows.Err())
 	}
 	return nil
 }

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -86,33 +86,24 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	db := d.DB.WithContext(ctx)
-	mdb := db.Model(dbmodel.CloudCredential{})
+	db = db.Model(dbmodel.CloudCredential{})
+	db = db.Preload("Cloud").Preload("Owner").Preload("Models")
 	if cloud == "" {
-		mdb = mdb.Where("owner_identity_name = ?", identityName)
+		db = db.Where("owner_identity_name = ?", identityName)
 	} else {
-		mdb = mdb.Where("cloud_name = ? AND owner_identity_name = ?", cloud, identityName)
+		db = db.Where("cloud_name = ? AND owner_identity_name = ?", cloud, identityName)
 	}
-	rows, err := mdb.Rows()
-	if err != nil {
+
+	var creds []dbmodel.CloudCredential
+	if err := db.Find(&creds).Error; err != nil {
 		return errors.E(op, dbError(err))
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cred dbmodel.CloudCredential
-		if err := db.ScanRows(rows, &cred); err != nil {
-			return errors.E(op, dbError(err))
-		}
-		err = d.GetCloudCredential(ctx, &cred)
-		if err != nil {
-			return err
-		}
-		if err := f(&cred); err != nil {
+	for _, c := range creds {
+		if err := f(&c); err != nil {
 			return err
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return errors.E(op, dbError(err))
-	}
+
 	return nil
 }
 

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -269,6 +269,10 @@ func (s *dbSuite) TestForEachCloudCredential(c *qt.C) {
 			var credentials []string
 			if test.f == nil {
 				test.f = func(cred *dbmodel.CloudCredential) error {
+					// Check preloads/joins are populated (not zero values)
+					c.Check(cred.Cloud.Name, qt.Matches, "cloud-.*")
+					c.Check(cred.Owner.Name, qt.Matches, ".*@canonical.com")
+
 					credentials = append(credentials, cred.Tag().String())
 					return nil
 				}

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -159,29 +159,15 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 
 	db := d.DB.WithContext(ctx)
 	db = preloadModel("", db)
-	rows, err := db.Model(&dbmodel.Model{}).Rows()
-	if err != nil {
-		return errors.E(op, err)
+
+	var models []dbmodel.Model
+	if err := db.Find(&models).Error; err != nil {
+		return errors.E(op, dbError(err))
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var m dbmodel.Model
-		if err := db.ScanRows(rows, &m); err != nil {
-			return errors.E(op, err)
-		}
-		// ScanRows does not use the preloads added on L141, therefore
-		// we need to fetch each model to load the associated
-		// fields otherwise the only populated fields will be association
-		// IDs.
-		if err := d.GetModel(ctx, &m); err != nil {
-			return errors.E(op, err)
-		}
+	for _, m := range models {
 		if err := f(&m); err != nil {
 			return err
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return errors.E(op, dbError(err))
 	}
 	return nil
 }

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -548,6 +548,12 @@ func (s *dbSuite) TestForEachModel(c *qt.C) {
 
 	var models []string
 	err = s.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
+		// Check preloads/joins are populated (not zero values)
+		c.Check(m.Owner.Name, qt.Matches, ".*@canonical.com")
+		c.Check(m.Controller.Name, qt.Equals, "test")
+		c.Check(m.CloudRegion.Name, qt.Equals, "test-region")
+		c.Check(m.CloudCredential.Name, qt.Equals, "test-cred")
+
 		models = append(models, m.UUID.String)
 		return nil
 	})

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -86,19 +86,10 @@ func (d *Database) ListResources(ctx context.Context, limit, offset int, namePre
 	if err != nil {
 		return nil, err
 	}
-	rows, err := query.Rows()
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	resources := make([]Resource, 0)
-	for rows.Next() {
-		var res Resource
-		err := db.ScanRows(rows, &res)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, res)
+
+	var resources []Resource
+	if err := query.Find(&resources).Error; err != nil {
+		return nil, errors.E(op, dbError(err))
 	}
 	return resources, nil
 }


### PR DESCRIPTION
## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->
Several `Database` methods were making O(n) number of queries due to their usage of `ScanRows` and separately issuing a get query in a loop. This would've likely led to high latency in pathological cases and thus poor UX.

I've replaced most such usage with `Find`, which is able to use preloads/joins. I've also added preloads where they were missing. This should be no less efficient than the previous method, which was also spilling the query result into a slice before iterating over it.

Affected methods:
- ForAllControllers (previous PR)
- ForEachCloudCredential
- ForEachModel
- ListResources

ForEachAuditLogEntry was not changed to avoid potentially high memory usage.

Fix for https://warthogs.atlassian.net/browse/JUJU-8348

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
