### PR TITLE
feat: enable bootstrap stop

### DIFF
--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -57,6 +57,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
 	jaasCmd.Register(cmd.NewBootstrapStatusCommand())
 	jaasCmd.Register(cmd.NewBootstrapStartCommand())
+	jaasCmd.Register(cmd.NewBootstrapStopCommand())
 	return jaasCmd
 }
 

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -348,6 +348,11 @@ func (b *bootstrapManager) BootstrapJob(
 // runBootstrap wraps the logic of running a controller bootstrap for JIMM into
 // a self-contained function. It is expected, and only expected to be run from within
 // the [bootstrapManager.BootstrapJob].
+//
+// The jobCtx is expected to be the context of the job, and as such will be cancelled
+// when the job is stopped or cancelled. The jobCtx is NOT expected to be used for
+// any store operations, or other operations that should continue even if the job
+// is cancelled.
 func (b *bootstrapManager) runBootstrap(
 	jobCtx context.Context,
 	p JobParams,

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -270,16 +270,14 @@ func (b *bootstrapManager) BootstrapJob(
 	executor BootstrapExecutor,
 	user *openfga.User,
 ) jobtracker.JobFunc {
-	const bootstrapLockTTL = 40 * time.Minute
-
-	return func(ctx context.Context) error {
-		jobId, ok := jobtracker.JobIdFromContext(ctx)
+	return func(jobCtx context.Context) error {
+		jobId, ok := jobtracker.JobIdFromContext(jobCtx)
 		if !ok {
 			return fmt.Errorf("failed to get job ID from context")
 		}
 
 		logCtx := zapctx.WithFields(
-			ctx,
+			jobCtx,
 			zap.String("job-id", jobId.String()),
 			zap.String("controller-name", p.ControllerName),
 		)
@@ -289,7 +287,9 @@ func (b *bootstrapManager) BootstrapJob(
 			"starting bootstrap job",
 		)
 
-		if err := b.store.LockBootstrap(ctx, bootstrapLockTTL); err != nil {
+		// Lock the bootstrap for the same length the process is allowed to run for
+		// before being killed.
+		if err := b.store.LockBootstrap(jobCtx, jujucommands.CommandKillDelay); err != nil {
 			zapctx.Error(
 				logCtx,
 				"failed to acquire bootstrap lock",
@@ -299,7 +299,7 @@ func (b *bootstrapManager) BootstrapJob(
 		}
 
 		defer func() {
-			if err := b.store.UnlockBootstrap(ctx); err != nil {
+			if err := b.store.UnlockBootstrap(jobCtx); err != nil {
 				zapctx.Error(
 					logCtx,
 					"failed to unlock bootstrap lock",
@@ -311,7 +311,7 @@ func (b *bootstrapManager) BootstrapJob(
 		// TODO: If we remove the 1 bootstrap lock, in theory two API requests to bootstrap controllers
 		// could be made at the same time, and both would pass this check but only one could succeed.
 		// This needs to be fixed.
-		err := b.store.GetController(ctx, &dbmodel.Controller{Name: p.ControllerName})
+		err := b.store.GetController(jobCtx, &dbmodel.Controller{Name: p.ControllerName})
 		if err == nil {
 			return errors.E(errors.CodeAlreadyExists, fmt.Errorf("controller %q already exists", p.ControllerName))
 		}
@@ -321,7 +321,7 @@ func (b *bootstrapManager) BootstrapJob(
 
 		// TODO(ale8k): When downloading, it takes a while and the CLI has no output. Download progress would be a VERY nice to have here.
 		binary, err := b.binaryStore.Get(
-			ctx,
+			jobCtx,
 			jujuclistore.JujuBinarySpec{
 				Version: p.CLIVersion,
 				// This is a best effort. The launchpad URL just so happens to have similar filenames to runtime.GOOS and runtime.GOARCH.
@@ -338,7 +338,7 @@ func (b *bootstrapManager) BootstrapJob(
 		zapctx.Debug(logCtx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 		defer binaryDone(binary)
 
-		if err := b.runBootstrap(ctx, p, jobId, executor, binary, user); err != nil {
+		if err := b.runBootstrap(jobCtx, p, jobId, executor, binary, user); err != nil {
 			return errors.E(fmt.Errorf("run bootstrap failed: %w", err))
 		}
 		return nil
@@ -349,7 +349,7 @@ func (b *bootstrapManager) BootstrapJob(
 // a self-contained function. It is expected, and only expected to be run from within
 // the [bootstrapManager.BootstrapJob].
 func (b *bootstrapManager) runBootstrap(
-	ctx context.Context,
+	jobCtx context.Context,
 	p JobParams,
 	jobId uuid.UUID,
 	executor BootstrapExecutor,
@@ -357,7 +357,7 @@ func (b *bootstrapManager) runBootstrap(
 	user *openfga.User,
 ) error {
 	outputCh, clientStore, cleanup, err := executor.RunWrapper(
-		ctx,
+		jobCtx,
 		binary.FullPath,
 		p.JujuDataDir,
 		jujucommands.BootstrapCmdParams{
@@ -379,26 +379,38 @@ func (b *bootstrapManager) runBootstrap(
 	}
 	defer cleanup()
 
+	// For the following code, we want it to keep running
+	// and logging failures even when the jobCtx is cancelled, i.e.,
+	// in the case of running bootstrap-stop.
+	// As such, we use an independent storeCtx
+	// for the erroneous logs.
+	storeCtx := context.Background()
+
 	for output := range outputCh {
 		if output.Err != nil {
 			if writeLogErr := b.store.AddBootstrapLog(
-				ctx,
+				storeCtx,
 				jobId,
 				output.Err.Error(),
 			); writeLogErr != nil {
-				zapctx.Error(ctx, "failed to write bootstrap error", zap.Error(writeLogErr), zap.String("jobId", jobId.String()))
+				zapctx.Error(storeCtx, "failed to write bootstrap error", zap.Error(writeLogErr), zap.String("jobId", jobId.String()))
 			}
 			return errors.E(fmt.Errorf("bootstrap command failed: %w", output.Err))
 		}
 		if writeLogErr := b.store.AddBootstrapLog(
-			ctx,
+			storeCtx,
 			jobId,
 			output.Line,
 		); writeLogErr != nil {
 			// If we fail to write the log, we log the error but continue.
 			// This is because the bootstrap process may still succeed, and we
 			// don't want to fail the entire job just because we couldn't log.
-			zapctx.Error(ctx, "failed to write bootstrap log", zap.Error(writeLogErr), zap.String("jobId", jobId.String()))
+			zapctx.Error(
+				storeCtx,
+				"failed to write bootstrap log",
+				zap.Error(writeLogErr),
+				zap.String("jobId", jobId.String()),
+			)
 		}
 	}
 
@@ -444,8 +456,13 @@ func (b *bootstrapManager) runBootstrap(
 	// If the controller cannot be reached, we'll end up with dangling resources to a now no-longer accessible controller (from the clients perspective).
 	// So... Find a nice way to remove controllers if the add fail / clean up dangling ones later.
 	// Once fixed, this can be tested by just making the controller addr something that doesn't exist, and we can test the solution.
+
+	// We use store context here as there's a small chance that somebody
+	// could cancel the context between the controller being successfully bootstrapped
+	// and adding the controller, in which case we'd be left with a bootstrapped
+	// controller that JIMM isn't aware of.
 	if err := b.jujuManager.AddController(
-		ctx,
+		storeCtx,
 		user,
 		&dbCtrl,
 		dbCtrlCreds,

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -7,10 +7,18 @@ package jujucommands
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"sync"
+	"time"
 
+	"github.com/juju/zaputil/zapctx"
 	"github.com/mitchellh/go-linereader"
+	"go.uber.org/zap"
+)
+
+const (
+	CommandKillDelay = time.Minute * 40
 )
 
 // OutputLine represents a line of output from a juju command.
@@ -51,7 +59,19 @@ func (b *CommandRunner) RunJujuCmd(ctx context.Context, args []string) (<-chan O
 	// G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
 	// We manage the args via specific <command>.go files, so the args are not tainted.
 	cmd := exec.CommandContext(ctx, b.command, args...)
+
+	// If the terminate takes very long, the WaitDelay
+	// will kick in and kill the process. We set it to the same
+	// as our bootstrap lock.
+	cmd.WaitDelay = CommandKillDelay
 	cmd.Env = append(cmd.Env, "JUJU_DATA="+b.jujuDataDir)
+	cmd.Cancel = func() error {
+		err := cmd.Process.Signal(os.Interrupt)
+		if err != nil {
+			zapctx.Error(ctx, "failed to send interrupt signal to command", zap.Error(err))
+		}
+		return err
+	}
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
@@ -74,12 +94,9 @@ func (b *CommandRunner) RunJujuCmd(ctx context.Context, args []string) (<-chan O
 
 	readLines := func(r *linereader.Reader) {
 		defer wg.Done()
+
 		for line := range r.Ch {
-			select {
-			case outputCh <- OutputLine{Line: line}:
-			case <-ctx.Done():
-				return
-			}
+			outputCh <- OutputLine{Line: line}
 		}
 	}
 

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -73,3 +73,4 @@ parts:
       ln -sf jaas bin/juju-update-migrated-model
       ln -sf jaas bin/juju-update-service-account-credential
       ln -sf jaas bin/juju-bootstrap-status
+      ln -sf jaas bin/juju-bootstrap-stop


### PR DESCRIPTION
## Description
Enables bootstrap stop. It also fixes the following:
1. We were cancelling the context on the readers, but we want the readers to continue when the context is cancelled, the process should close those channels.
2. The default Cancel func of CommandContext is a kill signal, it now uses an interrupt (which is what juju expects for cleanup)
3. When the job context is cancelled, we need to continue writing logs from stderr, but because the same context was used to write logs to the store, we never saw the error logs. It now uses an independent store context.
4. There was a small chance (which I did indeed hit funnily enough) between the bootstrapping on the controller and the addition to our store that we don't add the controller because the context was cancelled.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
