### PR TITLE
feat: use jujuparams and not jujucloud

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -56,6 +56,7 @@ type bootstrapCommand struct {
 	controllerVersion string
 	timeout           int
 	detach            bool
+	credentialName    string
 }
 
 // NewBootstrapStartCommand returns a command to start a job
@@ -96,8 +97,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	f.IntVar(&c.timeout, "timeout", 0, "The timeout in seconds for the bootstrap operation.")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
-	// TODO(ale8k): Support passing cloud & cloudcredential files, for now we're looking up clouds and credentials added to the store.
-	// See cmd/juju/cloud/add.go L311 on a nice way to do this and credential will be somewhere in there too.
+	f.StringVar(&c.credentialName, "credential", "", "The name of the cloud credential to use for bootstrapping.")
 }
 
 // Info implements modelcmd.Command.
@@ -125,15 +125,20 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return fmt.Errorf("failed to get credential for cloud %q: %w", c.cloud, err)
 	}
 
-	var firstCredential jujucloud.Credential
-	for _, v := range bootstrapCredential.AuthCredentials {
-		firstCredential = v
-		break
+	var credToUse jujucloud.Credential
+	if c.credentialName != "" {
+		cred, ok := bootstrapCredential.AuthCredentials[c.credentialName]
+		if !ok {
+			return fmt.Errorf("credential %q not found for cloud %q", c.credentialName, c.cloud)
+		}
+		credToUse = cred
+	} else {
+		credToUse = bootstrapCredential.AuthCredentials[bootstrapCredential.DefaultCredential]
 	}
 
 	cloudCred := jujuparams.CloudCredential{
-		AuthType:   string(firstCredential.AuthType()),
-		Attributes: firstCredential.Attributes(),
+		AuthType:   string(credToUse.AuthType()),
+		Attributes: credToUse.Attributes(),
 	}
 
 	req := apiparams.BootstrapStartParams{

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -125,13 +125,24 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return fmt.Errorf("failed to get credential for cloud %q: %w", c.cloud, err)
 	}
 
+	var firstCredential jujucloud.Credential
+	for _, v := range bootstrapCredential.AuthCredentials {
+		firstCredential = v
+		break
+	}
+
+	cloudCred := jujuparams.CloudCredential{
+		AuthType:   string(firstCredential.AuthType()),
+		Attributes: firstCredential.Attributes(),
+	}
+
 	req := apiparams.BootstrapStartParams{
 		CloudName:         c.cloud,
 		RegionName:        c.region,
 		ControllerName:    c.controllerName,
 		ControllerVersion: c.controllerVersion,
 		Cloud:             cloudToParams(*bootstrapCloud),
-		Credential:        *bootstrapCredential,
+		Credential:        cloudCred,
 
 		Flags: apiparams.BootstrapFlags{
 			Timeout: c.timeout,

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -60,7 +60,7 @@ func (s *bootstrapCmdSuite) TestArgParsing(c *gc.C) {
 				c.Check(command.controllerVersion, gc.Equals, "controller-version")
 			},
 		}, {
-			args: []string{"test-cloud/region", "controller-name", "controller-version", "--timeout=60", "--detach"},
+			args: []string{"test-cloud/region", "controller-name", "controller-version", "--timeout=60", "--detach", "--credential=mycredential"},
 			checkFlags: func(c *gc.C, command *bootstrapCommand) {
 				c.Check(command.cloud, gc.Equals, "test-cloud")
 				c.Check(command.region, gc.Equals, "region")
@@ -68,6 +68,7 @@ func (s *bootstrapCmdSuite) TestArgParsing(c *gc.C) {
 				c.Check(command.controllerVersion, gc.Equals, "controller-version")
 				c.Check(command.timeout, gc.Equals, 60)
 				c.Check(command.detach, gc.Equals, true)
+				c.Check(command.credentialName, gc.Equals, "mycredential")
 			},
 		}, {
 			args:     []string{"test-cloud/region"},

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -95,7 +95,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 	cloudName := "aws"
 
 	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
-		DefaultCredential: "default-cred-value-for-test",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"default": jujucloud.NewCredential("auth-type-for-test", nil),
+		},
 	}, nil)
 	s.client.EXPECT().Bootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
 		expected := &params.BootstrapStartParams{
@@ -103,8 +105,8 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 			CloudName:      cloudName,
 			RegionName:     "region",
 			Cloud:          jujuparams.Cloud{},
-			Credential: jujucloud.CloudCredential{
-				DefaultCredential: "default-cred-value-for-test",
+			Credential: jujuparams.CloudCredential{
+				AuthType: "auth-type-for-test",
 			},
 			Flags: params.BootstrapFlags{
 				Timeout: 60,
@@ -117,9 +119,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 		// AWS is dynamically populated, i.e., 32 regions.
 		// So we expect just ec2 and it should be ok.
 		c.Assert(bsp.Cloud.Type, gc.DeepEquals, "ec2")
-		c.Assert(bsp.Credential, gc.DeepEquals, expected.Credential)
 		c.Assert(bsp.Flags.Timeout, gc.Equals, expected.Flags.Timeout)
 		c.Assert(bsp.ControllerVersion, gc.Equals, expected.ControllerVersion)
+		c.Assert(bsp.Credential.AuthType, gc.Equals, "auth-type-for-test")
 
 		return &params.BootstrapStartResponse{
 			JobID: "test-job-id",

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -643,6 +644,14 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		cloudNameAndRegion = fmt.Sprintf("%s/%s", req.CloudName, req.RegionName)
 	}
 
+	in := cloud.NewCredential(
+		cloud.AuthType(req.Credential.AuthType),
+		req.Credential.Attributes,
+	)
+
+	cloudCred := cloud.NewEmptyCloudCredential()
+	cloudCred.AuthCredentials["default"] = in
+
 	params := bootstrap.BootstrapParams{
 		CLIVersion: "3.6.8",
 
@@ -651,7 +660,7 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		BootstrapTimeout:   req.Flags.Timeout,
 
 		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
-		CloudCred:     req.Credential,
+		CloudCred:     *cloudCred,
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
@@ -217,7 +216,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 			Timeout: 3600,
 		},
 		Cloud:             jujuparams.Cloud{},
-		Credential:        jujucloud.CloudCredential{},
+		Credential:        jujuparams.CloudCredential{},
 		ControllerVersion: "3.6.8",
 	}
 

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -5,7 +5,6 @@ package params
 import (
 	"time"
 
-	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 )
 
@@ -617,7 +616,7 @@ type BootstrapStartParams struct {
 	Cloud jujuparams.Cloud `json:"cloud,omitempty"`
 	// Credential contains the cloud credential and its tag, this credential will be used against the
 	// the cloud provided to bootstrap the controller.
-	Credential jujucloud.CloudCredential `json:"credential"`
+	Credential jujuparams.CloudCredential `json:"credential"`
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.
 	ControllerName string `json:"controller-name"`


### PR DESCRIPTION
## Description
In my original PR, we used jujucloud.CloudCredential (because it was easier), it enabled us to send a set of credentials and not worry about which the user has picked as juju will iterate over them. Now, we're explicitly sending a single credential and taking the first. 

It is picking the default credential unless otherwise specified by a new --credential flag.


This also needs Q/A'ing before merging.  So do not merge this until it is QA'd. Once #1682 is merged, this can be rebased with v3 and QA'd by updating the env to point at JIMM.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
