### PR TITLE
ci: free up space in dashboard job

### DIFF
--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -26,6 +26,24 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'test-dashboard')
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Free additional space
+        shell: bash
+        run: |
+          # Remove tools/caches that aren't required for this run.
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/CodeQL
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/Ruby
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/Java_Temurin-Hotspot_jdk
+          
       - name: Checkout JIMM repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
Sometimes the dashboard test job fails because it runs out of space on disk. This change is a copy-paste from the same tweaks made in the dashboard repo in https://github.com/canonical/juju-dashboard/pull/1953.