### PR TITLE
Update bootstrap start cli command

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -35,13 +35,11 @@ logs are streamed to stdout.
 Use the --detach flag to start the bootstrap job and return immediately,
 printing only the job ID, without waiting for the job to complete.
 
-The final argument, version, denotes the version of the Juju CLI
-to use for the bootstrap behind the scenes when bootstrapping via JIMM.
+The final argument, version, denotes the Juju controller to be bootstrapped.
 `
 	bootstrapExamples = `
-	juju [jaas] bootstrap <cloud[/region]> <controller name> <cli version>
+	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
-	juju [jaas] bootstrap mycloud/region mycontroller 3.6.9 --agent-version=3.6.8
 `
 )
 
@@ -53,13 +51,12 @@ type bootstrapCommand struct {
 	store            jujuclient.ClientStore
 	bootstrapAPIFunc func() (JIMMAPI, error)
 
-	cloud          string
-	region         string
-	controllerName string
-	cliVersion     string
-	agentVersion   string
-	timeout        int
-	detach         bool
+	cloud             string
+	region            string
+	controllerName    string
+	controllerVersion string
+	timeout           int
+	detach            bool
 }
 
 // NewBootstrapStartCommand returns a command to start a job
@@ -86,7 +83,7 @@ func (c *bootstrapCommand) Init(args []string) error {
 		return fmt.Errorf("cloud name %q not valid", c.cloud)
 	}
 	c.controllerName = args[1]
-	c.cliVersion = args[2]
+	c.controllerVersion = args[2]
 
 	return nil
 }
@@ -98,7 +95,6 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml": cmd.FormatYaml,
 		"json": cmd.FormatJson,
 	})
-	f.StringVar(&c.agentVersion, "agent-version", "", "The version of the Juju agent to use for the bootstrap.")
 	f.IntVar(&c.timeout, "timeout", 0, "The timeout in seconds for the bootstrap operation.")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
 	// TODO(ale8k): Support passing cloud & cloudcredential files, for now we're looking up clouds and credentials added to the store.
@@ -142,16 +138,15 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	req := apiparams.BootstrapStartParams{
-		CloudName:      c.cloud,
-		RegionName:     c.region,
-		ControllerName: c.controllerName,
-		CLIVersion:     c.cliVersion,
-		Cloud:          cloudToParams(*bootstrapCloud),
-		Credential:     *bootstrapCredential,
+		CloudName:         c.cloud,
+		RegionName:        c.region,
+		ControllerName:    c.controllerName,
+		ControllerVersion: c.controllerVersion,
+		Cloud:             cloudToParams(*bootstrapCloud),
+		Credential:        *bootstrapCredential,
 
 		Flags: apiparams.BootstrapFlags{
-			AgentVersion: c.agentVersion,
-			Timeout:      c.timeout,
+			Timeout: c.timeout,
 		},
 	}
 
@@ -168,7 +163,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 
 	if c.detach {
 		fmt.Printf(`
-Bootstrap job started successfully.
+Bootstrap job started.
 You can track the progress via bootstrap-status with the job ID:
 	juju [jaas] bootstrap-status %s
 

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
+	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 
 	jimmAPI "github.com/canonical/jimm/v3/pkg/api"
@@ -31,10 +34,14 @@ logs are streamed to stdout.
 
 Use the --detach flag to start the bootstrap job and return immediately,
 printing only the job ID, without waiting for the job to complete.
+
+The final argument, version, denotes the version of the Juju CLI
+to use for the bootstrap behind the scenes when bootstrapping via JIMM.
 `
 	bootstrapExamples = `
