### PR TITLE
refactor: use jujuparams over jujucloud for bootstrap credential

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -83,6 +83,7 @@ type bootstrapCommand struct {
 
 	// Flags
 
+	credentialName         string
 	timeout                int
 	publicDNSAddress       string
 	controllerServiceType  string
@@ -127,6 +128,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"yaml": cmd.FormatYaml,
 		"json": cmd.FormatJson,
 	})
+	f.StringVar(&c.credentialName, "credential", "", "The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud.")
 	f.IntVar(&c.timeout, "timeout", 0, "The timeout in seconds for the bootstrap operation.")
 	f.StringVar(&c.publicDNSAddress, "public-dns-address", "", "Public DNS address (with port) of the controller")
 	f.StringVar(
@@ -162,9 +164,29 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return fmt.Errorf("failed to get cloud %q: %w", c.cloud, err)
 	}
 
-	bootstrapCredential, err := c.store.CredentialForCloud(c.cloud)
+	cloudCreds, err := c.store.CredentialForCloud(c.cloud)
 	if err != nil {
 		return fmt.Errorf("failed to get credential for cloud %q: %w", c.cloud, err)
+	}
+
+	var bootstrapCred jujucloud.Credential
+	switch {
+	case len(cloudCreds.AuthCredentials) == 1 && c.credentialName == "":
+		// If there's only one credential and the user didn't specify a credential name, use it.
+		for _, cred := range cloudCreds.AuthCredentials {
+			bootstrapCred = cred
+			break
+		}
+	case c.credentialName != "":
+		// If a credential name is provided, use it.
+		var ok bool
+		bootstrapCred, ok = cloudCreds.AuthCredentials[c.credentialName]
+		if !ok {
+			return fmt.Errorf("no credential found with name %q", c.credentialName)
+		}
+	default:
+		// If there are multiple credentials and no name is provided, return an error.
+		return fmt.Errorf("multiple credentials found for cloud %q, please specify one using --credential", c.cloud)
 	}
 
 	req := apiparams.BootstrapStartParams{
@@ -173,7 +195,10 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		ControllerName:    c.controllerName,
 		ControllerVersion: c.controllerVersion,
 		Cloud:             cloudToParams(*bootstrapCloud),
-		Credential:        *bootstrapCredential,
+		Credential: jujuparams.CloudCredential{
+			Attributes: bootstrapCred.Attributes(),
+			AuthType:   string(bootstrapCred.AuthType()),
+		},
 
 		Flags: apiparams.BootstrapFlags{
 			Timeout:                c.timeout,

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -184,9 +184,16 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		if !ok {
 			return fmt.Errorf("no credential found with name %q", c.credentialName)
 		}
+	case cloudCreds.DefaultCredential != "" && c.credentialName == "":
+		// If there's a default credential and the user didn't specify a credential name, use it.
+		var ok bool
+		bootstrapCred, ok = cloudCreds.AuthCredentials[cloudCreds.DefaultCredential]
+		if !ok {
+			return fmt.Errorf("default credential %q not found for cloud %q", cloudCreds.DefaultCredential, c.cloud)
+		}
 	default:
 		// If there are multiple credentials and no name is provided, return an error.
-		return fmt.Errorf("multiple credentials found for cloud %q, please specify one using --credential", c.cloud)
+		return fmt.Errorf("multiple credentials found for cloud %q, please set a default or specify one using --credential", c.cloud)
 	}
 
 	req := apiparams.BootstrapStartParams{

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -95,7 +95,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 	cloudName := "aws"
 
 	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
-		DefaultCredential: "default-cred-value-for-test",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
 	}, nil)
 	s.client.EXPECT().Bootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
 		expected := &params.BootstrapStartParams{
@@ -104,7 +106,7 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 			RegionName:     "region",
 			Cloud:          jujuparams.Cloud{},
 			Credential: jujuparams.CloudCredential{
-				AuthType:   "",
+				AuthType:   string(jujucloud.UserPassAuthType),
 				Attributes: map[string]string{},
 			},
 			Flags: params.BootstrapFlags{
@@ -158,7 +160,9 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.store.EXPECT().CredentialForCloud("aws").Return(&jujucloud.CloudCredential{
-		DefaultCredential: "default-cred-value-for-test",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
 	}, nil)
 	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{
 		JobID: "test-job-id",
@@ -261,7 +265,7 @@ func (s *bootstrapCmdSuite) TestBootstrapMultipleCredentials(c *gc.C) {
 	}
 
 	err := command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, `multiple credentials found for cloud "aws", please specify one using --credential`)
+	c.Assert(err, gc.ErrorMatches, `multiple credentials found for cloud "aws", please set a default or specify one using --credential`)
 
 	// Now specify a credential and verify the command works.
 	command.credentialName = "cred-2"
@@ -289,4 +293,86 @@ func (s *bootstrapCmdSuite) TestBootstrapMultipleCredentials(c *gc.C) {
 
 	err = command.Run(ctx)
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *bootstrapCmdSuite) TestBootstrapWithDefaultCredential(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		DefaultCredential: "cred-1",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+			"cred-2": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
+	}, nil)
+
+	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{JobID: "test-job-id"}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	command := &bootstrapCommand{
+		store: s.store,
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	command.SetFlags(f)
+	command.controllerName = "controller-name"
+	command.cloud = cloudName
+	command.region = "region"
+	command.controllerVersion = "controller-version"
+	command.timeout = 60
+	command.detach = true
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+
+	err := command.Run(ctx)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *bootstrapCmdSuite) TestBootstrapSpecifiedCredentialWithDefault(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		DefaultCredential: "cred-1",
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+			"cred-2": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
+	}, nil)
+
+	command := &bootstrapCommand{
+		store: s.store,
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	command.SetFlags(f)
+	command.controllerName = "controller-name"
+	command.cloud = cloudName
+	command.region = "region"
+	command.controllerVersion = "controller-version"
+	command.timeout = 60
+	command.detach = true
+	command.credentialName = "cred-3" // Use a different credential than the default.
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+
+	err := command.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, `no credential found with name "cred-3"`)
 }

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -103,8 +103,9 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 			CloudName:      cloudName,
 			RegionName:     "region",
 			Cloud:          jujuparams.Cloud{},
