### PR TITLE
feat: expose k8s svc options

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -43,13 +43,13 @@ service if it knows it is supported by the cluster. This is performed by
 interrogating the cluster for a well known managed deployment such as microk8s,
 GKE or EKS.
 
-When bootstrapping to a k8s cluster Juju does not recognise, there's no
+When bootstrapping to a Kubernetes cluster Juju does not recognise, there's no
 guarantee a load balancer is available, so Juju defaults to a controller
 service type of ClusterIP. In the case of bootstrapping via JIMM, this will 
 not work unless JIMM is deployed within the same cluster. There are three bootstrap
 options available to tell Juju how to set up the controller service. Part of
 the solution may require a load balancer for the cluster to be set up manually
-first, or perhaps an external k8s service via a FQDN will be used
+first, or perhaps an external Kubernetes service via a FQDN will be used
 (this is a cluster specific implementation decision which Juju needs to be
 informed about so it can set things up correctly). The three relevant bootstrap
 options are (see list of bootstrap config items below for a full explanation):
@@ -64,6 +64,7 @@ other controllers for cross-model (cross-controller, actually) relations to work
 	bootstrapExamples = `
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --controller-service-type=loadbalancer
 `
 )
 

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -35,6 +35,31 @@ Use the --detach flag to start the bootstrap job and return immediately,
 printing only the job ID, without waiting for the job to complete.
 
 The final argument, version, denotes the Juju controller to be bootstrapped.
+
+Bootstrapping to a k8s cluster requires that the service set up to handle
+requests to the controller be accessible outside the cluster. Typically this
+means a service type of LoadBalancer is needed, and Juju does create such a
+service if it knows it is supported by the cluster. This is performed by
+interrogating the cluster for a well known managed deployment such as microk8s,
+GKE or EKS.
+
+When bootstrapping to a k8s cluster Juju does not recognise, there's no
+guarantee a load balancer is available, so Juju defaults to a controller
+service type of ClusterIP. In the case of bootstrapping via JIMM, this will 
+not work unless JIMM is deployed within the same cluster. There are three bootstrap
+options available to tell Juju how to set up the controller service. Part of
+the solution may require a load balancer for the cluster to be set up manually
+first, or perhaps an external k8s service via a FQDN will be used
+(this is a cluster specific implementation decision which Juju needs to be
+informed about so it can set things up correctly). The three relevant bootstrap
+options are (see list of bootstrap config items below for a full explanation):
+
+- controller-service-type
+- controller-external-name 
+- controller-external-ips
+
+Juju advertises those addresses to other controllers (including JIMM), so they must be resolveable from
+other controllers for cross-model (cross-controller, actually) relations to work.
 `
 	bootstrapExamples = `
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -54,8 +54,15 @@ type bootstrapCommand struct {
 	region            string
 	controllerName    string
 	controllerVersion string
-	timeout           int
-	detach            bool
+
+	// Flags
+
+	timeout                int
+	publicDNSAddress       string
+	controllerServiceType  string
+	controllerExternalIPs  string
+	controllerExternalName string
+	detach                 bool
 }
 
 // NewBootstrapStartCommand returns a command to start a job
@@ -95,6 +102,15 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 	f.IntVar(&c.timeout, "timeout", 0, "The timeout in seconds for the bootstrap operation.")
+	f.StringVar(&c.publicDNSAddress, "public-dns-address", "", "Public DNS address (with port) of the controller")
+	f.StringVar(
+		&c.controllerServiceType,
+		"controller-service-type",
+		"",
+		"Controls the kubernetes service type for Juju controllers, see https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec valid values are one of cluster, loadbalancer, external",
+	)
+	f.StringVar(&c.controllerExternalIPs, "controller-external-ips", "", "Specifies a comma separated list of external IPs for a k8s controller of type external")
+	f.StringVar(&c.controllerExternalName, "controller-external-name", "", "Sets the external name for a k8s controller of type external")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
 	// TODO(ale8k): Support passing cloud & cloudcredential files, for now we're looking up clouds and credentials added to the store.
 	// See cmd/juju/cloud/add.go L311 on a nice way to do this and credential will be somewhere in there too.
