### PR TITLE
fix: pin delve and air versions

### DIFF
--- a/local/jimm/Dockerfile
+++ b/local/jimm/Dockerfile
@@ -2,8 +2,8 @@
 # Installing air to avoid breakages when we update our Go version before a new air image is available.
 FROM golang:1.24 AS dev
 
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.25.2
+RUN go install github.com/air-verse/air@v1.62.0
 
 ENTRYPOINT [ "air" ]
 


### PR DESCRIPTION
This prevents either of them expecting a newer Go version than we've specified.

This was noticed with air v1.63.0 requiring Go 1.25, but we're still using 1.24.

## Description
<!-- *(mandatory)* Detail your pull request, with the what, why and how. -->

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
