### PR TITLE
feat(security-events): add system security events

### DIFF
--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -45,6 +45,7 @@ func start(ctx context.Context, s *service.Service) error {
 	logLevel := os.Getenv("JIMM_LOG_LEVEL")
 	logDevMode, _ := strconv.ParseBool(os.Getenv("JIMM_LOG_DEV_MODE"))
 	logger.SetupLogger(ctx, logLevel, logDevMode)
+	logger.LogJimmStartup(ctx)
 	zapctx.Info(ctx, "jimm info",
 		zap.String("version", version.VersionInfo.Version),
 		zap.String("commit", version.VersionInfo.GitCommit),
@@ -258,6 +259,8 @@ func start(ctx context.Context, s *service.Service) error {
 	s.OnShutdown(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+
+		logger.LogJimmShutdown(ctx)
 
 		zapctx.Warn(ctx, "HTTP server shutdown triggered")
 		err = httpsrv.Shutdown(ctx)

--- a/internal/logger/default_logger.go
+++ b/internal/logger/default_logger.go
@@ -25,6 +25,7 @@ func SetupLogger(ctx context.Context, logLevel string, devMode bool) {
 		fmt.Printf("ERROR: log level %q cannot be parsed, defaulting to info\n", logLevel)
 		pLogLevel = zap.InfoLevel
 	}
+	SystemMonitoringWarning(ctx, pLogLevel)
 	if devMode {
 		devConfig := zap.NewDevelopmentEncoderConfig()
 		devConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder

--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -4,6 +4,7 @@ package logger
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/juju/zaputil/zapctx"
@@ -14,7 +15,6 @@ import (
 type eventLevel string
 
 const (
-	info     eventLevel = "INFO"
 	warning  eventLevel = "WARN"
 	critical eventLevel = "CRITICAL"
 )
@@ -35,8 +35,6 @@ func (s securityEvent) toZapFields() []zapcore.Field {
 
 func logSecurityEvent(ctx context.Context, event securityEvent) {
 	switch event.Severity {
-	case info:
-		zapctx.Info(ctx, event.Event, event.toZapFields()...)
 	case warning:
 		zapctx.Warn(ctx, event.Event, event.toZapFields()...)
 	case critical:
@@ -58,7 +56,7 @@ func LogSuccessfulLogin(ctx context.Context, identityId string) {
 	logSecurityEvent(ctx, securityEvent{
 		Event:       "authn_login_success:" + identityId,
 		Description: "login succeeded",
-		Severity:    info,
+		Severity:    warning,
 	})
 }
 
@@ -79,4 +77,36 @@ func LogGrantJimmAdmins(ctx context.Context, identityIds []string) {
 		Description: "JIMM admin role was granted.",
 		Severity:    warning,
 	})
+}
+
+// LogJimmStartup logs that JIMM has started.
+func LogJimmStartup(ctx context.Context) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "sys_startup",
+		Description: "JIMM has started.",
+		Severity:    warning,
+	})
+}
+
+// LogJimmShutdown logs that JIMM is shutting down.
+func LogJimmShutdown(ctx context.Context) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "sys_shutdown",
+		Description: "JIMM is shutting down.",
+		Severity:    warning,
+	})
+}
+
+// SystemMonitoringWarning prints a warning to stdout about potential issues with logging security events
+// if the logger level is lower than warn.
+func SystemMonitoringWarning(ctx context.Context, loggerLevel zapcore.Level) {
+	if loggerLevel < zapcore.WarnLevel {
+		logSecurityEvent(ctx, securityEvent{
+			Event: "sys_monitor_disabled",
+			Description: "Security events are using the default logger.\n" +
+				fmt.Sprintf("Logger level '%s' may hide security events below this severity.\n", loggerLevel.String()) +
+				"Set your logger to at least \"WARN\" level to ensure visibility of security events.\n",
+			Severity: critical,
+		})
+	}
 }


### PR DESCRIPTION
## Description

Add security events for startup, shutdown and disable monitoring.

> The log level has been set to at least WARNING for all events. This is because we use the default logger to record security events, and we recommend configuring the log level to at least WARN to ensure that these events are captured. Setting the level to INFO could result in excessive logging, which may not be suitable for production environments. 
Keep in mind the only security event set to INFO would be successful login.