### PR TITLE
Update bootstrap start jujuapi method

### DIFF
--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -625,12 +625,22 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
+	cloudNameAndRegion := req.CloudName
+
+	if req.RegionName != "" {
+		cloudNameAndRegion = fmt.Sprintf("%s/%s", req.CloudName, req.RegionName)
+	}
+
 	params := bootstrap.BootstrapParams{
-		ControllerName: req.ControllerName,
-		CloudName:      req.CloudName,
-		CloudRegion:    req.RegionName,
-		AgentVersion:   req.Flags.AgentVersion,
-		TimeoutSeconds: req.Flags.Timeout,
+		CLIVersion: "3.6.8",
+
+		CloudNameAndRegion: cloudNameAndRegion,
+		ControllerName:     req.ControllerName,
+		AgentVersion:       req.Flags.AgentVersion,
+		BootstrapTimeout:   req.Flags.Timeout,
+
+		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
+		CloudCred:     req.Credential,
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)

--- a/internal/jujuapi/jimm_relation.go
+++ b/internal/jujuapi/jimm_relation.go
@@ -1,3 +1,0 @@
-// Copyright 2025 Canonical.
-
-package jujuapi

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	jujucloud "github.com/juju/juju/cloud"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
 
@@ -201,6 +203,9 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 			AgentVersion: "1.0.0",
 			Timeout:      3600,
 		},
+		Cloud:      jujuparams.Cloud{},
+		Credential: jujucloud.CloudCredential{},
+		CLIVersion: "3.6.8",
 	}
 
 	response, err := root.BootstrapStart(ctx, params)

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -626,8 +626,8 @@ type BootstrapStartParams struct {
 	// Flags hold modifiers for the bootstrap job.
 	Flags BootstrapFlags `json:"flags"`
 
-	// CLIVersion is the version of the Juju CLI that is being used.
-	CLIVersion string `json:"cli-version"`
+	// ControllerVersion is the version of the controller to be bootstrapped.
+	ControllerVersion string `json:"controller-version"`
 }
 
 // BootstrapStartResponse holds the response for starting

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -5,6 +5,7 @@ package params
 import (
 	"time"
 
+	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 )
 
@@ -614,10 +615,21 @@ type BootstrapStartParams struct {
 	CloudName string `json:"cloud-name"`
 	// RegionName specifies the target region for the controller.
 	RegionName string `json:"region-name"`
+	// Cloud holds the cloud definition that will be used to bootstrap the controller.
+	Cloud jujuparams.Cloud `json:"cloud,omitempty"`
+	// Credential contains the cloud credential and its tag, this credential will be used against the
+	// the cloud provided to bootstrap the controller.
+	// We're using jujucloud.CloudCredential as there's an API client func using this type to add clouds.
+	// Seen here: api/client/cloud/cloud.go L271.
+	Credential jujucloud.CloudCredential `json:"credential"`
+
 	// ControllerName specifies the name of the controller as recorded in JIMM.
 	ControllerName string `json:"controller-name"`
 	// Flags hold modifiers for the bootstrap job.
 	Flags BootstrapFlags `json:"flags"`
+
+	// CLIVersion is the version of the Juju CLI that is being used.
+	CLIVersion string `json:"cli-version"`
 }
 
 // BootstrapStartResponse holds the response for starting

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -619,8 +619,6 @@ type BootstrapStartParams struct {
 	Cloud jujuparams.Cloud `json:"cloud,omitempty"`
 	// Credential contains the cloud credential and its tag, this credential will be used against the
 	// the cloud provided to bootstrap the controller.
-	// We're using jujucloud.CloudCredential as there's an API client func using this type to add clouds.
-	// Seen here: (juju 3.6) https://github.com/juju/juju/blob/adbd5a2255e4efd0d0c10089813a0af981290da1/api/client/cloud/cloud.go#L271
 	Credential jujucloud.CloudCredential `json:"credential"`
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -620,7 +620,7 @@ type BootstrapStartParams struct {
 	// Credential contains the cloud credential and its tag, this credential will be used against the
 	// the cloud provided to bootstrap the controller.
 	// We're using jujucloud.CloudCredential as there's an API client func using this type to add clouds.
-	// Seen here: api/client/cloud/cloud.go L271.
+	// Seen here: (juju 3.6) https://github.com/juju/juju/blob/adbd5a2255e4efd0d0c10089813a0af981290da1/api/client/cloud/cloud.go#L271
 	Credential jujucloud.CloudCredential `json:"credential"`
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.


### PR DESCRIPTION
## Description
Based on: #1678

Updates the params to accept a cloud, a credential and the cli version. You'll notice we use `jujucloud.CloudCredential` within our params to pass the credential. This decision was made because Juju does the same. But, they send a "TaggedCredential", containing the `jujucloud.CloudCredential`. We just need the credential so I've omitted the wrapper. 

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