@@ -134,7 +150,11 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		Credential:        *bootstrapCredential,
 
 		Flags: apiparams.BootstrapFlags{
-			Timeout: c.timeout,
+			Timeout:                c.timeout,
+			PublicDNSAddress:       c.publicDNSAddress,
+			ControllerServiceType:  c.controllerServiceType,
+			ControllerExternalIPs:  c.controllerExternalIPs,
+			ControllerExternalName: c.controllerExternalName,
 		},
 	}
 

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -185,6 +185,11 @@ func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.Use
 				PersonalCloud:      params.PersonalCloud,
 				// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 				LoginTokenRefreshURL: b.jimmWellknownJWKSEndpoint,
+
+				PublicDNSAddress:       params.PublicDNSAddress,
+				ControllerServiceType:  params.ControllerServiceType,
+				ControllerExternalIPs:  params.ControllerExternalIPs,
+				ControllerExternalName: params.ControllerExternalName,
 			},
 			DefaultBootstrapExecutor{},
 			user,
@@ -248,6 +253,14 @@ type JobParams struct {
 	// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 
 	LoginTokenRefreshURL string
+
+	// Controller public dns address (if any) and k8s service options to expose a k8s
+	// controller.
+
+	PublicDNSAddress       string
+	ControllerServiceType  string
+	ControllerExternalIPs  string
+	ControllerExternalName string
 }
 
 // BootstrapJob returns a [jobtracker.JobFunc] [for use in the [jobtracker.Tracker]] responsible for
@@ -348,13 +361,17 @@ func (b *bootstrapManager) runBootstrap(
 		binary.FullPath,
 		p.JujuDataDir,
 		jujucommands.BootstrapCmdParams{
-			CloudNameAndRegion:   p.CloudNameAndRegion,
-			ControllerName:       p.ControllerName,
-			AgentVersion:         p.AgentVersion,
-			BootstrapTimeout:     p.BootstrapTimeout,
-			LoginTokenRefreshURL: p.LoginTokenRefreshURL,
-			PersonalCloud:        p.PersonalCloud,
-			CloudCred:            p.CloudCred,
+			CloudNameAndRegion:     p.CloudNameAndRegion,
+			ControllerName:         p.ControllerName,
+			AgentVersion:           p.AgentVersion,
+			BootstrapTimeout:       p.BootstrapTimeout,
+			LoginTokenRefreshURL:   p.LoginTokenRefreshURL,
+			PersonalCloud:          p.PersonalCloud,
+			CloudCred:              p.CloudCred,
+			PublicDNSAddress:       p.PublicDNSAddress,
+			ControllerServiceType:  p.ControllerServiceType,
+			ControllerExternalIPs:  p.ControllerExternalIPs,
+			ControllerExternalName: p.ControllerExternalName,
 		},
 	)
 	if err != nil {
@@ -412,6 +429,7 @@ func (b *bootstrapManager) runBootstrap(
 		PublicAddress: ctrlDetails.PublicDNSName,
 		CACertificate: ctrlDetails.CACert,
 		Addresses:     dbmodel.HostPorts{jujuparams.FromProviderHostPorts(hps)},
+		TLSHostname:   "juju-apiserver",
 	}
 
 	account, err := clientStore.AccountDetails(p.ControllerName)

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -322,6 +322,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 			PublicAddress: ctrlDetails.PublicDNSName,
 			CACertificate: ctrlDetails.CACert,
 			Addresses:     dbmodel.HostPorts{jujuparams.FromProviderHostPorts(hps)},
+			TLSHostname:   "juju-apiserver",
 		},
 		gomock.Any(),
 	).Return(nil).Times(1)
@@ -940,6 +941,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 			PublicAddress: ctrlDetails.PublicDNSName,
 			CACertificate: ctrlDetails.CACert,
 			Addresses:     dbmodel.HostPorts{jujuparams.FromProviderHostPorts(hps)},