-			Credential: jujucloud.CloudCredential{
-				DefaultCredential: "default-cred-value-for-test",
+			Credential: jujuparams.CloudCredential{
+				AuthType:   "",
+				Attributes: map[string]string{},
 			},
 			Flags: params.BootstrapFlags{
 				Timeout: 60,
@@ -227,4 +228,65 @@ func (s *bootstrapCmdSuite) TestBootstrapFailsToGetCredential(c *gc.C) {
 
 	err := command.Run(ctx)
 	c.Assert(err, gc.ErrorMatches, `failed to get credential for cloud "aws": credential not found`)
+}
+
+func (s *bootstrapCmdSuite) TestBootstrapMultipleCredentials(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	s.store.EXPECT().CredentialForCloud("aws").Return(&jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": {Label: "cred-1"},
+			"cred-2": {Label: "cred-2"},
+		},
+	}, nil).Times(2)
+
+	command := &bootstrapCommand{
+		store: s.store,
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	command.SetFlags(f)
+	command.controllerName = "controller-name"
+	command.cloud = "aws" // Need a valid cloud to reach credential error.
+	command.region = "region"
+	command.controllerVersion = "controller-version"
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+
+	err := command.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, `multiple credentials found for cloud "aws", please specify one using --credential`)
+
+	// Now specify a credential and verify the command works.
+	command.credentialName = "cred-2"
+
+	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{
+		JobID: "test-job-id",
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+		Status:    params.StatusSuccessful,
+		Logs:      []string{"log-line", "log-line"},
+		Watermark: 2,
+	}, nil)
+
+	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		c.Check(string(b), gc.Equals, "log-line\n")
+		return len(b), nil
+	}).Times(2)
+
+	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		c.Check(string(b), gc.Equals, "Bootstrap job completed successfully.\n")
+		return len(b), nil
+	})
+
+	err = command.Run(ctx)
+	c.Assert(err, gc.IsNil)
 }

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -277,7 +277,7 @@ type JobParams struct {
 	ControllerName     string
 	AgentVersion       string
 	BootstrapTimeout   int
-	CloudCred          jujucloud.CloudCredential
+	CloudCred          jujucloud.Credential
 	// PersonalCloud is the personally defined cloud. Only necessary if the cloud is not a public
 	// cloud.
 	PersonalCloud jujucloud.Cloud

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -49,7 +49,7 @@ var (
 		AgentVersion:       "3.6.3",
 		BootstrapTimeout:   0,
 
-		CloudCred:     jujucloud.CloudCredential{},
+		CloudCred:     jujucloud.Credential{},
 		PersonalCloud: jujucloud.Cloud{},
 
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -19,7 +19,7 @@ type BootstrapParams struct {
 	ControllerName     string
 	BootstrapTimeout   int
 
-	CloudCred jujucloud.CloudCredential
+	CloudCred jujucloud.Credential
 	// PersonalCloud is the cloud-definition for a non-public cloud.
 	PersonalCloud jujucloud.Cloud
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -651,7 +652,12 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		BootstrapTimeout:   req.Flags.Timeout,
 
 		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
-		CloudCred:     req.Credential,
+		CloudCred: cloud.NewNamedCredential(
+			"bootstrap-credential",
+			cloud.AuthType(req.Credential.AuthType),
+			req.Credential.Attributes,
+			false,
+		),
 
 		PublicDNSAddress:       req.Flags.PublicDNSAddress,
 		ControllerServiceType:  req.Flags.ControllerServiceType,

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
@@ -217,7 +216,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 			Timeout: 3600,
 		},
 		Cloud:             jujuparams.Cloud{},
-		Credential:        jujucloud.CloudCredential{},
+		Credential:        jujuparams.CloudCredential{},
 		ControllerVersion: "3.6.8",
 	}
 

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -31,7 +31,7 @@ type BootstrapCmdParams struct {
 	// May be left unset, if set, a personal cloud will be created and used for bootstrap.
 	PersonalCloud jujucloud.Cloud
 	// The credential to use for the cloud.
-	CloudCred jujucloud.CloudCredential
+	CloudCred jujucloud.Credential
 
 	// Controller public dns address (if any) and k8s service options to expose a k8s
 	// controller.
@@ -176,7 +176,15 @@ func (c *bootstrapCmd) Run(ctx context.Context, p BootstrapCmdParams) (<-chan Ou
 		}
 	}
 
-	if err := store.UpdateCredential(cloudName, p.CloudCred); err != nil {
+	// Create a cloudCredential at the last possible moment from the provided credential.
+	// A cloudCredential holds a map of credentials for the cloud with optional defaults.
+	// We only accept a single credential for bootstrapping.
+	cloudCred := jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			p.CloudCred.Label: p.CloudCred,
+		},
+	}
+	if err := store.UpdateCredential(cloudName, cloudCred); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to set credential: %w", err)
 	}
 

