### PR TITLE
fix: jimm cannot start without token refresh url set

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -448,10 +448,6 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 		return nil, errors.E(op, err, "failed to parse final redirect url for the dashboard")
 	}
 
-	// Scheme is not optional, so we aren't using ParseURLWithOptionalScheme here.
-	if _, err := url.Parse(p.BootstrapLoginTokenRefreshURL); err != nil {
-		return nil, errors.E(op, err, "failed to parse login token refresh URL")
-	}
 	jimmParameters.BootstrapLoginTokenRefreshURL = p.BootstrapLoginTokenRefreshURL
 
 	s.jimm, err = jimm.New(jimmParameters)

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
 	"time"
@@ -122,8 +123,12 @@ func NewBootstrapManager(
 	if binaryStore == nil {
 		return nil, errors.E("binary store cannot be nil")
 	}
-	if jimmWellknownJWKSEndpoint == "" {
-		return nil, errors.E("jimm well-known JWKs endpoint cannot be empty")
+	// validate the JWKs endpoint URL if provided.
+	if jimmWellknownJWKSEndpoint != "" {
+		// Scheme is not optional, so we aren't using ParseURLWithOptionalScheme here.
+		if _, err := url.Parse(jimmWellknownJWKSEndpoint); err != nil {
+			return nil, errors.E(err, "failed to parse bootstrap login token refresh URL")
+		}
 	}
 	if credentialStore == nil {
 		return nil, errors.E("credential store cannot be nil")
@@ -184,6 +189,10 @@ func (b *bootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobI
 // StartBootstrap starts a bootstrap job with the provided parameters.
 func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
 	const op = errors.Op("jimm.StartBootstrapJob")
+
+	if b.jimmWellknownJWKSEndpoint == "" {
+		return "", errors.E(op, "bootstrap login token refresh URL is not configured. Cannot proceed with bootstrap. Please configure it and try again.")
+	}
 
 	if err := params.validate(); err != nil {
 		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -126,6 +126,30 @@ func (s *bootstrapManagerSuite) Init(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 }
 
+func (s *bootstrapManagerSuite) TestStartBootstrapJob_LoginTokenRefreshURLNotConfigured(c *qt.C) {
+	ctx := c.Context()
+	ctrl, mocks, user := setupTest(c)
+	defer ctrl.Finish()
+	manager, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, mocks.jujuManager, mocks.binaryStore, "", mocks.credentialStore)
+	c.Assert(err, qt.IsNil)
+	_, err = manager.StartBootstrapJob(ctx, user, bootstrap.BootstrapParams{})
+	c.Assert(err, qt.ErrorMatches, "bootstrap login token refresh URL is not configured.*")
+}
+
+func (s *bootstrapManagerSuite) TestStartBootstrapJob_LoginTokenRefreshURLEmpty(c *qt.C) {
+	ctrl, mocks, _ := setupTest(c)
+	defer ctrl.Finish()
+	_, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, mocks.jujuManager, mocks.binaryStore, "", mocks.credentialStore)
+	c.Assert(err, qt.IsNil)
+}
+
+func (s *bootstrapManagerSuite) TestStartBootstrapJob_LoginTokenRefreshURLMalformed(c *qt.C) {
+	ctrl, mocks, _ := setupTest(c)
+	defer ctrl.Finish()
+	_, err := bootstrap.NewBootstrapManager(s.db, s.jobTracker, mocks.jujuManager, mocks.binaryStore, ":/url/", mocks.credentialStore)
+	c.Assert(err, qt.ErrorMatches, ".*failed to parse bootstrap login token refresh URL.*")
+}
+
 func (s *bootstrapManagerSuite) TestGetJobInfo(c *qt.C) {
 	ctx := c.Context()
 	read := make(chan struct{})


### PR DESCRIPTION
Before the token refresh url was necessary to start jimm, now jimm will start without it being configured and it will error out just when the user tries to bootstrap a controller.

I've simply pushed down the validation to the manager.