### PR TITLE
chore: don't mask auth errors

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -175,8 +175,7 @@ func NewAuthenticationService(ctx context.Context, params AuthenticationServiceP
 
 	provider, err := oidc.NewProvider(ctx, params.IssuerURL)
 	if err != nil {
-		zapctx.Error(ctx, "failed to create oidc provider", zap.Error(err))
-		return nil, errors.E(op, errors.CodeServerConfiguration, err, "failed to create oidc provider")
+		return nil, errors.E(op, errors.CodeServerConfiguration, fmt.Errorf("failed to create oidc provider: %v", err))
 	}
 
 	authSvc := &AuthenticationService{
@@ -246,7 +245,7 @@ func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oa
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(op, err, "authorisation code exchange failed")
+		return nil, errors.E(op, fmt.Errorf("authorisation code exchange failed: %v", err))
 	}
 
 	return t, nil
@@ -274,8 +273,7 @@ func (as *AuthenticationService) Device(ctx context.Context) (*oauth2.DeviceAuth
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		zapctx.Error(ctx, "device auth call failed", zap.Error(err))
-		return nil, errors.E(op, err, "device auth call failed")
+		return nil, errors.E(op, fmt.Errorf("device auth call failed: %v", err))
 	}
 
 	return resp, nil
@@ -294,7 +292,7 @@ func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oau
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(op, err, "device access token call failed")
+		return nil, errors.E(op, fmt.Errorf("device access token call failed: %v", err))
 	}
 
 	return t, nil
@@ -317,8 +315,7 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		zapctx.Error(ctx, "failed to verify id token", zap.Error(err))
-		return nil, errors.E(op, err, "failed to verify id token")
+		return nil, errors.E(op, fmt.Errorf("failed to verify id token: %v", err))
 	}
 
 	return token, nil
@@ -337,7 +334,7 @@ func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
-		return "", errors.E(op, err, "failed to extract claims")
+		return "", errors.E(op, fmt.Errorf("failed to extract claims: %v", err))
 	}
 
 	return claims.Email, nil
@@ -353,13 +350,12 @@ func (as *AuthenticationService) MintSessionToken(email string) (string, error) 
 		Expiration(time.Now().Add(as.sessionTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(op, err, "failed to build access token")
+		return "", errors.E(op, fmt.Errorf("failed to build access token: %v", err))
 	}
 
 	freshToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		zapctx.Error(context.Background(), "failed to sign access token", zap.Error(err))
-		return "", errors.E(op, err, "failed to sign access token")
+		return "", errors.E(op, fmt.Errorf("failed to sign access token: %v", err))
 	}
 
 	return base64.StdEncoding.EncodeToString(freshToken), nil
@@ -380,13 +376,12 @@ func (as *AuthenticationService) NewMigrationToken(ctx context.Context, username
 		Expiration(time.Now().Add(migrationTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(op, err, "failed to mint migration token")
+		return "", errors.E(op, fmt.Errorf("failed to mint migration token: %v", err))
 	}
 
 	migrationToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		zapctx.Error(context.Background(), "failed to sign migration token", zap.Error(err))
-		return "", errors.E(op, err, "failed to sign migration token")
+		return "", errors.E(op, fmt.Errorf("failed to sign migration token: %v", err))
 	}
 
 	return base64.StdEncoding.EncodeToString(migrationToken), nil
@@ -490,8 +485,7 @@ func (as *AuthenticationService) VerifyClientCredentials(ctx context.Context, cl
 
 	_, err = cfg.Token(ctx)
 	if err != nil {
-		zapctx.Error(ctx, "client credential verification failed", zap.Error(err))
-		return errors.E(errors.CodeUnauthorized, "invalid client credentials")
+		return errors.E(errors.CodeUnauthorized, fmt.Errorf("invalid client credentials: %v", err))
 	}
 	return nil
 }
@@ -548,7 +542,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return ctx, errors.E(op, err, "failed to retrieve session")
+		return ctx, errors.E(op, fmt.Errorf("failed to retrieve session: %v", err))
 	}
 	session = sessionCrossOriginSafe(session, as.secureCookies)
 
@@ -561,8 +555,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	if err != nil {
 		// If the user's access token AND refresh token have expired
 		// then we will fail authentication here.
-		zapctx.Error(ctx, "failed to validate and update status token", zap.Error(err))
-		return ctx, errors.E(op, err)
+		return ctx, errors.E(op, fmt.Errorf("failed to validate and update status token: %v", err))
 	}
 
 	ctx = ContextWithSessionIdentity(ctx, identityId)
