### PR TITLE
Implement StartBootstrap

### DIFF
--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -7,6 +7,8 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,6 +35,11 @@ var (
 	}
 )
 
+const (
+	bootstrapJobType     = "bootstrap"
+	maxBootstrapDuration = 60 * time.Minute
+)
+
 // Store defines the store methods required by the manager.
 type Store interface {
 	QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error)
@@ -49,9 +56,10 @@ type Store interface {
 type JobTracker interface {
 	// GetJob retrieves a job entry by its ID.
 	GetJob(ctx context.Context, jobId uuid.UUID) (dbmodel.JobTrackerEntry, error)
-
 	// StopJob stops a job by its ID.
 	StopJob(ctx context.Context, jobId uuid.UUID) error
+	// Run runs a new job and returns the job ID.
+	Run(ctx context.Context, jobType string, job jobtracker.JobFunc, maxDuration time.Duration) (uuid.UUID, error)
 }
 
 // JujuManager defines the juju manager methods required by the job.
@@ -65,38 +73,42 @@ type BinaryStore interface {
 }
 
 type bootstrapManager struct {
-	authSvc *openfga.OFGAClient
-
-	store       Store
-	jobtracker  JobTracker
-	jujuManager JujuManager
-	binaryStore BinaryStore
+	store                     Store
+	tracker                   JobTracker
+	jujuManager               JujuManager
+	binaryStore               BinaryStore
+	jimmWellknownJWKSEndpoint string
 }
 
 // NewBootstrapManager creates a new BootstrapManager instance.
-// TODO(ale8k): Remove authSvc later, it isn't used.
 func NewBootstrapManager(
-	authSvc *openfga.OFGAClient,
 	store Store,
 	jobtracker JobTracker,
 	jujuManager JujuManager,
 	binaryStore BinaryStore,
+	jimmWellknownJWKSEndpoint string,
 ) (*bootstrapManager, error) {
 	if store == nil {
 		return nil, errors.E("store cannot be nil")
 	}
-	if authSvc == nil {
-		return nil, errors.E("authorisation service cannot be nil")
-	}
 	if jobtracker == nil {
 		return nil, errors.E("job tracker cannot be nil")
 	}
+	if jujuManager == nil {
+		return nil, errors.E("juju manager cannot be nil")
+	}
+	if binaryStore == nil {
+		return nil, errors.E("binary store cannot be nil")
+	}
+	if jimmWellknownJWKSEndpoint == "" {
+		return nil, errors.E("jimm well-known JWKs endpoint cannot be empty")
+	}
 	return &bootstrapManager{
-		store:       store,
-		authSvc:     authSvc,
-		jobtracker:  jobtracker,
-		jujuManager: jujuManager,
-		binaryStore: binaryStore,
+		store:                     store,
+		tracker:                   jobtracker,
+		jujuManager:               jujuManager,
+		binaryStore:               binaryStore,
+		jimmWellknownJWKSEndpoint: jimmWellknownJWKSEndpoint,
 	}, nil
 }
 
@@ -106,7 +118,7 @@ func NewBootstrapManager(
 func (b *bootstrapManager) GetBootstrapStatusAndLogs(ctx context.Context, _ *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error) {
 	const op = errors.Op("jimm.GetBootstrapStatusAndLogs")
 
-	job, err := b.jobtracker.GetJob(ctx, jobId)
+	job, err := b.tracker.GetJob(ctx, jobId)
 	if err != nil {
 		return params.BootstrapStatusResponse{}, errors.E(op, "failed to get job status", err)
 	}
@@ -123,18 +135,6 @@ func (b *bootstrapManager) GetBootstrapStatusAndLogs(ctx context.Context, _ *ope
 	}, nil
 }
 
-// StartBootstrap starts a bootstrap job with the provided parameters.
-func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
-	const op = errors.Op("jimm.StartBootstrap")
-
-	err := params.validate()
-	if err != nil {
-		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))
-	}
-
-	return "", errors.E(op, "not implemented")
-}
-
 // StopBootstrap stops a bootstrap job by its ID.
 func (b *bootstrapManager) StopBootstrap(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
 	const op = errors.Op("jimm.StopBootstrap")
@@ -147,12 +147,56 @@ func (b *bootstrapManager) StopBootstrap(ctx context.Context, user *openfga.User
 		return errors.E(op, "job ID cannot be nil")
 	}
 
-	err := b.jobtracker.StopJob(ctx, jobId)
+	err := b.tracker.StopJob(ctx, jobId)
 	if err != nil {
 		return errors.E(op, "failed to stop job", err)
 	}
 
 	return nil
+}
+
+// StartBootstrap starts a bootstrap job with the provided parameters.
+func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
+	const op = errors.Op("jimm.StartBootstrap")
+
+	if err := params.validate(); err != nil {
+		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))
+	}
+
+	temp, err := os.MkdirTemp("", "juju-data-dir")
+	if err != nil {
+		return "", errors.E(op, fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
+	}
+
+	jobId, err := b.tracker.Run(
+		ctx,
+		bootstrapJobType,
+		b.BootstrapJob(
+			JobParams{
+				// Runner args.
+				JujuDataDir: temp,
+				// Binary args.
+				CLIVersion: params.CLIVersion,
+				// User defined command arguments
+				CloudNameAndRegion: params.CloudNameAndRegion,
+				ControllerName:     params.ControllerName,
+				AgentVersion:       params.AgentVersion,
+				BootstrapTimeout:   params.BootstrapTimeout,
+				CloudCred:          params.CloudCred,
+				PersonalCloud:      params.PersonalCloud,
+				// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
+				LoginTokenRefreshURL: b.jimmWellknownJWKSEndpoint, // TODO: Set the correct login token refresh URL
+			},
+			DefaultBootstrapExecutor{},
+			user,
+		),
+		maxBootstrapDuration,
+	)
+	if err != nil {
+		return "", errors.E(op, fmt.Errorf("failed to start bootstrap job: %w", err))
+	}
+
+	return jobId.String(), nil
 }
 
 // BootstrapExecutor holds a wrapper to run a command. It is primarily for testing
