### PR TITLE
Fix juju cli store 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -350,6 +350,7 @@ require (
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/zitadel/logging v0.6.1 // indirect
 	github.com/zitadel/oidc/v3 v3.35.0 // indirect
 	github.com/zitadel/schema v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1062,6 +1062,8 @@ github.com/testcontainers/testcontainers-go v0.15.0 h1:3Ex7PUGFv0b2bBsdOv6R42+SK
 github.com/testcontainers/testcontainers-go v0.15.0/go.mod h1:PkohMRH2X8Hib0IWtifVexDfLPVT+tb5E9hsf7cW12w=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQdrZk=
 github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn4UKG+hGqeJs=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=

--- a/internal/jujuclistore/export_test.go
+++ b/internal/jujuclistore/export_test.go
@@ -1,0 +1,7 @@
+// Copyright 2025 Canonical.
+
+package jujuclistore
+
+var (
+	MaxExtractSize = maxExtractSize
+)

--- a/internal/jujuclistore/store.go
+++ b/internal/jujuclistore/store.go
@@ -3,6 +3,7 @@
 package jujuclistore
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,6 +21,9 @@ import (
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/retry"
 	"github.com/juju/version/v2"
+	"github.com/juju/zaputil/zapctx"
+	"github.com/ulikunitz/xz"
+	"go.uber.org/zap"
 )
 
 const timeoutRequestDuration = 5 * time.Minute
@@ -29,7 +34,10 @@ const launchPadURL = "https://launchpad.net/juju"
 // launchPadTemplate is the template for constructing the download URL for Juju binaries.
 const launchPadTemplate = "{{.BaseURL}}/{{.VersionWithMinor}}/{{.VersionWithPatch}}/+download/juju-{{.VersionWithPatch}}-{{.Os}}-{{.Arch}}.tar.xz"
 
-var retryRequestError = jujuerrors.New("retry request error")
+var (
+	retryRequestError error = jujuerrors.New("retry request error")
+	maxExtractSize    int64 = 200 * 1024 * 1024
+)
 
 // Config holds the configuration for the Juju binary fetcher.
 type Config struct {
@@ -122,7 +130,6 @@ func (p *jujuCLIStore) Get(ctx context.Context, spec JujuBinarySpec) (*Binary, e
 	if err != nil {
 		return nil, jujuerrors.Annotatef(err, "invalid version %q", spec.Version)
 	}
-
 	err = p.template.Execute(&buf, map[string]string{
 		"BaseURL":          p.config.BaseURL,
 		"VersionWithMinor": fmt.Sprintf("%d.%d", v.Major, v.Minor),
@@ -134,6 +141,15 @@ func (p *jujuCLIStore) Get(ctx context.Context, spec JujuBinarySpec) (*Binary, e
 		return nil, err
 	}
 	url := buf.String()
+	zapctx.Debug(
+		ctx,
+		"getting Juju binary",
+		zap.String("version", spec.Version),
+		zap.String("os", spec.Os),
+		zap.String("arch", spec.Arch),
+		zap.String("url", url),
+	)
+
 	// worst case the lock will be help for the duration of the download
 	// of the binary. For now it is acceptable because we support bootstrapping
 	// one controller at a time.
@@ -144,11 +160,12 @@ func (p *jujuCLIStore) Get(ctx context.Context, spec JujuBinarySpec) (*Binary, e
 		binary.referenceCount.Add(1) // Increment reference count
 		return binary, nil
 	}
-	err = p.freeEntry(ctx)
+	err = p.freeEntry()
 	if err != nil {
 		return nil, err
 	}
 	var file *os.File
+
 	err = retry.Call(retry.CallArgs{
 		Func: func() error {
 			file, err = p.downloadFile(ctx, url)
@@ -169,6 +186,7 @@ func (p *jujuCLIStore) Get(ctx context.Context, spec JujuBinarySpec) (*Binary, e
 	if err != nil {
 		return nil, err
 	}
+
 	binary = &Binary{
 		FullPath: file.Name(),
 	}
@@ -180,7 +198,7 @@ func (p *jujuCLIStore) Get(ctx context.Context, spec JujuBinarySpec) (*Binary, e
 // freeEntry checks if the entries map has reached the maximum number of entries.
 // If it has, it deletes a random entry from the map.
 // It should be called when the entries map is locked to ensure thread safety.
-func (p *jujuCLIStore) freeEntry(ctx context.Context) error {
+func (p *jujuCLIStore) freeEntry() error {
 	if len(p.entries) < p.config.MaxEntries {
 		return nil
 	}
@@ -225,21 +243,72 @@ func (p *jujuCLIStore) downloadFile(ctx context.Context, downloadUrl string) (*o
 		return nil, err
 	}
 	defer resp.Body.Close()
+
 	if (resp.StatusCode >= 500 && resp.StatusCode < 600) || resp.StatusCode == http.StatusTooManyRequests {
 		return nil, retryRequestError
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, jujuerrors.Errorf("request failed with status %d", resp.StatusCode)
 	}
-	file, err := os.CreateTemp(p.config.Dir, "juju-*")
+
+	xzReader, err := xz.NewReader(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, jujuerrors.Annotatef(err, "failed to create xz reader for %s", downloadUrl)
 	}
-	_, err = io.Copy(file, resp.Body)
-	if err != nil {
-		file.Close()
-		os.Remove(file.Name())
-		return nil, err
+	tarReader := tar.NewReader(xzReader)
+	// 200mb - limit download size should malicious actor send large file
+	// and destroy jimm's memory with decompression bomb.
+
+	limitedReader := io.LimitReader(tarReader, maxExtractSize)
+
+	var binaryFile *os.File
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip non-regular files and non-binary files
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		zapctx.Debug(ctx, "processing tar header", zap.String("name", hdr.Name))
+		if filepath.Base(hdr.Name) != "juju" {
+			continue
+		}
+
+		// Create a temp file for the binary
+		f, err := os.CreateTemp(p.config.Dir, "juju-*")
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := io.Copy(f, limitedReader); err != nil {
+			f.Close()
+			os.Remove(f.Name())
+			return nil, err
+		}
+
+		if err := f.Chmod(0755); err != nil {
+			f.Close()
+			os.Remove(f.Name())
+			return nil, jujuerrors.Annotatef(err, "failed to set permissions on binary file %s", f.Name())
+		}
+		binaryFile = f
+		break
 	}
-	return file, nil
+
+	if binaryFile == nil {
+		return nil, fmt.Errorf("juju binary not found in archive")
+	}
+
+	if err := binaryFile.Close(); err != nil {
+		return nil, jujuerrors.Annotatef(err, "failed to close binary file %s", binaryFile.Name())
+	}
+
+	return binaryFile, nil
 }

--- a/internal/jujuclistore/store.go
+++ b/internal/jujuclistore/store.go
@@ -257,7 +257,7 @@ func (p *jujuCLIStore) downloadFile(ctx context.Context, downloadUrl string) (*o
 	}
 	tarReader := tar.NewReader(xzReader)
 	// 200mb - limit download size should malicious actor send large file
-	// and destroy jimm's memory with decompression bomb.
+	// and destroy jimm's disk with decompression bomb.
 
 	limitedReader := io.LimitReader(tarReader, maxExtractSize)
 

--- a/internal/jujuclistore/store_test.go
+++ b/internal/jujuclistore/store_test.go
@@ -3,6 +3,8 @@
 package jujuclistore
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,7 +14,43 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/ulikunitz/xz"
 )
+
+// simulates having a xz compressed tar file stream
+func makeTarXz(t *testing.T, name string, content []byte) []byte {
+	var buf bytes.Buffer
+
+	// XZ compressor
+	xzw, err := xz.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("failed to create xz writer: %v", err)
+	}
+
+	tw := tar.NewWriter(xzw)
+
+	hdr := &tar.Header{
+		Name: name,
+		Mode: 0755,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("failed to write tar content: %v", err)
+	}
+
+	// Close in correct order
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := xzw.Close(); err != nil {
+		t.Fatalf("xz close: %v", err)
+	}
+
+	return buf.Bytes()
+}
 
 func TestStore(t *testing.T) {
 	c := qt.New(t)
@@ -21,10 +59,12 @@ func TestStore(t *testing.T) {
 		Os:      "linux",
 		Arch:    "amd64",
 	}
+
+	archive := makeTarXz(t, "juju", []byte("im a juju binary"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.URL.Path, qt.Equals, "/3.6/3.6.2/+download/juju-3.6.2-linux-amd64.tar.xz")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("test content"))
+		_, err := w.Write(archive)
 		c.Assert(err, qt.IsNil)
 	}))
 	defer server.Close()
@@ -41,7 +81,71 @@ func TestStore(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	content, err := io.ReadAll(file)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(content), qt.Equals, "test content")
+	c.Assert(string(content), qt.Equals, "im a juju binary")
+	c.Assert(binary.FullPath, qt.Matches, fmt.Sprintf("%s/juju-.*", os.TempDir()))
+}
+
+func TestStoreWithTarMissingJujuBinary(t *testing.T) {
+	c := qt.New(t)
+	jujuSpec := JujuBinarySpec{
+		Version: "3.6.2",
+		Os:      "linux",
+		Arch:    "amd64",
+	}
+
+	archive := makeTarXz(t, "diary.txt", []byte("my diary"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/3.6/3.6.2/+download/juju-3.6.2-linux-amd64.tar.xz")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(archive)
+		c.Assert(err, qt.IsNil)
+	}))
+	defer server.Close()
+
+	store, err := NewJujuCLIStore(Config{
+		BaseURL: server.URL,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = store.Get(t.Context(), jujuSpec)
+	c.Assert(err, qt.ErrorMatches, "juju binary not found in archive")
+}
+
+func TestStoreProtectsAgainstDecompressionBomb(t *testing.T) {
+	c := qt.New(t)
+	jujuSpec := JujuBinarySpec{
+		Version: "3.6.2",
+		Os:      "linux",
+		Arch:    "amd64",
+	}
+
+	// Set an extract size 1 byte smaller than the content size
+	// to trigger the decompression bomb protection
+	c.Patch(&maxExtractSize, int64(9))
+	tenBytesContent := []byte("123456789therestofthiswillbemissing") // We'll expect the 0 to missing
+	archive := makeTarXz(t, "juju", tenBytesContent)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/3.6/3.6.2/+download/juju-3.6.2-linux-amd64.tar.xz")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(archive)
+		c.Assert(err, qt.IsNil)
+	}))
+	defer server.Close()
+
+	store, err := NewJujuCLIStore(Config{
+		BaseURL: server.URL,
+	})
+	c.Assert(err, qt.IsNil)
+	binary, err := store.Get(t.Context(), jujuSpec)
+	c.Assert(err, qt.IsNil)
+	defer binary.Done()
+
+	file, err := os.Open(binary.FullPath)
+	c.Assert(err, qt.IsNil)
+	content, err := io.ReadAll(file)
+	c.Assert(err, qt.IsNil)
+	// We expect the content to be truncated to the maxExtractSize
+	c.Assert(string(content), qt.Equals, "123456789")
 	c.Assert(binary.FullPath, qt.Matches, fmt.Sprintf("%s/juju-.*", os.TempDir()))
 }
 
@@ -68,7 +172,11 @@ func TestStoreError(t *testing.T) {
 
 func TestStoreRetry(t *testing.T) {
 	c := qt.New(t)
+
+	archive := makeTarXz(t, "juju", []byte("im a juju binary"))
+
 	retryCount := 0
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if retryCount < 2 {
 			retryCount++
@@ -76,7 +184,7 @@ func TestStoreRetry(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("test content"))
+		_, err := w.Write(archive)
 		c.Assert(err, qt.IsNil)
 	}))
 	defer server.Close()
@@ -99,16 +207,20 @@ func TestStoreRetry(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	content, err := io.ReadAll(file)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(content), qt.Equals, "test content")
+	c.Assert(string(content), qt.Equals, "im a juju binary")
 }
 
 func TestStoreCache(t *testing.T) {
 	c := qt.New(t)
+
+	archive := makeTarXz(t, "juju", []byte("im a juju binary"))
+
 	called := 0
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called++
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("test content"))
+		_, err := w.Write(archive)
 		c.Assert(err, qt.IsNil)
 	}))
 	defer server.Close()
