### PR TITLE
ci: enhance release workflow

### DIFF
--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -1,13 +1,30 @@
 name: Juju dashboard integration test
 
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
+    types: [labeled]
+  schedule:
+    # Run twice a week: Mondays and Wednesdays at 03:00 UTC
+    - cron: '0 3 * * 1,3'
 
 jobs:
-  startjimm:
+  test-dashboard:
     name: Test JIMM with the Juju dashboard
-    runs-on: [self-hosted-linux-amd64-jammy-large]
+    runs-on: ubuntu-22.04
+    # This conditional ensures we only run the test when the test-dashboard label is added.
+    # See https://stackoverflow.com/a/74829754
+    # Because we also call this from other events, we need to allow those too.
+    #
+    # Allow 'push' events as workflow_call passes the same event payload from the 
+    # calling workflow and we trigger releases on tag push.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'test-dashboard')
+
     steps:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,9 +1,7 @@
 name: Release binaries
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
 
 # GitHub considers creating releases and uploading assets as writing contents.
 permissions:
@@ -12,7 +10,6 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-22.04
-    environment: Release Environment
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-server-rock.yaml
+++ b/.github/workflows/release-server-rock.yaml
@@ -1,12 +1,8 @@
 name: Release Server ROCK
 
 on:
-  # Note that when running via workflow_dispatch, the github.ref_name
-  # variable will match the selected branch name used.
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
 
 jobs:
   publish:

--- a/.github/workflows/release-snaps.yaml
+++ b/.github/workflows/release-snaps.yaml
@@ -2,9 +2,7 @@ name: Release Snaps
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v3*'
+  workflow_call:
 
 jobs:
   build-and-release-jaas-plugin:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+# This workflow is triggered on git tag creation.
+#
+# It runs the various workflows we have for releasing artefacts 
+# and creating release notes. We have multiple release workflows
+# because they each have different requirements.
+#
+# Before the release, the workflow runs the dashboard tests to ensure
+# that the new version of JIMM works with the Juju dashboard.
+# Our main integration tests are run for every PR so they are not
+# needed here, while the dashboard tests are slower and only
+# run periodically and on releases.
+
+name: Release pre-checks
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# GITHUB_TOKEN permissions can only be the same or more restrictive in nested workflows.
+# See https://docs.github.com/en/actions/reference/workflows-and-actions/reusable-workflows
+permissions:
+  contents: write
+
+jobs:
+  dashboard-tests:
+    uses: ./.github/workflows/dashboard-tests.yaml
+    secrets: inherit
+
+  release-binaries:
+    needs: dashboard-tests
+    uses: ./.github/workflows/release-binaries.yaml
+    secrets: inherit
+    permissions:
+      contents: write
+
+  release-server-rock:
+    needs: dashboard-tests
+    uses: ./.github/workflows/release-server-rock.yaml
+    secrets: inherit
+
+  release-snaps:
+    needs: dashboard-tests
+    uses: ./.github/workflows/release-snaps.yaml
+    secrets: inherit


### PR DESCRIPTION
## Description
This PR follows up on https://github.com/canonical/jimm/pull/1685 to only run the dashboard tests periodically and before releases.

In order to make it easier to run the dashboard tests before releases I've needed to slightly adjust our release workflows. We currently have 3 - release rocks, release snaps, run go-releaser (for release notes). Instead of updating each, I've created a "Release pre-checks" workflow that runs any pre-checks then triggers the individual release jobs. You can see an example of this working successfully on my fork here https://github.com/kian99/jimm/actions/runs/17610849517/job/50033609571, everything succeeded to the point where it attempted to release and failed due to lack of secrets.

I've also made a few changes to the dashboard-tests workflow.
1. It runs on a Github runner instead of a self-hosted. I had switched it to a self-hosted runner previously as I thought it was needed but running it on my fork on Github runners showed it was slightly faster there. Also, if jobs don't need the beefier machines of a self-hosted runner the suggestion is to use Github runners.
2. The dashboard tests can be triggered by adding a label to the PR called "test-dashboard". I think this will be useful when we want to update the dashboard image to a new revision and verify the change in the PR before landing it. I tested this on my fork here https://github.com/kian99/jimm/pull/2 and when the label is added the dashboard tests run. To retrigger the tests, the label must be removed and added again.

I've also tried to leave some comments for the non-intuitive bits of Github Actions.
