### PR TITLE
fix(batch-openfga-req): batch openfga requests

### DIFF
--- a/internal/jimm/permissions/export_test.go
+++ b/internal/jimm/permissions/export_test.go
@@ -11,6 +11,7 @@ import (
 var (
 	ResolveTag                     = resolveTag
 	DetermineAccessLevelAfterGrant = determineAccessLevelAfterGrant
+	BatchSizeOpenfga               = BATCH_SIZE_OPENFGA
 )
 
 // PermissionManager is a type alias to export PermissionManager for use in tests.

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -18,6 +18,13 @@ import (
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
+// BATCH_SIZE_OPENFGA defines the maximum number of tuples to process in a single batch operation.
+// This is the default for maxTuplesPerWrite
+// See: https://openfga.dev/docs/getting-started/setup-openfga/configuration
+// TODO: this value should be received from the OpenFGA charm's relation, so we make sure that we batch
+// requests according to the deployed OpenFGA instance configuration.
+const BATCH_SIZE_OPENFGA = 100
+
 // AddRelation checks user permission and add given relations tuples.
 // At the moment user is required be admin.
 func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
@@ -29,11 +36,19 @@ func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User,
 	if err != nil {
 		return errors.E(err)
 	}
-	err = j.authSvc.AddRelation(ctx, parsedTuples...)
-	if err != nil {
-		return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
+		end := i + BATCH_SIZE_OPENFGA
+		if end > len(parsedTuples) {
+			end = len(parsedTuples)
+		}
+		batch := parsedTuples[i:end]
+
+		err = j.authSvc.AddRelation(ctx, batch...)
+		if err != nil {
+			return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+		}
+		j.logUserUpdates(ctx, user, batch, true)
 	}
-	j.logUserUpdates(ctx, user, parsedTuples, true)
 	return nil
 }
 
@@ -48,11 +63,19 @@ func (j *permissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 	if err != nil {
 		return errors.E(op, err)
 	}
-	err = j.authSvc.RemoveRelation(ctx, parsedTuples...)
-	if err != nil {
-		return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
+		end := i + BATCH_SIZE_OPENFGA
+		if end > len(parsedTuples) {
+			end = len(parsedTuples)
+		}
+		batch := parsedTuples[i:end]
+
+		err = j.authSvc.RemoveRelation(ctx, batch...)
+		if err != nil {
+			return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+		}
+		j.logUserUpdates(ctx, user, batch, true)
 	}
-	j.logUserUpdates(ctx, user, parsedTuples, false)
 	return nil
 }
 

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 
+	petname "github.com/dustinkirkland/golang-petname"
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/permissions"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
@@ -463,4 +465,72 @@ func (s *permissionManagerSuite) TestRelationshipLogUserUpdated(c *qt.C) {
 	err = s.manager.AddRelation(ctx, u, tuples)
 	c.Assert(err, qt.IsNil)
 	c.Assert(logs.Len(), qt.Equals, 3)
+}
+
+func (s *permissionManagerSuite) TestAddRelationBatch(c *qt.C) {
+	c.Parallel()
+
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, s.ofgaClient)
+	u.JimmAdmin = true
+
+	_, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(c.Context(), c, s.db)
+	tuples := []apiparams.RelationshipTuple{}
+
+	expectedLength := permissions.BatchSizeOpenfga*2 + 1
+	for range expectedLength {
+		u, err := dbmodel.NewIdentity(petname.Generate(3, "-"+"canonical.com"))
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(s.db.DB.Create(u).Error, qt.IsNil)
+		tuples = append(tuples, apiparams.RelationshipTuple{
+			Object:       u.Tag().String(),
+			Relation:     names.ReaderRelation.String(),
+			TargetObject: model.ResourceTag().String(),
+		})
+	}
+
+	err := s.manager.AddRelation(c.Context(), u, tuples)
+	c.Assert(err, qt.IsNil)
+
+	tuplesListed, _, err := s.manager.ListRelationshipTuples(c.Context(), s.adminUser, apiparams.RelationshipTuple{
+		Relation:     names.ReaderRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}, 100, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(tuplesListed, qt.HasLen, 100)
+}
+
+func (s *permissionManagerSuite) TestRemoveRelationBatch(c *qt.C) {
+	c.Parallel()
+
+	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, s.ofgaClient)
+	u.JimmAdmin = true
+
+	_, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(c.Context(), c, s.db)
+	tuples := []apiparams.RelationshipTuple{}
+
+	for range permissions.BatchSizeOpenfga*2 + 1 {
+		u, err := dbmodel.NewIdentity(petname.Generate(3, "-"+"canonical.com"))
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(s.db.DB.Create(u).Error, qt.IsNil)
+		tuples = append(tuples, apiparams.RelationshipTuple{
+			Object:       u.Tag().String(),
+			Relation:     names.ReaderRelation.String(),
+			TargetObject: model.ResourceTag().String(),
+		})
+	}
+
+	err := s.manager.AddRelation(c.Context(), u, tuples)
+	c.Assert(err, qt.IsNil)
+
+	err = s.manager.RemoveRelation(c.Context(), u, tuples)
+	c.Assert(err, qt.IsNil)
+
+	tuplesListed, _, err := s.manager.ListRelationshipTuples(c.Context(), s.adminUser, apiparams.RelationshipTuple{
+		Relation:     names.ReaderRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}, 100, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(tuplesListed, qt.HasLen, 0)
 }


### PR DESCRIPTION
## Description

openfga has a maxTuplesPerWrite config value (default to 100). We want to support JIMM.AddRelation with more than the openfga config value, so we are batching requests to OpenFga. This has some challenges:
 - we need the openfga charm to share this config value with us.
 - we need to handle partial failures. 

Both are working in progress because we are waiting on other projects' work, but this is a good intermediate step to solve the issue to avoid the error. 

The full solution to this issue is to make this operation idempotempt (which currently is not) because it would leverage a new feature in the openfga 1.10 to avoid `confict on duplicated write` (Read more: https://github.com/openfga/go-sdk/blob/v0.7.3/README.md#conflict-options-for-write-operations).
But it has a broader scope crossing some teams:
- update openfga charm
- update openfga canonical wrapper client
- (potentially) update terraform

partially fix #1729