### PR TITLE
feat: support controller's proxy for multi storage

### DIFF
--- a/internal/db/controllerproxy.go
+++ b/internal/db/controllerproxy.go
@@ -1,36 +1,61 @@
+// Copyright 2025 Canonical.
+
 package db
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
 )
 
+const (
+	// These constant are used to create the appropriate identifiers for controller proxy data.
+	controllerProxySecretKind = "controllerProxy"
+)
+
+type controllerProxy struct {
+	Type   string                 `json:"type"`
+	Config map[string]interface{} `json:"config"`
+}
+
 // GetControllerProxy retrieves the proxy configuration for the specified controller ID.
-func (d *Database) GetControllerProxy(ctx context.Context, controllerID uint) (proxy *dbmodel.ControllerProxy, err error) {
-	const op = errors.Op("db.GetControllerProxy")
+func (d *Database) GetControllerProxy(ctx context.Context, controllerName string) (_ string, _ map[string]interface{}, err error) {
+	const op = errors.Op("database.GetControllerProxy")
+
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return "", nil, errors.E(op, err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
-	db := d.DB.WithContext(ctx)
-
-	proxy = &dbmodel.ControllerProxy{}
-	if err := db.Where("controller_id = ?", controllerID).First(proxy).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+	secret := dbmodel.NewSecret(controllerProxySecretKind, controllerName, nil)
+	err = d.GetSecret(ctx, &secret)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get secret data", zap.Error(err))
+		return "", nil, errors.E(op, err)
 	}
-	return proxy, nil
+	// secretData is stored as a JSON object in the database.
+	// So we need to unmarshal and extract the relevant fields.
+	var secretData controllerProxy
+	err = json.Unmarshal(secret.Data, &secretData)
+	if err != nil {
+		zapctx.Error(ctx, "failed to unmarshal secret data", zap.Error(err))
+		return "", nil, errors.E(op, err)
+	}
+	return secretData.Type, secretData.Config, nil
 }
 
-// AddControllerProxy adds a new proxy configuration for the specified controller ID.
-func (d *Database) AddControllerProxy(ctx context.Context, proxy dbmodel.ControllerProxy) (err error) {
-	const op = errors.Op("db.AddControllerProxy")
+// PutControllerProxy stores the proxy configuration for the specified controller ID.
+func (d *Database) PutControllerProxy(ctx context.Context, controllerName string, proxyType string, config map[string]interface{}) (err error) {
+	const op = errors.Op("database.PutControllerProxy")
+
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
 	}
@@ -39,10 +64,36 @@ func (d *Database) AddControllerProxy(ctx context.Context, proxy dbmodel.Control
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
-	db := d.DB.WithContext(ctx)
+	secretData := controllerProxy{
+		Type:   proxyType,
+		Config: config,
+	}
+	dataJson, err := json.Marshal(secretData)
+	if err != nil {
+		zapctx.Error(ctx, "failed to marshal proxy secret data", zap.Error(err))
+		return errors.E(op, err, "failed to marshal proxy secret data")
+	}
+	secret := dbmodel.NewSecret(controllerProxySecretKind, controllerName, dataJson)
+	return d.UpsertSecret(ctx, &secret)
+}
 
-	if err := db.Create(&proxy).Error; err != nil {
-		return errors.E(op, dbError(err))
+// DeleteControllerProxy removes the proxy configuration for the specified controller ID.
+func (d *Database) DeleteControllerProxy(ctx context.Context, controllerName string) (err error) {
+	const op = errors.Op("database.DeleteControllerProxy")
+
+	if err := d.ready(); err != nil {
+		return errors.E(op, err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+
+	secret := dbmodel.NewSecret(controllerProxySecretKind, controllerName, nil)
+	err = d.DeleteSecret(ctx, &secret)
+	if err != nil {
+		zapctx.Error(ctx, "failed to delete controller proxy", zap.Error(err))
+		return errors.E(op, err, "failed to delete controller proxy")
 	}
 	return nil
 }

--- a/internal/db/controllerproxy_test.go
+++ b/internal/db/controllerproxy_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Canonical.
+
 package db_test
 
 import (
@@ -5,7 +7,6 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
-	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 )
@@ -28,26 +29,24 @@ func (s *dbSuite) TestAddControllerProxy(c *qt.C) {
 	err = s.Database.AddController(context.Background(), controller)
 	c.Assert(err, qt.Equals, nil)
 
-	controllerProxy := dbmodel.ControllerProxy{
-		ControllerId: controller.ID,
-		Type:         proxy.ProxierTypeKey,
-		Config: map[string]interface{}{
-			"api-host": "https://local",
-		},
+	proxyType := proxy.ProxierTypeKey
+	config := map[string]interface{}{
+		"api-host": "https://local",
 	}
 
-	err = s.Database.AddControllerProxy(c.Context(), controllerProxy)
+	err = s.Database.PutControllerProxy(c.Context(), controller.Name, proxyType, config)
 	c.Assert(err, qt.IsNil)
 
-	storedProxy, err := s.Database.GetControllerProxy(c.Context(), controllerProxy.ControllerId)
+	storedType, storedConfig, err := s.Database.GetControllerProxy(c.Context(), controller.Name)
 	c.Assert(err, qt.IsNil)
-	c.Assert(storedProxy, jimmtest.DBObjectEquals, &controllerProxy)
+	c.Assert(storedType, qt.Equals, proxyType)
+	c.Assert(storedConfig, qt.DeepEquals, config)
 }
 
 func (s *dbSuite) TestGetControllerProxy_NotFound(c *qt.C) {
 	err := s.Database.Migrate(context.Background())
 	c.Assert(err, qt.IsNil)
 
-	_, err = s.Database.GetControllerProxy(c.Context(), 999)
+	_, _, err = s.Database.GetControllerProxy(c.Context(), "non-existent-controller")
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }

--- a/internal/jimm/credentials/credentials.go
+++ b/internal/jimm/credentials/credentials.go
@@ -19,6 +19,7 @@ import (
 //   - JWK expiry
 //   - JWK private key
 //   - OAuth session signing secret
+//   - Controller proxy config
 type CredentialStore interface {
 	// Get retrieves the stored attributes of a cloud credential.
 	Get(context.Context, names.CloudCredentialTag) (map[string]string, error)
@@ -54,4 +55,13 @@ type CredentialStore interface {
 
 	// PutJWKSExpiry sets the expiry time for the current JWKS within the store.
 	PutJWKSExpiry(ctx context.Context, expiry time.Time) error
+
+	// GetControllerProxy retrieves the proxy configuration for the specified controller name.
+	GetControllerProxy(ctx context.Context, controllerName string) (_ string, _ map[string]interface{}, err error)
+
+	// PutControllerProxy stores the proxy configuration for the specified controller name.
+	PutControllerProxy(ctx context.Context, controllerName string, proxyType string, config map[string]interface{}) (err error)
+
+	// DeleteControllerProxy removes the proxy configuration for the specified controller name.
+	DeleteControllerProxy(ctx context.Context, controllerName string) (err error)
 }

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -8,14 +8,12 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -1611,12 +1609,8 @@ func TestCloudCredentialAttributeStore(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
-	attrStore := testCloudCredentialAttributeStore{
-		attrs: make(map[string]map[string]string),
-	}
-
 	j := newTestJujuManager(c, &parameters{
-		CredentialStore: attrStore,
+		CredentialStore: jimmtest.NewInMemoryCredentialStore(),
 	})
 
 	env := jimmtest.ParseEnvironment(c, `clouds:
@@ -1673,66 +1667,6 @@ func TestCloudCredentialAttributeStore(t *testing.T) {
 	attr, _, err = j.GetCloudCredentialAttributes(ctx, user, &cred, true)
 	c.Assert(err, qt.IsNil)
 	c.Check(attr, qt.DeepEquals, args.Credential.Attributes)
-}
-
-type testCloudCredentialAttributeStore struct {
-	attrs map[string]map[string]string
-}
-
-func (s testCloudCredentialAttributeStore) Get(_ context.Context, tag names.CloudCredentialTag) (map[string]string, error) {
-	return s.attrs[tag.String()], nil
-}
-
-func (s testCloudCredentialAttributeStore) Put(_ context.Context, tag names.CloudCredentialTag, attr map[string]string) error {
-	s.attrs[tag.String()] = attr
-	return nil
-}
-
-func (s testCloudCredentialAttributeStore) GetControllerCredentials(ctx context.Context, controllerName string) (string, string, error) {
-	return "", "", errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) PutControllerCredentials(ctx context.Context, controllerName string, username string, password string) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) GetJWKS(ctx context.Context) (jwk.Set, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) GetJWKSPrivateKey(ctx context.Context) ([]byte, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) GetJWKSExpiry(ctx context.Context) (time.Time, error) {
-	return time.Now(), errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) PutJWKS(ctx context.Context, jwks jwk.Set) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-func (s testCloudCredentialAttributeStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) CleanupJWKS(ctx context.Context) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) CleanupOAuthSecrets(ctx context.Context) error {
-	return errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) GetOAuthSecret(ctx context.Context) ([]byte, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
-}
-
-func (s testCloudCredentialAttributeStore) PutOAuthSecret(ctx context.Context, raw []byte) error {
-	return errors.E(errors.CodeNotImplemented)
 }
 
 func TestCopyCredential(t *testing.T) {

--- a/internal/jimm/juju/controllerproxy.go
+++ b/internal/jimm/juju/controllerproxy.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Canonical.
+
+package juju
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+
+	"github.com/juju/juju/proxy"
+)
+
+// ControllerProxy represents a proxy configuration for accessing a controller.
+type ControllerProxy struct {
+	Type   string
+	Config map[string]interface{}
+}
+
+// ProxyFactory defines an interface for creating proxier instances from a type key and configuration map.
+type ProxyFactory interface {
+	ProxierFromConfig(typeKey string, config map[string]interface{}) (proxy.Proxier, error)
+}
+
+// ToProxier attempts to convert the stored proxy configuration into a working
+// proxier object using the provided proxy factory.
+func (c ControllerProxy) ToProxier(proxyFactory ProxyFactory) (proxy.Proxier, error) {
+	// The factory uses the Config map to decode settings into the specific config struct
+	// for each proxier type. This process has two key effects:
+	// - Any keys in Config that do not exist in the config struct are ignored.
+	// - Any fields in the config struct that are missing from Config are set to their zero value.
+	// As a result, the proxier receives a config struct without validation of its values.
+	// If required config values are missing or incorrect, the proxy may fail to start when `.Start()` is called.
+	proxier, err := proxyFactory.ProxierFromConfig(c.Type, c.Config)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+	return proxier, nil
+}
+
+// ControllerProxy retrieves the proxy configuration for the specified controller.
+func (j *JujuManager) ControllerProxy(ctx context.Context, controllerName string) (ControllerProxy, error) {
+	op := errors.Op("jimm.ControllerProxy")
+	var proxy ControllerProxy
+	proxyType, proxyConfig, err := j.CredentialStore.GetControllerProxy(ctx, controllerName)
+	if err != nil {
+		return proxy, errors.E(op, err)
+	}
+	proxy.Type = proxyType
+	proxy.Config = proxyConfig
+
+	return proxy, nil
+}

--- a/internal/jimm/juju/controllerproxy_test.go
+++ b/internal/jimm/juju/controllerproxy_test.go
@@ -1,0 +1,77 @@
+package juju_test
+
+import (
+	"testing"
+
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
+	"github.com/juju/juju/proxy/factory"
+)
+
+func TestControllerProxy(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"api-host":              "https://127.0.0.1:443",
+		"ca-cert":               "cadata====",
+		"namespace":             "test",
+		"remote-port":           "8123",
+		"service":               "test",
+		"service-account-token": "token====",
+	}
+	controllerProxy := juju.ControllerProxy{
+		Type:   proxy.ProxierTypeKey,
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	proxier, err := controllerProxy.ToProxier(defaultFactory)
+	if err != nil {
+		t.Fatalf("ToProxier() unexpected error: %v", err)
+	}
+	rawConfigFromProxier, err := proxier.RawConfig()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rawConfigFromProxier, qt.DeepEquals, rawConfig)
+}
+
+func TestControllerProxy_Invalid_ZeroValues(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"another-field": "",
+	}
+
+	controllerProxy := juju.ControllerProxy{
+		Type:   proxy.ProxierTypeKey,
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	proxier, err := controllerProxy.ToProxier(defaultFactory)
+	c.Assert(err, qt.IsNil)
+	rawConfigFromProxier, err := proxier.RawConfig()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rawConfigFromProxier, qt.DeepEquals, map[string]interface{}{
+		"api-host":              "",
+		"ca-cert":               "",
+		"namespace":             "",
+		"remote-port":           "",
+		"service":               "",
+		"service-account-token": "",
+	})
+}
+
+func TestControllerProxy_Invalid_Type(t *testing.T) {
+	c := qt.New(t)
+	rawConfig := map[string]interface{}{
+		"api-host": "https://localhost",
+	}
+	controllerProxy := juju.ControllerProxy{
+		Type:   "invalid-type",
+		Config: rawConfig,
+	}
+	defaultFactory, err := factory.NewDefaultFactory()
+	c.Assert(err, qt.IsNil)
+	_, err = controllerProxy.ToProxier(defaultFactory)
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err.Error(), qt.Equals, "proxy register for key invalid-type not found")
+}

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -29,6 +29,7 @@ type InMemoryCredentialStore struct {
 	oauthSessionStoreSecret   []byte
 	controllerCredentials     map[string]controllerCredentials
 	cloudCredentialAttributes map[string]map[string]string
+	controllerProxyConfigs    map[string]controllerProxyConfig
 }
 
 // NewInMemoryCredentialStore returns a new instance of `InMemoryCredentialStore`
@@ -187,5 +188,77 @@ func (s *InMemoryCredentialStore) PutJWKSExpiry(ctx context.Context, expiry time
 
 	s.expiry = expiry
 
+	return nil
+}
+
+// controllerProxyConfig holds proxy configuration for a controller.
+type controllerProxyConfig struct {
+	proxyType string
+	config    map[string]interface{}
+}
+
+// Add a field to store proxy configurations.
+func (s *InMemoryCredentialStore) ensureControllerProxyConfig() {
+	if s.controllerProxyConfigs == nil {
+		s.controllerProxyConfigs = make(map[string]controllerProxyConfig)
+	}
+}
+
+// GetControllerProxy retrieves the proxy configuration for the specified controller name.
+func (s *InMemoryCredentialStore) GetControllerProxy(ctx context.Context, controllerName string) (string, map[string]interface{}, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.controllerProxyConfigs == nil {
+		return "", nil, errors.E(errors.CodeNotFound)
+	}
+
+	cfg, ok := s.controllerProxyConfigs[controllerName]
+	if !ok {
+		return "", nil, errors.E(errors.CodeNotFound)
+	}
+
+	// Deep copy config map
+	configCopy := make(map[string]interface{}, len(cfg.config))
+	for k, v := range cfg.config {
+		configCopy[k] = v
+	}
+
+	return cfg.proxyType, configCopy, nil
+}
+
+// PutControllerProxy stores the proxy configuration for the specified controller name.
+func (s *InMemoryCredentialStore) PutControllerProxy(ctx context.Context, controllerName string, proxyType string, config map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureControllerProxyConfig()
+
+	configCopy := make(map[string]interface{}, len(config))
+	for k, v := range config {
+		configCopy[k] = v
+	}
+
+	s.controllerProxyConfigs[controllerName] = controllerProxyConfig{
+		proxyType: proxyType,
+		config:    configCopy,
+	}
+	return nil
+}
+
+// DeleteControllerProxy removes the proxy configuration for the specified controller name.
+func (s *InMemoryCredentialStore) DeleteControllerProxy(ctx context.Context, controllerName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.controllerProxyConfigs == nil {
+		return errors.E(errors.CodeNotFound)
+	}
+
+	if _, ok := s.controllerProxyConfigs[controllerName]; !ok {
+		return errors.E(errors.CodeNotFound)
+	}
+
+	delete(s.controllerProxyConfigs, controllerName)
 	return nil
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -29,6 +29,11 @@ const (
 )
 
 const (
+	typeKey   = "type"
+	configKey = "config"
+)
+
+const (
 	jwksKey        = "jwks"
 	jwksExpiryKey  = "jwks-expiry"
 	jwksPrivateKey = "jwks-private"
@@ -176,6 +181,96 @@ func (s *VaultStore) GetControllerCredentials(ctx context.Context, controllerNam
 		password = passwordI.(string)
 	}
 	return username, password, nil
+}
+
+// PutControllerProxy stores the proxy configuration for the specified controller name.
+func (s *VaultStore) PutControllerProxy(ctx context.Context, controllerName string, proxyType string, config map[string]interface{}) (err error) {
+	if len(config) == 0 {
+		return errors.E("config cannot be empty")
+	}
+	if proxyType == "" {
+		return errors.E("proxy type cannot be empty")
+	}
+
+	const op = errors.Op("vault.PutControllerProxy")
+
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+
+	client, err := s.client(ctx)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	data := map[string]interface{}{
+		typeKey:   proxyType,
+		configKey: config,
+	}
+	_, err = client.KVv2(s.KVPath).Put(ctx, s.controllerProxyPath(controllerName), data)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+// GetControllerProxy retrieves the proxy configuration for the specified controller name.
+func (s *VaultStore) GetControllerProxy(ctx context.Context, controllerName string) (_ string, _ map[string]interface{}, err error) {
+	const op = errors.Op("vault.GetControllerProxy")
+
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+
+	client, err := s.client(ctx)
+	if err != nil {
+		return "", nil, errors.E(op, err)
+	}
+
+	secret, err := client.KVv2(s.KVPath).Get(ctx, s.controllerProxyPath(controllerName))
+	if err != nil {
+		if goerr.Unwrap(err) == api.ErrSecretNotFound {
+			return "", nil, errors.E(op, errors.CodeNotFound, err)
+		}
+		return "", nil, errors.E(op, err)
+	}
+	if secret == nil || secret.Data == nil {
+		return "", nil, errors.E(op, errors.CodeNotFound, "no proxy config exists yet")
+	}
+	var proxyType string
+	var config map[string]interface{}
+	typeI, ok := secret.Data[typeKey]
+	if ok {
+		proxyType, _ = typeI.(string)
+	}
+	configI, ok := secret.Data[configKey]
+	if ok {
+		config, _ = configI.(map[string]interface{})
+	}
+	return proxyType, config, nil
+}
+
+// DeleteControllerProxy removes the proxy configuration for the specified controller name.
+func (s *VaultStore) DeleteControllerProxy(ctx context.Context, controllerName string) (err error) {
+	const op = errors.Op("vault.DeleteControllerProxy")
+
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+
+	client, err := s.client(ctx)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	err = client.KVv2(s.KVPath).Delete(ctx, s.controllerProxyPath(controllerName))
+	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
+		// Ignore the error if attempting to delete something that isn't there.
+		err = nil
+	}
+	if err != nil {
+		return errors.E(op, err)
+	}
+	return nil
 }
 
 // PutControllerCredentials stores the controller credentials in a vault
@@ -516,4 +611,8 @@ func (s *VaultStore) path(tag names.CloudCredentialTag) string {
 
 func (s *VaultStore) controllerCredentialsPath(controllerName string) string {
 	return path.Join("creds", controllerName)
+}
+
+func (s *VaultStore) controllerProxyPath(controllerName string) string {
+	return path.Join("proxy", controllerName)
 }

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/vault"
 )
@@ -183,4 +184,73 @@ func TestGetAndPutJWKSPrivateKey(t *testing.T) {
 	keyPem, err := store.GetJWKSPrivateKey(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(keyPem), qt.Contains, "-----BEGIN RSA PRIVATE KEY-----")
+}
+
+func TestGetAndPutControllerProxy(t *testing.T) {
+	c := qt.New(t)
+
+	st := newStore(c)
+	ctx := context.Background()
+	controllerName := "controller-1"
+	proxyType := "http"
+	config := map[string]interface{}{
+		"host": "proxy.example.com",
+		"port": "8080",
+	}
+	err := st.PutControllerProxy(ctx, controllerName, proxyType, config)
+	c.Assert(err, qt.IsNil)
+	gotType, gotConfig, err := st.GetControllerProxy(ctx, controllerName)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotType, qt.Equals, proxyType)
+	c.Check(gotConfig, qt.DeepEquals, config)
+}
+
+func TestPutControllerProxyNotValid(t *testing.T) {
+	c := qt.New(t)
+
+	st := newStore(c)
+	ctx := context.Background()
+	controllerName := "controller-1"
+
+	err := st.PutControllerProxy(ctx, controllerName, "", map[string]interface{}{"a": "A"})
+	c.Assert(err, qt.ErrorMatches, "proxy type cannot be empty")
+
+	err = st.PutControllerProxy(ctx, controllerName, "http", nil)
+	c.Assert(err, qt.ErrorMatches, "config cannot be empty")
+}
+
+func TestGetControllerProxyNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	st := newStore(c)
+	ctx := context.Background()
+	controllerName := "controller-not-found"
+
+	_, _, err := st.GetControllerProxy(ctx, controllerName)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}
+
+func TestDeleteControllerProxy(t *testing.T) {
+	c := qt.New(t)
+
+	st := newStore(c)
+	ctx := context.Background()
+	controllerName := "controller-1"
+	proxyType := "http"
+	config := map[string]interface{}{
+		"host": "proxy.example.com",
+		"port": "8080",
+	}
+	err := st.PutControllerProxy(ctx, controllerName, proxyType, config)
+	c.Assert(err, qt.IsNil)
+	gotType, gotConfig, err := st.GetControllerProxy(ctx, controllerName)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotType, qt.Equals, proxyType)
+	c.Check(gotConfig, qt.DeepEquals, config)
+
+	err = st.DeleteControllerProxy(ctx, controllerName)
+	c.Assert(err, qt.IsNil)
+
+	_, _, err = st.GetControllerProxy(ctx, controllerName)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }


### PR DESCRIPTION
Since proxy-config can contain credentials I've moved the proxy-config to vault.
To support that we need to implement the methods to storage proxy config for:
- CredentialStore
- Database
- InMemoryStore

An implementation note: the struct implementing `ToProxier` has been moved one layer up, to `internal/jimm/juju` to make sure the struct logic is not tight to the storage of the proxy config.
