### PR TITLE
feat: add controller config to jimm's db

### DIFF
--- a/internal/db/controllerproxy.go
+++ b/internal/db/controllerproxy.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// GetControllerProxy retrieves the proxy configuration for the specified controller ID.
+func (d *Database) GetControllerProxy(ctx context.Context, controllerID uint) (proxy *dbmodel.ControllerProxy, err error) {
+	const op = errors.Op("db.GetControllerProxy")
+	if err := d.ready(); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	proxy = &dbmodel.ControllerProxy{}
+	if err := db.Where("controller_id = ?", controllerID).First(proxy).Error; err != nil {
+		return nil, errors.E(op, dbError(err))
+	}
+	return proxy, nil
+}
+
+// AddControllerProxy adds a new proxy configuration for the specified controller ID.
+func (d *Database) AddControllerProxy(ctx context.Context, proxy dbmodel.ControllerProxy) (err error) {
+	const op = errors.Op("db.AddControllerProxy")
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	db := d.DB.WithContext(ctx)
+
+	if err := db.Create(&proxy).Error; err != nil {
+		return errors.E(op, dbError(err))
+	}
+	return nil
+}

--- a/internal/db/controllerproxy_test.go
+++ b/internal/db/controllerproxy_test.go
@@ -1,0 +1,53 @@
+package db_test
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
+)
+
+func (s *dbSuite) TestAddControllerProxy(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := &dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-0000-0000000000001",
+		CloudName: "test-cloud",
+	}
+	err = s.Database.AddController(context.Background(), controller)
+	c.Assert(err, qt.Equals, nil)
+
+	controllerProxy := dbmodel.ControllerProxy{
+		ControllerId: controller.ID,
+		Type:         proxy.ProxierTypeKey,
+		Config: map[string]interface{}{
+			"api-host": "https://local",
+		},
+	}
+
+	err = s.Database.AddControllerProxy(c.Context(), controllerProxy)
+	c.Assert(err, qt.IsNil)
+
+	storedProxy, err := s.Database.GetControllerProxy(c.Context(), controllerProxy.ControllerId)
+	c.Assert(err, qt.IsNil)
+	c.Assert(storedProxy, jimmtest.DBObjectEquals, &controllerProxy)
+}
+
+func (s *dbSuite) TestGetControllerProxy_NotFound(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	_, err = s.Database.GetControllerProxy(c.Context(), 999)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}

--- a/internal/dbmodel/controllerproxy.go
+++ b/internal/dbmodel/controllerproxy.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Canonical.
+
+package dbmodel
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/proxy"
+)
+
+// ControllerProxy represents a proxy configuration for accessing a controller.
+type ControllerProxy struct {
+
+	// Note that we do not use gorm.Model to avoid the use of soft-deletes.
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	ControllerId uint
+
+	Type   string
+	Config Map
+}
+
+// ProxyFactory defines an interface for creating proxier instances from a type key and configuration map.
+type ProxyFactory interface {
+	ProxierFromConfig(typeKey string, config map[string]interface{}) (proxy.Proxier, error)
+}
+
+// ToProxier attempts to convert the stored proxy configuration into a working
+// proxier object using the provided proxy factory.
+func (c ControllerProxy) ToProxier(proxyFactory ProxyFactory) (proxy.Proxier, error) {
+	// The factory uses the Config map to decode settings into the specific config struct
+	// for each proxier type. This process has two key effects:
+	// - Any keys in Config that do not exist in the config struct are ignored.
+	// - Any fields in the config struct that are missing from Config are set to their zero value.
+	// As a result, the proxier receives a config struct without validation of its values.
+	// If required config values are missing or incorrect, the proxy may fail to start when `.Start()` is called.
+	proxier, err := proxyFactory.ProxierFromConfig(c.Type, c.Config)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return proxier, nil
+}

--- a/internal/dbmodel/controllerproxy_test.go
+++ b/internal/dbmodel/controllerproxy_test.go
@@ -1,0 +1,77 @@
+package dbmodel_test
+
+import (
+	"testing"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
+	"github.com/juju/juju/proxy/factory"
+)
+
+func TestControllerProxy(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"api-host":              "https://127.0.0.1:443",
+		"ca-cert":               "cadata====",
+		"namespace":             "test",
+		"remote-port":           "8123",
+		"service":               "test",
+		"service-account-token": "token====",
+	}
+	controllerProxy := dbmodel.ControllerProxy{
+		Type:   proxy.ProxierTypeKey,
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	proxier, err := controllerProxy.ToProxier(defaultFactory)
+	if err != nil {
+		t.Fatalf("ToProxier() unexpected error: %v", err)
+	}
+	rawConfigFromProxier, err := proxier.RawConfig()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rawConfigFromProxier, qt.DeepEquals, rawConfig)
+}
+
+func TestControllerProxy_Invalid_ZeroValues(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"another-field": "",
+	}
+
+	controllerProxy := dbmodel.ControllerProxy{
+		Type:   proxy.ProxierTypeKey,
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	proxier, err := controllerProxy.ToProxier(defaultFactory)
+	c.Assert(err, qt.IsNil)
+	rawConfigFromProxier, err := proxier.RawConfig()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rawConfigFromProxier, qt.DeepEquals, map[string]interface{}{
+		"api-host":              "",
+		"ca-cert":               "",
+		"namespace":             "",
+		"remote-port":           "",
+		"service":               "",
+		"service-account-token": "",
+	})
+}
+
+func TestControllerProxy_Invalid_Type(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"api-host": "https://localhost",
+	}
+	controllerProxy := dbmodel.ControllerProxy{
+		Type:   "invalid-type",
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	_, err = controllerProxy.ToProxier(defaultFactory)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Equals, "proxy register for key invalid-type not found")
+}

--- a/internal/dbmodel/sql/postgres/033_controller_proxy.up.sql
+++ b/internal/dbmodel/sql/postgres/033_controller_proxy.up.sql
@@ -1,0 +1,12 @@
+-- Add controller_proxies info table.
+
+CREATE TABLE IF NOT EXISTS controller_proxies (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE,
+    controller_id INTEGER NOT NULL REFERENCES controllers (id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    config JSONB NOT NULL,
+    UNIQUE (controller_id)
+);
+

--- a/internal/testutils/jimmtest/cmp.go
+++ b/internal/testutils/jimmtest/cmp.go
@@ -49,6 +49,7 @@ var DBObjectEquals = qt.CmpEquals(
 	cmpopts.IgnoreFields(dbmodel.Model{}, "ID", "CreatedAt", "UpdatedAt", "OwnerIdentityName", "ControllerID", "CloudRegionID", "CloudCredentialID"),
 	cmpopts.IgnoreFields(dbmodel.ApplicationOffer{}, "ID", "CreatedAt", "UpdatedAt", "ModelID"),
 	cmpopts.IgnoreFields(dbmodel.RoleEntry{}, "CreatedAt", "UpdatedAt"),
+	cmpopts.IgnoreFields(dbmodel.ControllerProxy{}, "ID", "CreatedAt", "UpdatedAt"),
 )
 
 // CmpEquals uses cmp.Diff (see http://godoc.org/github.com/google/go-cmp/cmp#Diff)


### PR DESCRIPTION
## Description
Add controller-proxy to jimm's db, add crud methods and ToProxier method.
I've done the schema and the code to match as much as possible juju's code.

Only interesting bit is that the `ToProxier` takes a factory interface, in this way we can build test with our custom factory returning a mock proxy. In production we will most likely use the default factory coming from juju.