### PR TITLE
refactor: use lower jwks cache age

### DIFF
--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -96,12 +96,17 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	actualMaxAge := int64(maxAgeSeconds)
 	expiresTime := now.Add(maxAgeSeconds * time.Second)
 
+	// If the expiry is sooner than now + maxAgeSeconds, use the expiry instead.
+	// If the expiry is in the past, set a low cache value of 30s.
 	if expiry.After(now) {
 		remaining := int64(expiry.Sub(now).Seconds())
 		if remaining < maxAgeSeconds {
 			actualMaxAge = remaining
 			expiresTime = expiry
 		}
+	} else {
+		actualMaxAge = 10
+		expiresTime = now.Add(10 * time.Second)
 	}
 	w.Header().Set("Cache-Control", fmt.Sprintf("must-revalidate, max-age=%d, immutable", actualMaxAge))
 	w.Header().Set("Expires", expiresTime.Format(time.RFC1123))

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -4,7 +4,6 @@ package jimmhttp
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 	"time"
 
@@ -89,19 +88,22 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Calculate remaining max-age from now to expiry time
-	maxAge := expiry.Sub(time.Now().UTC())
-	// Format expiry into expires header valid string (RFC 1123)
-	expires := expiry.Format(time.RFC1123)
+	// Set cache headers to a maximum age of 10 minutes (600 seconds)
+	// to ensure clients do not cache for too long.
+	// If expiry is less than 10 minutes, use the actual expiry
+	const maxAgeSeconds = 600
+	now := time.Now().UTC()
+	actualMaxAge := int64(maxAgeSeconds)
+	expiresTime := now.Add(maxAgeSeconds * time.Second)
 
-	// The cache is shared and set to:
-	//	- must-revalidate (to indicate it is a long running cache)
-	//	- maximum age (which is likely months, in our case 3)
-	// 	- immutable (so the client of this JWKS knows it will not change until the rotation date)
-
-	w.Header().Add("Cache-Control", fmt.Sprintf("must-revalidate, max-age=%d, immutable", int64(math.Floor(maxAge.Seconds()))))
-	// We also use expires as I've noticed some JWK cache clients in golang specifically
-	// look at the expires header over max-age directive... No idea why.
-	w.Header().Add("Expires", expires)
+	if expiry.After(now) {
+		remaining := int64(expiry.Sub(now).Seconds())
+		if remaining < maxAgeSeconds {
+			actualMaxAge = remaining
+			expiresTime = expiry
+		}
+	}
+	w.Header().Set("Cache-Control", fmt.Sprintf("must-revalidate, max-age=%d, immutable", actualMaxAge))
+	w.Header().Set("Expires", expiresTime.Format(time.RFC1123))
 	render.JSON(w, r, ks)
 }

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -161,5 +161,22 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	remaining := int(expiryShort.Sub(now).Seconds())
 	regexMaxAge := fmt.Sprintf(("(%d|%d)"), remaining, remaining-1)
 	c.Assert(resp.Header.Get("Cache-Control"), qt.Matches, fmt.Sprintf("must-revalidate, max-age=%s, immutable", regexMaxAge))
-	c.Assert(resp.Header.Get("Expires"), qt.Equals, expiryShort.Format(time.RFC1123))
+	regexExpiry := fmt.Sprintf("(%s|%s)", expiryShort.Format(time.RFC1123), expiryShort.Add(-1*time.Second).Format(time.RFC1123))
+	c.Assert(resp.Header.Get("Expires"), qt.Matches, regexExpiry)
+
+	// Test with expiry in the past (should use max-age=10)
+	expiryPast := now.Add(-5 * time.Minute)
+	err = store.PutJWKSExpiry(ctx, expiryPast)
+	c.Assert(err, qt.IsNil)
+	rr = setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
+	resp = rr.Result()
+	defer resp.Body.Close()
+	code = rr.Code
+	b, err = io.ReadAll(resp.Body)
+	c.Assert(err, qt.IsNil)
+	c.Assert(b, qt.JSONEquals, jwks)
+	c.Assert(code, qt.Equals, http.StatusOK)
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=10, immutable")
+	regexExpiryPast := fmt.Sprintf("(%s|%s)", now.Add(10*time.Second).Format(time.RFC1123), now.Add(9*time.Second).Format(time.RFC1123))
+	c.Assert(resp.Header.Get("Expires"), qt.Matches, regexExpiryPast)
 }

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -131,23 +130,36 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	err = store.PutJWKS(ctx, jwks)
 	c.Assert(err, qt.IsNil)
 
-	expiry := time.Now().UTC().AddDate(0, 3, 0)
-	maxAge := expiry.Sub(time.Now().UTC())
-	secondsToExpiry := int64(math.Floor(maxAge.Seconds()))
-
+	// Test with expiry > 10min (should use 10min)
+	now := time.Now().UTC()
+	expiry := now.Add(30 * time.Minute)
 	err = store.PutJWKSExpiry(ctx, expiry)
 	c.Assert(err, qt.IsNil)
-
 	rr := setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
-
 	resp := rr.Result()
 	defer resp.Body.Close()
 	code := rr.Code
 	b, err := io.ReadAll(resp.Body)
-
 	c.Assert(err, qt.IsNil)
 	c.Assert(b, qt.JSONEquals, jwks)
 	c.Assert(code, qt.Equals, http.StatusOK)
-	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, fmt.Sprintf("must-revalidate, max-age=%d, immutable", secondsToExpiry))
-	c.Assert(resp.Header.Get("Expires"), qt.Equals, expiry.Format(time.RFC1123))
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=600, immutable")
+	c.Assert(resp.Header.Get("Expires"), qt.Matches, now.Add(10*time.Minute).Format(time.RFC1123))
+
+	// Test with expiry < 5min (should use actual expiry)
+	expiryShort := now.Add(3 * time.Minute)
+	err = store.PutJWKSExpiry(ctx, expiryShort)
+	c.Assert(err, qt.IsNil)
+	rr = setupWellknownHandlerAndRecorder(c, "/jwks.json", store)
+	resp = rr.Result()
+	defer resp.Body.Close()
+	code = rr.Code
+	b, err = io.ReadAll(resp.Body)
+	c.Assert(err, qt.IsNil)
+	c.Assert(b, qt.JSONEquals, jwks)
+	c.Assert(code, qt.Equals, http.StatusOK)
+	remaining := int(expiryShort.Sub(now).Seconds())
+	regexMaxAge := fmt.Sprintf(("(%d|%d)"), remaining, remaining-1)
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Matches, fmt.Sprintf("must-revalidate, max-age=%s, immutable", regexMaxAge))
+	c.Assert(resp.Header.Get("Expires"), qt.Equals, expiryShort.Format(time.RFC1123))
 }


### PR DESCRIPTION
## Description
This PR lowers the cache header timeout in our JWKS handler. This will tell clients to refresh their JWKS public key more frequently which should help in scenarios where users are recovering a JIMM instance and will allow them to avoid restarting Juju controllers to refresh the JIMM public key. We don't expect many clients to be fetching the JWKS, one per Juju controller.

The new max age is 10 minutes unless the JWKS expiry is <10 min.

This may also help scenarios described in #1727. To further alleviate issues with public key expiry, we also need to generate a new JWKS before the old one expires and store both.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
