### PR TITLE
feat: complete migrations when model info is called

### DIFF
--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -274,20 +274,29 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 func (j *JujuManager) modelInfo(ctx context.Context, model *dbmodel.Model, api API) (*jujuparams.ModelInfo, error) {
 	modelInfo := &jujuparams.ModelInfo{UUID: model.UUID.String}
 	errFromAPI := api.ModelInfo(ctx, modelInfo)
-	var err error
+
+	if errFromAPI == nil {
+		return j.reactToModelInfoSuccess(ctx, model, modelInfo)
+	} else {
+		return j.reactToModelInfoError(ctx, errFromAPI, model, modelInfo)
+	}
+}
+
+func (j *JujuManager) reactToModelInfoError(ctx context.Context, errFromAPI error, model *dbmodel.Model, modelInfo *jujuparams.ModelInfo) (*jujuparams.ModelInfo, error) {
 	switch model.MigrationMode {
 	case dbmodel.MigrationModeNone:
-		err = j.maybeCleanupModel(ctx, errFromAPI, model)
+		err := j.maybeCleanupModel(ctx, errFromAPI, model)
 		if err != nil {
-			return nil, err
+			zapctx.Error(ctx, "error cleaning model", zap.Error(err))
+			return nil, errors.E("internal server error")
 		}
-		// we need to return both the modelInfo and the error, because
-		// the error from the API must be propagated to the caller.
-		return modelInfo, errFromAPI
+		// propagate the error to the caller.
+		return nil, errFromAPI
 	case dbmodel.MigrationModeMigrateInternal:
-		err = j.checkModelMigratedInternal(ctx, errFromAPI, model, errFromAPI == nil && modelInfo.Migration.End != nil)
+		err := j.checkModelMigratedInternal(ctx, errFromAPI, model)
 		if err != nil {
-			return nil, err
+			zapctx.Error(ctx, "error checking model migration", zap.Error(err))
+			return nil, errors.E("internal server error")
 		}
 		// If the model has been migrated internally, we call api.ModelInfo again
 		// to get the updated model information from the new controller.
@@ -301,9 +310,34 @@ func (j *JujuManager) modelInfo(ctx context.Context, model *dbmodel.Model, api A
 		defer api.Close()
 		errFromAPI := api.ModelInfo(ctx, modelInfo)
 		return modelInfo, errFromAPI
+	// If the migration mode is exporting or importing, we return the error as is.
+	case dbmodel.MigrationModeExporting, dbmodel.MigrationModeImporting:
+		return nil, errFromAPI
 	default:
-		return nil, errors.E("unknown migration mode: " + string(model.MigrationMode))
+		return nil, errors.E("model in unsupported migration mode")
 	}
+
+}
+
+func (j *JujuManager) reactToModelInfoSuccess(ctx context.Context, model *dbmodel.Model, modelInfo *jujuparams.ModelInfo) (*jujuparams.ModelInfo, error) {
+	switch model.MigrationMode {
+	case dbmodel.MigrationModeNone, dbmodel.MigrationModeExporting, dbmodel.MigrationModeImporting:
+		return modelInfo, nil
+	case dbmodel.MigrationModeMigrateInternal:
+		// If the migration end time is set, it means the model has
+		// failed to migrate otherwise we'd expect a redirect error.
+		if modelInfo.Migration.End != nil {
+			model.MigrationFailed()
+			if err := j.Database.UpdateModel(ctx, model); err != nil {
+				return nil, errors.E(fmt.Errorf("failed to update model after failed migration: %w", err))
+			}
+			return modelInfo, nil
+		}
+		return modelInfo, nil
+	default:
+		return nil, errors.E("model in unsupported migration mode")
+	}
+
 }
 
 // modelSummariesMap is a safe map to add records concurrently because the access is guarded by a Mutex.

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -261,23 +261,49 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 	}
 	defer api.Close()
 
