### PR TITLE
feat: security events

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -6,7 +6,6 @@ package service
 
 import (
 	"context"
-	goerr "errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -747,7 +746,7 @@ func newOpenFGAClient(ctx context.Context, p OpenFGAParams) (*openfga.OFGAClient
 // controller.
 func ensureControllerAdministrators(ctx context.Context, client *openfga.OFGAClient, controllerUUID string, admins []string) error {
 	controller := names.NewControllerTag(controllerUUID)
-	errs := make([]error, 0, len(admins))
+	tuples := []openfga.Tuple{}
 	for _, username := range admins {
 		userTag := names.NewUserTag(username)
 		i, err := dbmodel.NewIdentity(userTag.Id())
@@ -760,21 +759,20 @@ func ensureControllerAdministrators(ctx context.Context, client *openfga.OFGACli
 			return errors.E(err)
 		}
 		if !isAdmin {
-			tuple := openfga.Tuple{
+			tuples = append(tuples, openfga.Tuple{
 				Object:   ofganames.ConvertTag(userTag),
 				Relation: ofganames.AdministratorRelation,
 				Target:   ofganames.ConvertTag(controller),
-			}
-			err := client.AddRelation(ctx, tuple)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-			logger.LogGrantJimmAdmin(ctx, username)
+			})
 		}
 	}
-	if len(errs) > 0 {
-		return goerr.Join(errs...)
+	if len(tuples) == 0 {
+		return nil
 	}
+	err := client.AddRelation(ctx, tuples...)
+	if err != nil {
+		return err
+	}
+	logger.LogGrantJimmAdmins(ctx, admins)
 	return nil
 }

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"context"
+	goerr "errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -746,7 +747,7 @@ func newOpenFGAClient(ctx context.Context, p OpenFGAParams) (*openfga.OFGAClient
 // controller.
 func ensureControllerAdministrators(ctx context.Context, client *openfga.OFGAClient, controllerUUID string, admins []string) error {
 	controller := names.NewControllerTag(controllerUUID)
-	tuples := []openfga.Tuple{}
+	errs := make([]error, 0, len(admins))
 	for _, username := range admins {
 		userTag := names.NewUserTag(username)
 		i, err := dbmodel.NewIdentity(userTag.Id())
@@ -759,15 +760,21 @@ func ensureControllerAdministrators(ctx context.Context, client *openfga.OFGACli
 			return errors.E(err)
 		}
 		if !isAdmin {
-			tuples = append(tuples, openfga.Tuple{
+			tuple := openfga.Tuple{
 				Object:   ofganames.ConvertTag(userTag),
 				Relation: ofganames.AdministratorRelation,
 				Target:   ofganames.ConvertTag(controller),
-			})
+			}
+			err := client.AddRelation(ctx, tuple)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			logger.LogGrantJimmAdmin(ctx, username)
 		}
 	}
-	if len(tuples) == 0 {
-		return nil
+	if len(errs) > 0 {
+		return goerr.Join(errs...)
 	}
-	return client.AddRelation(ctx, tuples...)
+	return nil
 }

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
@@ -161,10 +162,16 @@ func (j *loginManager) LoginClientCredentials(ctx context.Context, clientID stri
 
 	err = j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
 	if err != nil {
+		logger.LogFailedLogin(ctx, clientIdWithDomain)
 		return nil, errors.E(op, err)
 	}
-
-	return j.UserLogin(ctx, clientIdWithDomain)
+	user, err := j.UserLogin(ctx, clientIdWithDomain)
+	if err != nil {
+		logger.LogFailedLogin(ctx, clientIdWithDomain)
+		return nil, errors.E(op, err)
+	}
+	logger.LogSuccessfulLogin(ctx, clientIdWithDomain)
+	return user, nil
 }
 
 // LoginWithSessionToken verifies a user's session token before the user is logged in.
@@ -172,11 +179,18 @@ func (j *loginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 	const op = errors.Op("jimm.LoginWithSessionToken")
 	jwtToken, err := j.oAuthAuthenticator.VerifySessionToken(sessionToken)
 	if err != nil {
+		logger.LogFailedLogin(ctx, "unkown session token")
 		return nil, errors.E(op, err)
 	}
 
 	email := jwtToken.Subject()
-	return j.UserLogin(ctx, email)
+	user, err := j.UserLogin(ctx, email)
+	if err != nil {
+		logger.LogFailedLogin(ctx, email)
+		return nil, errors.E(op, err)
+	}
+	logger.LogSuccessfulLogin(ctx, email)
+	return user, nil
 }
 
 // LoginWithSessionCookie uses the identity ID expected to have come from a session cookie, to log the user in.
@@ -190,7 +204,13 @@ func (j *loginManager) LoginWithSessionCookie(ctx context.Context, identityID st
 	if identityID == "" {
 		return nil, errors.E(op, "missing cookie identity")
 	}
-	return j.UserLogin(ctx, identityID)
+	user, err := j.UserLogin(ctx, identityID)
+	if err != nil {
+		logger.LogFailedLogin(ctx, identityID)
+		return nil, errors.E(op, err)
+	}
+	logger.LogSuccessfulLogin(ctx, identityID)
+	return user, nil
 }
 
 // UserLogin fetches the identity specified by a user's email or a service account ID

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -179,7 +179,7 @@ func (j *loginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 	const op = errors.Op("jimm.LoginWithSessionToken")
 	jwtToken, err := j.oAuthAuthenticator.VerifySessionToken(sessionToken)
 	if err != nil {
-		logger.LogFailedLogin(ctx, "unkown session token")
+		logger.LogFailedLogin(ctx, "unknown session token")
 		return nil, errors.E(op, err)
 	}
 

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -46,7 +46,7 @@ func (r *controllerRoot) Offer(ctx context.Context, args jujuparams.AddApplicati
 		Results: make([]jujuparams.ErrorResult, len(args.Offers)),
 	}
 	for i, addOfferParams := range args.Offers {
-		result.Results[i].Error = mapError(r.offer(ctx, addOfferParams))
+		result.Results[i].Error = r.mapError(ctx, r.offer(ctx, addOfferParams))
 	}
 	return result, nil
 }
@@ -95,7 +95,7 @@ func (r *controllerRoot) GetConsumeDetails(ctx context.Context, args jujuparams.
 	for i, offerURL := range args.OfferURLs.OfferURLs {
 		var err error
 		results.Results[i].ConsumeOfferDetails, err = r.getConsumeDetails(ctx, user, args.OfferURLs.BakeryVersion, offerURL)
-		results.Results[i].Error = mapError(err)
+		results.Results[i].Error = r.mapError(ctx, err)
 	}
 	return results, nil
 }
@@ -162,7 +162,7 @@ func (r *controllerRoot) ModifyOfferAccess(ctx context.Context, args jujuparams.
 	}
 
 	for i, change := range args.Changes {
-		results.Results[i].Error = mapError(r.modifyOfferAccess(ctx, change))
+		results.Results[i].Error = r.mapError(ctx, r.modifyOfferAccess(ctx, change))
 	}
 	return results, nil
 }
@@ -208,7 +208,7 @@ func (r *controllerRoot) DestroyOffers(ctx context.Context, args jujuparams.Dest
 	}
 
 	for i, offerURL := range args.OfferURLs {
-		results.Results[i].Error = mapError(r.jimm.JujuManager().DestroyOffer(ctx, r.user, offerURL, args.Force))
+		results.Results[i].Error = r.mapError(ctx, r.jimm.JujuManager().DestroyOffer(ctx, r.user, offerURL, args.Force))
 	}
 	return results, nil
 }
@@ -221,7 +221,7 @@ func (r *controllerRoot) ApplicationOffers(ctx context.Context, args jujuparams.
 		details, err := r.jimm.JujuManager().GetApplicationOffer(ctx, r.user, offerURL)
 		result.Results[i] = jujuparams.ApplicationOfferResult{
 			Result: details,
-			Error:  mapError(err),
+			Error:  r.mapError(ctx, err),
 		}
 	}
 

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -73,12 +73,12 @@ func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (j
 	for i, ent := range ents.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			cloudResults[i].Error = mapError(errors.E(op, errors.CodeBadRequest, err))
+			cloudResults[i].Error = r.mapError(ctx, errors.E(op, errors.CodeBadRequest, err))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			cloudResults[i].Error = mapError(errors.E(op, err))
+			cloudResults[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		cloudResults[i].Cloud = new(jujuparams.Cloud)
@@ -114,12 +114,12 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 	for i, ent := range userclouds.UserClouds {
 		user, err := r.masquerade(ctx, ent.UserTag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		cld, err := names.ParseCloudTag(ent.CloudTag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		err = r.jimm.JujuManager().ForEachUserCloudCredential(ctx, user.Identity, cld, func(c *dbmodel.CloudCredential) error {
@@ -127,7 +127,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 			return nil
 		})
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 		}
 	}
 
@@ -142,7 +142,7 @@ func (r *controllerRoot) RevokeCredentialsCheckModels(ctx context.Context, args 
 	results := make([]jujuparams.ErrorResult, len(args.Credentials))
 	for i, ent := range args.Credentials {
 		if err := r.revokeCredential(ctx, ent.Tag, ent.Force); err != nil {
-			results[i].Error = mapError(err)
+			results[i].Error = r.mapError(ctx, err)
 		}
 	}
 	return jujuparams.ErrorResults{
@@ -170,7 +170,7 @@ func (r *controllerRoot) Credential(ctx context.Context, args jujuparams.Entitie
 	for i, e := range args.Entities {
 		cred, err := r.credential(ctx, e.Tag)
 		if err != nil {
-			results[i].Error = mapError(err)
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		results[i].Result = cred
@@ -281,10 +281,10 @@ func userModelAccess(ctx context.Context, user *openfga.User, model names.ModelT
 
 // CredentialContents implements the CredentialContents method of the Cloud (v5) facade.
 func (r *controllerRoot) CredentialContents(ctx context.Context, args jujuparams.CloudCredentialArgs) (jujuparams.CredentialContentResults, error) {
-	return getIdentityCredentials(ctx, r.user, r.jimm, args)
+	return r.getIdentityCredentials(ctx, r.user, r.jimm, args)
 }
 
-func getIdentityCredentials(ctx context.Context, user *openfga.User, j JIMM, args jujuparams.CloudCredentialArgs) (jujuparams.CredentialContentResults, error) {
+func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openfga.User, j JIMM, args jujuparams.CloudCredentialArgs) (jujuparams.CredentialContentResults, error) {
 	const op = errors.Op("jujuapi.CredentialContents")
 
 	credentialContents := func(c *dbmodel.CloudCredential) (*jujuparams.ControllerCredentialInfo, error) {
@@ -319,12 +319,12 @@ func getIdentityCredentials(ctx context.Context, user *openfga.User, j JIMM, arg
 		cct := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", arg.CloudName, user.Name, arg.CredentialName))
 		cred, err := j.JujuManager().GetCloudCredential(ctx, user, cct)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		results[i].Result, err = credentialContents(cred)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 		}
 	}
 	if len(results) > 0 {
@@ -336,7 +336,7 @@ func getIdentityCredentials(ctx context.Context, user *openfga.User, j JIMM, arg
 		var err error
 		result.Result, err = credentialContents(c)
 		if err != nil {
-			result.Error = mapError(errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(op, err))
 		}
 		results = append(results, result)
 		return nil
@@ -358,12 +358,12 @@ func (r *controllerRoot) RemoveClouds(ctx context.Context, args jujuparams.Entit
 	for i, entity := range args.Entities {
 		tag, err := names.ParseCloudTag(entity.Tag)
 		if err != nil {
-			result.Results[i].Error = mapError(errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		err = r.jimm.JujuManager().RemoveCloud(ctx, r.user, tag)
 		if err != nil {
-			result.Results[i].Error = mapError(errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
 		}
 	}
 	return result, nil
@@ -377,7 +377,7 @@ func (r *controllerRoot) CheckCredentialsModels(ctx context.Context, args jujupa
 func (r *controllerRoot) ModifyCloudAccess(ctx context.Context, args jujuparams.ModifyCloudAccessRequest) (jujuparams.ErrorResults, error) {
 	results := make([]jujuparams.ErrorResult, len(args.Changes))
 	for i, change := range args.Changes {
-		results[i].Error = mapError(r.modifyCloudAccess(ctx, change))
+		results[i].Error = r.mapError(ctx, r.modifyCloudAccess(ctx, change))
 	}
 	return jujuparams.ErrorResults{
 		Results: results,
@@ -428,7 +428,7 @@ func (r *controllerRoot) updateCredentials(ctx context.Context, args []jujuparam
 		models, err := r.updateCredential(ctx, arg, skipCheck, skipUpdate)
 		results.Results[i] = jujuparams.UpdateCredentialResult{
 			CredentialTag: arg.Tag,
-			Error:         mapError(err),
+			Error:         r.mapError(ctx, err),
 			Models:        models,
 		}
 		results.Results[i].CredentialTag = arg.Tag
@@ -457,7 +457,7 @@ func (r *controllerRoot) UpdateCloud(ctx context.Context, args jujuparams.Update
 	for i := range args.Clouds {
 		err := r.updateCloud()
 		if err != nil {
-			results.Results[i].Error = mapError(err)
+			results.Results[i].Error = r.mapError(ctx, err)
 		}
 	}
 	return results, nil
@@ -477,12 +477,12 @@ func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities
 	for i, ent := range args.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -206,12 +206,12 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 	for i, arg := range args.Entities {
 		mt, err := names.ParseModelTag(arg.Tag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		status, err := r.jimm.JujuManager().ModelStatus(ctx, r.user, mt)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		results[i] = *status
@@ -262,12 +262,12 @@ func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparam
 	for i, arg := range args.Entities {
 		tag, err := names.ParseUserTag(arg.Tag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		access, err := r.jimm.PermissionManager().GetJimmControllerAccess(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		results[i].Result = &jujuparams.UserAccess{
@@ -290,7 +290,7 @@ func (r *controllerRoot) InitiateMigration(ctx context.Context, args jujuparams.
 	for i, spec := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateMigration(ctx, r.user, spec)
 		if err != nil {
-			result.Error = mapError(errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(op, err))
 		}
 		results[i] = result
 	}

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -515,7 +515,7 @@ func (r *controllerRoot) MigrateModel(ctx context.Context, args apiparams.Migrat
 	for i, arg := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateInternalMigration(ctx, r.user, arg.TargetModelNameOrUUID, arg.TargetController)
 		if err != nil {
-			result.Error = mapError(errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(op, err))
 		}
 		results[i] = result
 	}

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -92,11 +92,11 @@ func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpMod
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModel(ctx, r.user, mt, args.Simplified)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 		}
 	}
 	return jujuparams.StringResults{
@@ -164,7 +164,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 		mt, err := names.ParseModelTag(arg.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		results[i].Result, err = r.jimm.JujuManager().ModelInfo(ctx, r.user, mt)
@@ -174,7 +174,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 				// does.
 				err = errors.E(op, errors.CodeUnauthorized, "unauthorized")
 			}
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 		} else if r.controllerUUIDMasking {
 			results[i].Result.ControllerUUID = r.params.ControllerUUID
 		}
@@ -221,7 +221,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 		mt, err := names.ParseModelTag(model.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 
@@ -229,7 +229,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 			if errors.ErrorCode(err) != errors.CodeNotFound {
 				// It isn't an error to try and destroy an already
 				// destroyed model.
-				results[i].Error = mapError(errors.E(op, err))
+				results[i].Error = r.mapError(ctx, errors.E(op, err))
 			}
 		}
 	}
@@ -250,12 +250,12 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		mt, err := names.ParseModelTag(change.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		user, err := parseUserTag(change.UserTag)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
 		switch change.Action {
@@ -269,7 +269,7 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			err = errors.E(op, errors.CodeUnauthorized, "unauthorized")
 		}
-		results[i].Error = mapError(err)
+		results[i].Error = r.mapError(ctx, err)
 	}
 	return jujuparams.ErrorResults{
 		Results: results,
@@ -289,11 +289,11 @@ func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entit
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModelDB(ctx, r.user, mt)
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 		}
 	}
 	return jujuparams.MapResults{
@@ -309,7 +309,7 @@ func (r *controllerRoot) ChangeModelCredential(ctx context.Context, args jujupar
 	defer cancel()
 	results := make([]jujuparams.ErrorResult, len(args.Models))
 	for i, arg := range args.Models {
-		results[i].Error = mapError(r.changeModelCredential(ctx, arg))
+		results[i].Error = r.mapError(ctx, r.changeModelCredential(ctx, arg))
 	}
 	return jujuparams.ErrorResults{
 		Results: results,
@@ -347,10 +347,10 @@ func (r *controllerRoot) ValidateModelUpgrades(ctx context.Context, args jujupar
 		modelTag, err := names.ParseModelTag(arg.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", modelTag.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
 			continue
 		}
-		results[i].Error = mapError(r.jimm.JujuManager().ValidateModelUpgrade(ctx, r.user, modelTag, args.Force))
+		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().ValidateModelUpgrade(ctx, r.user, modelTag, args.Force))
 	}
 	return jujuparams.ErrorResults{
 		Results: results,
@@ -366,10 +366,10 @@ func (r *controllerRoot) SetModelDefaults(ctx context.Context, args jujuparams.S
 		cloudTag, err := names.ParseCloudTag(config.CloudTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", cloudTag.String()))
 		if err != nil {
-			results[i].Error = mapError(errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
-		results[i].Error = mapError(r.jimm.JujuManager().SetModelDefaults(ctx, r.user.Identity, cloudTag, config.CloudRegion, config.Config))
+		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().SetModelDefaults(ctx, r.user.Identity, cloudTag, config.CloudRegion, config.Config))
 	}
 
 	return jujuparams.ErrorResults{
@@ -384,10 +384,10 @@ func (r *controllerRoot) UnsetModelDefaults(ctx context.Context, args jujuparams
 		cloudTag, err := names.ParseCloudTag(key.CloudTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", cloudTag.String()))
 		if err != nil {
-			results[i].Error = mapError(err)
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
-		results[i].Error = mapError(r.jimm.JujuManager().UnsetModelDefaults(ctx, r.user.Identity, cloudTag, key.CloudRegion, key.Keys))
+		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().UnsetModelDefaults(ctx, r.user.Identity, cloudTag, key.CloudRegion, key.Keys))
 	}
 
 	return jujuparams.ErrorResults{
@@ -406,12 +406,12 @@ func (r *controllerRoot) ModelDefaultsForClouds(ctx context.Context, args jujupa
 		cloudTag, err := names.ParseCloudTag(entity.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", cloudTag.String()))
 		if err != nil {
-			result.Results[i].Error = mapError(errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		defaults, err := r.jimm.JujuManager().ModelDefaultsForCloud(ctx, r.user.Identity, cloudTag)
 		if err != nil {
-			result.Results[i].Error = mapError(errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
 			continue
 		}
 		result.Results[i] = defaults

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/streamproxy"
 )
 
@@ -77,6 +78,11 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 	}
 
 	if !user.JimmAdmin {
+		logger.LogUnauthorizedAccess(
+			ctx,
+			user.Name,
+			"unauthorized access to stream controller proxy. User is not a JIMM admin",
+		)
 		writeError("unauthorized", errors.CodeUnauthorized)
 		return
 	}

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/streamproxy"
 )
@@ -82,6 +83,11 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		writeError(err.Error(), errors.CodeUnauthorized)
 		return
 	} else if !ok {
+		logger.LogUnauthorizedAccess(
+			ctx,
+			user.Name,
+			fmt.Sprintf("unauthorized access for stream model proxy for model %s", modelTag.Id()),
+		)
 		writeError(fmt.Sprintf("unauthorized access to endpoint: %s", finalPath), errors.CodeUnauthorized)
 		return
 	}

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 
@@ -68,7 +68,7 @@ func (r *controllerRoot) UserInfo(ctx context.Context, req jujuparams.UserInfoRe
 	for i, ent := range req.Entities {
 		ui, err := r.userInfo(ent.Tag)
 		if err != nil {
-			res.Results[i].Error = mapError(err)
+			res.Results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		res.Results[i].Result = ui

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -130,9 +130,13 @@ func (r *controllerRoot) mapError(ctx context.Context, err error) *jujuparams.Er
 	if errors.ErrorCode(err) == errors.CodeUnauthorized {
 		// Here we log the unauthorized access attempt.
 		// We use the error as a best effort description of what went wrong.
+		username := "unknown"
+		if r.user != nil {
+			username = r.user.Name
+		}
 		logger.LogUnauthorizedAccess(
 			ctx,
-			r.user.Name,
+			username,
 			fmt.Sprintf("unauthorized access attempt, error: %v", err),
 		)
 	}

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -5,6 +5,7 @@ package jujuapi
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"regexp"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/jimm/jujuauth"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
+	"github.com/canonical/jimm/v3/internal/logger"
 	jimmRPC "github.com/canonical/jimm/v3/internal/rpc"
 	"github.com/canonical/jimm/v3/internal/rpcproxy"
 )
@@ -32,12 +34,6 @@ const (
 	maxRequestConcurrency = 10
 	pingTimeout           = 180 * time.Second
 )
-
-// A root is an rpc.Root enhanced so that it can notify on ping requests.
-type root interface {
-	rpc.Root
-	setPingF(func())
-}
 
 // An apiServer is a jimmhttp.WSServer that serves the controller API.
 type apiServer struct {
@@ -101,7 +97,7 @@ func (s *apiServer) Kill() {
 }
 
 // serveRoot serves an RPC root object on a websocket connection.
-func serveRoot(ctx context.Context, root root, logger auditLogger, wsConn *websocket.Conn) {
+func serveRoot(ctx context.Context, root *controllerRoot, logger auditLogger, wsConn *websocket.Conn) {
 	// Note that although NewConn accepts a `RecorderFactory` input, the call to conn.ServeRoot
 	// also accepts a `RecorderFactory` and will override anything set during the call to NewConn.
 	conn := rpc.NewConn(
@@ -112,7 +108,7 @@ func serveRoot(ctx context.Context, root root, logger auditLogger, wsConn *webso
 		return NewRecorder(logger)
 	}
 	conn.ServeRoot(root, rpcRecorderFactory, func(err error) error {
-		return mapError(err)
+		return root.mapError(ctx, err)
 	})
 	defer conn.Close()
 	t := time.AfterFunc(pingTimeout, func() {
@@ -126,13 +122,20 @@ func serveRoot(ctx context.Context, root root, logger auditLogger, wsConn *webso
 }
 
 // mapError maps JIMM errors to errors suitable for use with the juju API.
-func mapError(err error) *jujuparams.Error {
+func (r *controllerRoot) mapError(ctx context.Context, err error) *jujuparams.Error {
 	if err == nil {
 		return nil
 	}
-	// TODO the error mapper should really accept a context from the RPC package.
-	zapctx.Debug(context.TODO(), "rpc error", zaputil.Error(err))
-
+	zapctx.Debug(ctx, "rpc error", zaputil.Error(err))
+	if errors.ErrorCode(err) == errors.CodeUnauthorized {
+		// Here we log the unauthorized access attempt.
+		// We use the error as a best effort description of what went wrong.
+		logger.LogUnauthorizedAccess(
+			ctx,
+			r.user.Name,
+			fmt.Sprintf("unauthorized access attempt, error: %v", err),
+		)
+	}
 	return &jujuparams.Error{
 		Message: err.Error(),
 		Code:    string(errors.ErrorCode(err)),

--- a/internal/logger/default_logger.go
+++ b/internal/logger/default_logger.go
@@ -13,6 +13,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// logAppID is the application ID used in all log entries.
+const logAppID = "jimm"
+
 // SetupLogger sets up the default logger.
 // The local logger is a colorized plain text logger.
 // The production logger is a JSON structured logger.
@@ -35,9 +38,12 @@ func SetupLogger(ctx context.Context, logLevel string, devMode bool) {
 	} else {
 		prodConfig := zap.NewProductionConfig()
 		prodConfig.Level = zap.NewAtomicLevelAt(pLogLevel)
-		prodConfig.DisableStacktrace = true                     // Disable stacktraces in prod as they are overly verbose and clutter the logs.
+		prodConfig.DisableStacktrace = true // Disable stacktraces in prod as they are overly verbose and clutter the logs.
+		prodConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		prodConfig.EncoderConfig.TimeKey = "datetime"
 		proLogger := zap.Must(prodConfig.Build())               // this panics if an error is encountered during Build
 		proLogger = proLogger.WithOptions(zap.AddCallerSkip(1)) // skip zapctx
+		proLogger = proLogger.With(zap.String("appid", logAppID))
 		zapctx.Default = proLogger
 	}
 }

--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Canonical.
+
+package logger
+
+import (
+	"context"
+
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type eventLevel string
+
+const (
+	info     eventLevel = "INFO"
+	warning  eventLevel = "WARN"
+	critical eventLevel = "CRITICAL"
+)
+
+type securityEvent struct {
+	Event       string
+	Description string
+	Severity    eventLevel
+}
+
+func (s securityEvent) ToZapFields() []zapcore.Field {
+	return []zapcore.Field{
+		zap.String("event", s.Event),
+		zap.String("description", s.Description),
+		zap.String("severity", string(s.Severity)),
+	}
+}
+
+func logSecurityEvent(ctx context.Context, event securityEvent) {
+	switch event.Severity {
+	case info:
+		zapctx.Info(ctx, event.Event, event.ToZapFields()...)
+	case warning:
+		zapctx.Warn(ctx, event.Event, event.ToZapFields()...)
+	case critical:
+		zapctx.Error(ctx, event.Event, event.ToZapFields()...)
+	}
+}
+
+// LogFailedLogin logs a failed login attempt for the given identityId.
+func LogFailedLogin(ctx context.Context, identityId string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "authn_login_fail:" + identityId,
+		Description: "login failed",
+		Severity:    warning,
+	})
+}
+
+// LogSuccessfulLogin logs a successful login attempt for the given identityId.
+func LogSuccessfulLogin(ctx context.Context, identityId string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "authn_login_success:" + identityId,
+		Description: "login succeeded",
+		Severity:    info,
+	})
+}
+
+// LogUnauthorizedAccess logs an unauthorized access attempt for the given identityId.
+func LogUnauthorizedAccess(ctx context.Context, identityId string, description string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "authz_fail:" + identityId,
+		Description: description,
+		Severity:    critical,
+	})
+}
+
+// LogGrantJimmAdmin logs the granting of JIMM admin role to the given identityId.
+func LogGrantJimmAdmin(ctx context.Context, identityId string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "authz_admin:" + identityId,
+		Description: "JIMM admin role was granted.",
+		Severity:    warning,
+	})
+}

--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -4,6 +4,7 @@ package logger
 
 import (
 	"context"
+	"strings"
 
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -24,7 +25,7 @@ type securityEvent struct {
 	Severity    eventLevel
 }
 
-func (s securityEvent) ToZapFields() []zapcore.Field {
+func (s securityEvent) toZapFields() []zapcore.Field {
 	return []zapcore.Field{
 		zap.String("event", s.Event),
 		zap.String("description", s.Description),
@@ -35,11 +36,11 @@ func (s securityEvent) ToZapFields() []zapcore.Field {
 func logSecurityEvent(ctx context.Context, event securityEvent) {
 	switch event.Severity {
 	case info:
-		zapctx.Info(ctx, event.Event, event.ToZapFields()...)
+		zapctx.Info(ctx, event.Event, event.toZapFields()...)
 	case warning:
-		zapctx.Warn(ctx, event.Event, event.ToZapFields()...)
+		zapctx.Warn(ctx, event.Event, event.toZapFields()...)
 	case critical:
-		zapctx.Error(ctx, event.Event, event.ToZapFields()...)
+		zapctx.Error(ctx, event.Event, event.toZapFields()...)
 	}
 }
 
@@ -70,10 +71,11 @@ func LogUnauthorizedAccess(ctx context.Context, identityId string, description s
 	})
 }
 
-// LogGrantJimmAdmin logs the granting of JIMM admin role to the given identityId.
-func LogGrantJimmAdmin(ctx context.Context, identityId string) {
+// LogGrantJimmAdmins logs the granting of JIMM admin role to the given identityIds.
+func LogGrantJimmAdmins(ctx context.Context, identityIds []string) {
+	identities := strings.Join(identityIds, ", ")
 	logSecurityEvent(ctx, securityEvent{
-		Event:       "authz_admin:" + identityId,
+		Event:       "authz_admin:" + identities,
 		Description: "JIMM admin role was granted.",
 		Severity:    warning,
 	})

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -317,7 +317,7 @@ func (p *modelProxy) sendError(ctx context.Context, socket *writeLockConn, req *
 		logger.LogUnauthorizedAccess(
 			ctx,
 			p.tokenGen.GetUser().String(),
-			fmt.Sprintf("unauthorized access to model proxy for model %s", p.modelUUID),
+			fmt.Sprintf("unauthorized access in model proxy for model %s", p.modelUUID),
 		)
 	}
 	msg := createErrResponse(err, req)

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/servermon"
 	"github.com/canonical/jimm/v3/internal/utils"
@@ -307,10 +308,17 @@ type modelProxy struct {
 	deviceOAuthResponse *oauth2.DeviceAuthResponse
 }
 
-func (p *modelProxy) sendError(socket *writeLockConn, req *message, err error) {
+func (p *modelProxy) sendError(ctx context.Context, socket *writeLockConn, req *message, err error) {
 	if req == nil {
 		// If there was no message to error on, just return.
 		return
+	}
+	if errors.ErrorCode(err) == errors.CodeUnauthorized {
+		logger.LogUnauthorizedAccess(
+			ctx,
+			p.tokenGen.GetUser().String(),
+			fmt.Sprintf("unauthorized access to model proxy for model %s", p.modelUUID),
+		)
 	}
 	msg := createErrResponse(err, req)
 	if msg != nil {
@@ -415,7 +423,7 @@ func (p *clientProxy) start(ctx context.Context) error {
 		err := p.makeControllerConnection(ctx)
 		if err != nil {
 			zapctx.Error(ctx, "error connecting to controller", zap.Error(err))
-			p.sendError(p.src, msg, err)
+			p.sendError(ctx, p.src, msg, err)
 			return fmt.Errorf("failed to connect to controller: %w", err)
 		}
 		if err := p.auditLogMessage(msg, false); err != nil {
@@ -426,7 +434,7 @@ func (p *clientProxy) start(ctx context.Context) error {
 		if msg.Type == "Admin" {
 			toClient, toController, err := p.handleAdminFacade(ctx, msg)
 			if err != nil {
-				p.sendError(p.src, msg, err)
+				p.sendError(ctx, p.src, msg, err)
 				continue
 			}
 			// If there is a response for the client, send it to the client and continue.
@@ -446,7 +454,7 @@ func (p *clientProxy) start(ctx context.Context) error {
 		if msg.Type == "KeyManager" {
 			toClient, err := p.handleKeyManagerFacade(ctx, msg)
 			if err != nil {
-				p.sendError(p.src, msg, err)
+				p.sendError(ctx, p.src, msg, err)
 				continue
 			}
 			p.src.sendMessage(nil, toClient)
@@ -455,7 +463,7 @@ func (p *clientProxy) start(ctx context.Context) error {
 		p.msgs.addMessage(msg)
 		if err := p.dst.writeJson(msg); err != nil {
 			zapctx.Error(ctx, "clientProxy error writing to dst", zap.Error(err))
-			p.sendError(p.src, msg, err)
+			p.sendError(ctx, p.src, msg, err)
 			p.msgs.removeMessage(msg.RequestID)
 			continue
 		}
@@ -526,7 +534,7 @@ func (p *controllerProxy) start(ctx context.Context) error {
 
 		if err := modifyControllerResponse(msg); err != nil {
 			zapctx.Error(ctx, "Failed to modify message", zap.Error(err))
-			p.handleError(msg, err)
+			p.handleError(ctx, msg, err)
 			// An error when modifying the message is a show stopper.
 			return fmt.Errorf("error modifying controller response: %w", err)
 		}
@@ -567,14 +575,14 @@ func (p *controllerProxy) processControllerErrors(ctx context.Context, msg *mess
 	permissionsRequired, err := checkPermissionsRequired(ctx, msg)
 	if err != nil {
 		zapctx.Error(ctx, "failed to determine if more permissions required", zap.Error(err))
-		p.handleError(msg, err)
+		p.handleError(ctx, msg, err)
 		return false
 	}
 	if permissionsRequired != nil {
 		zapctx.Error(ctx, "Access Required error")
 		if err := p.redoLogin(ctx, permissionsRequired); err != nil {
 			zapctx.Error(ctx, "Failed to redo login", zap.Error(err))
-			p.handleError(msg, err)
+			p.handleError(ctx, msg, err)
 			return false
 		}
 		// Write back to the controller.
@@ -589,8 +597,8 @@ func (p *controllerProxy) processControllerErrors(ctx context.Context, msg *mess
 	return true
 }
 
-func (p *controllerProxy) handleError(msg *message, err error) {
-	p.sendError(p.dst, msg, err)
+func (p *controllerProxy) handleError(ctx context.Context, msg *message, err error) {
+	p.sendError(ctx, p.dst, msg, err)
 	p.msgs.removeMessage(msg.RequestID)
 }
 


### PR DESCRIPTION
## Description
In this PR we add security events for JIMM:
he work is split for different commits to help with the review:
1. refactor the production logger to resemble more the logs for SSLDC
2. add the security logger utils methods
3. login events
4. jimm admin events
5. unauthorized events

Example how the logs look like:

```console
{"level":"error","datetime":"2025-09-05T07:04:17.455Z","caller":"logger/securityevent_logger.go:42","msg":"authz_fail:jimm-test43cc8c@canonical.com","appid":"jimm","event":"authz_fail:jimm-test43cc8c@canonical.com","description":"unauthorized access attempt, error: unauthorized","severity":"CRITICAL"}
```


## Some notes
1.
At the moment the logs are just zapctx logs, in the future (if needed) we could add an interface for logger and log these security events where we want. I didn't do it right now, because these SSDLC specs change a lot from one to another. But feel free to suggest the change if you think it's necessary.

2.
Not really sure what to test here, these are just logs, if our `unauthorized`, `login` logic is right we don't have anything to test.

3.
rebac unauthorized access would be in a follow-up. 