@@ -138,16 +250,19 @@ func TestStoreCache(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	content, err := io.ReadAll(file)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(content), qt.Equals, "test content")
+	c.Assert(string(content), qt.Equals, "im a juju binary")
 
 	c.Assert(binary.FullPath, qt.Equals, binaryAgain.FullPath) // Ensure the same binary is returned
 }
 
 func TestStoreMaxEntriesCleanup(t *testing.T) {
 	c := qt.New(t)
+
+	archive := makeTarXz(t, "juju", []byte("im a juju binary"))
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("test content"))
+		_, err := w.Write(archive)
 		c.Assert(err, qt.IsNil)
 	}))
 	defer server.Close()
@@ -201,9 +316,12 @@ func TestStoreMaxEntriesCleanup(t *testing.T) {
 
 func TestStoreReferenceCount(t *testing.T) {
 	c := qt.New(t)
+
+	archive := makeTarXz(t, "juju", []byte("im a juju binary"))
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("test content"))
+		_, err := w.Write(archive)
 		c.Assert(err, qt.IsNil)
 	}))
 	defer server.Close()
@@ -241,7 +359,7 @@ func TestStoreReferenceCount(t *testing.T) {
 	binary1.Done()                                               // Mark the first binary as done
 	c.Assert(binary1.referenceCount.Load(), qt.Equals, int32(1)) // Reference count
 
-	err = store.freeEntry(context.Background()) // This should not delete binary1 since its reference count is 1
+	err = store.freeEntry() // This should not delete binary1 since its reference count is 1
 	c.Assert(err, qt.ErrorMatches, `no entries to delete, max entries limit reached: \d+`)
 
 	c.Assert(len(store.entries), qt.Equals, 2) // Ensure two entries are still kept
@@ -250,7 +368,7 @@ func TestStoreReferenceCount(t *testing.T) {
 	c.Assert(binary1.referenceCount.Load(), qt.Equals, int32(0)) // Reference count
 
 	// Now the reference count is zero, so it can be deleted
-	err = store.freeEntry(context.Background()) // This should not delete binary1 since its reference count is 1
+	err = store.freeEntry() // This should delete binary1 since its reference count is 0
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(len(store.entries), qt.Equals, 1) // Ensure two entries are still kept

--- a/internal/jujuclistore/store_test.go
+++ b/internal/jujuclistore/store_test.go
@@ -121,7 +121,7 @@ func TestStoreProtectsAgainstDecompressionBomb(t *testing.T) {
 	// Set an extract size 1 byte smaller than the content size
 	// to trigger the decompression bomb protection
 	c.Patch(&maxExtractSize, int64(9))
-	tenBytesContent := []byte("123456789therestofthiswillbemissing") // We'll expect the 0 to missing
+	tenBytesContent := []byte("123456789therestofthiswillbemissing") // We'll expect string to missing
 	archive := makeTarXz(t, "juju", tenBytesContent)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
The original implementation assumed the downloaded file with the binary to begin with and this assumption was incorrect. Juju tars and compresses the artefacts alongside another another binary called "juju-metadata".

This pull request has adjusted the cli store slightly to do the following:
1. Decompress the stream (using the xz package - perhaps this isn't the best one looking at it's README)
2. Unpack the tar looking for the "./juju" header for the juju binary file
3. Chmod the binary file 

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
