### PR TITLE
feat: fix integration tests and add juju-dashboard to docker compose

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+
       - name: Setup Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,11 +12,6 @@ jobs:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4
 
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
-        with:
-          detached: true
-
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,13 +7,13 @@ on:
 jobs:
   startjimm:
     name: Test JIMM with Juju controller
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted-linux-amd64-jammy-large]
     steps:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4
 
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+        uses: canonical/action-tmate@main
         with:
           detached: true
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -25,7 +25,7 @@ jobs:
         id: jaas
         with:
           jimm-version: dev
-          juju-channel: "3.6/edge" # Temporary change while 3.6.3 is on 3/stable and broken with JIMM.
+          juju-channel: "3.6/stable"
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       # Build the JAAS plugin to test any changes made 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           detached: true
 
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Setup Go
         uses: actions/setup-go@v4
         with:

--- a/docker-compose.common.yaml
+++ b/docker-compose.common.yaml
@@ -20,7 +20,6 @@ services:
       VAULT_ROLE_SECRET_ID: test-secret-id
       # Note: By default we should use Vault as that is the primary means of secret storage.
       INSECURE_SECRET_STORAGE: ${INSECURE_SECRET_STORAGE:-false}
-      # JIMM_DASHBOARD_LOCATION: ""
       JIMM_DNS_NAME: "jimm.localhost"
       JIMM_LISTEN_ADDR: "0.0.0.0:80"
       JIMM_TEST_PGXDSN: "postgresql://jimm:jimm@db/jimm"
@@ -40,7 +39,8 @@ services:
       JIMM_OAUTH_CLIENT_ID: "jimm-device"
       JIMM_OAUTH_CLIENT_SECRET: "SwjDofnbDzJDm9iyfUhEp67FfUFMY8L4"
       JIMM_OAUTH_SCOPES: "openid profile email" # Space separated list of scopes
-      JIMM_DASHBOARD_FINAL_REDIRECT_URL: "https://jaas.ai" # Example URL
+      JIMM_DASHBOARD_FINAL_REDIRECT_URL: "https://juju-dashboard.localhost"
+      CORS_ALLOWED_ORIGINS: "https://juju-dashboard.localhost"
       JIMM_ACCESS_TOKEN_EXPIRY_DURATION: 100h
       JIMM_SECURE_SESSION_COOKIES: false
       JIMM_SESSION_COOKIE_MAX_AGE: 86400

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -138,6 +138,20 @@ services:
       timeout: 10s
       retries: 30
 
+  juju-dashboard:
+    image: ghcr.io/canonical/juju-dashboard:0.14.0-beta.0
+    container_name: juju-dashboard
+    profiles: ["dev"]
+    labels:
+      traefik.enable: true
+      traefik.http.routers.juju-dashboard.rule: Host(`juju-dashboard.localhost`)
+      traefik.http.routers.juju-dashboard.entrypoints: websecure
+      traefik.http.routers.juju-dashboard.tls: true
+      traefik.http.services.juju-dashboard.loadbalancer.server.port: 8080
+    volumes:
+      - ./local/dashboard/config.js:/srv/configs/config.js
+      - ./local/dashboard/nginx.conf:/srv/configs/nginx.conf
+
 volumes:
   go-modules:
   go-cache:

--- a/local/dashboard/config.js
+++ b/local/dashboard/config.js
@@ -1,0 +1,21 @@
+// This file contains the configuration for the Juju Dashboard application.
+// In the future we would like to supply this by env vars.
+
+var jujuDashboardConfig = {
+  // API host to allow app to connect and retrieve models. This address should
+  // begin with `ws://` or `wss://` and end with `/api`.
+  controllerAPIEndpoint: "wss://jimm.localhost:443/api",
+  // Configurable base url to allow hosting the dashboard at different paths.
+  baseAppURL: "/",
+  // The URL of the third party identity provider. This is typically provided
+  // by the controller when logging in so it's not currently used directly.
+  // But it is available in the charm so putting it here in the event that we
+  // would like to use it in the future.
+  identityProviderURL: "",
+  // Is this application being rendered in Juju and not JAAS. This flag should
+  // only be used for superficial updates like logos. Use feature detection
+  // for other environment features.
+  isJuju: false,
+  // If true, then Google Analytics and Sentry data will be sent.
+  analyticsEnabled: false,
+};

--- a/local/dashboard/nginx.conf
+++ b/local/dashboard/nginx.conf
@@ -1,0 +1,31 @@
+# The following is the Nginx configuration for the Juju Dashboard.
+# In the future we'd like to remove this file and supply only necessary
+# configuration via env vars.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
+
+    root /srv;
+    index index.html;
+
+    server_name _;
+
+    location / {
+        try_files /index.html =404;
+    }
+
+    location /config.js {
+        try_files /config.js =404;
+    }
+
+    location /assets {
+        try_files $uri =404; 
+    }
+
+}

--- a/local/traefik/certs/san.conf
+++ b/local/traefik/certs/san.conf
@@ -2,5 +2,5 @@
 [v3_req]
 subjectKeyIdentifier = hash
 basicConstraints     = critical,CA:false
-subjectAltName       = DNS:jimm.localhost,IP:127.0.0.1,DNS:localhost,DNS:juju-apiserver,DNS:juju-mongodb
+subjectAltName       = DNS:jimm.localhost,DNS:juju-dashboard.localhost,IP:127.0.0.1,DNS:localhost,DNS:juju-apiserver,DNS:juju-mongodb
 keyUsage             = critical,digitalSignature,keyEncipherment


### PR DESCRIPTION
## Description
This PR fixes the integration test workflow (see below) and adds the juju-dashboard to our docker compose. Now `docker compose --profile dev up` will also bring up a dashboard container that you can use to interact with JIMM.

The dashboard doesn't currently support being configured via environment variables as it is normally operated by the charm but I have discussed with the web team the idea that we would configure the dashboard by only supplying some environment variables.

This work is a precursor to running the dashboards integration tests with JIMM periodically/on release.

--------------------

Additionally, the integration test action started failing recently and it seems to be related to memory issues as when I tried to debug the issue by SSH'ing into the runner, the SSH connection is closed once we reach the stage where we compile the `jaas` CLI plugin. By switching to a Canonical self-hosted runner, the integration test now works successfully.

Partially fixes [JUJU-7937](https://warthogs.atlassian.net/browse/JUJU-7937)

[JUJU-7937]: https://warthogs.atlassian.net/browse/JUJU-7937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