--- a/internal/jujucommands/bootstrap_test.go
+++ b/internal/jujucommands/bootstrap_test.go
@@ -127,12 +127,11 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_RunBootstrapCmd_PersonalCloud
 		return outputCh, nil
 	}).AnyTimes()
 
-	cloudCred := *jujucloud.NewEmptyCloudCredential()
-	cloudCred.AuthCredentials["default"] = jujucloud.NewCredential(jujucloud.CertificateAuthType, map[string]string{
+	cloudCred := jujucloud.NewNamedCredential("bootstrap-credential", jujucloud.CertificateAuthType, map[string]string{
 		"server-cert": "server-cert",
 		"client-cert": "client-cert",
 		"client-key":  "client-key",
-	})
+	}, false)
 
 	p := jujucommands.BootstrapCmdParams{
 		CloudNameAndRegion:   "testcloud/testregion",
@@ -172,12 +171,12 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_RunBootstrapCmd_PersonalCloud
 	personalCloudCred, err := store.CredentialForCloud("testcloud")
 	c.Assert(err, qt.IsNil)
 	// Check just attributes, if the populated in memory credential is set for the "testcloud",
-	// then we're sure the default credential to be used is the one we provided for our provided cloud.
+	// then we're sure the credential to be used is the one we provided for our provided cloud.
 	// (Given it also exists in the temp directory)
 	c.Assert(
-		personalCloudCred.AuthCredentials["default"].Attributes(),
+		personalCloudCred.AuthCredentials["bootstrap-credential"].Attributes(),
 		qt.DeepEquals,
-		cloudCred.AuthCredentials["default"].Attributes(),
+		cloudCred.Attributes(),
 	)
 
 	// This was set to a temp dir until cleanup runs. We can use it to check the file exists.
@@ -207,10 +206,9 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_RunBootstrapCmd_PublicCloudWr
 		return outputCh, nil
 	}).AnyTimes()
 
-	cloudCred := *jujucloud.NewEmptyCloudCredential()
-	cloudCred.AuthCredentials["default"] = jujucloud.NewCredential(jujucloud.AccessKeyAuthType, map[string]string{
+	cloudCred := jujucloud.NewNamedCredential("bootstrap-credential", jujucloud.AccessKeyAuthType, map[string]string{
 		"aws-secret": "my-secret",
-	})
+	}, false)
 	p := jujucommands.BootstrapCmdParams{
 		CloudNameAndRegion:   "aws/us-east-1",
 		ControllerName:       "my-controller",
@@ -237,9 +235,9 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_RunBootstrapCmd_PublicCloudWr
 	personalCloudCred, err := store.CredentialForCloud("aws")
 	c.Assert(err, qt.IsNil)
 	c.Assert(
-		personalCloudCred.AuthCredentials["default"].Attributes(),
+		personalCloudCred.AuthCredentials["bootstrap-credential"].Attributes(),
 		qt.DeepEquals,
-		cloudCred.AuthCredentials["default"].Attributes(),
+		cloudCred.Attributes(),
 	)
 
 	// Make sure no personal cloud was written.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -5,7 +5,6 @@ package params
 import (
 	"time"
 
-	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 )
 
@@ -624,7 +623,7 @@ type BootstrapStartParams struct {
 	Cloud jujuparams.Cloud `json:"cloud,omitempty"`
 	// Credential contains the cloud credential and its tag, this credential will be used against the
 	// the cloud provided to bootstrap the controller.
-	Credential jujucloud.CloudCredential `json:"credential"`
+	Credential jujuparams.CloudCredential `json:"credential"`
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.
 	ControllerName string `json:"controller-name"`


### PR DESCRIPTION
## Description
This PR replaces our usage of `jujucloud.CloudCredential` with `jujuparams.CloudCredential` when sending the data over the wire. The former is used by the Juju CLI and holds a map of credentials for the cloud while the latter holds a single credential. Now, during bootstrap, if your client has multiple credentials for the cloud you are attempting to bootstrap, you must specify the credential name, unless a default is set. If your client only holds a single credential for that cloud, that credential will be used implicitly.

Fixes [JUJU-8531](https://warthogs.atlassian.net/browse/JUJU-8531)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


[JUJU-8531]: https://warthogs.atlassian.net/browse/JUJU-8531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