### PR TITLE
feat: make jobs more generic

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -202,7 +202,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		stringConfigValues[k] = strVal
 	}
 
-	req := apiparams.BootstrapStartParams{
+	req := apiparams.BootstrapParams{
 		CloudName:         c.cloud,
 		RegionName:        c.region,
 		ControllerName:    c.controllerName,
@@ -221,7 +221,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer client.Close()
 
-	resp, err := client.Bootstrap(&req)
+	resp, err := client.StartBootstrapJob(&req)
 	if err != nil {
 		return err
 	}
@@ -229,8 +229,8 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 	if c.detach {
 		fmt.Printf(`
 Bootstrap job started.
-You can track the progress via bootstrap-status with the job ID:
-	juju [jaas] bootstrap-status %s
+You can track the progress via job-status with the job ID:
+	juju [jaas] job-status %s
 
 	`,
 			resp.JobID,
@@ -239,8 +239,8 @@ You can track the progress via bootstrap-status with the job ID:
 		fmt.Printf(`
 Starting bootstrap job.
 
-Should you cancel this process, you can track the progress via bootstrap-status with the job ID:
-	juju [jaas] bootstrap-status %s
+Should you cancel this process, you can track the progress via job-status with the job ID:
+	juju [jaas] job-status %s
 
 	`,
 			resp.JobID,
@@ -262,7 +262,7 @@ Should you cancel this process, you can track the progress via bootstrap-status 
 		follow:              true,
 	}
 
-	return poller.watchBootstrapLogs()
+	return poller.watchJobLogs()
 }
 
 func (c *bootstrapCommand) newClient() (JIMMAPI, error) {

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -99,8 +99,8 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
 		},
 	}, nil)
-	s.client.EXPECT().Bootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
-		expected := &params.BootstrapStartParams{
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartJobResponse, error) {
+		expected := &params.BootstrapParams{
 			ControllerName: "controller-name",
 			CloudName:      cloudName,
 			RegionName:     "region",
@@ -125,7 +125,7 @@ func (s *bootstrapCmdSuite) TestBootstrapRunDetached(c *gc.C) {
 		c.Assert(bsp.Config, gc.DeepEquals, expected.Config)
 		c.Assert(bsp.ControllerVersion, gc.Equals, expected.ControllerVersion)
 
-		return &params.BootstrapStartResponse{
+		return &params.StartJobResponse{
 			JobID: "test-job-id",
 		}, nil
 	})
@@ -172,12 +172,12 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
 		},
 	}, nil)
-	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).Return(&params.StartJobResponse{
 		JobID: "test-job-id",
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status:    params.StatusSuccessful,
 		Logs:      []string{"log-line", "log-line"},
 		Watermark: 2,
@@ -189,7 +189,7 @@ func (s *bootstrapCmdSuite) TestBootstrapWatchLogs(c *gc.C) {
 	}).Times(2)
 
 	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
-		c.Check(string(b), gc.Equals, "Bootstrap job completed successfully.\n")
+		c.Check(string(b), gc.Equals, "Job completed successfully.\n")
 		return len(b), nil
 	})
 
@@ -278,12 +278,12 @@ func (s *bootstrapCmdSuite) TestBootstrapMultipleCredentials(c *gc.C) {
 	// Now specify a credential and verify the command works.
 	command.credentialName = "cred-2"
 
-	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).Return(&params.StartJobResponse{
 		JobID: "test-job-id",
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status:    params.StatusSuccessful,
 		Logs:      []string{"log-line", "log-line"},
 		Watermark: 2,
@@ -295,7 +295,7 @@ func (s *bootstrapCmdSuite) TestBootstrapMultipleCredentials(c *gc.C) {
 	}).Times(2)
 
 	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
-		c.Check(string(b), gc.Equals, "Bootstrap job completed successfully.\n")
+		c.Check(string(b), gc.Equals, "Job completed successfully.\n")
 		return len(b), nil
 	})
 
@@ -317,7 +317,7 @@ func (s *bootstrapCmdSuite) TestBootstrapWithDefaultCredential(c *gc.C) {
 		},
 	}, nil)
 
