### PR TITLE
feat: add logging for user creation and updates

### DIFF
--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
@@ -36,8 +37,12 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	db := d.DB.WithContext(ctx)
-	if err := db.Where("name = ?", u.Name).FirstOrCreate(&u).Error; err != nil {
+	result := db.Where("name = ?", u.Name).FirstOrCreate(&u)
+	if result.Error != nil {
 		return errors.E(op, err)
+	}
+	if result.RowsAffected == 1 {
+		logger.LogUserCreated(ctx, u.Name)
 	}
 	return nil
 }

--- a/internal/db/identity_test.go
+++ b/internal/db/identity_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -60,6 +63,31 @@ func (s *dbSuite) TestGetIdentity(c *qt.C) {
 	err = s.Database.GetIdentity(ctx, u4)
 	c.Assert(err, qt.IsNil)
 	c.Check(u4, qt.DeepEquals, u3)
+}
+
+func (s *dbSuite) TestIdentityUserCreatedLogging(c *qt.C) {
+	ctx := context.Background()
+
+	err := s.Database.Migrate(ctx)
+	c.Assert(err, qt.IsNil)
+
+	core, logs := observer.New(zap.InfoLevel)
+	ctx = zapctx.WithLogger(ctx, zap.New(core))
+
+	i, err := dbmodel.NewIdentity("bob")
+	c.Assert(err, qt.IsNil)
+	err = s.Database.GetIdentity(ctx, i)
+	c.Assert(err, qt.IsNil)
+	// Logging creation
+	c.Assert(logs.Len(), qt.Equals, 1)
+	c.Assert(logs.All()[0].Message, qt.Equals, "user_created:bob")
+
+	i, err = dbmodel.NewIdentity("bob")
+	c.Assert(err, qt.IsNil)
+	err = s.Database.GetIdentity(ctx, i)
+	c.Assert(err, qt.IsNil)
+	// No new creation, no extra logging
+	c.Assert(logs.Len(), qt.Equals, 1)
 }
 
 func TestUpdateIdentityUnconfiguredDatabase(t *testing.T) {

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
@@ -32,6 +33,7 @@ func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User,
 	if err != nil {
 		return errors.E(op, errors.CodeOpenFGARequestFailed, err)
 	}
+	j.logUserUpdates(ctx, user, parsedTuples, true)
 	return nil
 }
 
@@ -50,6 +52,7 @@ func (j *permissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 	if err != nil {
 		return errors.E(op, errors.CodeOpenFGARequestFailed, err)
 	}
+	j.logUserUpdates(ctx, user, parsedTuples, false)
 	return nil
 }
 
@@ -249,4 +252,14 @@ func (j *permissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 	}
 
 	return &t, nil
+}
+
+// logUserUpdates logs tuple relation changes if they are for a user.
+// This should be the closest equivalent of logging an RBAC role in our Zanzibar-style openfga graph.
+func (j *permissionManager) logUserUpdates(ctx context.Context, user *openfga.User, tuples []openfga.Tuple, isAddition bool) {
+	for _, tuple := range tuples {
+		if tuple.Object.Kind.String() == openfga.UserType.String() {
+			logger.LogUserUpdated(ctx, user.Name, tuple.Object.ID, tuple.Relation.String(), tuple.Target.ID, isAddition)
+		}
+	}
 }

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -4,9 +4,13 @@ package permissions_test
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -424,4 +428,39 @@ func (s *permissionManagerSuite) TestCheckRelationsWithErrors(c *qt.C) {
 	c.Assert(results[0].Error, qt.IsNil)
 	c.Assert(results[1].Allowed, qt.IsFalse)
 	c.Assert(results[1].Error, qt.IsNotNil)
+}
+
+func (s *permissionManagerSuite) TestRelationshipLogUserUpdated(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	adminId := "admin@canonical.com"
+
+	u := openfga.NewUser(&dbmodel.Identity{Name: adminId}, s.ofgaClient)
+	u.JimmAdmin = true
+
+	user, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	tuples := []apiparams.RelationshipTuple{
+		{
+			Object:       user.Tag().String(),
+			Relation:     names.ReaderRelation.String(),
+			TargetObject: model.ResourceTag().String(),
+		},
+	}
+
+	core, logs := observer.New(zap.InfoLevel)
+	ctx = zapctx.WithLogger(ctx, zap.New(core))
+
+	err := s.manager.AddRelation(ctx, u, tuples)
+	c.Assert(err, qt.IsNil)
+	c.Assert(logs.Len(), qt.Equals, 1)
+	c.Assert(logs.All()[0].Message, qt.Contains, fmt.Sprintf("user_updated:%s,%s,add,", adminId, user.Name))
+
+	err = s.manager.RemoveRelation(ctx, u, tuples)
+	c.Assert(err, qt.IsNil)
+	c.Assert(logs.Len(), qt.Equals, 2)
+
+	err = s.manager.AddRelation(ctx, u, tuples)
+	c.Assert(err, qt.IsNil)
+	c.Assert(logs.Len(), qt.Equals, 3)
 }

--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -79,6 +79,28 @@ func LogGrantJimmAdmins(ctx context.Context, identityIds []string) {
 	})
 }
 
+// LogUserCreated logs the creation of a user, implicitly an identity
+func LogUserCreated(ctx context.Context, identityId string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       fmt.Sprintf("user_created:%s", identityId),
+		Description: fmt.Sprintf("User %s was created.", identityId),
+		Severity:    warning,
+	})
+}
+
+// LogUserUpdated logs updates to a user, implicitly adding or removing an openfga relation
+func LogUserUpdated(ctx context.Context, adminID string, userID string, relation string, target string, isAddition bool) {
+	action := "add"
+	if !isAddition {
+		action = "remove"
+	}
+	logSecurityEvent(ctx, securityEvent{
+		Event:       fmt.Sprintf("user_updated:%s,%s,%s,%s:%s", adminID, userID, action, relation, target), // ?
+		Description: fmt.Sprintf("User %s updated %s to %s relation %s to object %s", adminID, userID, action, relation, target),
+		Severity:    warning,
+	})
+}
+
 // LogJimmStartup logs that JIMM has started.
 func LogJimmStartup(ctx context.Context) {
 	logSecurityEvent(ctx, securityEvent{


### PR DESCRIPTION
## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->
Add logging for user creation and updates, matching https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---security-event-logging#%EE%B0%823.4-user-related-events-%5Buser%5D-9 as much as possible.

For user creation, we do not have a "creator" user to log, only the created user.

For user updates, the RBAC assumptions in the spec don't really match openfga so we only log relations made directly from users.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