-	juju [jaas] bootstrap mycloud/region mycontroller
-	juju [jaas] bootstrap mycloud/region mycontroller --agent-version=3.6.8
+	juju [jaas] bootstrap <cloud[/region]> <controller name> <cli version>
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.9 --agent-version=3.6.8
 `
 )
 
@@ -49,6 +56,7 @@ type bootstrapCommand struct {
 	cloud          string
 	region         string
 	controllerName string
+	cliVersion     string
 	agentVersion   string
 	timeout        int
 	detach         bool
@@ -67,8 +75,8 @@ func NewBootstrapStartCommand() cmd.Command {
 
 // Init implements modelcmd.Command.
 func (c *bootstrapCommand) Init(args []string) error {
-	if len(args) < 2 {
-		return fmt.Errorf("expected at least 2 arguments, got %d", len(args))
+	if len(args) < 3 {
+		return fmt.Errorf("expected at least 3 arguments, got %d", len(args))
 	}
 	c.cloud = args[0]
 	if i := strings.IndexRune(c.cloud, '/'); i > 0 {
@@ -78,6 +86,7 @@ func (c *bootstrapCommand) Init(args []string) error {
 		return fmt.Errorf("cloud name %q not valid", c.cloud)
 	}
 	c.controllerName = args[1]
+	c.cliVersion = args[2]
 
 	return nil
 }
@@ -92,13 +101,15 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.agentVersion, "agent-version", "", "The version of the Juju agent to use for the bootstrap.")
 	f.IntVar(&c.timeout, "timeout", 0, "The timeout in seconds for the bootstrap operation.")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
+	// TODO(ale8k): Support passing cloud & cloudcredential files, for now we're looking up clouds and credentials added to the store.
+	// See cmd/juju/cloud/add.go L311 on a nice way to do this and credential will be somewhere in there too.
 }
 
 // Info implements modelcmd.Command.
 func (c *bootstrapCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "bootstrap",
-		Args:     "<cloud name>[/region] <controller name>",
+		Args:     "<cloud name>[/region] <controller name> <juju version>",
 		Purpose:  "Bootstrap a Juju controller via JIMM",
 		Doc:      bootstrapDoc,
 		Examples: bootstrapExamples,
@@ -107,10 +118,37 @@ func (c *bootstrapCommand) Info() *cmd.Info {
 
 // Run implements modelcmd.Command.
 func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
+
+	// Check built in clouds like localhost (lxd).
+	builtinClouds, err := common.BuiltInClouds()
+	if err != nil {
+		return err
+	}
+
+	if _, isABuiltinCloud := builtinClouds[c.cloud]; isABuiltinCloud {
+		return fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", c.cloud)
+	}
+
+	// We use [jujucloud.CloudByName] and not [common.CloudByName] as the JIMM bootstrap
+	// will NOT support builtin clouds (localhost, microk8s, docker-desktop, etc.).
+	bootstrapCloud, err := jujucloud.CloudByName(c.cloud)
+	if err != nil {
+		return fmt.Errorf("failed to get cloud %q: %w", c.cloud, err)
+	}
+
+	bootstrapCredential, err := c.store.CredentialForCloud(c.cloud)
+	if err != nil {
+		return fmt.Errorf("failed to get credential for cloud %q: %w", c.cloud, err)
+	}
+
 	req := apiparams.BootstrapStartParams{
 		CloudName:      c.cloud,
 		RegionName:     c.region,
 		ControllerName: c.controllerName,
+		CLIVersion:     c.cliVersion,
+		Cloud:          cloudToParams(*bootstrapCloud),
+		Credential:     *bootstrapCredential,
+
 		Flags: apiparams.BootstrapFlags{
 			AgentVersion: c.agentVersion,
 			Timeout:      c.timeout,
@@ -128,15 +166,34 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 
-	err = c.out.Write(ctxt, resp)
-	if err != nil {
-		return err
+	if c.detach {
+		fmt.Printf(`
+Bootstrap job started successfully.
+You can track the progress via bootstrap-status with the job ID:
+	juju [jaas] bootstrap-status %s
+
+	`,
+			resp.JobID,
+		)
+	} else {
+		fmt.Printf(`
+Starting bootstrap job.
+
+Should you cancel this process, you can track the progress via bootstrap-status with the job ID:
+	juju [jaas] bootstrap-status %s
+
+	`,
+			resp.JobID,
+		)
 	}
+
 	if c.detach {
 		return nil
 	}
+
 	// Don't use c.out for the logs since c.out
 	// attempts to format the output.
+
 	poller := logPoller{
 		client:              client,
 		jobId:               resp.JobID,
@@ -144,6 +201,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		out:                 ctxt.Stdout,
 		follow:              true,
 	}
+
 	return poller.watchBootstrapLogs()
 }
 
@@ -159,4 +217,43 @@ func (c *bootstrapCommand) newClient() (JIMMAPI, error) {
 	}
 
 	return jimmAPI.NewClient(apiCaller), nil
+}
+
+// CloudToParams converts a jujucloud.Cloud to a jujuparams.Cloud.
+// Copied from api/client/cloud/cloud.go.
+func cloudToParams(cloud jujucloud.Cloud) jujuparams.Cloud {
+	authTypes := make([]string, len(cloud.AuthTypes))
+	for i, authType := range cloud.AuthTypes {
+		authTypes[i] = string(authType)
+	}
+	regions := make([]jujuparams.CloudRegion, len(cloud.Regions))
+	for i, region := range cloud.Regions {
+		regions[i] = jujuparams.CloudRegion{
+			Name:             region.Name,
+			Endpoint:         region.Endpoint,
+			IdentityEndpoint: region.IdentityEndpoint,
+			StorageEndpoint:  region.StorageEndpoint,
+		}
+	}
+	var regionConfig map[string]map[string]interface{}
+	for r, attr := range cloud.RegionConfig {
+		if regionConfig == nil {
+			regionConfig = make(map[string]map[string]interface{})
+		}
+		regionConfig[r] = attr
+	}
+	return jujuparams.Cloud{
+		Type:              cloud.Type,
+		HostCloudRegion:   cloud.HostCloudRegion,
+		AuthTypes:         authTypes,
+		Endpoint:          cloud.Endpoint,
+		IdentityEndpoint:  cloud.IdentityEndpoint,
+		StorageEndpoint:   cloud.StorageEndpoint,
+		Regions:           regions,
+		CACertificates:    cloud.CACertificates,
+		SkipTLSVerify:     cloud.SkipTLSVerify,
+		Config:            cloud.Config,
+		RegionConfig:      regionConfig,
+		IsControllerCloud: cloud.IsControllerCloud,
+	}
 }

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/gnuflag"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -114,17 +113,6 @@ func (c *bootstrapCommand) Info() *cmd.Info {
 
 // Run implements modelcmd.Command.
 func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
-
-	// Check built in clouds like localhost (lxd).
-	builtinClouds, err := common.BuiltInClouds()
-	if err != nil {
-		return err
-	}
-
-	if _, isABuiltinCloud := builtinClouds[c.cloud]; isABuiltinCloud {
-		return fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", c.cloud)
-	}
-
 	// We use [jujucloud.CloudByName] and not [common.CloudByName] as the JIMM bootstrap
 	// will NOT support builtin clouds (localhost, microk8s, docker-desktop, etc.).
 	bootstrapCloud, err := jujucloud.CloudByName(c.cloud)

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -43,30 +43,29 @@ func (s *bootstrapCmdSuite) TestArgParsing(c *gc.C) {
 		errMatch   string
 	}{
 		{
-			args: []string{"test-cloud", "controller-name", "cli-version"},
+			args: []string{"test-cloud", "controller-name", "controller-version"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
-				c.Check(command.cliVersion, gc.Equals, "cli-version")
+				c.Check(command.controllerVersion, gc.Equals, "controller-version")
 			},
 		},
 		{
-			args: []string{"test-cloud/region", "controller-name", "cli-version"},
+			args: []string{"test-cloud/region", "controller-name", "controller-version"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "region")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
-				c.Check(command.cliVersion, gc.Equals, "cli-version")
+				c.Check(command.controllerVersion, gc.Equals, "controller-version")
 			},
 		}, {
-			args: []string{"test-cloud/region", "controller-name", "cli-version", "--agent-version=3.6.8", "--timeout=60", "--detach"},
+			args: []string{"test-cloud/region", "controller-name", "controller-version", "--timeout=60", "--detach"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "region")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
-				c.Check(command.cliVersion, gc.Equals, "cli-version")
-				c.Check(command.agentVersion, gc.Equals, "3.6.8")
+				c.Check(command.controllerVersion, gc.Equals, "controller-version")
 				c.Check(command.timeout, gc.Equals, 60)
 				c.Check(command.detach, gc.Equals, true)
 			},
@@ -108,10 +107,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 				DefaultCredential: "default-cred-value-for-test",
 			},
 			Flags: params.BootstrapFlags{
-				AgentVersion: "3.6.8",
-				Timeout:      60,
+				Timeout: 60,
 			},
-			CLIVersion: "cli-version",
+			ControllerVersion: "controller-version",
 		}
 		c.Assert(bsp.ControllerName, gc.Equals, expected.ControllerName)
 		c.Assert(bsp.CloudName, gc.Equals, expected.CloudName)
@@ -120,9 +118,8 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 		// So we expect just ec2 and it should be ok.
 		c.Assert(bsp.Cloud.Type, gc.DeepEquals, "ec2")
 		c.Assert(bsp.Credential, gc.DeepEquals, expected.Credential)
-		c.Assert(bsp.Flags.AgentVersion, gc.Equals, expected.Flags.AgentVersion)
 		c.Assert(bsp.Flags.Timeout, gc.Equals, expected.Flags.Timeout)
-		c.Assert(bsp.CLIVersion, gc.Equals, expected.CLIVersion)
+		c.Assert(bsp.ControllerVersion, gc.Equals, expected.ControllerVersion)
 
 		return &params.BootstrapStartResponse{
 			JobID: "test-job-id",
@@ -142,8 +139,7 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 	command.controllerName = "controller-name"
 	command.cloud = cloudName
 	command.region = "region"
-	command.cliVersion = "cli-version"
-	command.agentVersion = "3.6.8"
+	command.controllerVersion = "controller-version"
 	command.timeout = 60
 	command.detach = true
 
@@ -216,7 +212,7 @@ func (s *bootstrapCmdSuite) TestBootstrapRejectsBuiltinClouds(c *gc.C) {
 	command.controllerName = "controller-name"
 	command.cloud = "localhost" // A built-in cloud.
 	command.region = "region"
-	command.cliVersion = "cli-version"
+	command.controllerVersion = "controller-version"
 
 	ctx := &cmd.Context{
 		Context: context.Background(),
@@ -245,7 +241,7 @@ func (s *bootstrapCmdSuite) TestBootstrapFailsToGetCredential(c *gc.C) {
 	command.controllerName = "controller-name"
 	command.cloud = "aws" // Need a valid cloud to reach credential error.
 	command.region = "region"
-	command.cliVersion = "cli-version"
+	command.controllerVersion = "controller-version"
 
 	ctx := &cmd.Context{
 		Context: context.Background(),

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -200,29 +200,6 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapCmdSuite) TestBootstrapRejectsBuiltinClouds(c *gc.C) {
-	command := &bootstrapCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
-			return s.client, nil
-		},
-	}
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	f.SetOutput(s.writer)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = "localhost" // A built-in cloud.
-	command.region = "region"
-	command.controllerVersion = "controller-version"
-
-	ctx := &cmd.Context{
-		Context: context.Background(),
-		Stdout:  s.writer,
-	}
-
-	err := command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, `bootstrap via JIMM does not support built-in clouds like "localhost"`)
-}
-
 func (s *bootstrapCmdSuite) TestBootstrapFailsToGetCredential(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -4,12 +4,14 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/gnuflag"
+	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
@@ -20,6 +22,7 @@ import (
 type bootstrapCmdSuite struct {
 	client *mocks.MockJIMMAPI
 	writer *mocks.MockWriter
+	store  *mocks.MockClientStore
 }
 
 var _ = gc.Suite(&bootstrapCmdSuite{})
@@ -28,6 +31,7 @@ func (s *bootstrapCmdSuite) SetupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.client = mocks.NewMockJIMMAPI(ctrl)
 	s.writer = mocks.NewMockWriter(ctrl)
+	s.store = mocks.NewMockClientStore(ctrl)
 
 	return ctrl
 }
@@ -39,33 +43,36 @@ func (s *bootstrapCmdSuite) TestArgParsing(c *gc.C) {
 		errMatch   string
 	}{
 		{
-			args: []string{"test-cloud", "controller-name"},
+			args: []string{"test-cloud", "controller-name", "cli-version"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
+				c.Check(command.cliVersion, gc.Equals, "cli-version")
 			},
 		},
 		{
-			args: []string{"test-cloud/region", "controller-name"},
+			args: []string{"test-cloud/region", "controller-name", "cli-version"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "region")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
+				c.Check(command.cliVersion, gc.Equals, "cli-version")
 			},
 		}, {
-			args: []string{"test-cloud/region", "controller-name", "--agent-version=3.6.8", "--timeout=60", "--detach"},
+			args: []string{"test-cloud/region", "controller-name", "cli-version", "--agent-version=3.6.8", "--timeout=60", "--detach"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "region")
 				c.Check(command.controllerName, gc.Equals, "controller-name")
+				c.Check(command.cliVersion, gc.Equals, "cli-version")
 				c.Check(command.agentVersion, gc.Equals, "3.6.8")
 				c.Check(command.timeout, gc.Equals, 60)
 				c.Check(command.detach, gc.Equals, true)
 			},
 		}, {
 			args:     []string{"test-cloud/region"},
-			errMatch: "expected at least 2 arguments, got 1",
+			errMatch: "expected at least 3 arguments, got 1",
 		},
 	}
 	for i, test := range tests {
@@ -86,27 +93,45 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
+	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		DefaultCredential: "default-cred-value-for-test",
+	}, nil)
 	s.client.EXPECT().Bootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
-		c.Assert(bsp.ControllerName, gc.Equals, "controller-name")
-		c.Assert(bsp.CloudName, gc.Equals, "test-cloud")
-		c.Assert(bsp.RegionName, gc.Equals, "region")
-		c.Assert(bsp.Flags.AgentVersion, gc.Equals, "3.6.8")
-		c.Assert(bsp.Flags.Timeout, gc.Equals, 60)
+		expected := &params.BootstrapStartParams{
+			ControllerName: "controller-name",
+			CloudName:      cloudName,
+			RegionName:     "region",
+			Cloud:          jujuparams.Cloud{},
+			Credential: jujucloud.CloudCredential{
+				DefaultCredential: "default-cred-value-for-test",
+			},
+			Flags: params.BootstrapFlags{
+				AgentVersion: "3.6.8",
+				Timeout:      60,
+			},
+			CLIVersion: "cli-version",
+		}
+		c.Assert(bsp.ControllerName, gc.Equals, expected.ControllerName)
+		c.Assert(bsp.CloudName, gc.Equals, expected.CloudName)
+		c.Assert(bsp.RegionName, gc.Equals, expected.RegionName)
+		// AWS is dynamically populated, i.e., 32 regions.
+		// So we expect just ec2 and it should be ok.
+		c.Assert(bsp.Cloud.Type, gc.DeepEquals, "ec2")
+		c.Assert(bsp.Credential, gc.DeepEquals, expected.Credential)
+		c.Assert(bsp.Flags.AgentVersion, gc.Equals, expected.Flags.AgentVersion)
+		c.Assert(bsp.Flags.Timeout, gc.Equals, expected.Flags.Timeout)
+		c.Assert(bsp.CLIVersion, gc.Equals, expected.CLIVersion)
+
 		return &params.BootstrapStartResponse{
 			JobID: "test-job-id",
 		}, nil
 	})
 	s.client.EXPECT().Close().Return(nil)
 
-	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
-		resp := &params.BootstrapStartResponse{}
-		err := json.Unmarshal(b, resp)
-		c.Check(err, gc.IsNil)
-		c.Check(resp.JobID, gc.Equals, "test-job-id")
-		return len(b), nil
-	})
-
 	command := &bootstrapCommand{
+		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
@@ -115,8 +140,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 	f.SetOutput(s.writer)
 	command.SetFlags(f)
 	command.controllerName = "controller-name"
-	command.cloud = "test-cloud"
+	command.cloud = cloudName
 	command.region = "region"
+	command.cliVersion = "cli-version"
 	command.agentVersion = "3.6.8"
 	command.timeout = 60
 	command.detach = true
@@ -134,17 +160,13 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
+	s.store.EXPECT().CredentialForCloud("aws").Return(&jujucloud.CloudCredential{
+		DefaultCredential: "default-cred-value-for-test",
+	}, nil)
 	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{
 		JobID: "test-job-id",
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
-	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
-		resp := &params.BootstrapStartResponse{}
-		err := json.Unmarshal(b, resp)
-		c.Check(err, gc.IsNil)
-		c.Check(resp.JobID, gc.Equals, "test-job-id")
-		return len(b), nil
-	})
 
 	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
 		Status:    params.StatusSuccessful,
@@ -163,6 +185,7 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	})
 
 	command := &bootstrapCommand{
+		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
@@ -170,6 +193,7 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	f.SetOutput(s.writer)
 	command.SetFlags(f)
+	command.cloud = "aws"
 
 	ctx := &cmd.Context{
 		Context: context.Background(),
@@ -178,4 +202,56 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 
 	err := command.Run(ctx)
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *bootstrapCmdSuite) TestBootstrapRejectsBuiltinClouds(c *gc.C) {
+	command := &bootstrapCommand{
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	command.SetFlags(f)
+	command.controllerName = "controller-name"
+	command.cloud = "localhost" // A built-in cloud.
+	command.region = "region"
+	command.cliVersion = "cli-version"
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+
+	err := command.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, `bootstrap via JIMM does not support built-in clouds like "localhost"`)
+}
+
+func (s *bootstrapCmdSuite) TestBootstrapFailsToGetCredential(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	s.store.EXPECT().CredentialForCloud("aws").Return(nil, errors.New("credential not found"))
+
+	command := &bootstrapCommand{
+		store: s.store,
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	command.SetFlags(f)
+	command.controllerName = "controller-name"
+	command.cloud = "aws" // Need a valid cloud to reach credential error.
+	command.region = "region"
+	command.cliVersion = "cli-version"
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+
+	err := command.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, `failed to get credential for cloud "aws": credential not found`)
 }

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -56,6 +56,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
 	jaasCmd.Register(cmd.NewBootstrapStatusCommand())
+	jaasCmd.Register(cmd.NewBootstrapStartCommand())
 	return jaasCmd
 }
 

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -307,6 +307,7 @@ func (b *bootstrapManager) BootstrapJob(
 			return errors.E(fmt.Errorf("failed to check if controller exists: %w", err))
 		}
 
+		// TODO(ale8k): When downloading, it takes a while and the CLI has no output. Download progress would be a VERY nice to have here.
 		binary, err := b.binaryStore.Get(
 			ctx,
 			jujuclistore.JujuBinarySpec{
@@ -322,7 +323,6 @@ func (b *bootstrapManager) BootstrapJob(
 		if err != nil {
 			return errors.E(fmt.Errorf("failed to get Juju binary: %w", err))
 		}
-
 		zapctx.Debug(logCtx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 		defer binaryDone(binary)
 
@@ -393,6 +393,12 @@ func (b *bootstrapManager) runBootstrap(
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to get controller details: %w", err))
 	}
+	// TODO(ale8k): At the moment, we can't reach added k8s controllers because the controller is not reachable.
+	// The CLI spins up a kube-proxy to reach it and we could do the same. The controller details of said controller
+	// may contain proxy details and those proxy details can be used to launch a proxy to contact the controller.
+	// Accessed like so: [ctrlDetails.Proxy.Proxier.Start].
+	//
+	// As such, AddController fails.
 
 	hps, err := network.ParseProviderHostPorts(ctrlDetails.APIEndpoints...)
 	if err != nil {
@@ -421,7 +427,6 @@ func (b *bootstrapManager) runBootstrap(
 		AdminIdentityName: account.User,
 		AdminPassword:     account.Password,
 	}
-
 	if err := b.jujuManager.AddController(
 		ctx,
 		user,

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -393,11 +393,7 @@ func (b *bootstrapManager) runBootstrap(
 		return errors.E(fmt.Errorf("failed to get controller details: %w", err))
 	}
 	// TODO(ale8k): At the moment, we can't reach added k8s controllers because the controller is not reachable.
-	// The CLI spins up a kube-proxy to reach it and we could do the same. The controller details of said controller
-	// may contain proxy details and those proxy details can be used to launch a proxy to contact the controller.
-	// Accessed like so: [ctrlDetails.Proxy.Proxier.Start].
-	//
-	// As such, AddController fails.
+	// Card: https://warthogs.atlassian.net/browse/JUJU-8436
 
 	hps, err := network.ParseProviderHostPorts(ctrlDetails.APIEndpoints...)
 	if err != nil {

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -180,7 +180,6 @@ func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.Use
 				// User defined command arguments
 				CloudNameAndRegion: params.CloudNameAndRegion,
 				ControllerName:     params.ControllerName,
-				AgentVersion:       params.AgentVersion,
 				BootstrapTimeout:   params.BootstrapTimeout,
 				CloudCred:          params.CloudCred,
 				PersonalCloud:      params.PersonalCloud,

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -221,6 +221,11 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.
 	c.Assert(err, qt.ErrorMatches, "failed to get job status")
 }
 
+// TODO
+func (s *bootstrapManagerSuite) TestStartBootstrap(c *qt.C) {
+
+}
+
 func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 	testCtx := c.Context()
 

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -221,11 +221,6 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.
 	c.Assert(err, qt.ErrorMatches, "failed to get job status")
 }
 
-// TODO
-func (s *bootstrapManagerSuite) TestStartBootstrap(c *qt.C) {
-
-}
-
 func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 	testCtx := c.Context()
 

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	jujucloud "github.com/juju/juju/cloud"
-	semversion "github.com/juju/version"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 )
@@ -18,7 +17,6 @@ type BootstrapParams struct {
 
 	CloudNameAndRegion string
 	ControllerName     string
-	AgentVersion       string
 	BootstrapTimeout   int
 
 	CloudCred jujucloud.CloudCredential
@@ -37,11 +35,6 @@ func (p BootstrapParams) validate() error {
 	}
 	if p.ControllerName == "" {
 		msgs = append(msgs, "controller name cannot be empty")
-	}
-	if p.AgentVersion != "" {
-		if _, err := semversion.Parse(p.AgentVersion); err != nil {
-			msgs = append(msgs, fmt.Sprintf("invalid agent version: %v", err))
-		}
 	}
 	if p.BootstrapTimeout < 0 {
 		msgs = append(msgs, "bootstrap timeout cannot be less than zero")

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -15,7 +15,6 @@ func TestValidateBootstrapParams_AllValid(t *testing.T) {
 
 		CloudNameAndRegion: "cloud/region",
 		ControllerName:     "my-controller",
-		AgentVersion:       "1.2.3",
 		BootstrapTimeout:   60,
 		// CloudCred & PersonalCloud are not validated.
 	}
@@ -74,7 +73,6 @@ func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
 				CLIVersion:         "1.0.0",
 				CloudNameAndRegion: "cloud/region",
 				ControllerName:     "my-controller",
-				AgentVersion:       "invalid-version",
 			},
 			want: []string{
 				"invalid-version",

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -27,7 +27,7 @@ func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
 		name   string
 		params BootstrapParams
 		want   []string
-	}{ // do agent and bs timeout
+	}{
 		{
 			name:   "all empty",
 			params: BootstrapParams{},
@@ -65,17 +65,6 @@ func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
 			},
 			want: []string{
 				"controller name cannot be empty",
-			},
-		},
-		{
-			name: "agent version invalid",
-			params: BootstrapParams{
-				CLIVersion:         "1.0.0",
-				CloudNameAndRegion: "cloud/region",
-				ControllerName:     "my-controller",
-			},
-			want: []string{
-				"invalid-version",
 			},
 		},
 		{

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -636,7 +636,6 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 
 		CloudNameAndRegion: cloudNameAndRegion,
 		ControllerName:     req.ControllerName,
-		AgentVersion:       req.Flags.AgentVersion,
 		BootstrapTimeout:   req.Flags.Timeout,
 
 		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
@@ -623,6 +624,17 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 
 	if !r.user.JimmAdmin {
 		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	// Check built in clouds like localhost (lxd).
+	builtinClouds, err := common.BuiltInClouds()
+	if err != nil {
+		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeIncompatibleClouds, "unauthorized")
+	}
+
+	if _, isABuiltinCloud := builtinClouds[req.CloudName]; isABuiltinCloud {
+		return apiparams.BootstrapStartResponse{},
+			errors.E(op, errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
 	}
 
 	cloudNameAndRegion := req.CloudName

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -177,6 +177,20 @@ func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeUnauthorized)
 }
 
+func (s *jimmUnitTestSuite) TestBootstrapStart_RejectsBuiltinClouds(c *gc.C) {
+	ctx := context.Background()
+
+	jimm := &jimmtest.JIMM{}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	params := params.BootstrapStartParams{
+		CloudName: "localhost",
+	}
+
+	_, err := root.BootstrapStart(ctx, params)
+	c.Assert(err, gc.ErrorMatches, `.*bootstrap via JIMM does not support built-in clouds like "localhost"`)
+}
+
 func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 	ctx := context.Background()
 	var startBootstrapErr error

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -200,8 +200,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 		CloudName:      "cloud",
 		RegionName:     "region",
 		Flags: params.BootstrapFlags{
-			AgentVersion: "1.0.0",
-			Timeout:      3600,
+			Timeout: 3600,
 		},
 		Cloud:             jujuparams.Cloud{},
 		Credential:        jujucloud.CloudCredential{},

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -602,8 +602,6 @@ type BootstrapStatusResponse struct {
 // BootstrapFlags holds the flags that can be used
 // when bootstrapping a new controller.
 type BootstrapFlags struct {
-	// The agent version to use for the bootstrap.
-	AgentVersion string `json:"agent-version,omitempty"`
 	// The timeout in seconds for the bootstrap.
 	Timeout int `json:"timeout,omitempty"`
 }


### PR DESCRIPTION
## Description
Based on: #1680

This PR updates the CLI to pass the CLI version, prevents built-in clouds, retrieves the cloud and credential, updates the printed line to be human readable only and maps the cloud to the expected param type.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
