### PR TITLE
chore(docker-image): move from bitnami to bitnamilegacy namespace for keycloack image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
         condition: service_healthy
 
   keycloak:
-    image: docker.io/bitnami/keycloak:23
+    image: docker.io/bitnamilegacy/keycloak:23
     container_name: keycloak
     hostname: keycloak.localhost
     environment:

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -155,7 +155,7 @@ func (c *bootstrapCmd) Run(ctx context.Context, p BootstrapCmdParams) (<-chan Ou
 
 	for line := range outputCh {
 		if line.Err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to update public clouds: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to update public clouds: %w", line.Err)
 		}
 	}
 


### PR DESCRIPTION
Bitnami changed their registry policy: here the details https://github.com/bitnami/containers/issues/83267.

TLDR: the bitnami registry will contain security hardened images (now it's empty), and all the old images are now moved to bitnamilegacy and will not receive any update.