-	s.client.EXPECT().Bootstrap(gomock.Any()).Return(&params.BootstrapStartResponse{JobID: "test-job-id"}, nil)
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).Return(&params.StartJobResponse{JobID: "test-job-id"}, nil)
 	s.client.EXPECT().Close().Return(nil)
 
 	command := &bootstrapCommand{

--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -7,9 +7,9 @@ import "github.com/canonical/jimm/v3/pkg/api/params"
 // JIMMAPI is an interface that defines the methods required for JIMM client operations.
 type JIMMAPI interface {
 	Close() error
-	BootstrapStatus(req *params.BootstrapStatusRequest) (params.BootstrapStatusResponse, error)
-	Bootstrap(req *params.BootstrapStartParams) (*params.BootstrapStartResponse, error)
-	BootstrapStop(req *params.BootstrapStopRequest) error
+	GetJobInfo(req *params.GetJobInfoRequest) (params.GetJobInfoResponse, error)
+	StopJob(req *params.StopJobRequest) error
+	StartBootstrapJob(req *params.BootstrapParams) (*params.StartJobResponse, error)
 	ListMigrationTargets(req *params.ListMigrationTargetsRequest) ([]params.ControllerInfo, error)
 	PrepareModelMigration(req *params.PrepareModelMigrationRequest) (params.PrepareModelMigrationResponse, error)
 }

--- a/cmd/jaas/cmd/jobstatus.go
+++ b/cmd/jaas/cmd/jobstatus.go
@@ -20,59 +20,59 @@ import (
 )
 
 const (
-	bootstrapStatusCommandDoc = `
-Displays logs for a bootstrap job.
+	jobStatusCommandDoc = `
+Displays logs for a job.
 `
-	bootstrapStatusCommandExample = `
-    juju bootstrap-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+	jobStatusCommandExample = `
+    juju job-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
 `
 )
 
-// sleepBetweenGetLogs is the duration to wait between successive calls to get logs for a bootstrap job.
+// sleepBetweenGetLogs is the duration to wait between successive calls to get logs for a job.
 const sleepBetweenGetLogs = 1 * time.Second
 
-// NewbootstrapStatusCommand returns a command to display logs for a bootstrap job.
-func NewBootstrapStatusCommand() cmd.Command {
-	cmd := &bootstrapStatusCommand{
+// NewJobStatusCommand returns a command to display logs for a job.
+func NewJobStatusCommand() cmd.Command {
+	cmd := &jobStatusCommand{
 		store: jujuclient.NewFileClientStore(),
 	}
-	cmd.bootstrapAPIFunc = cmd.newClient
+	cmd.jobAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
 }
 
-// bootstrapStatusCommand displays logs for a bootstrap job.
-type bootstrapStatusCommand struct {
+// jobStatusCommand displays logs for a job.
+type jobStatusCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store            jujuclient.ClientStore
-	dialOpts         *jujuapi.DialOpts
-	jobId            string
-	bootstrapAPIFunc func() (JIMMAPI, error)
+	store      jujuclient.ClientStore
+	dialOpts   *jujuapi.DialOpts
+	jobId      string
+	jobAPIFunc func() (JIMMAPI, error)
 
 	sleepBetweenGetLogs time.Duration
 	follow              bool
 }
 
 // Info implements cmd.Info interface.
-func (c *bootstrapStatusCommand) Info() *cmd.Info {
+func (c *jobStatusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:     "bootstrap-status",
+		Name:     "job-status",
 		Args:     "<job uuid>",
-		Purpose:  "Displays logs for a bootstrap job",
-		Doc:      bootstrapStatusCommandDoc,
-		Examples: bootstrapStatusCommandExample,
+		Purpose:  "Displays logs for a job",
+		Doc:      jobStatusCommandDoc,
+		Examples: jobStatusCommandExample,
 	})
 }
 
 // SetFlags implements cmd.SetFlags interface.
-func (c *bootstrapStatusCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *jobStatusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.follow, "f", false, "follow the logs of the bootstrap job")
+	f.BoolVar(&c.follow, "f", false, "follow the logs of the job")
 }
 
 // Init implements the cmd.Command interface.
-func (c *bootstrapStatusCommand) Init(args []string) error {
+func (c *jobStatusCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.E("missing job id")
 	}
@@ -86,8 +86,8 @@ func (c *bootstrapStatusCommand) Init(args []string) error {
 }
 
 // Run implements cmd.Command.Run interface.
-func (c *bootstrapStatusCommand) Run(ctxt *cmd.Context) error {
-	client, err := c.bootstrapAPIFunc()
+func (c *jobStatusCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.jobAPIFunc()
 	if err != nil {
 		return fmt.Errorf("failed to create JIMM client: %v", err)
 	}
@@ -100,7 +100,7 @@ func (c *bootstrapStatusCommand) Run(ctxt *cmd.Context) error {
 		out:                 ctxt.Stdout,
 		follow:              c.follow,
 	}
-	return poller.watchBootstrapLogs()
+	return poller.watchJobLogs()
 }
 
 type logPoller struct {
@@ -111,21 +111,21 @@ type logPoller struct {
 	follow              bool
 }
 
-func (p logPoller) watchBootstrapLogs() error {
+func (p logPoller) watchJobLogs() error {
 	watermark := 0
 
 	for {
-		response, err := p.client.BootstrapStatus(&params.BootstrapStatusRequest{
+		response, err := p.client.GetJobInfo(&params.GetJobInfoRequest{
 			JobID:     p.jobId,
 			Watermark: watermark,
 		})
 		if err != nil {
-			return errors.E(err, "failed to get bootstrap status")
+			return errors.E(err, "failed to get job info")
 		}
 		for _, log := range response.Logs {
 			_, err = p.out.Write([]byte(log + "\n"))
 			if err != nil {
-				return errors.E(err, "failed to write bootstrap log")
+				return errors.E(err, "failed to write job log")
 			}
 		}
 		watermark = response.Watermark
@@ -133,24 +133,24 @@ func (p logPoller) watchBootstrapLogs() error {
 		case params.StatusRunning:
 			// If the job is still running, we just continue to the next iteration.
 		case params.StatusSuccessful:
-			_, err = p.out.Write([]byte("Bootstrap job completed successfully.\n"))
+			_, err = p.out.Write([]byte("Job completed successfully.\n"))
 			if err != nil {
-				return errors.E(err, "failed to write bootstrap success message")
+				return errors.E(err, "failed to write job success message")
 			}
 			return nil
 		case params.StatusFailed:
-			_, err = p.out.Write([]byte("Bootstrap job failed: " + response.Error + "\n"))
+			_, err = p.out.Write([]byte("Job failed: " + response.Error + "\n"))
 			if err != nil {
-				return errors.E(err, "failed to write bootstrap error")
+				return errors.E(err, "failed to write job error")
 			}
 			return nil
 		case params.StatusPending:
-			_, err := p.out.Write([]byte("Bootstrap job is pending...\n"))
+			_, err := p.out.Write([]byte("Job is pending...\n"))
 			if err != nil {
-				return errors.E(err, "failed to write bootstrap pending message")
+				return errors.E(err, "failed to write job pending message")
 			}
 		default:
-			return errors.E("unknown bootstrap job status: %s", response.Status)
+			return errors.E("unknown job status: %s", response.Status)
 		}
 		if !p.follow {
 			return nil
@@ -159,7 +159,7 @@ func (p logPoller) watchBootstrapLogs() error {
 	}
 }
 
-func (s *bootstrapStatusCommand) newClient() (JIMMAPI, error) {
+func (s *jobStatusCommand) newClient() (JIMMAPI, error) {
 	currentController, err := s.store.CurrentController()
 	if err != nil {
 		return nil, errors.E(err, "could not determine controller")

--- a/cmd/jaas/cmd/jobstatus_unit_test.go
+++ b/cmd/jaas/cmd/jobstatus_unit_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type bootstrapStatusSuite struct {
+type jobStatusSuite struct {
 	client *mocks.MockJIMMAPI
 	writer *mocks.MockWriter
 }
 
-var _ = gc.Suite(&bootstrapStatusSuite{})
+var _ = gc.Suite(&jobStatusSuite{})
 
-func (s *bootstrapStatusSuite) SetupMocks(c *gc.C) *gomock.Controller {
+func (s *jobStatusSuite) SetupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.client = mocks.NewMockJIMMAPI(ctrl)
 	s.writer = mocks.NewMockWriter(ctrl)
@@ -28,18 +28,18 @@ func (s *bootstrapStatusSuite) SetupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *bootstrapStatusSuite) TestBootstrapStatus(c *gc.C) {
+func (s *jobStatusSuite) TestJobStatus(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status: params.StatusSuccessful,
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
-	s.writer.EXPECT().Write([]byte("Bootstrap job completed successfully.\n"))
+	s.writer.EXPECT().Write([]byte("Job completed successfully.\n"))
 
-	command := &bootstrapStatusCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStatusCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId:               "test-job-id",
@@ -54,19 +54,19 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapStatusSuite) TestBootstrapStatus_Failed(c *gc.C) {
+func (s *jobStatusSuite) TestJobStatus_Failed(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status: params.StatusFailed,
-		Error:  "Bootstrap job failed",
+		Error:  "Job failed",
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
-	s.writer.EXPECT().Write([]byte("Bootstrap job failed: Bootstrap job failed\n"))
+	s.writer.EXPECT().Write([]byte("Job failed: Job failed\n"))
 
-	command := &bootstrapStatusCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStatusCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId:               "test-job-id",
@@ -81,11 +81,11 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_Failed(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapStatusSuite) TestBootstrapStatus_Running(c *gc.C) {
+func (s *jobStatusSuite) TestJobStatus_Running(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status:    params.StatusRunning,
 		Logs:      []string{"log1", "log2"},
 		Watermark: 2,
@@ -95,11 +95,11 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_Running(c *gc.C) {
 	s.writer.EXPECT().Write([]byte("log2\n"))
 
 	s.client.EXPECT().
-		BootstrapStatus(&params.BootstrapStatusRequest{
+		GetJobInfo(&params.GetJobInfoRequest{
 			JobID:     "test-job-id",
 			Watermark: 2,
 		}).
-		Return(params.BootstrapStatusResponse{
+		Return(params.GetJobInfoResponse{
 			Status:    params.StatusRunning,
 			Logs:      []string{"log3"},
 			Watermark: 3,
@@ -107,17 +107,17 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_Running(c *gc.C) {
 	s.writer.EXPECT().Write([]byte("log3\n"))
 
 	s.client.EXPECT().
-		BootstrapStatus(&params.BootstrapStatusRequest{
+		GetJobInfo(&params.GetJobInfoRequest{
 			JobID:     "test-job-id",
 			Watermark: 3,
 		}).
-		Return(params.BootstrapStatusResponse{
+		Return(params.GetJobInfoResponse{
 			Status: params.StatusSuccessful,
 		}, nil)
-	s.writer.EXPECT().Write([]byte("Bootstrap job completed successfully.\n"))
+	s.writer.EXPECT().Write([]byte("Job completed successfully.\n"))
 
-	command := &bootstrapStatusCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStatusCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId:               "test-job-id",
@@ -132,11 +132,11 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_Running(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapStatusSuite) TestBootstrapStatus_NoFollow(c *gc.C) {
+func (s *jobStatusSuite) TestJobStatus_NoFollow(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status:    params.StatusRunning,
 		Logs:      []string{"log1", "log2"},
 		Watermark: 2,
@@ -145,8 +145,8 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_NoFollow(c *gc.C) {
 	s.writer.EXPECT().Write([]byte("log1\n"))
 	s.writer.EXPECT().Write([]byte("log2\n"))
 
-	command := &bootstrapStatusCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStatusCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId:               "test-job-id",
@@ -163,11 +163,11 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_NoFollow(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapStatusSuite) TestBootstrapStatus_AfterCompletion(c *gc.C) {
+func (s *jobStatusSuite) TestJobStatus_AfterCompletion(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 
-	s.client.EXPECT().BootstrapStatus(gomock.Any()).Return(params.BootstrapStatusResponse{
+	s.client.EXPECT().GetJobInfo(gomock.Any()).Return(params.GetJobInfoResponse{
 		Status:    params.StatusSuccessful,
 		Logs:      []string{"log1", "log2"},
 		Watermark: 2,
@@ -175,10 +175,10 @@ func (s *bootstrapStatusSuite) TestBootstrapStatus_AfterCompletion(c *gc.C) {
 	s.client.EXPECT().Close().Return(nil)
 	s.writer.EXPECT().Write([]byte("log1\n"))
 	s.writer.EXPECT().Write([]byte("log2\n"))
-	s.writer.EXPECT().Write([]byte("Bootstrap job completed successfully.\n"))
+	s.writer.EXPECT().Write([]byte("Job completed successfully.\n"))
 
-	command := &bootstrapStatusCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStatusCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId:               "test-job-id",

--- a/cmd/jaas/cmd/jobstop.go
+++ b/cmd/jaas/cmd/jobstop.go
@@ -17,47 +17,47 @@ import (
 )
 
 const (
-	bootstrapStopCommandDoc = `
-Stop a bootstrap job.
+	jobStopCommandDoc = `
+Stop a job.
 `
-	bootstrapStopCommandExample = `
-    juju bootstrap-stop 2cb433a6-04eb-4ec4-9567-90426d20a004 
+	jobStopCommandExample = `
+    juju job-stop 2cb433a6-04eb-4ec4-9567-90426d20a004 
 `
 )
 
-// NewBootstrapStopCommand returns a command to stop a bootstrap job.
-func NewBootstrapStopCommand() cmd.Command {
-	cmd := &bootstrapStopCommand{
+// NewJobStopCommand returns a command to stop a job.
+func NewJobStopCommand() cmd.Command {
+	cmd := &jobStopCommand{
 		store: jujuclient.NewFileClientStore(),
 	}
-	cmd.bootstrapAPIFunc = cmd.newClient
+	cmd.jobAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
 }
 
-// bootstrapStopCommand to stop a bootstrap job.
-type bootstrapStopCommand struct {
+// jobStopCommand to stop a job.
+type jobStopCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store            jujuclient.ClientStore
-	dialOpts         *jujuapi.DialOpts
-	jobId            string
-	bootstrapAPIFunc func() (JIMMAPI, error)
+	store      jujuclient.ClientStore
+	dialOpts   *jujuapi.DialOpts
+	jobId      string
+	jobAPIFunc func() (JIMMAPI, error)
 }
 
 // Info implements cmd.Info interface.
-func (c *bootstrapStopCommand) Info() *cmd.Info {
+func (c *jobStopCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:     "bootstrap-stop",
+		Name:     "job-stop",
 		Args:     "<job uuid>",
-		Purpose:  "Stop a bootstrap job",
-		Doc:      bootstrapStopCommandDoc,
-		Examples: bootstrapStopCommandExample,
+		Purpose:  "Stop a job",
+		Doc:      jobStopCommandDoc,
+		Examples: jobStopCommandExample,
 	})
 }
 
 // Init implements the cmd.Command interface.
-func (c *bootstrapStopCommand) Init(args []string) error {
+func (c *jobStopCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.E("missing job id")
 	}
@@ -70,26 +70,26 @@ func (c *bootstrapStopCommand) Init(args []string) error {
 }
 
 // Run implements cmd.Command.Run interface.
-func (c *bootstrapStopCommand) Run(ctxt *cmd.Context) error {
-	client, err := c.bootstrapAPIFunc()
+func (c *jobStopCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.jobAPIFunc()
 	if err != nil {
 		return fmt.Errorf("failed to create JIMM client: %v", err)
 	}
 
-	err = client.BootstrapStop(&params.BootstrapStopRequest{
+	err = client.StopJob(&params.StopJobRequest{
 		JobID: c.jobId,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to stop bootstrap job: %v", err)
+		return fmt.Errorf("failed to stop job: %v", err)
 	}
-	_, err = ctxt.Stdout.Write([]byte(fmt.Sprintf("Bootstrap job %s has been stopped.\n", c.jobId)))
+	_, err = ctxt.Stdout.Write([]byte(fmt.Sprintf("Job %s has been stopped.\n", c.jobId)))
 	if err != nil {
 		return fmt.Errorf("failed to write output: %v", err)
 	}
 	return nil
 }
 
-func (s *bootstrapStopCommand) newClient() (JIMMAPI, error) {
+func (s *jobStopCommand) newClient() (JIMMAPI, error) {
 	currentController, err := s.store.CurrentController()
 	if err != nil {
 		return nil, errors.E(err, "could not determine controller")

--- a/cmd/jaas/cmd/jobstop_unit_test.go
+++ b/cmd/jaas/cmd/jobstop_unit_test.go
@@ -14,14 +14,14 @@ import (
 	"github.com/canonical/jimm/v3/cmd/jaas/cmd/mocks"
 )
 
-type bootstrapStopSuite struct {
+type jobStopSuite struct {
 	client *mocks.MockJIMMAPI
 	writer *mocks.MockWriter
 }
 
-var _ = gc.Suite(&bootstrapStopSuite{})
+var _ = gc.Suite(&jobStopSuite{})
 
-func (s *bootstrapStopSuite) SetupMocks(c *gc.C) *gomock.Controller {
+func (s *jobStopSuite) SetupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.client = mocks.NewMockJIMMAPI(ctrl)
 	s.writer = mocks.NewMockWriter(ctrl)
@@ -29,15 +29,15 @@ func (s *bootstrapStopSuite) SetupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *bootstrapStopSuite) TestBootstrapStop(c *gc.C) {
+func (s *jobStopSuite) TestJobStop(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 	jobId := "test-job-id"
-	s.client.EXPECT().BootstrapStop(gomock.Any()).Return(nil)
-	s.writer.EXPECT().Write(fmt.Appendf(nil, "Bootstrap job %s has been stopped.\n", jobId))
+	s.client.EXPECT().StopJob(gomock.Any()).Return(nil)
+	s.writer.EXPECT().Write(fmt.Appendf(nil, "Job %s has been stopped.\n", jobId))
 
-	command := &bootstrapStopCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStopCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId: jobId,
@@ -50,14 +50,14 @@ func (s *bootstrapStopSuite) TestBootstrapStop(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *bootstrapStopSuite) TestBootstrapStopError(c *gc.C) {
+func (s *jobStopSuite) TestJobStopError(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()
 	jobId := "test-job-id"
-	s.client.EXPECT().BootstrapStop(gomock.Any()).Return(errors.New("an error"))
+	s.client.EXPECT().StopJob(gomock.Any()).Return(errors.New("an error"))
 
-	command := &bootstrapStopCommand{
-		bootstrapAPIFunc: func() (JIMMAPI, error) {
+	command := &jobStopCommand{
+		jobAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 		jobId: jobId,
@@ -67,5 +67,5 @@ func (s *bootstrapStopSuite) TestBootstrapStopError(c *gc.C) {
 		Stdout:  s.writer,
 	}
 	err := command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, "failed to stop bootstrap job: an error")
+	c.Assert(err, gc.ErrorMatches, "failed to stop job: an error")
 }

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -40,122 +40,6 @@ func (m *MockJIMMAPI) EXPECT() *MockJIMMAPIMockRecorder {
 	return m.recorder
 }
 
-// Bootstrap mocks base method.
-func (m *MockJIMMAPI) Bootstrap(req *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", req)
-	ret0, _ := ret[0].(*params.BootstrapStartResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Bootstrap indicates an expected call of Bootstrap.
-func (mr *MockJIMMAPIMockRecorder) Bootstrap(req any) *MockJIMMAPIBootstrapCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockJIMMAPI)(nil).Bootstrap), req)
-	return &MockJIMMAPIBootstrapCall{Call: call}
-}
-
-// MockJIMMAPIBootstrapCall wrap *gomock.Call
-type MockJIMMAPIBootstrapCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockJIMMAPIBootstrapCall) Return(arg0 *params.BootstrapStartResponse, arg1 error) *MockJIMMAPIBootstrapCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockJIMMAPIBootstrapCall) Do(f func(*params.BootstrapStartParams) (*params.BootstrapStartResponse, error)) *MockJIMMAPIBootstrapCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJIMMAPIBootstrapCall) DoAndReturn(f func(*params.BootstrapStartParams) (*params.BootstrapStartResponse, error)) *MockJIMMAPIBootstrapCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// BootstrapStatus mocks base method.
-func (m *MockJIMMAPI) BootstrapStatus(req *params.BootstrapStatusRequest) (params.BootstrapStatusResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BootstrapStatus", req)
-	ret0, _ := ret[0].(params.BootstrapStatusResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BootstrapStatus indicates an expected call of BootstrapStatus.
-func (mr *MockJIMMAPIMockRecorder) BootstrapStatus(req any) *MockJIMMAPIBootstrapStatusCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapStatus", reflect.TypeOf((*MockJIMMAPI)(nil).BootstrapStatus), req)
-	return &MockJIMMAPIBootstrapStatusCall{Call: call}
-}
-
-// MockJIMMAPIBootstrapStatusCall wrap *gomock.Call
-type MockJIMMAPIBootstrapStatusCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockJIMMAPIBootstrapStatusCall) Return(arg0 params.BootstrapStatusResponse, arg1 error) *MockJIMMAPIBootstrapStatusCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockJIMMAPIBootstrapStatusCall) Do(f func(*params.BootstrapStatusRequest) (params.BootstrapStatusResponse, error)) *MockJIMMAPIBootstrapStatusCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJIMMAPIBootstrapStatusCall) DoAndReturn(f func(*params.BootstrapStatusRequest) (params.BootstrapStatusResponse, error)) *MockJIMMAPIBootstrapStatusCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// BootstrapStop mocks base method.
-func (m *MockJIMMAPI) BootstrapStop(req *params.BootstrapStopRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BootstrapStop", req)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// BootstrapStop indicates an expected call of BootstrapStop.
-func (mr *MockJIMMAPIMockRecorder) BootstrapStop(req any) *MockJIMMAPIBootstrapStopCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapStop", reflect.TypeOf((*MockJIMMAPI)(nil).BootstrapStop), req)
-	return &MockJIMMAPIBootstrapStopCall{Call: call}
-}
-
-// MockJIMMAPIBootstrapStopCall wrap *gomock.Call
-type MockJIMMAPIBootstrapStopCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockJIMMAPIBootstrapStopCall) Return(arg0 error) *MockJIMMAPIBootstrapStopCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockJIMMAPIBootstrapStopCall) Do(f func(*params.BootstrapStopRequest) error) *MockJIMMAPIBootstrapStopCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJIMMAPIBootstrapStopCall) DoAndReturn(f func(*params.BootstrapStopRequest) error) *MockJIMMAPIBootstrapStopCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Close mocks base method.
 func (m *MockJIMMAPI) Close() error {
 	m.ctrl.T.Helper()
@@ -190,6 +74,45 @@ func (c *MockJIMMAPICloseCall) Do(f func() error) *MockJIMMAPICloseCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockJIMMAPICloseCall) DoAndReturn(f func() error) *MockJIMMAPICloseCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetJobInfo mocks base method.
+func (m *MockJIMMAPI) GetJobInfo(req *params.GetJobInfoRequest) (params.GetJobInfoResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetJobInfo", req)
+	ret0, _ := ret[0].(params.GetJobInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetJobInfo indicates an expected call of GetJobInfo.
+func (mr *MockJIMMAPIMockRecorder) GetJobInfo(req any) *MockJIMMAPIGetJobInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobInfo", reflect.TypeOf((*MockJIMMAPI)(nil).GetJobInfo), req)
+	return &MockJIMMAPIGetJobInfoCall{Call: call}
+}
+
+// MockJIMMAPIGetJobInfoCall wrap *gomock.Call
+type MockJIMMAPIGetJobInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIGetJobInfoCall) Return(arg0 params.GetJobInfoResponse, arg1 error) *MockJIMMAPIGetJobInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIGetJobInfoCall) Do(f func(*params.GetJobInfoRequest) (params.GetJobInfoResponse, error)) *MockJIMMAPIGetJobInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIGetJobInfoCall) DoAndReturn(f func(*params.GetJobInfoRequest) (params.GetJobInfoResponse, error)) *MockJIMMAPIGetJobInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -268,6 +191,83 @@ func (c *MockJIMMAPIPrepareModelMigrationCall) Do(f func(*params.PrepareModelMig
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockJIMMAPIPrepareModelMigrationCall) DoAndReturn(f func(*params.PrepareModelMigrationRequest) (params.PrepareModelMigrationResponse, error)) *MockJIMMAPIPrepareModelMigrationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// StartBootstrapJob mocks base method.
+func (m *MockJIMMAPI) StartBootstrapJob(req *params.BootstrapParams) (*params.StartJobResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartBootstrapJob", req)
+	ret0, _ := ret[0].(*params.StartJobResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartBootstrapJob indicates an expected call of StartBootstrapJob.
+func (mr *MockJIMMAPIMockRecorder) StartBootstrapJob(req any) *MockJIMMAPIStartBootstrapJobCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBootstrapJob", reflect.TypeOf((*MockJIMMAPI)(nil).StartBootstrapJob), req)
+	return &MockJIMMAPIStartBootstrapJobCall{Call: call}
+}
+
+// MockJIMMAPIStartBootstrapJobCall wrap *gomock.Call
+type MockJIMMAPIStartBootstrapJobCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIStartBootstrapJobCall) Return(arg0 *params.StartJobResponse, arg1 error) *MockJIMMAPIStartBootstrapJobCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIStartBootstrapJobCall) Do(f func(*params.BootstrapParams) (*params.StartJobResponse, error)) *MockJIMMAPIStartBootstrapJobCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIStartBootstrapJobCall) DoAndReturn(f func(*params.BootstrapParams) (*params.StartJobResponse, error)) *MockJIMMAPIStartBootstrapJobCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// StopJob mocks base method.
+func (m *MockJIMMAPI) StopJob(req *params.StopJobRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopJob", req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopJob indicates an expected call of StopJob.
+func (mr *MockJIMMAPIMockRecorder) StopJob(req any) *MockJIMMAPIStopJobCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopJob", reflect.TypeOf((*MockJIMMAPI)(nil).StopJob), req)
+	return &MockJIMMAPIStopJobCall{Call: call}
+}
+
+// MockJIMMAPIStopJobCall wrap *gomock.Call
+type MockJIMMAPIStopJobCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIStopJobCall) Return(arg0 error) *MockJIMMAPIStopJobCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIStopJobCall) Do(f func(*params.StopJobRequest) error) *MockJIMMAPIStopJobCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIStopJobCall) DoAndReturn(f func(*params.StopJobRequest) error) *MockJIMMAPIStopJobCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -55,9 +55,9 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewSetControllerDeprecatedCommand())
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
-	jaasCmd.Register(cmd.NewBootstrapStatusCommand())
+	jaasCmd.Register(cmd.NewJobStatusCommand())
+	jaasCmd.Register(cmd.NewJobStopCommand())
 	jaasCmd.Register(cmd.NewBootstrapStartCommand())
-	jaasCmd.Register(cmd.NewBootstrapStopCommand())
 	return jaasCmd
 }
 

--- a/internal/db/export_test.go
+++ b/internal/db/export_test.go
@@ -17,7 +17,7 @@ var (
 	OAuthSessionStoreSecretTag = oauthSessionStoreSecretTag
 	NewUUID                    = &newUUID
 	MigrationTableName         = migrationTableName
-	BootstrapLogLockQuery      = &bootstrapLoglockQuery
+	JobLogLockQuery            = &jobLoglockQuery
 )
 
 func (d *Database) MigrateFromSource(ctx context.Context, fs embed.FS, sqlPath string) error {

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -14,12 +14,12 @@ import (
 
 var (
 	// Blocks most concurrent writes and schema changes but allows reads.
-	bootstrapLoglockQuery = "LOCK TABLE bootstrap_logs IN EXCLUSIVE MODE"
+	jobLoglockQuery = "LOCK TABLE job_logs IN EXCLUSIVE MODE"
 )
 
-// AddBootstrapLog adds a bootstrap log entry to the store.
-func (d *Database) AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine string) (err error) {
-	const op = errors.Op("db.AddBootstrapLog")
+// AddJobLog adds a job log entry to the store.
+func (d *Database) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine string) (err error) {
+	const op = errors.Op("db.AddJobLog")
 
 	if err := d.ready(); err != nil {
 		return errors.E(op, err)
@@ -27,14 +27,14 @@ func (d *Database) AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine
 
 	return d.Transaction(func(d *Database) error {
 		// Blocks all other operations, including reads, writes, and other locks.
-		if err := d.DB.Exec(bootstrapLoglockQuery).Error; err != nil {
-			return errors.E(op, "failed to lock bootstrap_logs table", err)
+		if err := d.DB.Exec(jobLoglockQuery).Error; err != nil {
+			return errors.E(op, "failed to lock job_logs table", err)
 		}
 
-		// Get the current line number for this bootstrap job.
+		// Get the current line number for this job.
 		var currentLineNumber int
 		err = d.DB.WithContext(ctx).
-			Model(&dbmodel.BootstrapLog{}).
+			Model(&dbmodel.JobLog{}).
 			Where("job_id = ?", jobId).
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error
@@ -44,9 +44,9 @@ func (d *Database) AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine
 
 		nextLineNumber := currentLineNumber + 1
 
-		log, err := dbmodel.NewBootstrapLog(jobId, nextLineNumber, logLine)
+		log, err := dbmodel.NewJobLog(jobId, nextLineNumber, logLine)
 		if err != nil {
-			return errors.E(op, "failed to construct bootstrap log", err)
+			return errors.E(op, "failed to construct job log", err)
 		}
 
 		if err := d.DB.WithContext(ctx).Create(log).Error; err != nil {
@@ -56,13 +56,13 @@ func (d *Database) AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine
 	})
 }
 
-// QueryBootstrapLog queries for bootstrap logs based on the jobId and offset.
+// QueryJobLog queries for job logs based on the jobId and offset.
 //
 // It returns the next offset value to use, and this offset value may be the same
 // as the one initially presented / previously returned. This means no new logs have
 // come in, but they may later, and the client should query again for logs after some time.
-func (d *Database) QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error) {
-	const op = errors.Op("db.QueryBootstrapLog")
+func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error) {
+	const op = errors.Op("db.QueryJobLog")
 
 	if err := d.ready(); err != nil {
 		return loggies, nextOffsetValue, errors.E(op, err)
@@ -72,7 +72,7 @@ func (d *Database) QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offse
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
-	var logs []dbmodel.BootstrapLog
+	var logs []dbmodel.JobLog
 	err = d.Transaction(func(d *Database) error {
 		// Make sure job exists, if it doesn't, there's no point running the query
 		if err := d.DB.WithContext(ctx).First(&dbmodel.JobTrackerEntry{JobID: jobId}, "job_id = ?", jobId).Error; err != nil {
@@ -80,7 +80,7 @@ func (d *Database) QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offse
 		}
 
 		query := d.DB.WithContext(ctx).
-			Model(&dbmodel.BootstrapLog{}).
+			Model(&dbmodel.JobLog{}).
 			Where("job_id = ?", jobId)
 
 		var count int64
@@ -100,7 +100,7 @@ func (d *Database) QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offse
 		// Get the next line number
 		var currentLineNumber int
 		err = d.DB.WithContext(ctx).
-			Model(&dbmodel.BootstrapLog{}).
+			Model(&dbmodel.JobLog{}).
 			Where("job_id = ?", jobId).
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error

--- a/internal/db/job_logs_test.go
+++ b/internal/db/job_logs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
 
-func (s *dbSuite) TestBootstrapLogs_AddBootstrapLog(c *qt.C) {
+func (s *dbSuite) TestJobLogs_AddJobLog(c *qt.C) {
 	ctx := c.Context()
 
 	err := s.Database.Migrate(ctx)
@@ -22,17 +22,17 @@ func (s *dbSuite) TestBootstrapLogs_AddBootstrapLog(c *qt.C) {
 
 	// Test where job id doesn't exist
 	jobThatDoesntExistId := uuid.New()
-	err = s.Database.AddBootstrapLog(ctx, jobThatDoesntExistId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
+	err = s.Database.AddJobLog(ctx, jobThatDoesntExistId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
 	c.Assert(err, qt.ErrorMatches, ".*violates foreign key constraint.*")
 
 	// Test success
-	err = s.Database.AddBootstrapLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
+	err = s.Database.AddJobLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
 	c.Assert(err, qt.IsNil)
 	// Test adding second line
-	err = s.Database.AddBootstrapLog(ctx, jobId, "Fetching Juju agent binaries")
+	err = s.Database.AddJobLog(ctx, jobId, "Fetching Juju agent binaries")
 	c.Assert(err, qt.IsNil)
 	// Check all lines exist
-	var logs []dbmodel.BootstrapLog
+	var logs []dbmodel.JobLog
 	err = s.Database.DB.Where("job_id = ?", jobId).Order("line_number asc").Find(&logs).Error
 	c.Assert(err, qt.IsNil)
 
@@ -45,10 +45,10 @@ func (s *dbSuite) TestBootstrapLogs_AddBootstrapLog(c *qt.C) {
 	// Test adding another where job id is different
 	jobId2, err := s.Database.AddJob(ctx, "test-job")
 	c.Assert(err, qt.IsNil)
-	err = s.Database.AddBootstrapLog(ctx, jobId2, "Creating Juju controller \"diglett2\" on the-most-amazing-cloud")
+	err = s.Database.AddJobLog(ctx, jobId2, "Creating Juju controller \"diglett2\" on the-most-amazing-cloud")
 	c.Assert(err, qt.IsNil)
 
-	var logs2 []dbmodel.BootstrapLog
+	var logs2 []dbmodel.JobLog
 	err = s.Database.DB.Where("job_id = ?", jobId2).Order("line_number asc").Find(&logs2).Error
 	c.Assert(err, qt.IsNil)
 
@@ -57,7 +57,7 @@ func (s *dbSuite) TestBootstrapLogs_AddBootstrapLog(c *qt.C) {
 	c.Assert(logs2[0].LogLine, qt.Equals, "Creating Juju controller \"diglett2\" on the-most-amazing-cloud")
 }
 
-func (s *dbSuite) TestBootstrapLogs_QueryBootstrapLogs(c *qt.C) {
+func (s *dbSuite) TestJobLogs_QueryJobLogs(c *qt.C) {
 	ctx := c.Context()
 
 	err := s.Database.Migrate(ctx)
@@ -65,7 +65,7 @@ func (s *dbSuite) TestBootstrapLogs_QueryBootstrapLogs(c *qt.C) {
 
 	// Query where the job doesn't exist
 	jobIdThatDoesntExist := uuid.New()
-	_, _, err = s.Database.QueryBootstrapLog(ctx, jobIdThatDoesntExist, 0)
+	_, _, err = s.Database.QueryJobLog(ctx, jobIdThatDoesntExist, 0)
 	c.Assert(err, qt.ErrorMatches, "job not found")
 
 	// Add job to reference
@@ -73,7 +73,7 @@ func (s *dbSuite) TestBootstrapLogs_QueryBootstrapLogs(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	// Query with no logs
-	loggies, nextOffsetVal, err := s.Database.QueryBootstrapLog(ctx, jobId, 0)
+	loggies, nextOffsetVal, err := s.Database.QueryJobLog(ctx, jobId, 0)
 	c.Assert(err, qt.IsNil)
 	c.Assert(loggies, qt.HasLen, 0)
 	c.Assert(nextOffsetVal, qt.Equals, 0)
@@ -82,30 +82,30 @@ func (s *dbSuite) TestBootstrapLogs_QueryBootstrapLogs(c *qt.C) {
 	offsetTracker := 0
 	collectedLogs := make([]string, 0)
 
-	newLogs, nextOffsetValue, err := s.Database.QueryBootstrapLog(ctx, jobId, offsetTracker)
+	newLogs, nextOffsetValue, err := s.Database.QueryJobLog(ctx, jobId, offsetTracker)
 	c.Assert(err, qt.IsNil)
 	offsetTracker = nextOffsetValue
 	collectedLogs = append(collectedLogs, newLogs...)
 
-	c.Assert(s.Database.AddBootstrapLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud"), qt.IsNil)
-	c.Assert(s.Database.AddBootstrapLog(ctx, jobId, "Fetching Juju agent binaries"), qt.IsNil)
+	c.Assert(s.Database.AddJobLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud"), qt.IsNil)
+	c.Assert(s.Database.AddJobLog(ctx, jobId, "Fetching Juju agent binaries"), qt.IsNil)
 
-	newLogs, nextOffsetValue, err = s.Database.QueryBootstrapLog(ctx, jobId, offsetTracker)
+	newLogs, nextOffsetValue, err = s.Database.QueryJobLog(ctx, jobId, offsetTracker)
 	c.Assert(err, qt.IsNil)
 	offsetTracker = nextOffsetValue
 	collectedLogs = append(collectedLogs, newLogs...)
 
-	c.Assert(s.Database.AddBootstrapLog(ctx, jobId, "Binaries contain gems"), qt.IsNil)
-	c.Assert(s.Database.AddBootstrapLog(ctx, jobId, "Gems appear to be very expensive"), qt.IsNil)
+	c.Assert(s.Database.AddJobLog(ctx, jobId, "Binaries contain gems"), qt.IsNil)
+	c.Assert(s.Database.AddJobLog(ctx, jobId, "Gems appear to be very expensive"), qt.IsNil)
 
-	newLogs, nextOffsetValue, err = s.Database.QueryBootstrapLog(ctx, jobId, offsetTracker)
+	newLogs, nextOffsetValue, err = s.Database.QueryJobLog(ctx, jobId, offsetTracker)
 	c.Assert(err, qt.IsNil)
 	offsetTracker = nextOffsetValue
 	collectedLogs = append(collectedLogs, newLogs...)
 
 	c.Assert(collectedLogs, qt.HasLen, 4)
 
-	newLogs, nextOffsetValue, err = s.Database.QueryBootstrapLog(ctx, jobId, offsetTracker)
+	newLogs, nextOffsetValue, err = s.Database.QueryJobLog(ctx, jobId, offsetTracker)
 	c.Assert(err, qt.IsNil)
 	// This means no new logs have come in, but they may later, and the client should query again for logs
 	// after some time.
@@ -115,7 +115,7 @@ func (s *dbSuite) TestBootstrapLogs_QueryBootstrapLogs(c *qt.C) {
 
 // This test is a behaviour check, that is, we want our lock does indeed reject
 // on an ACCESS EXCLUSIVE mode when inserting new logs.
-func (s *dbSuite) TestBootstrapLogs_lockBootstrapLogs(c *qt.C) {
+func (s *dbSuite) TestJobLogs_lockJobLogs(c *qt.C) {
 	ctx := c.Context()
 
 	err := s.Database.Migrate(ctx)
@@ -131,14 +131,14 @@ func (s *dbSuite) TestBootstrapLogs_lockBootstrapLogs(c *qt.C) {
 	lockAcquired := make(chan bool)
 
 	// Adjust the query to use NOWAIT, such that it can error immediately
-	// within our AddBootstrapLog call. The routine below will successfully
+	// within our AddJobLog call. The routine below will successfully
 	// acquire a lock because none is present yet. When we attempt to acquire
-	// it again in our AddBootstrapLogs call, it is going to immediately error
+	// it again in our AddJobLogs call, it is going to immediately error
 	// and not queue.
-	c.Patch(db.BootstrapLogLockQuery, *db.BootstrapLogLockQuery+" NOWAIT")
+	c.Patch(db.JobLogLockQuery, *db.JobLogLockQuery+" NOWAIT")
 	go func() {
 		err := s.Database.Transaction(func(d *db.Database) error {
-			err := d.DB.Exec(*db.BootstrapLogLockQuery).Error
+			err := d.DB.Exec(*db.JobLogLockQuery).Error
 			if err != nil {
 				return err
 			}
@@ -153,6 +153,6 @@ func (s *dbSuite) TestBootstrapLogs_lockBootstrapLogs(c *qt.C) {
 
 	<-lockAcquired
 
-	err = s.Database.AddBootstrapLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
-	c.Assert(err, qt.ErrorMatches, "failed to lock bootstrap_logs table")
+	err = s.Database.AddJobLog(ctx, jobId, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
+	c.Assert(err, qt.ErrorMatches, "failed to lock job_logs table")
 }

--- a/internal/dbmodel/job_logs.go
+++ b/internal/dbmodel/job_logs.go
@@ -8,23 +8,23 @@ import (
 	"github.com/google/uuid"
 )
 
-// BootstrapLog represents a log entry for a bootstrap job.
-type BootstrapLog struct {
+// JobLog represents a log entry for a job.
+type JobLog struct {
 	// JobID is the unique identifier for the job. References a [JobTrackerEntry].
 	JobID uuid.UUID `gorm:"type:uuid;not null;primaryKey"`
-	// LineNumber is the line number of a running bootstrap. It is used to offset the log lines
+	// LineNumber is the line number of a running job. It is used to offset the log lines
 	// when fetching logs.
 	LineNumber int `gorm:"not null;primaryKey"`
-	// LogLine is an actual log line from the bootstrap job.
+	// LogLine is an actual log line from the job.
 	LogLine string `gorm:"type:text;not null"`
 
 	Job JobTrackerEntry `gorm:"constraint:OnDelete:CASCADE;foreignKey:JobID;references:JobID"`
 }
 
-// NewBootstrapLog creates a new BootstrapLog with the given jobId, lineNumber, and logLine.
+// NewJobLog creates a new JobLog with the given jobId, lineNumber, and logLine.
 // It returns an error if any of the parameters are invalid.
-func NewBootstrapLog(jobId uuid.UUID, lineNumber int, logLine string) (*BootstrapLog, error) {
-	res := &BootstrapLog{}
+func NewJobLog(jobId uuid.UUID, lineNumber int, logLine string) (*JobLog, error) {
+	res := &JobLog{}
 
 	if jobId == uuid.Nil {
 		return res, errors.New("job id cannot be nil")

--- a/internal/dbmodel/job_logs_test.go
+++ b/internal/dbmodel/job_logs_test.go
@@ -13,37 +13,37 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
 
-type bootstrapLogsSuite struct {
+type jobLogsSuite struct {
 	Database *gorm.DB
 }
 
-func (j *bootstrapLogsSuite) Init(c *qt.C) {
+func (j *jobLogsSuite) Init(c *qt.C) {
 	j.Database = gormDB(c)
 }
 
-func (j *bootstrapLogsSuite) TestJobTracker_NewBootstrapLog(c *qt.C) {
+func (j *jobLogsSuite) TestJobTracker_NewJobLog(c *qt.C) {
 	id := uuid.New()
 
-	_, err := dbmodel.NewBootstrapLog(uuid.UUID{}, -1, "test log line")
+	_, err := dbmodel.NewJobLog(uuid.UUID{}, -1, "test log line")
 	c.Assert(err, qt.ErrorMatches, ".*job id cannot be nil.*")
 
-	_, err = dbmodel.NewBootstrapLog(id, -1, "test log line")
+	_, err = dbmodel.NewJobLog(id, -1, "test log line")
 	c.Assert(err, qt.ErrorMatches, ".*line number must be non-negative.*")
 
-	_, err = dbmodel.NewBootstrapLog(id, 0, "")
+	_, err = dbmodel.NewJobLog(id, 0, "")
 	c.Assert(err, qt.ErrorMatches, ".*log line cannot be empty.*")
 }
 
-func (j *bootstrapLogsSuite) TestBootstrapLog(c *qt.C) {
+func (j *jobLogsSuite) TestJobLog(c *qt.C) {
 	db := j.Database
 
 	// Test a bad log entry
-	badEntry := &dbmodel.BootstrapLog{}
+	badEntry := &dbmodel.JobLog{}
 	c.Assert(db.First(badEntry).Error, qt.IsNotNil)
 
 	// Test with invalid FK
 	badJobId := uuid.New()
-	entry, err := dbmodel.NewBootstrapLog(badJobId, 0, "hi")
+	entry, err := dbmodel.NewJobLog(badJobId, 0, "hi")
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Create(entry).Error, qt.ErrorMatches, ".*violates foreign key constraint.*")
 
@@ -55,18 +55,18 @@ func (j *bootstrapLogsSuite) TestBootstrapLog(c *qt.C) {
 	c.Assert(db.Create(job).Error, qt.IsNil)
 
 	// Create a log entry for the job
-	entry, err = dbmodel.NewBootstrapLog(job.JobID, 0, "Creating Juju controller \"aws-controller\" on aws/us-east-1")
+	entry, err = dbmodel.NewJobLog(job.JobID, 0, "Creating Juju controller \"aws-controller\" on aws/us-east-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Create(entry).Error, qt.IsNil)
 
 	// Quickly grab the log in a fresh entry
-	log := &dbmodel.BootstrapLog{}
+	log := &dbmodel.JobLog{}
 	c.Assert(db.First(log, "job_id = ? AND line_number = ?", job.JobID, 0).Error, qt.IsNil)
 	c.Assert(log.JobID, qt.Equals, job.JobID)
 	c.Assert(log.LineNumber, qt.Equals, 0)
 	c.Assert(log.LogLine, qt.Equals, "Creating Juju controller \"aws-controller\" on aws/us-east-1")
 }
 
-func TestBootstrapLogsSuite(t *testing.T) {
-	qtsuite.Run(qt.New(t), &bootstrapLogsSuite{})
+func TestJobLogsSuite(t *testing.T) {
+	qtsuite.Run(qt.New(t), &jobLogsSuite{})
 }

--- a/internal/dbmodel/sql/postgres/033_rename_job_logs.up.sql
+++ b/internal/dbmodel/sql/postgres/033_rename_job_logs.up.sql
@@ -1,0 +1,3 @@
+--- Rename bootstrap_logs to job_logs to reflect its generic usage
+
+ALTER TABLE bootstrap_logs RENAME TO job_logs;

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -43,13 +43,13 @@ const (
 
 // Store defines the store methods required by the manager.
 type Store interface {
-	QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error)
+	QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error)
 
 	// BootstrapJob store methods:
 
 	LockBootstrap(ctx context.Context, ttl time.Duration) error
 	GetController(ctx context.Context, controller *dbmodel.Controller) (err error)
-	AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine string) (err error)
+	AddJobLog(ctx context.Context, jobId uuid.UUID, logLine string) (err error)
 	UnlockBootstrap(ctx context.Context) error
 }
 
@@ -73,7 +73,7 @@ type BinaryStore interface {
 	Get(ctx context.Context, spec jujuclistore.JujuBinarySpec, logFunction func(string)) (*jujuclistore.Binary, error)
 }
 
-// JujuCommands defines the Juju CLI methods that the bootstrap job requires.
+// JujuCommands defines the Juju CLI methods that the bootstrap-related jobs require.
 type JujuCommands interface {
 	Bootstrap(ctx context.Context, p jujucommands.BootstrapCmdParams) (<-chan jujucommands.OutputLine, jujuclient.ClientStore, func(), error)
 	DestroyController(ctx context.Context, p jujucommands.DestroyControllerCmdParams) (<-chan jujucommands.OutputLine, error)
@@ -125,22 +125,22 @@ func NewBootstrapManager(
 	}, nil
 }
 
-// GetBootstrapStatusAndLogs retrieves the status and logs of a bootstrap job.
+// GetJobInfo retrieves the status and logs of a bootstrap job.
 // It requires the user to be an admin and returns the status, error message, logs,
 // and a watermark for pagination.
-func (b *bootstrapManager) GetBootstrapStatusAndLogs(ctx context.Context, _ *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error) {
-	const op = errors.Op("jimm.GetBootstrapStatusAndLogs")
+func (b *bootstrapManager) GetJobInfo(ctx context.Context, _ *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error) {
+	const op = errors.Op("jimm.GetJobInfo")
 
 	job, err := b.tracker.GetJob(ctx, jobId)
 	if err != nil {
-		return params.BootstrapStatusResponse{}, errors.E(op, "failed to get job status", err)
+		return params.GetJobInfoResponse{}, errors.E(op, "failed to get job info", err)
 	}
 
-	loggies, newOffset, err := b.store.QueryBootstrapLog(ctx, jobId, offset)
+	loggies, newOffset, err := b.store.QueryJobLog(ctx, jobId, offset)
 	if err != nil {
-		return params.BootstrapStatusResponse{}, errors.E(op, "failed to query bootstrap logs", err)
+		return params.GetJobInfoResponse{}, errors.E(op, "failed to query job logs", err)
 	}
-	return params.BootstrapStatusResponse{
+	return params.GetJobInfoResponse{
 		Status:    params.JobStatus(job.Status),
 		Error:     job.Error,
 		Logs:      loggies,
@@ -148,9 +148,9 @@ func (b *bootstrapManager) GetBootstrapStatusAndLogs(ctx context.Context, _ *ope
 	}, nil
 }
 
-// StopBootstrap stops a bootstrap job by its ID.
-func (b *bootstrapManager) StopBootstrap(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
-	const op = errors.Op("jimm.StopBootstrap")
+// StopJob stops a bootstrap job by its ID.
+func (b *bootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
+	const op = errors.Op("jimm.StopJob")
 
 	if user == nil {
 		return errors.E(op, "user cannot be nil")
@@ -169,8 +169,8 @@ func (b *bootstrapManager) StopBootstrap(ctx context.Context, user *openfga.User
 }
 
 // StartBootstrap starts a bootstrap job with the provided parameters.
-func (b *bootstrapManager) StartBootstrap(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
-	const op = errors.Op("jimm.StartBootstrap")
+func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
+	const op = errors.Op("jimm.StartBootstrapJob")
 
 	if err := params.validate(); err != nil {
 		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))
@@ -343,7 +343,7 @@ func (b *bootstrapManager) BootstrapJob(
 			return errors.E(fmt.Errorf("failed to check if controller exists: %w", err))
 		}
 
-		b.writeBootstrapLog(jobCtx, jobId,
+		b.writeJobLog(jobCtx, jobId,
 			fmt.Sprintf("Downloading the Juju CLI, version %s for bootstrap. This may take a few minutes", p.CLIVersion))
 
 		binary, err := b.binaryStore.Get(
@@ -358,7 +358,7 @@ func (b *bootstrapManager) BootstrapJob(
 				Arch: runtime.GOARCH,
 			},
 			func(line string) {
-				b.writeBootstrapLog(jobCtx, jobId, line)
+				b.writeJobLog(jobCtx, jobId, line)
 			},
 		)
 		if err != nil {
@@ -517,18 +517,18 @@ func (b *bootstrapManager) tryCleanupController(ctx context.Context, jujuCmd Juj
 func (b *bootstrapManager) consumeCommandOutput(ctx context.Context, outputCh <-chan jujucommands.OutputLine, jobId uuid.UUID) error {
 	for output := range outputCh {
 		if output.Err != nil {
-			b.writeBootstrapLog(ctx, jobId, output.Err.Error())
+			b.writeJobLog(ctx, jobId, output.Err.Error())
 			return errors.E(fmt.Errorf("command failed: %w", output.Err))
 		}
-		b.writeBootstrapLog(ctx, jobId, output.Line)
+		b.writeJobLog(ctx, jobId, output.Line)
 	}
 	return nil
 }
 
-// writeBootstrapLog writes logs to the store to eventually be displayed to users.
+// writeJobLog writes logs to the store to eventually be displayed to users.
 // Errors are masked but logged to avoid failing the bootstrap process.
-func (b *bootstrapManager) writeBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine string) {
-	if err := b.store.AddBootstrapLog(ctx, jobId, logLine); err != nil {
+func (b *bootstrapManager) writeJobLog(ctx context.Context, jobId uuid.UUID, logLine string) {
+	if err := b.store.AddJobLog(ctx, jobId, logLine); err != nil {
 		zapctx.Error(ctx, "failed to write bootstrap log", zap.Error(err), zap.String("jobId", jobId.String()))
 	}
 }

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -124,7 +124,7 @@ func (s *bootstrapManagerSuite) Init(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 }
 
-func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs(c *qt.C) {
+func (s *bootstrapManagerSuite) TestGetJobInfo(c *qt.C) {
 	ctx := c.Context()
 	read := make(chan struct{})
 	defer close(read)
@@ -151,7 +151,7 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs(c *qt.C) {
 					write <- struct{}{} // Signal that a batch of logs has been written.
 					<-read              // Wait for the read before writing the next batch.
 				}
-				err := s.db.AddBootstrapLog(ctx, jobId, "bootstrap logs "+fmt.Sprint(rune(i)))
+				err := s.db.AddJobLog(ctx, jobId, "bootstrap logs "+fmt.Sprint(rune(i)))
 				c.Check(err, qt.IsNil)
 			}
 			// We need to signal that we've written the last batch of logs.
@@ -166,7 +166,7 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs(c *qt.C) {
 	for batch := 0; batch < numLogs/batchSize+1; batch++ {
 		<-write // Wait for the batch of logs to be written.
 
-		response, err := manager.GetBootstrapStatusAndLogs(ctx, s.adminUser, jobId, watermark)
+		response, err := manager.GetJobInfo(ctx, s.adminUser, jobId, watermark)
 		c.Assert(err, qt.IsNil)
 		logs := []string{}
 		for j := 0; j < int(math.Min(float64(batchSize), float64(numLogs-batch*batchSize))); j++ {
@@ -179,13 +179,13 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs(c *qt.C) {
 	}
 
 	// check last batch is empty.
-	response, err := manager.GetBootstrapStatusAndLogs(ctx, s.adminUser, jobId, watermark)
+	response, err := manager.GetJobInfo(ctx, s.adminUser, jobId, watermark)
 	c.Assert(response.Status == params.StatusSuccessful || response.Status == params.StatusRunning, qt.IsTrue)
 	c.Assert(err, qt.IsNil)
 	c.Assert(response.Logs, qt.HasLen, 0)
 }
 
-func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobFailed(c *qt.C) {
+func (s *bootstrapManagerSuite) TestGetJobInfo_JobFailed(c *qt.C) {
 	ctx := c.Context()
 	ctrl, mocks, _ := setupTest(c)
 	defer ctrl.Finish()
@@ -201,9 +201,9 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobFailed(c *qt.C)
 		1*time.Minute,
 	)
 	c.Assert(err, qt.IsNil)
-	var response params.BootstrapStatusResponse
+	var response params.GetJobInfoResponse
 	for range 10 {
-		response, err = manager.GetBootstrapStatusAndLogs(ctx, s.adminUser, jobId, 0)
+		response, err = manager.GetJobInfo(ctx, s.adminUser, jobId, 0)
 		c.Assert(err, qt.IsNil)
 		if response.Status == params.StatusFailed {
 			break
@@ -214,7 +214,7 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobFailed(c *qt.C)
 	c.Assert(response.Error, qt.Equals, "I died really fast")
 }
 
-func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.C) {
+func (s *bootstrapManagerSuite) TestGetJobInfo_JobNotFound(c *qt.C) {
 	ctx := c.Context()
 	jobId := uuid.New()
 
@@ -224,8 +224,8 @@ func (s *bootstrapManagerSuite) TestGetBootstrapStatusAndLogs_JobNotFound(c *qt.
 	manager, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, mocks.jujuManager, mocks.binaryStore, loginTokenRefreshURLParam)
 	c.Assert(err, qt.IsNil)
 
-	_, err = manager.GetBootstrapStatusAndLogs(ctx, s.adminUser, jobId, 0)
-	c.Assert(err, qt.ErrorMatches, "failed to get job status")
+	_, err = manager.GetJobInfo(ctx, s.adminUser, jobId, 0)
+	c.Assert(err, qt.ErrorMatches, "failed to get job info")
 }
 
 func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
@@ -296,7 +296,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		Return(mocks.executor)
 	// We don't know the jobid to expect it yet. I did test by moving this line below the call, and it does
 	// pass, but it'd be racey between the starting of the job routine and the EXPECT.
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ctrlDetails := &jujuclient.ControllerDetails{
 		APIEndpoints: []string{
 			"10.0.0.1:17070",
@@ -466,7 +466,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 
 	// Mocked in order of execution:
 	mocks.store.EXPECT().LockBootstrap(gomock.Any(), gomock.Any()).Return(nil)
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mocks.store.EXPECT().GetController(
 		gomock.Any(),
 		&dbmodel.Controller{Name: jobParams.ControllerName},
@@ -518,7 +518,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 
 	// Mocked in order of execution:
 	mocks.store.EXPECT().LockBootstrap(gomock.Any(), gomock.Any()).Return(nil)
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mocks.store.EXPECT().GetController(
 		gomock.Any(),
 		&dbmodel.Controller{Name: jobParams.ControllerName},
@@ -635,7 +635,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 	)
 	mocks.commandFactory.EXPECT().New(binaryPath, jobParams.JujuDataDir).
 		Return(mocks.executor)
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mocks.store.EXPECT().UnlockBootstrap(gomock.Any()).Return(nil)
 
 	job := manager.BootstrapJob(
@@ -717,7 +717,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		Return(mocks.executor)
 	// We don't know the jobid to expect it yet. I did test by moving this line below the call, and it does
 	// pass, but it'd be racey between the starting of the job routine and the EXPECT.
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ctrlDetails := &jujuclient.ControllerDetails{
 		APIEndpoints: []string{
 			"10.0.0.1:17070",
@@ -835,7 +835,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		Return(mocks.executor)
 	// We don't know the jobid to expect it yet. I did test by moving this line below the call, and it does
 	// pass, but it'd be racey between the starting of the job routine and the EXPECT.
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ctrlDetails := &jujuclient.ControllerDetails{
 		APIEndpoints: []string{
 			"10.0.0.1:17070",
@@ -953,7 +953,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		Return(mocks.executor)
 	// We don't know the jobid to expect it yet. I did test by moving this line below the call, and it does
 	// pass, but it'd be racey between the starting of the job routine and the EXPECT.
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ctrlDetails := &jujuclient.ControllerDetails{
 		APIEndpoints: []string{
 			"10.0.0.1:17070",
@@ -1089,7 +1089,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 	)
 	mocks.commandFactory.EXPECT().New(binaryPath, jobParams.JujuDataDir).
 		Return(mocks.executor)
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ctrlDetails := &jujuclient.ControllerDetails{
 		APIEndpoints: []string{
 			"10.0.0.1:17070",
@@ -1237,7 +1237,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 	})
 	mocks.commandFactory.EXPECT().New(binaryPath, jobParams.JujuDataDir).
 		Return(mocks.executor)
-	mocks.store.EXPECT().AddBootstrapLog(gomock.Any(), gomock.Any(), gomock.Any()).
+	mocks.store.EXPECT().AddJobLog(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, u uuid.UUID, s string) error {
 			if err := ctx.Err(); err != nil {
 				c.Errorf("expected valid context, got error: %v", err)

--- a/internal/jimm/bootstrap/mocks/store.go
+++ b/internal/jimm/bootstrap/mocks/store.go
@@ -43,40 +43,40 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// AddBootstrapLog mocks base method.
-func (m *MockStore) AddBootstrapLog(ctx context.Context, jobId uuid.UUID, logLine string) error {
+// AddJobLog mocks base method.
+func (m *MockStore) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddBootstrapLog", ctx, jobId, logLine)
+	ret := m.ctrl.Call(m, "AddJobLog", ctx, jobId, logLine)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddBootstrapLog indicates an expected call of AddBootstrapLog.
-func (mr *MockStoreMockRecorder) AddBootstrapLog(ctx, jobId, logLine any) *MockStoreAddBootstrapLogCall {
+// AddJobLog indicates an expected call of AddJobLog.
+func (mr *MockStoreMockRecorder) AddJobLog(ctx, jobId, logLine any) *MockStoreAddJobLogCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBootstrapLog", reflect.TypeOf((*MockStore)(nil).AddBootstrapLog), ctx, jobId, logLine)
-	return &MockStoreAddBootstrapLogCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddJobLog", reflect.TypeOf((*MockStore)(nil).AddJobLog), ctx, jobId, logLine)
+	return &MockStoreAddJobLogCall{Call: call}
 }
 
-// MockStoreAddBootstrapLogCall wrap *gomock.Call
-type MockStoreAddBootstrapLogCall struct {
+// MockStoreAddJobLogCall wrap *gomock.Call
+type MockStoreAddJobLogCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStoreAddBootstrapLogCall) Return(err error) *MockStoreAddBootstrapLogCall {
+func (c *MockStoreAddJobLogCall) Return(err error) *MockStoreAddJobLogCall {
 	c.Call = c.Call.Return(err)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStoreAddBootstrapLogCall) Do(f func(context.Context, uuid.UUID, string) error) *MockStoreAddBootstrapLogCall {
+func (c *MockStoreAddJobLogCall) Do(f func(context.Context, uuid.UUID, string) error) *MockStoreAddJobLogCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStoreAddBootstrapLogCall) DoAndReturn(f func(context.Context, uuid.UUID, string) error) *MockStoreAddBootstrapLogCall {
+func (c *MockStoreAddJobLogCall) DoAndReturn(f func(context.Context, uuid.UUID, string) error) *MockStoreAddJobLogCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -157,42 +157,42 @@ func (c *MockStoreLockBootstrapCall) DoAndReturn(f func(context.Context, time.Du
 	return c
 }
 
-// QueryBootstrapLog mocks base method.
-func (m *MockStore) QueryBootstrapLog(ctx context.Context, jobId uuid.UUID, offset int) ([]string, int, error) {
+// QueryJobLog mocks base method.
+func (m *MockStore) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int) ([]string, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryBootstrapLog", ctx, jobId, offset)
+	ret := m.ctrl.Call(m, "QueryJobLog", ctx, jobId, offset)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// QueryBootstrapLog indicates an expected call of QueryBootstrapLog.
-func (mr *MockStoreMockRecorder) QueryBootstrapLog(ctx, jobId, offset any) *MockStoreQueryBootstrapLogCall {
+// QueryJobLog indicates an expected call of QueryJobLog.
+func (mr *MockStoreMockRecorder) QueryJobLog(ctx, jobId, offset any) *MockStoreQueryJobLogCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBootstrapLog", reflect.TypeOf((*MockStore)(nil).QueryBootstrapLog), ctx, jobId, offset)
-	return &MockStoreQueryBootstrapLogCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryJobLog", reflect.TypeOf((*MockStore)(nil).QueryJobLog), ctx, jobId, offset)
+	return &MockStoreQueryJobLogCall{Call: call}
 }
 
-// MockStoreQueryBootstrapLogCall wrap *gomock.Call
-type MockStoreQueryBootstrapLogCall struct {
+// MockStoreQueryJobLogCall wrap *gomock.Call
+type MockStoreQueryJobLogCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStoreQueryBootstrapLogCall) Return(loggies []string, nextOffsetValue int, err error) *MockStoreQueryBootstrapLogCall {
+func (c *MockStoreQueryJobLogCall) Return(loggies []string, nextOffsetValue int, err error) *MockStoreQueryJobLogCall {
 	c.Call = c.Call.Return(loggies, nextOffsetValue, err)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStoreQueryBootstrapLogCall) Do(f func(context.Context, uuid.UUID, int) ([]string, int, error)) *MockStoreQueryBootstrapLogCall {
+func (c *MockStoreQueryJobLogCall) Do(f func(context.Context, uuid.UUID, int) ([]string, int, error)) *MockStoreQueryJobLogCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStoreQueryBootstrapLogCall) DoAndReturn(f func(context.Context, uuid.UUID, int) ([]string, int, error)) *MockStoreQueryBootstrapLogCall {
+func (c *MockStoreQueryJobLogCall) DoAndReturn(f func(context.Context, uuid.UUID, int) ([]string, int, error)) *MockStoreQueryJobLogCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/cloudcred/attr.go
+++ b/internal/jimm/cloudcred/attr.go
@@ -2,7 +2,7 @@
 //
 // Generated from:
 //   Juju Version:   3.6.9
-//   Module Version: v0.0.0-20250715080108-a48434d3928a
+//   Module Version: v0.0.0-20250811161541-735128dc9d23
 
 package cloudcred
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -306,12 +306,12 @@ type JujuManager interface {
 
 // BootstrapManager provides methods to manage bootstrap jobs.
 type BootstrapManager interface {
-	// GetBootstrapStatusAndLogs retrieves the status and logs of a bootstrap job.
-	GetBootstrapStatusAndLogs(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error)
-	// StartBootstrap starts a bootstrap job and returns the job ID.
-	StartBootstrap(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
-	// StopBootstrap stops a bootstrap job.
-	StopBootstrap(ctx context.Context, user *openfga.User, jobId uuid.UUID) error
+	// GetJobInfo retrieves the status and logs of a job.
+	GetJobInfo(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error)
+	// StopJob stops a job.
+	StopJob(ctx context.Context, user *openfga.User, jobId uuid.UUID) error
+	// StartBootstrapJob starts a bootstrap job and returns the job ID.
+	StartBootstrapJob(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
 }
 
 // Parameters holds the services and static fields passed to the jimm.New() constructor.

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -152,7 +152,7 @@ func (j *Tracker) GetJob(ctx context.Context, jobId uuid.UUID) (dbmodel.JobTrack
 	job := dbmodel.JobTrackerEntry{JobID: jobId}
 	err := j.store.GetJob(ctx, &job)
 	if err != nil {
-		return job, errors.E(op, "failed to get job status", err)
+		return job, errors.E(op, "failed to get job info", err)
 	}
 
 	return job, nil

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -66,9 +66,9 @@ func init() {
 		version := rpc.Method(r.Version)
 		prepareModelMigration := rpc.Method(r.PrepareModelMigration)
 		listMigrationTargetsMethod := rpc.Method(r.ListMigrationTargets)
-		bootstrapStatus := rpc.Method(r.BootstrapStatus)
-		bootstrapStart := rpc.Method(r.BootstrapStart)
-		bootstrapStop := rpc.Method(r.BootstrapStop)
+		getJobInfo := rpc.Method(r.GetJobInfo)
+		stopJob := rpc.Method(r.StopJob)
+		startBootstrapJob := rpc.Method(r.StartBootstrapJob)
 
 		// JIMM Generic RPC
 		r.AddMethod("JIMM", 4, "AddController", addControllerMethod)
@@ -109,9 +109,9 @@ func init() {
 		r.AddMethod("JIMM", 4, "PrepareModelMigration", prepareModelMigration)
 		r.AddMethod("JIMM", 4, "ListMigrationTargets", listMigrationTargetsMethod)
 		// JIMM Bootstrap
-		r.AddMethod("JIMM", 4, "BootstrapStatus", bootstrapStatus)
-		r.AddMethod("JIMM", 4, "BootstrapStart", bootstrapStart)
-		r.AddMethod("JIMM", 4, "BootstrapStop", bootstrapStop)
+		r.AddMethod("JIMM", 4, "GetJobInfo", getJobInfo)
+		r.AddMethod("JIMM", 4, "StopJob", stopJob)
+		r.AddMethod("JIMM", 4, "StartBootstrapJob", startBootstrapJob)
 
 		return []int{4}
 	}
@@ -602,39 +602,59 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 	}, nil
 }
 
-// BootstrapStatus retrieves the status of a bootstrap job, its logs and the watermark
+// GetJobInfo retrieves the status of a job, its logs and the watermark
 // for the logs.
-func (r *controllerRoot) BootstrapStatus(ctx context.Context, req apiparams.BootstrapStatusRequest) (apiparams.BootstrapStatusResponse, error) {
-	const op = errors.Op("jujuapi.BootstrapStatus")
+func (r *controllerRoot) GetJobInfo(ctx context.Context, req apiparams.GetJobInfoRequest) (apiparams.GetJobInfoResponse, error) {
+	const op = errors.Op("jujuapi.GetJobInfo")
 
 	if !r.user.JimmAdmin {
-		return apiparams.BootstrapStatusResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return apiparams.GetJobInfoResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobId, err := uuid.Parse(req.JobID)
 	if err != nil {
-		return apiparams.BootstrapStatusResponse{}, errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
+		return apiparams.GetJobInfoResponse{}, errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
 	}
 
-	return r.jimm.BootstrapManager().GetBootstrapStatusAndLogs(ctx, r.user, jobId, req.Watermark)
+	return r.jimm.BootstrapManager().GetJobInfo(ctx, r.user, jobId, req.Watermark)
 }
 
-// BootstrapStart starts a bootstrap job.
-func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.BootstrapStartParams) (apiparams.BootstrapStartResponse, error) {
-	const op = errors.Op("jujuapi.BootstrapStart")
+// StopJob stops a job.
+func (r *controllerRoot) StopJob(ctx context.Context, req apiparams.StopJobRequest) error {
+	const op = errors.Op("jujuapi.StopJob")
 
 	if !r.user.JimmAdmin {
-		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+	}
+
+	jobID, err := uuid.Parse(req.JobID)
+	if err != nil {
+		return errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
+	}
+
+	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
+	if err != nil {
+		return errors.E(op, fmt.Errorf("failed to stop job: %v", err))
+	}
+	return nil
+}
+
+// StartBootstrapJob starts a bootstrap job.
+func (r *controllerRoot) StartBootstrapJob(ctx context.Context, req apiparams.BootstrapParams) (apiparams.StartJobResponse, error) {
+	const op = errors.Op("jujuapi.StartBootstrapJob")
+
+	if !r.user.JimmAdmin {
+		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Check built in clouds like localhost (lxd).
 	builtinClouds, err := common.BuiltInClouds()
 	if err != nil {
-		return apiparams.BootstrapStartResponse{}, errors.E(op, errors.CodeIncompatibleClouds, "unauthorized")
+		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeIncompatibleClouds, "unauthorized")
 	}
 
 	if _, isABuiltinCloud := builtinClouds[req.CloudName]; isABuiltinCloud {
-		return apiparams.BootstrapStartResponse{},
+		return apiparams.StartJobResponse{},
 			errors.E(op, errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
 	}
 
@@ -661,31 +681,11 @@ func (r *controllerRoot) BootstrapStart(ctx context.Context, req apiparams.Boots
 		UserConfig: req.Config,
 	}
 
-	jobID, err := r.jimm.BootstrapManager().StartBootstrap(ctx, r.user, params)
+	jobID, err := r.jimm.BootstrapManager().StartBootstrapJob(ctx, r.user, params)
 	if err != nil {
-		return apiparams.BootstrapStartResponse{}, errors.E(op, fmt.Errorf("failed to start bootstrap job: %v", err))
+		return apiparams.StartJobResponse{}, errors.E(op, fmt.Errorf("failed to start bootstrap job: %v", err))
 	}
-	return apiparams.BootstrapStartResponse{
+	return apiparams.StartJobResponse{
 		JobID: jobID,
 	}, nil
-}
-
-// BootstrapStop stops a bootstrap job.
-func (r *controllerRoot) BootstrapStop(ctx context.Context, req apiparams.BootstrapStopRequest) error {
-	const op = errors.Op("jujuapi.BootstrapStop")
-
-	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
-	}
-
-	jobID, err := uuid.Parse(req.JobID)
-	if err != nil {
-		return errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
-	}
-
-	err = r.jimm.BootstrapManager().StopBootstrap(ctx, r.user, jobID)
-	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to stop bootstrap job: %v", err))
-	}
-	return nil
 }

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -137,11 +137,11 @@ func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 	jimm := &jimmtest.JIMM{
 		BootstapManager_: func() jimm.BootstrapManager {
 			return &mocks.BootstapManager{
-				GetBootstrapStatusAndLogs_: func(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error) {
+				GetJobInfo_: func(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error) {
 					if jobId != uuidGenerated {
-						return params.BootstrapStatusResponse{}, errors.E(errors.CodeNotFound, "job not found")
+						return params.GetJobInfoResponse{}, errors.E(errors.CodeNotFound, "job not found")
 					}
-					return params.BootstrapStatusResponse{
+					return params.GetJobInfoResponse{
 						Status: "running",
 						Logs:   []string{"bootstrap logs"},
 					}, nil
@@ -151,7 +151,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 	}
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
 
-	response, err := root.BootstrapStatus(ctx, params.BootstrapStatusRequest{
+	response, err := root.GetJobInfo(ctx, params.GetJobInfoRequest{
 		JobID:     uuidGenerated.String(),
 		Watermark: 0,
 	})
@@ -161,7 +161,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 	c.Assert(response.Logs, gc.DeepEquals, []string{"bootstrap logs"})
 
 	// Test job not found
-	_, err = root.BootstrapStatus(ctx, params.BootstrapStatusRequest{
+	_, err = root.GetJobInfo(ctx, params.GetJobInfoRequest{
 		JobID:     uuid.New().String(),
 		Watermark: 0,
 	})
@@ -169,7 +169,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStatus(c *gc.C) {
 
 	// Test unauthorized user
 	root = newTestControllerRoot(jimm, "alice@canonical.com", false)
-	_, err = root.BootstrapStatus(ctx, params.BootstrapStatusRequest{
+	_, err = root.GetJobInfo(ctx, params.GetJobInfoRequest{
 		JobID:     uuidGenerated.String(),
 		Watermark: 0,
 	})
@@ -182,11 +182,11 @@ func (s *jimmUnitTestSuite) TestBootstrapStart_RejectsBuiltinClouds(c *gc.C) {
 	jimm := &jimmtest.JIMM{}
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
 
-	params := params.BootstrapStartParams{
+	params := params.BootstrapParams{
 		CloudName: "localhost",
 	}
 
-	_, err := root.BootstrapStart(ctx, params)
+	_, err := root.StartBootstrapJob(ctx, params)
 	c.Assert(err, gc.ErrorMatches, `.*bootstrap via JIMM does not support built-in clouds like "localhost"`)
 }
 
@@ -197,7 +197,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 	jimm := &jimmtest.JIMM{
 		BootstapManager_: func() jimm.BootstrapManager {
 			return &mocks.BootstapManager{
-				StartBootstrap_: func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
+				StartBootstrapJob_: func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
 					if startBootstrapErr != nil {
 						return "", startBootstrapErr
 					}
@@ -208,7 +208,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 	}
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
 
-	params := params.BootstrapStartParams{
+	params := params.BootstrapParams{
 		ControllerName:    "controller",
 		CloudName:         "cloud",
 		RegionName:        "region",
@@ -218,20 +218,20 @@ func (s *jimmUnitTestSuite) TestBootstrapStart(c *gc.C) {
 		ControllerVersion: "3.6.8",
 	}
 
-	response, err := root.BootstrapStart(ctx, params)
+	response, err := root.StartBootstrapJob(ctx, params)
 	c.Assert(err, gc.IsNil)
 	c.Assert(response.JobID, gc.Not(gc.Equals), "")
 
 	// Test start bootstrap fails
 	startBootstrapErr = errors.E("foo")
-	_, err = root.BootstrapStart(ctx, params)
+	_, err = root.StartBootstrapJob(ctx, params)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Matches, "failed to start bootstrap job: foo")
 
 	startBootstrapErr = nil
 	// Test unauthorized user
 	root = newTestControllerRoot(jimm, "alice@canonical.com", false)
-	_, err = root.BootstrapStart(ctx, params)
+	_, err = root.StartBootstrapJob(ctx, params)
 	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeUnauthorized)
 }
 
@@ -242,7 +242,7 @@ func (s *jimmUnitTestSuite) TestBootstrapStop(c *gc.C) {
 	jimm := &jimmtest.JIMM{
 		BootstapManager_: func() jimm.BootstrapManager {
 			return &mocks.BootstapManager{
-				StopBootstrap_: func(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
+				StopJob_: func(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
 					if jobId != uuidGenerated {
 						return errors.E(errors.CodeNotFound, "job not found")
 					}
@@ -253,26 +253,26 @@ func (s *jimmUnitTestSuite) TestBootstrapStop(c *gc.C) {
 	}
 	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
 	// Test stop bootstrap job unauthorized user
-	err := root.BootstrapStop(ctx, params.BootstrapStopRequest{
+	err := root.StopJob(ctx, params.StopJobRequest{
 		JobID: uuidGenerated.String(),
 	})
 	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeUnauthorized)
 
 	// Test stop bootstrap job
 	root = newTestControllerRoot(jimm, "alice@canonical.com", true)
-	err = root.BootstrapStop(ctx, params.BootstrapStopRequest{
+	err = root.StopJob(ctx, params.StopJobRequest{
 		JobID: uuidGenerated.String(),
 	})
 	c.Assert(err, gc.IsNil)
 
 	// Test job not found
-	err = root.BootstrapStop(ctx, params.BootstrapStopRequest{
+	err = root.StopJob(ctx, params.StopJobRequest{
 		JobID: uuid.New().String(),
 	})
 	c.Assert(err, gc.ErrorMatches, ".*job not found.*")
 
 	// Test stop bootstrap not valid job ID
-	err = root.BootstrapStop(ctx, params.BootstrapStopRequest{
+	err = root.StopJob(ctx, params.StopJobRequest{
 		JobID: "not-a-valid-uuid",
 	})
 	c.Assert(err, gc.NotNil)

--- a/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
@@ -14,28 +14,28 @@ import (
 )
 
 type BootstapManager struct {
-	GetBootstrapStatusAndLogs_ func(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error)
-	StartBootstrap_            func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
-	StopBootstrap_             func(ctx context.Context, user *openfga.User, jobId uuid.UUID) error
+	GetJobInfo_        func(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error)
+	StopJob_           func(ctx context.Context, user *openfga.User, jobId uuid.UUID) error
+	StartBootstrapJob_ func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error)
 }
 
-func (b *BootstapManager) GetBootstrapStatusAndLogs(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.BootstrapStatusResponse, error) {
-	if b.GetBootstrapStatusAndLogs_ == nil {
-		return params.BootstrapStatusResponse{}, errors.E(errors.CodeNotImplemented)
+func (b *BootstapManager) GetJobInfo(ctx context.Context, user *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error) {
+	if b.GetJobInfo_ == nil {
+		return params.GetJobInfoResponse{}, errors.E(errors.CodeNotImplemented)
 	}
-	return b.GetBootstrapStatusAndLogs_(ctx, user, jobId, offset)
+	return b.GetJobInfo_(ctx, user, jobId, offset)
 }
 
-func (b *BootstapManager) StartBootstrap(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
-	if b.StartBootstrap_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
-	}
-	return b.StartBootstrap_(ctx, user, params)
-}
-
-func (b *BootstapManager) StopBootstrap(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
-	if b.StopBootstrap_ == nil {
+func (b *BootstapManager) StopJob(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
+	if b.StopJob_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return b.StopBootstrap_(ctx, user, jobId)
+	return b.StopJob_(ctx, user, jobId)
+}
+
+func (b *BootstapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (string, error) {
+	if b.StartBootstrapJob_ == nil {
+		return "", errors.E(errors.CodeNotImplemented)
+	}
+	return b.StartBootstrapJob_(ctx, user, params)
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -267,21 +267,21 @@ func (c *Client) ListMigrationTargets(req *params.ListMigrationTargetsRequest) (
 	return response.Controllers, err
 }
 
-// BootstrapStatus retrieves the status and logs of a bootstrap job.
-func (c *Client) BootstrapStatus(req *params.BootstrapStatusRequest) (params.BootstrapStatusResponse, error) {
-	var response params.BootstrapStatusResponse
-	err := c.caller.APICall("JIMM", 4, "", "BootstrapStatus", req, &response)
+// GetJobInfo retrieves the status and logs of a job.
+func (c *Client) GetJobInfo(req *params.GetJobInfoRequest) (params.GetJobInfoResponse, error) {
+	var response params.GetJobInfoResponse
+	err := c.caller.APICall("JIMM", 4, "", "GetJobInfo", req, &response)
 	return response, err
 }
 
-// Bootstrap starts a bootstrap operation on the JIMM server.
-func (c *Client) Bootstrap(req *params.BootstrapStartParams) (*params.BootstrapStartResponse, error) {
-	var response params.BootstrapStartResponse
-	err := c.caller.APICall("JIMM", 4, "", "BootstrapStart", req, &response)
-	return &response, err
+// StopJob stops a job on the JIMM server.
+func (c *Client) StopJob(req *params.StopJobRequest) error {
+	return c.caller.APICall("JIMM", 4, "", "StopJob", req, nil)
 }
 
-// BootstrapStop stops a bootstrap operation on the JIMM server.
-func (c *Client) BootstrapStop(req *params.BootstrapStopRequest) error {
-	return c.caller.APICall("JIMM", 4, "", "BootstrapStop", req, nil)
+// StartBootstrapJob starts a bootstrap operation on the JIMM server.
+func (c *Client) StartBootstrapJob(req *params.BootstrapParams) (*params.StartJobResponse, error) {
+	var response params.StartJobResponse
+	err := c.caller.APICall("JIMM", 4, "", "StartBootstrapJob", req, &response)
+	return &response, err
 }

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -568,15 +568,7 @@ type ListMigrationTargetsRequest struct {
 	ModelTag string `json:"model-tag"`
 }
 
-// BootstrapStatusRequest holds the request to get the status of a bootstrap job.
-type BootstrapStatusRequest struct {
-	// JobID is the ID of the bootstrap job to get the status for.
-	JobID string `json:"job-id"`
-	// Watermark is the line number to start reading logs from.
-	Watermark int `json:"watermark"`
-}
-
-// JobStatus represents the status of a bootstrap job.
+// JobStatus represents the status of a job.
 type JobStatus string
 
 const (
@@ -586,21 +578,42 @@ const (
 	StatusFailed     JobStatus = "failed"
 )
 
-// BootstrapStatusResponse holds the response for a bootstrap job status.
-type BootstrapStatusResponse struct {
-	// Status is the status of the bootstrap job.
+// GetJobInfoRequest holds the request to get the status of a job.
+type GetJobInfoRequest struct {
+	// JobID is the ID of the job to get the status for.
+	JobID string `json:"job-id"`
+	// Watermark is the line number to start reading logs from.
+	Watermark int `json:"watermark"`
+}
+
+// GetJobInfoResponse holds the response for a job status.
+type GetJobInfoResponse struct {
+	// Status is the status of the job.
 	Status JobStatus `json:"status"`
-	// Logs are the logs for the bootstrap job.
+	// Logs are the logs for the job.
 	Logs []string `json:"logs"`
 	// Watermark is the line number to use for the next request.
 	Watermark int `json:"watermark"`
-	// Error is the error message if the bootstrap job failed.
+	// Error is the error message if the job failed.
 	Error string `json:"error,omitempty"`
 }
 
-// BootstrapStartParams holds parameters for starting
+// StopJobRequest holds the request to stop a job.
+type StopJobRequest struct {
+	// JobID is the ID of the job to stop.
+	JobID string `json:"job-id"`
+}
+
+// StartJobResponse holds the response for starting
+// a controller job.
+type StartJobResponse struct {
+	// JobID is the ID of the job that was started.
+	JobID string `json:"job-id"`
+}
+
+// BootstrapParams holds parameters for starting
 // a controller bootstrap job.
-type BootstrapStartParams struct {
+type BootstrapParams struct {
 	// CloudName specifies the target cloud for the controller.
 	CloudName string `json:"cloud-name"`
 	// RegionName specifies the target region for the controller.
@@ -618,17 +631,4 @@ type BootstrapStartParams struct {
 
 	// ControllerVersion is the version of the controller to be bootstrapped.
 	ControllerVersion string `json:"controller-version"`
-}
-
-// BootstrapStartResponse holds the response for starting
-// a controller bootstrap job.
-type BootstrapStartResponse struct {
-	// JobID is the ID of the bootstrap job that was started.
-	JobID string `json:"job-id"`
-}
-
-// BootstrapStopRequest holds the request to stop a bootstrap job.
-type BootstrapStopRequest struct {
-	// JobID is the ID of the bootstrap job to stop.
-	JobID string `json:"job-id"`
 }

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -72,5 +72,6 @@ parts:
       ln -sf jaas bin/juju-unregister-controller
       ln -sf jaas bin/juju-update-migrated-model
       ln -sf jaas bin/juju-update-service-account-credential
-      ln -sf jaas bin/juju-bootstrap-status
-      ln -sf jaas bin/juju-bootstrap-stop
+      ln -sf jaas bin/juju-job-status
+      ln -sf jaas bin/juju-job-stop
+      ln -sf jaas bin/juju-bootstrap


### PR DESCRIPTION
## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->

Rename the various bootstrap job APIs to be generic and applicable to other cases of running a `juju` cli command in a JIMM facade API triggered from the `jaas` CLI.

Starting a job is not generic, so there's `GetJobInfo` and `StopJob`, but `StartBootstrapJob`. I will be adding `StartDestroyControllerJob` in a future PR.

The manager is also not generic, under the assumption that "job" is generally bootstrap-related or similar.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