@@ -190,8 +234,6 @@ type JobParams struct {
 	// CLI Download params.
 
 	CLIVersion string
-	CLIOs      string
-	CLIArch    string
 
 	// User defined command arguments
 
@@ -265,18 +307,26 @@ func (b *bootstrapManager) BootstrapJob(
 			return errors.E(fmt.Errorf("failed to check if controller exists: %w", err))
 		}
 
+		// TODO(ale8k): When downloading, it takes a while and the CLI has no output. Download progress would be a VERY nice to have here.
 		binary, err := b.binaryStore.Get(
 			ctx,
 			jujuclistore.JujuBinarySpec{
 				Version: p.CLIVersion,
-				Os:      p.CLIVersion,
-				Arch:    p.CLIArch,
+				// This is a best effort. The launchpad URL just so happens to have similar filenames to runtime.GOOS and runtime.GOARCH.
+				// If this ever changes, we should update the binary store to use the correct URL
+				// or we should detect the OS and arch here. We don't want to detect it in the binary store
+				// because the consumer may want to detect it in different ways.
+				Os:   runtime.GOOS,
+				Arch: runtime.GOARCH,
 			},
 		)
 		if err != nil {
 			return errors.E(fmt.Errorf("failed to get Juju binary: %w", err))
 		}
-
+		// TODO(ale8k): Is it possible to tell the client to only attempt to get status after binary is downloaded?
+		// Because as it stands, the client will be unncessarily polling (perhaps we could put download progress in the logs?).
+		// That way the status calls wouldn't be unncessary and serve a purpose.
+		zapctx.Debug(logCtx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 		defer binaryDone(binary)
 
 		if err := b.runBootstrap(ctx, p, jobId, executor, binary, user); err != nil {
@@ -318,6 +368,13 @@ func (b *bootstrapManager) runBootstrap(
 
 	for output := range outputCh {
 		if output.Err != nil {
+			if writeLogErr := b.store.AddBootstrapLog(
+				ctx,
+				jobId,
+				output.Err.Error(),
+			); writeLogErr != nil {
+				zapctx.Error(ctx, "failed to write bootstrap error", zap.Error(writeLogErr), zap.String("jobId", jobId.String()))
+			}
 			return errors.E(fmt.Errorf("bootstrap command failed: %w", output.Err))
 		}
 		if writeLogErr := b.store.AddBootstrapLog(
@@ -339,6 +396,12 @@ func (b *bootstrapManager) runBootstrap(
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to get controller details: %w", err))
 	}
+	// TODO(ale8k): At the moment, we can't reach added k8s controllers because the controller is not reachable.
+	// The CLI spins up a kube-proxy to reach it and we could do the same. The controller details of said controller
+	// may contain proxy details and those proxy details can be used to launch a proxy to contact the controller.
+	// Accessed like so: [ctrlDetails.Proxy.Proxier.Start].
+	//
+	// As such, AddController fails.
 
 	hps, err := network.ParseProviderHostPorts(ctrlDetails.APIEndpoints...)
 	if err != nil {
@@ -367,6 +430,10 @@ func (b *bootstrapManager) runBootstrap(
 		AdminIdentityName: account.User,
 		AdminPassword:     account.Password,
 	}
+	// TODO(ale8k): Fix this...
+	// If the controller cannot be reached, we'll end up with dangling resources to a now no-longer accessible controller (from the clients perspective).
+	// So... Find a nice way to remove controllers if the add fail / clean up dangling ones later.
+	// Once fixed, this can be tested by just making the controller addr something that doesn't exist, and we can test the solution.
 	if err := b.jujuManager.AddController(
 		ctx,
 		user,

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -307,7 +307,6 @@ func (b *bootstrapManager) BootstrapJob(
 			return errors.E(fmt.Errorf("failed to check if controller exists: %w", err))
 		}
 
-		// TODO(ale8k): When downloading, it takes a while and the CLI has no output. Download progress would be a VERY nice to have here.
 		binary, err := b.binaryStore.Get(
 			ctx,
 			jujuclistore.JujuBinarySpec{
@@ -323,9 +322,7 @@ func (b *bootstrapManager) BootstrapJob(
 		if err != nil {
 			return errors.E(fmt.Errorf("failed to get Juju binary: %w", err))
 		}
-		// TODO(ale8k): Is it possible to tell the client to only attempt to get status after binary is downloaded?
-		// Because as it stands, the client will be unncessarily polling (perhaps we could put download progress in the logs?).
-		// That way the status calls wouldn't be unncessary and serve a purpose.
+
 		zapctx.Debug(logCtx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 		defer binaryDone(binary)
 
@@ -396,12 +393,6 @@ func (b *bootstrapManager) runBootstrap(
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to get controller details: %w", err))
 	}
-	// TODO(ale8k): At the moment, we can't reach added k8s controllers because the controller is not reachable.
-	// The CLI spins up a kube-proxy to reach it and we could do the same. The controller details of said controller
-	// may contain proxy details and those proxy details can be used to launch a proxy to contact the controller.
-	// Accessed like so: [ctrlDetails.Proxy.Proxier.Start].
-	//
-	// As such, AddController fails.
 
 	hps, err := network.ParseProviderHostPorts(ctrlDetails.APIEndpoints...)
 	if err != nil {
@@ -430,10 +421,7 @@ func (b *bootstrapManager) runBootstrap(
 		AdminIdentityName: account.User,
 		AdminPassword:     account.Password,
 	}
-	// TODO(ale8k): Fix this...
-	// If the controller cannot be reached, we'll end up with dangling resources to a now no-longer accessible controller (from the clients perspective).
-	// So... Find a nice way to remove controllers if the add fail / clean up dangling ones later.
-	// Once fixed, this can be tested by just making the controller addr something that doesn't exist, and we can test the solution.
+
 	if err := b.jujuManager.AddController(
 		ctx,
 		user,

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -54,6 +54,7 @@ var (
 
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,
 	}
+	//nolint:gosec
 	loginTokenRefreshURLParam = "jimm.com/.well-known/jwks.json"
 )
 

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"runtime"
 	"testing"
 	"time"
 
@@ -35,23 +36,25 @@ type bootstrapManagerSuite struct {
 	jobTracker *jobtracker.Tracker
 	adminUser  *openfga.User
 	db         *db.Database
-	ofgaClient *openfga.OFGAClient
 }
 
 var (
 	jobParams = bootstrap.JobParams{
-		JujuDataDir:          "/path/to/a/juju/data/dir",
-		CLIVersion:           "3.6.9",
-		CLIOs:                "linux",
-		CLIArch:              "aarch64",
-		CloudNameAndRegion:   "special-cloud",
-		ControllerName:       "a",
-		AgentVersion:         "3.6.3",
-		BootstrapTimeout:     0,
-		CloudCred:            jujucloud.CloudCredential{},
-		PersonalCloud:        jujucloud.Cloud{},
-		LoginTokenRefreshURL: "jimm.com/.well-known/jwks.json",
+		JujuDataDir: "/path/to/a/juju/data/dir",
+
+		CLIVersion: "3.6.9",
+
+		CloudNameAndRegion: "special-cloud",
+		ControllerName:     "a",
+		AgentVersion:       "3.6.3",
+		BootstrapTimeout:   0,
+
+		CloudCred:     jujucloud.CloudCredential{},
+		PersonalCloud: jujucloud.Cloud{},
+
+		LoginTokenRefreshURL: loginTokenRefreshURLParam,
 	}
+	loginTokenRefreshURLParam = "jimm.com/.well-known/jwks.json"
 )
 
 func pollJob(c *qt.C, s *bootstrapManagerSuite, id uuid.UUID, expectedStatus dbmodel.JobStatus) {
@@ -108,11 +111,6 @@ func (s *bootstrapManagerSuite) Init(c *qt.C) {
 
 	s.db = db
 
-	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
-	c.Assert(err, qt.IsNil)
-
-	s.ofgaClient = ofgaClient
-
 	jobtracker, err := jobtracker.New(db, 1*time.Minute)
 	s.jobTracker = jobtracker
 	c.Assert(err, qt.IsNil)
@@ -128,7 +126,7 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs(c *qt.C) {
 	ctrl, _, jujuManager, binaryStore, _, _, _ := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, s.db, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	numLogs := 101
@@ -184,7 +182,7 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobFailed(c *qt.C)
 	ctrl, _, jujuManager, binaryStore, _, _, _ := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, s.db, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	jobId, err := s.jobTracker.Run(ctx,
@@ -215,11 +213,16 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.
 	ctrl, _, jujuManager, binaryStore, _, _, _ := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, s.db, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	_, err = manager.GetBootstrapStatusAndLogs(ctx, s.adminUser, jobId, 0)
 	c.Assert(err, qt.ErrorMatches, "failed to get job status")
+}
+
+// TODO
+func (s *bootstrapManagerSuite) TestStartBootstrap(c *qt.C) {
+
 }
 
 func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
@@ -239,7 +242,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -255,8 +258,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		binary,
@@ -354,7 +357,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_FailsToLock(c *qt.C) {
 	ctrl, store, jujuManager, binaryStore, executor, _, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -384,7 +387,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ControllerExists(c *qt.C) {
 	ctrl, store, jujuManager, binaryStore, executor, _, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -419,7 +422,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ControllerRetrievalFails(c *qt.
 	ctrl, store, jujuManager, binaryStore, executor, _, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -454,7 +457,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 	ctrl, store, jujuManager, binaryStore, executor, _, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -469,8 +472,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		nil,
@@ -504,7 +507,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorRunWrapperFails(c *qt.C
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -519,8 +522,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorRunWrapperFails(c *qt.C
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		&jujuclistore.Binary{FullPath: binaryPath},
@@ -577,7 +580,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -593,8 +596,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		&jujuclistore.Binary{FullPath: binaryPath},
@@ -626,6 +629,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		},
 		nil,
 	).Times(1)
+	store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), testOutputLineError).Return(nil).Times(1)
 	store.EXPECT().UnlockBootstrap(gomock.Any()).Return(nil).Times(1)
 
 	job := manager.BootstrapJob(
@@ -656,7 +660,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -672,8 +676,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		&jujuclistore.Binary{FullPath: binaryPath},
@@ -756,7 +760,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -772,8 +776,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		&jujuclistore.Binary{FullPath: binaryPath},
@@ -856,7 +860,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 	ctrl, store, jujuManager, binaryStore, executor, clientStore, user := setupMocks(c)
 	defer ctrl.Finish()
 
-	manager, err := bootstrap.NewBootstrapManager(s.ofgaClient, store, s.jobTracker, jujuManager, binaryStore)
+	manager, err := bootstrap.NewBootstrapManager(store, s.jobTracker, jujuManager, binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
 	// Mocked in order of execution:
@@ -872,8 +876,8 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		gomock.Any(),
 		jujuclistore.JujuBinarySpec{
 			Version: jobParams.CLIVersion,
-			Os:      jobParams.CLIVersion,
-			Arch:    jobParams.CLIArch,
+			Os:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 		},
 	).Return(
 		&jujuclistore.Binary{FullPath: binaryPath},

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -220,11 +220,6 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.
 	c.Assert(err, qt.ErrorMatches, "failed to get job status")
 }
 
-// TODO
-func (s *bootstrapManagerSuite) TestStartBootstrap(c *qt.C) {
-
-}
-
 func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 	testCtx := c.Context()
 

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -22,8 +22,7 @@ type BootstrapParams struct {
 	BootstrapTimeout   int
 
 	CloudCred jujucloud.CloudCredential
-	// PersonalCloud is the personally defined cloud. Only necessary if the cloud is not a public
-	// cloud.
+	// PersonalCloud is the cloud-definition for a non-public cloud.
 	PersonalCloud jujucloud.Cloud
 }
 

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -6,33 +6,56 @@ import (
 	"fmt"
 	"strings"
 
+	jujucloud "github.com/juju/juju/cloud"
+	semversion "github.com/juju/version"
+
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 // BootstrapParams defines the parameters required for bootstrapping a JIMM controller.
 type BootstrapParams struct {
-	ControllerName string
-	CloudName      string
-	CloudRegion    string
-	AgentVersion   string
-	TimeoutSeconds int
+	CLIVersion string
+
+	CloudNameAndRegion string
+	ControllerName     string
+	AgentVersion       string
+	BootstrapTimeout   int
+
+	CloudCred jujucloud.CloudCredential
+	// PersonalCloud is the personally defined cloud. Only necessary if the cloud is not a public
+	// cloud.
+	PersonalCloud jujucloud.Cloud
 }
 
 // Validate checks if the BootstrapParams are valid.
 func (p BootstrapParams) validate() error {
 	var msgs []string
+	if p.CLIVersion == "" {
+		msgs = append(msgs, "CLI version cannot be empty")
+	}
+	if p.CloudNameAndRegion == "" {
+		msgs = append(msgs, "cloud name and region cannot be empty")
+	}
 	if p.ControllerName == "" {
 		msgs = append(msgs, "controller name cannot be empty")
 	}
-	if p.CloudName == "" {
-		msgs = append(msgs, "cloud name cannot be empty")
+	if p.AgentVersion != "" {
+		if _, err := semversion.Parse(p.AgentVersion); err != nil {
+			msgs = append(msgs, fmt.Sprintf("invalid agent version: %v", err))
+		}
 	}
-	if p.CloudRegion == "" {
-		msgs = append(msgs, "cloud region cannot be empty")
+	if p.BootstrapTimeout < 0 {
+		msgs = append(msgs, "bootstrap timeout cannot be less than zero")
 	}
-	if p.AgentVersion == "" {
-		msgs = append(msgs, "agent version cannot be empty")
+
+	// Don't validate cloud or cloud cred. Juju knows better how to validate those.
+	// And will return a better validation error if they are invalid.
+
+	if len(msgs) == 0 {
+		return nil
 	}
+
+	// If there are validation errors, return them as a single error.
 	if msgs != nil {
 		return errors.E(fmt.Sprintf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n")))
 	}

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -11,13 +11,16 @@ import (
 func TestValidateBootstrapParams_AllValid(t *testing.T) {
 	c := qt.New(t)
 	params := BootstrapParams{
-		ControllerName: "ctrl",
-		CloudName:      "cloud",
-		CloudRegion:    "region",
-		AgentVersion:   "1.2.3",
-		TimeoutSeconds: 60,
+		CLIVersion: "1.0.0",
+
+		CloudNameAndRegion: "cloud/region",
+		ControllerName:     "my-controller",
+		AgentVersion:       "1.2.3",
+		BootstrapTimeout:   60,
+		// CloudCred & PersonalCloud are not validated.
 	}
 	c.Assert(params.validate(), qt.IsNil)
+
 }
 
 func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
@@ -25,52 +28,69 @@ func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
 		name   string
 		params BootstrapParams
 		want   []string
-	}{
+	}{ // do agent and bs timeout
 		{
 			name:   "all empty",
 			params: BootstrapParams{},
 			want: []string{
+				"CLI version cannot be empty",
+				"cloud name and region cannot be empty",
 				"controller name cannot be empty",
-				"cloud name cannot be empty",
-				"cloud region cannot be empty",
-				"agent version cannot be empty",
 			},
 		},
 		{
-			name: "missing controller name",
+			name: "cli version empty",
 			params: BootstrapParams{
-				CloudName:    "cloud",
-				CloudRegion:  "region",
-				AgentVersion: "1.2.3",
+				CloudNameAndRegion: "cloud/region",
+				ControllerName:     "my-controller",
 			},
-			want: []string{"controller name cannot be empty"},
+			want: []string{
+				"CLI version cannot be empty",
+			},
 		},
 		{
-			name: "missing cloud name",
+			name: "cloud name and region empty",
 			params: BootstrapParams{
-				ControllerName: "ctrl",
-				CloudRegion:    "region",
-				AgentVersion:   "1.2.3",
+				CLIVersion:     "1.0.0",
+				ControllerName: "my-controller",
 			},
-			want: []string{"cloud name cannot be empty"},
+			want: []string{
+				"cloud name and region cannot be empty",
+			},
 		},
 		{
-			name: "missing cloud region",
+			name: "controller name empty",
 			params: BootstrapParams{
-				ControllerName: "ctrl",
-				CloudName:      "cloud",
-				AgentVersion:   "1.2.3",
+				CLIVersion:         "1.0.0",
+				CloudNameAndRegion: "cloud/region",
 			},
-			want: []string{"cloud region cannot be empty"},
+			want: []string{
+				"controller name cannot be empty",
+			},
 		},
 		{
-			name: "missing agent version",
+			name: "agent version invalid",
 			params: BootstrapParams{
-				ControllerName: "ctrl",
-				CloudName:      "cloud",
-				CloudRegion:    "region",
+				CLIVersion:         "1.0.0",
+				CloudNameAndRegion: "cloud/region",
+				ControllerName:     "my-controller",
+				AgentVersion:       "invalid-version",
 			},
-			want: []string{"agent version cannot be empty"},
+			want: []string{
+				"invalid-version",
+			},
+		},
+		{
+			name: "bootstrap timeout negative",
+			params: BootstrapParams{
+				CLIVersion:         "1.0.0",
+				CloudNameAndRegion: "cloud/region",
+				ControllerName:     "my-controller",
+				BootstrapTimeout:   -1,
+			},
+			want: []string{
+				"bootstrap timeout cannot be less than zero",
+			},
 		},
 	}
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -525,11 +525,11 @@ func New(p Parameters) (*JIMM, error) {
 		return nil, err
 	}
 	bootstrapManager, err := bootstrap.NewBootstrapManager(
-		j.OpenFGAClient,
 		j.Database,
 		jobTracker,
 		j.jujuManager,
 		binaryStore,
+		"fixed-later",
 	)
 	if err != nil {
 		return nil, err

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -625,12 +625,22 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
+	cloudNameAndRegion := req.CloudName
+
+	if req.RegionName != "" {
+		cloudNameAndRegion = fmt.Sprintf("%s/%s", req.CloudName, req.RegionName)
+	}
+
 	params := bootstrap.BootstrapParams{
-		ControllerName: req.ControllerName,
-		CloudName:      req.CloudName,
-		CloudRegion:    req.RegionName,
-		AgentVersion:   req.Flags.AgentVersion,
-		TimeoutSeconds: req.Flags.Timeout,
+		CLIVersion: "3.6.8",
+
+		CloudNameAndRegion: cloudNameAndRegion,
+		ControllerName:     req.ControllerName,
+		AgentVersion:       req.Flags.AgentVersion,
+		BootstrapTimeout:   req.Flags.Timeout,
+
+		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
+		CloudCred:     req.Credential,
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)

--- a/internal/jujuapi/jimm_relation.go
+++ b/internal/jujuapi/jimm_relation.go
@@ -1,3 +1,0 @@
-// Copyright 2025 Canonical.
-
-package jujuapi

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	jujucloud "github.com/juju/juju/cloud"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
 
@@ -201,6 +203,9 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 			AgentVersion: "1.0.0",
 			Timeout:      3600,
 		},
+		Cloud:      jujuparams.Cloud{},
+		Credential: jujucloud.CloudCredential{},
+		CLIVersion: "3.6.8",
 	}
 
 	response, err := root.BootstrapStart(ctx, params)

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -203,9 +203,9 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 			AgentVersion: "1.0.0",
 			Timeout:      3600,
 		},
-		Cloud:      jujuparams.Cloud{},
-		Credential: jujucloud.CloudCredential{},
-		CLIVersion: "3.6.8",
+		Cloud:             jujuparams.Cloud{},
+		Credential:        jujucloud.CloudCredential{},
+		ControllerVersion: "3.6.8",
 	}
 
 	response, err := root.BootstrapStart(ctx, params)


### PR DESCRIPTION
## Description
Based on: #1679

This PR implements StartBootstrap. It also updates the params to just use CLI version and include the cloud and credential. 

It also fixes the OS set for the binary downloaded and fixes where we didn't log the error line (so the CLI looked like it just failed randomly in Q/A). 

I've intentionally omitted writing the test for StartBootstrap as the vast majority is in BootstrapJob. 

There's a few todos scattered around that I'm going to create cards for following this PR. So please ignore them.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