-	mi := &jujuparams.ModelInfo{
-		UUID: mt.Id(),
-	}
-	if err := api.ModelInfo(ctx, mi); err != nil {
-		// If the model is not found or code not authorized on the backing controller then
-		// we delete the model from JIMM.
-		// Juju returns CodeAuthorized when the model is not found for this facade.
-		if errors.ErrorCode(err) == errors.CodeNotFound || errors.ErrorCode(err) == errors.CodeUnauthorized {
-			errDelete := j.deleteModel(ctx, mt)
-			if errDelete != nil {
-				return nil, errors.E(op, errDelete)
-			}
-		}
+	modelInfo, err := j.modelInfo(ctx, &m, api)
+	if err != nil {
 		return nil, errors.E(op, err)
 	}
 
-	return j.mergeModelInfo(ctx, user, mi, m)
+	return j.mergeModelInfo(ctx, user, modelInfo, m)
+}
+
+// modelInfo retrieves the model information from the controller and reacts
+// to the error to update JIMM's state.
+func (j *JujuManager) modelInfo(ctx context.Context, model *dbmodel.Model, api API) (*jujuparams.ModelInfo, error) {
+	modelInfo := &jujuparams.ModelInfo{UUID: model.UUID.String}
+	errFromAPI := api.ModelInfo(ctx, modelInfo)
+	var err error
+	switch model.MigrationMode {
+	case dbmodel.MigrationModeNone:
+		err = j.maybeCleanupModel(ctx, errFromAPI, model)
+		if err != nil {
+			return nil, err
+		}
+		// we need to return both the modelInfo and the error, because
+		// the error from the API must be propagated to the caller.
+		return modelInfo, errFromAPI
+	case dbmodel.MigrationModeMigrateInternal:
+		err = j.checkModelMigratedInternal(ctx, errFromAPI, model, errFromAPI == nil && modelInfo.Migration.End != nil)
+		if err != nil {
+			return nil, err
+		}
+		// If the model has been migrated internally, we call api.ModelInfo again
+		// to get the updated model information from the new controller.
+		if err := j.Database.GetModel(ctx, model); err != nil {
+			return nil, err
+		}
+		api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
+		if err != nil {
+			return nil, err
+		}
+		defer api.Close()
+		errFromAPI := api.ModelInfo(ctx, modelInfo)
+		return modelInfo, errFromAPI
+	default:
+		return nil, errors.E("unknown migration mode: " + string(model.MigrationMode))
+	}
 }
 
 // modelSummariesMap is a safe map to add records concurrently because the access is guarded by a Mutex.

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -58,13 +58,14 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 				zap.String("model-name", m.Name),
 				zap.String("migration-mode", string(m.MigrationMode)),
 			)
+			modelInfo := &jujuparams.ModelInfo{UUID: m.UUID.String}
+			errFromAPI := api.ModelInfo(ctx, modelInfo)
 			var err error
-
 			switch m.MigrationMode {
 			case dbmodel.MigrationModeNone:
-				err = j.maybeCleanupModel(ctx, api, m)
+				err = j.maybeCleanupModel(ctx, errFromAPI, m)
 			case dbmodel.MigrationModeMigrateInternal:
-				err = j.checkModelMigratedInternal(ctx, api, m)
+				err = j.checkModelMigratedInternal(ctx, errFromAPI, m, errFromAPI == nil && modelInfo.Migration.End != nil)
 			}
 			if err != nil {
 				zapctx.Error(ctx, "error processing model", zap.Error(err))
@@ -77,17 +78,12 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 
 // checkModelMigratedInternal checks if the model has been migrated from
 // one controller managed by JIMM to another controller managed by JIMM.
-func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, api API, m *dbmodel.Model) error {
+func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI error, m *dbmodel.Model, migrationEndSet bool) error {
 	const op = errors.Op("jimm.checkModelMigratedInternal")
-
-	// Check if the model has completed a migration.
-	// If modelInfo returns without an error, it definitely hasn't moved yet.
-	modelInfo := &jujuparams.ModelInfo{UUID: m.UUID.String}
-	err := api.ModelInfo(ctx, modelInfo)
-	if err == nil {
+	if errFromAPI == nil {
 		// If the migration end time is set, it means the model has
 		// failed to migrate otherwise we'd expect a redirect error.
-		if modelInfo.Migration.End != nil {
+		if migrationEndSet {
 			m.MigrationFailed()
 			if err := j.Database.UpdateModel(ctx, m); err != nil {
 				return errors.E(fmt.Errorf("failed to update model after failed migration: %w", err))
@@ -99,35 +95,35 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, api API, m
 	// Expect a redirect error if the model successfully migrated.
 	// This is the error that Juju controllers return when a model has been migrated.
 
-	isRedirectErr := errors.ErrorCode(err) == params.CodeRedirect
+	isRedirectErr := errors.ErrorCode(errFromAPI) == params.CodeRedirect
 	if !isRedirectErr {
-		return errors.E(op, fmt.Errorf("failed to get model info: %w", err))
+		return errors.E(op, errFromAPI)
 	}
 
 	// Parse the redirect error to get the new controller details.
-	errInfo := errors.ErrorInfo(err)
+	errInfo := errors.ErrorInfo(errFromAPI)
 	if errInfo == nil {
-		return errors.E(op, fmt.Errorf("missing error info in redirect error: %w", err))
+		return errors.E(op, fmt.Errorf("missing error info in redirect error: %w", errFromAPI))
 	}
 
 	var redirectInfo params.RedirectErrorInfo
-	err = params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("cannot unmarshal redirect error info: %w", err))
+	errFromAPI = params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
+	if errFromAPI != nil {
+		return errors.E(op, fmt.Errorf("cannot unmarshal redirect error info: %w", errFromAPI))
 	}
 
 	// We expect this controller will be known to JIMM.
 	controller := dbmodel.Controller{Name: redirectInfo.ControllerAlias}
-	err = j.Database.GetController(ctx, &controller)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, err))
+	errFromAPI = j.Database.GetController(ctx, &controller)
+	if errFromAPI != nil {
+		return errors.E(op, fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI))
 	}
 
 	m.InternalMigrationSuccess(controller.ID)
 
-	err = j.Database.UpdateModel(ctx, m)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to update model after migration: %w", err))
+	errFromAPI = j.Database.UpdateModel(ctx, m)
+	if errFromAPI != nil {
+		return errors.E(op, fmt.Errorf("failed to update model after migration: %w", errFromAPI))
 	}
 	zapctx.Info(ctx, "model successfully migrated to controller", zap.String("model", m.UUID.String), zap.String("controller_name", controller.Name))
 	return nil
@@ -137,22 +133,14 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, api API, m
 // This performs eventual cleanup of models that have been deleted through
 // the API (since the deletion of a model is not immediate) and handles
 // cases where the model was deleted directly on the underlying controller.
-func (j *JujuManager) maybeCleanupModel(ctx context.Context, api API, m *dbmodel.Model) error {
+func (j *JujuManager) maybeCleanupModel(ctx context.Context, errFromAPI error, m *dbmodel.Model) error {
 	const op = errors.Op("jimm.maybeCleanupModel")
-
-	err := api.ModelInfo(ctx, &jujuparams.ModelInfo{UUID: m.UUID.String})
-	if err == nil {
-		// If the call succeeds, the model exists and we can return.
-		return nil
-	}
 	// Some versions of juju return unauthorized for models that cannot be found.
-	modelDeleted := (errors.ErrorCode(err) == errors.CodeNotFound || errors.ErrorCode(err) == errors.CodeUnauthorized)
+	modelDeleted := (errors.ErrorCode(errFromAPI) == errors.CodeNotFound || errors.ErrorCode(errFromAPI) == errors.CodeUnauthorized)
 	if modelDeleted {
 		if err := j.deleteModel(ctx, m.ResourceTag()); err != nil {
 			return errors.E(op, fmt.Errorf("failed to delete model: %w", err))
 		}
-	} else {
-		return errors.E(op, fmt.Errorf("failed to get model info: %w", err))
 	}
 	return nil
 }

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/rpc/params"
-	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -58,18 +57,10 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 				zap.String("model-name", m.Name),
 				zap.String("migration-mode", string(m.MigrationMode)),
 			)
-			modelInfo := &jujuparams.ModelInfo{UUID: m.UUID.String}
-			errFromAPI := api.ModelInfo(ctx, modelInfo)
-			var err error
-			switch m.MigrationMode {
-			case dbmodel.MigrationModeNone:
-				err = j.maybeCleanupModel(ctx, errFromAPI, m)
-			case dbmodel.MigrationModeMigrateInternal:
-				err = j.checkModelMigratedInternal(ctx, errFromAPI, m, errFromAPI == nil && modelInfo.Migration.End != nil)
-			}
+
+			_, err := j.modelInfo(ctx, m, api)
 			if err != nil {
-				zapctx.Error(ctx, "error processing model", zap.Error(err))
-				continue
+				zapctx.Error(ctx, "error getting model info", zap.Error(err))
 			}
 		}
 	}
@@ -78,23 +69,11 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 
 // checkModelMigratedInternal checks if the model has been migrated from
 // one controller managed by JIMM to another controller managed by JIMM.