+			TLSHostname:   "juju-apiserver",
 		},
 		gomock.Any(),
 	).Return(

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -22,6 +22,14 @@ type BootstrapParams struct {
 	CloudCred jujucloud.CloudCredential
 	// PersonalCloud is the cloud-definition for a non-public cloud.
 	PersonalCloud jujucloud.Cloud
+
+	// Controller public dns address (if any) and k8s service options to expose a k8s
+	// controller.
+
+	PublicDNSAddress       string
+	ControllerServiceType  string
+	ControllerExternalIPs  string
+	ControllerExternalName string
 }
 
 // Validate checks if the BootstrapParams are valid.

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -652,6 +652,11 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 
 		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
 		CloudCred:     req.Credential,
+
+		PublicDNSAddress:       req.Flags.PublicDNSAddress,
+		ControllerServiceType:  req.Flags.ControllerServiceType,
+		ControllerExternalIPs:  req.Flags.ControllerExternalIPs,
+		ControllerExternalName: req.Flags.ControllerExternalName,
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -32,6 +32,14 @@ type BootstrapCmdParams struct {
 	PersonalCloud jujucloud.Cloud
 	// The credential to use for the cloud.
 	CloudCred jujucloud.CloudCredential
+
+	// Controller public dns address (if any) and k8s service options to expose a k8s
+	// controller.
+
+	PublicDNSAddress       string
+	ControllerServiceType  string
+	ControllerExternalIPs  string
+	ControllerExternalName string
 }
 
 // Validate validates the BootstrapCmdParams.
@@ -80,6 +88,28 @@ func (b BootstrapCmdParams) BuildBootstrapCmdArgs() []string {
 	if b.BootstrapTimeout > 0 {
 		args = append(args, "--config")
 		args = append(args, fmt.Sprintf("bootstrap-timeout=%d", b.BootstrapTimeout))
+	}
+
+	// Simply allow the user the pass the options through, Juju will validate the
+	// permutations of these options and respond accordingly.
+	if b.ControllerServiceType != "" {
+		args = append(args, "--config")
+		args = append(args, fmt.Sprintf("controller-service-type=%s", b.ControllerServiceType))
+	}
+
+	if b.ControllerExternalIPs != "" {
+		args = append(args, "--config")
+		args = append(args, fmt.Sprintf("controller-external-ips=%s", b.ControllerExternalIPs))
+	}
+
+	if b.ControllerExternalName != "" {
+		args = append(args, "--config")
+		args = append(args, fmt.Sprintf("controller-external-name=%s", b.ControllerExternalName))
+	}
+
+	if b.PublicDNSAddress != "" {
+		args = append(args, "--config")
+		args = append(args, fmt.Sprintf("public-dns-address=%s", b.PublicDNSAddress))
 	}
 
 	// Always add controller name & cloud at the end

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -604,6 +604,13 @@ type BootstrapStatusResponse struct {
 type BootstrapFlags struct {
 	// The timeout in seconds for the bootstrap.
 	Timeout int `json:"timeout,omitempty"`
+	// Controller public dns address (if any) and k8s service options to expose a k8s
+	// controller.
+
+	PublicDNSAddress       string `json:"public-dns-address,omitempty"`
+	ControllerServiceType  string `json:"controller-service-type,omitempty"`
+	ControllerExternalIPs  string `json:"controller-external-ips,omitempty"`
+	ControllerExternalName string `json:"controller-external-name,omitempty"`
 }
 
 // BootstrapStartParams holds parameters for starting


### PR DESCRIPTION
## Description
This PR exposes the k8s service options. It additionally adds a fixed hostname (which would in theory break controllers behind proxies, but with JIMM in front bootstrapping, I guess you'd never have a proxy in front of your controller anymore...?)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Can be tested via:
1. Pulling your microk8s config out and placing it into ~/.kube/config 
2. Switching to the new context
3. Enabling metallb on microk8s 
4. Running `./jaas bootstrap testk8scloud test16 3.6.8 --controller-service-type=loadbalancer`, a free IP of your NAT will be consumed by the LB (you should see it in the "contacting") and a controller will be bootstrapped.
