### PR TITLE
ci: add permissions for releasing server rock

### DIFF
--- a/.github/workflows/release-server-rock.yaml
+++ b/.github/workflows/release-server-rock.yaml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions: # Based on https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages
+    contents: read
+    packages: write
+    attestations: write
+    id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,12 @@ jobs:
   release-server-rock:
     needs: dashboard-tests
     uses: ./.github/workflows/release-server-rock.yaml
-    secrets: inherit
+    secrets: inherit 
+    permissions: # Based on https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages
+        contents: read
+        packages: write
+        attestations: write
+        id-token: write
 
   release-snaps:
     needs: dashboard-tests


### PR DESCRIPTION
## Description
The release server rock workflow is failing due to the error `denied: installation not allowed to Write organization package`. It seems the workflow is missing the necessary permissions. Because of the changes in https://github.com/canonical/jimm/pull/1703 I think I misunderstood the permissions of nested workflows. The pre-release workflow has permissions `content: write` but the workflow it invokes does not have the necessary permissions. This PR aims to address that.

I tried to test the changes on my fork, but there I get a different error that I'm unsure is related.