### PR TITLE
fix: tweak cache-control headers

### DIFF
--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -94,7 +94,6 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	const maxAgeSeconds = 600
 	now := time.Now().UTC()
 	actualMaxAge := int64(maxAgeSeconds)
-	expiresTime := now.Add(maxAgeSeconds * time.Second)
 
 	// If the expiry is sooner than now + maxAgeSeconds, use the expiry instead.
 	// If the expiry is in the past, set a low cache value of 30s.
@@ -102,13 +101,10 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 		remaining := int64(expiry.Sub(now).Seconds())
 		if remaining < maxAgeSeconds {
 			actualMaxAge = remaining
-			expiresTime = expiry
 		}
 	} else {
 		actualMaxAge = 10
-		expiresTime = now.Add(10 * time.Second)
 	}
-	w.Header().Set("Cache-Control", fmt.Sprintf("must-revalidate, max-age=%d, immutable", actualMaxAge))
-	w.Header().Set("Expires", expiresTime.Format(time.RFC1123))
+	w.Header().Set("Cache-Control", fmt.Sprintf("must-revalidate, max-age=%d", actualMaxAge))
 	render.JSON(w, r, ks)
 }

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -143,8 +143,7 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(b, qt.JSONEquals, jwks)
 	c.Assert(code, qt.Equals, http.StatusOK)
-	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=600, immutable")
-	c.Assert(resp.Header.Get("Expires"), qt.Matches, now.Add(10*time.Minute).Format(time.RFC1123))
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=600")
 
 	// Test with expiry < 5min (should use actual expiry)
 	expiryShort := now.Add(3 * time.Minute)
@@ -160,9 +159,7 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	c.Assert(code, qt.Equals, http.StatusOK)
 	remaining := int(expiryShort.Sub(now).Seconds())
 	regexMaxAge := fmt.Sprintf(("(%d|%d)"), remaining, remaining-1)
-	c.Assert(resp.Header.Get("Cache-Control"), qt.Matches, fmt.Sprintf("must-revalidate, max-age=%s, immutable", regexMaxAge))
-	regexExpiry := fmt.Sprintf("(%s|%s)", expiryShort.Format(time.RFC1123), expiryShort.Add(-1*time.Second).Format(time.RFC1123))
-	c.Assert(resp.Header.Get("Expires"), qt.Matches, regexExpiry)
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Matches, fmt.Sprintf("must-revalidate, max-age=%s", regexMaxAge))
 
 	// Test with expiry in the past (should use max-age=10)
 	expiryPast := now.Add(-5 * time.Minute)
@@ -176,7 +173,5 @@ func TestWellknownAPIJWKSJSONHandles200(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(b, qt.JSONEquals, jwks)
 	c.Assert(code, qt.Equals, http.StatusOK)
-	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=10, immutable")
-	regexExpiryPast := fmt.Sprintf("(%s|%s)", now.Add(10*time.Second).Format(time.RFC1123), now.Add(9*time.Second).Format(time.RFC1123))
-	c.Assert(resp.Header.Get("Expires"), qt.Matches, regexExpiryPast)
+	c.Assert(resp.Header.Get("Cache-Control"), qt.Equals, "must-revalidate, max-age=10")
 }


### PR DESCRIPTION
## Description
This PR tweaks the cache-control headers we use when sending our JWKS to clients.
Namely,
1. Don't set the `Expires` header, based on [MSDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#expires_or_max-age) it is out-dated and we can almost certainly safely stop using it.
> In HTTP/1.0, freshness used to be specified by the Expires header.
>
> The time format is difficult to parse, many implementation bugs were found, and it is possible to induce problems by intentionally shifting the system clock; therefore, max-age — for specifying an elapsed time — was adopted for Cache-Control in HTTP/1.1.
> If both Expires and Cache-Control: max-age are available, max-age is defined to be preferred. So it is not necessary to provide Expires now that HTTP/1.1 is widely used.
2. Remove the `immutable` keyword. I don't have a very strong argument on this one. When asking AI to evaluate the current cache-control headers it said `immutable` was not valid for a JWKS endpoint because 
> JWKS documents contain mutable signing keys used for JWT validation.
Keys can rotate:
> automatically
> due to compromise
> due to policy
> during deployment
> unexpectedly

JWKS endpoints from [Auth0](https://samples.auth0.com/.well-known/jwks.json) and [Google](https://www.googleapis.com/oauth2/v3/certs) also don't include this keyword. Digging further, the [MSDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) don't say too much on this header except that it,
> The immutable response directive indicates that the response will not be updated while it's [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#fresh_and_stale_based_on_age).

Partially addresses [JUJU-8776](https://warthogs.atlassian.net/browse/JUJU-8776)

[JUJU-8776]: https://warthogs.atlassian.net/browse/JUJU-8776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