@@ -584,27 +577,21 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		zapctx.Error(ctx, "failed to retrieve session", zap.Error(err))
-		return errors.E(op, err, "failed to retrieve session")
+		return errors.E(op, fmt.Errorf("failed to retrieve session: %v", err))
 	}
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		err := errors.E(op, "session is missing identity key")
-		zapctx.Error(ctx, "session is missing identity key", zap.Error(err))
-		return err
+		return errors.E(op, "session is missing identity key")
 	}
 
 	identityIdStr, ok := identityId.(string)
 	if !ok {
-		err := errors.E(op, fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
-		zapctx.Error(ctx, "failed to parse session identity key", zap.Error(err))
-		return err
+		return errors.E(op, fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
-		zapctx.Error(ctx, "failed to delete session", zap.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to delete session: %v", err))
 	}
 
 	if err := as.UpdateIdentity(ctx, identityIdStr, &oauth2.Token{
@@ -613,8 +600,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 		Expiry:       time.Now(),
 		TokenType:    "",
 	}); err != nil {
-		zapctx.Error(ctx, "failed to update identity", zap.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to update identity: %v", err))
 	}
 
 	return nil

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -265,7 +265,7 @@ func TestVerifyClientCredentials(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	err = authSvc.VerifyClientCredentials(ctx, "invalid-client-id", validClientSecret)
-	c.Assert(err, qt.ErrorMatches, "invalid client credentials")
+	c.Assert(err, qt.ErrorMatches, "invalid client credentials.*")
 }
 
 func assertSetCookiesIsCorrect(c *qt.C, parsedCookies []*http.Cookie) {
@@ -387,7 +387,7 @@ func TestAuthenticateBrowserSessionRejectsNoneDecryptableOrDecodableCookies(t *t
 
 	// The underlying error is a failed base64 decode
 	_, err = authSvc.AuthenticateBrowserSession(ctx, rec, req)
-	c.Assert(err, qt.ErrorMatches, "failed to retrieve session")
+	c.Assert(err, qt.ErrorMatches, "failed to retrieve session.*")
 
 	// Failure case 2: Value isn't valid but is base64 decoded
 	req, err = http.NewRequest("GET", "", nil)
@@ -400,7 +400,7 @@ func TestAuthenticateBrowserSessionRejectsNoneDecryptableOrDecodableCookies(t *t
 	rec = httptest.NewRecorder()
 
 	_, err = authSvc.AuthenticateBrowserSession(ctx, rec, req)
-	c.Assert(err, qt.ErrorMatches, "failed to retrieve session")
+	c.Assert(err, qt.ErrorMatches, "failed to retrieve session.*")
 }
 
 func TestAuthenticateBrowserSessionHandlesExpiredAccessTokens(t *testing.T) {

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -199,5 +199,5 @@ func TestCallbackFailsExchange(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - authorisation code exchange failed")
+	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+` - authorisation code exchange failed: oauth2: "invalid_grant" "Code not valid"`)
 }

--- a/internal/jujuapi/admin_test.go
+++ b/internal/jujuapi/admin_test.go
@@ -325,7 +325,7 @@ func (s *adminSuite) TestLoginWithClientCredentials(c *gc.C) {
 		ClientID:     "invalid-client-id",
 		ClientSecret: "invalid-secret",
 	}, &loginResult)
-	c.Assert(err, gc.ErrorMatches, `invalid client credentials \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `invalid client credentials: oauth2: "invalid_client" "Invalid client or Invalid client credentials" \(unauthorized access\)`)
 }
 
 // getDialWebsocketWithCustomCookieJar is mostly the default dialer configuration exception

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -126,8 +126,10 @@ func (r *controllerRoot) mapError(ctx context.Context, err error) *jujuparams.Er
 	if err == nil {
 		return nil
 	}
-	zapctx.Debug(ctx, "rpc error", zaputil.Error(err))
-	if errors.ErrorCode(err) == errors.CodeUnauthorized {
+	// If the error is an unauthorized error, we log it specifically for auditing purposes.
+	// Else, we log it as a warning.
+	switch errors.ErrorCode(err) {
+	case errors.CodeUnauthorized:
 		// Here we log the unauthorized access attempt.
 		// We use the error as a best effort description of what went wrong.
 		username := "unknown"
@@ -139,6 +141,8 @@ func (r *controllerRoot) mapError(ctx context.Context, err error) *jujuparams.Er
 			username,
 			fmt.Sprintf("unauthorized access attempt, error: %v", err),
 		)
+	default:
+		zapctx.Warn(ctx, "rpc error", zaputil.Error(err))
 	}
 	return &jujuparams.Error{
 		Message: err.Error(),


### PR DESCRIPTION
## Description
This PR ensures we don't mask errors that are useful to debugging authentication errors.

Normally when returning an error, one avoids logging the error at the same time because higher up the call stack the error may be logged again. This was happening in our authentication package where we were sometimes logging errors which would be logged again by our API handler. To avoid this let's either log an error where we can't return one or return an error and allow the caller to decide what to do with it.

Partially addresses [JUJU-8776](https://warthogs.atlassian.net/browse/JUJU-8776)



[JUJU-8776]: https://warthogs.atlassian.net/browse/JUJU-8776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