-func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI error, m *dbmodel.Model, migrationEndSet bool) error {
+func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI error, m *dbmodel.Model) error {
 	const op = errors.Op("jimm.checkModelMigratedInternal")
-	if errFromAPI == nil {
-		// If the migration end time is set, it means the model has
-		// failed to migrate otherwise we'd expect a redirect error.
-		if migrationEndSet {
-			m.MigrationFailed()
-			if err := j.Database.UpdateModel(ctx, m); err != nil {
-				return errors.E(fmt.Errorf("failed to update model after failed migration: %w", err))
-			}
-		}
-		return nil
-	}
 
 	// Expect a redirect error if the model successfully migrated.
 	// This is the error that Juju controllers return when a model has been migrated.
-
 	isRedirectErr := errors.ErrorCode(errFromAPI) == params.CodeRedirect
 	if !isRedirectErr {
 		return errors.E(op, errFromAPI)
@@ -107,22 +86,22 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI
 	}
 
 	var redirectInfo params.RedirectErrorInfo
-	errFromAPI = params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
-	if errFromAPI != nil {
-		return errors.E(op, fmt.Errorf("cannot unmarshal redirect error info: %w", errFromAPI))
+	err := params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("cannot unmarshal redirect error info: %w", err))
 	}
 
 	// We expect this controller will be known to JIMM.
 	controller := dbmodel.Controller{Name: redirectInfo.ControllerAlias}
-	errFromAPI = j.Database.GetController(ctx, &controller)
-	if errFromAPI != nil {
+	err = j.Database.GetController(ctx, &controller)
+	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI))
 	}
 
 	m.InternalMigrationSuccess(controller.ID)
 
-	errFromAPI = j.Database.UpdateModel(ctx, m)
-	if errFromAPI != nil {
+	err = j.Database.UpdateModel(ctx, m)
+	if err != nil {
 		return errors.E(op, fmt.Errorf("failed to update model after migration: %w", errFromAPI))
 	}
 	zapctx.Info(ctx, "model successfully migrated to controller", zap.String("model", m.UUID.String), zap.String("controller_name", controller.Name))

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -120,7 +120,6 @@ func TestModelCleanup(t *testing.T) {
 				case s.env.Models[1].UUID:
 					return nil
 				case s.env.Models[2].UUID:
-					c.Fatalf("unexpected call to ModelInfo_ for model %s", mi.UUID)
 					return nil
 				default:
 					return errors.E("new error")

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/life"
+	jujurpc "github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -1454,6 +1455,10 @@ controllers:
   uuid: 00000001-0000-0000-0000-000000000001
   cloud: test-cloud
   region: test-cloud-region
+- name: controller-2
+  uuid: 00000001-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-cloud-region
 models:
 - name: model-1
   uuid: 00000002-0000-0000-0000-000000000001
@@ -1722,6 +1727,67 @@ func TestModelInfoNotFound(t *testing.T) {
 
 }
 
+func TestModelInfoRedirect(t *testing.T) {
+	c := qt.New(t)
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				ModelInfo_: func(_ context.Context, mi *jujuparams.ModelInfo) error {
+					return errors.E(errors.CodeNotFound, "model not found")
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, modelInfoTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+	dbUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(dbUser, j.OpenFGAClient)
+	mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
+
+	ok, err := user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+
+	model := env.Models[0].DBObject(c, j.Database)
+	model.MigrationMode = dbmodel.MigrationModeMigrateInternal
+	err = j.Database.UpdateModel(t.Context(), &model)
+	c.Assert(err, qt.IsNil)
+
+	sourceController := env.Controllers[0].DBObject(c, j.Database)
+	targetController := env.Controllers[1].DBObject(c, j.Database)
+	c.Assert(model.ControllerID, qt.Equals, sourceController.ID)
+	numCalls := 0
+	j.Dialer = &jimmtest.Dialer{
+		API: &jimmtest.API{
+			ModelInfo_: func(ctx context.Context, mi *jujuparams.ModelInfo) error {
+				if numCalls == 0 {
+					numCalls++
+					return &jujurpc.RequestError{
+						Message: "redirect",
+						Code:    jujuparams.CodeRedirect,
+						Info: jujuparams.RedirectErrorInfo{
+							ControllerAlias: env.Controllers[1].Name,
+						}.AsMap(),
+					}
+				} else {
+					return nil
+				}
+			},
+		},
+	}
+
+	modelInfo, err := j.ModelInfo(t.Context(), user, names.NewModelTag(model.UUID.String))
+	c.Assert(err, qt.IsNil)
+	c.Assert(modelInfo.ControllerUUID, qt.Equals, targetController.UUID)
+
+	_, err = j.ModelInfo(t.Context(), user, names.NewModelTag(model.UUID.String))
+	c.Assert(err, qt.IsNil)
+	c.Assert(modelInfo.ControllerUUID, qt.Equals, targetController.UUID)
+}
 func TestModelStatusNotFound(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
In this pr we propose to finish the migration if we receive a redirect error during a ModelInfo call.
