### PR TITLE
ci: free up space in release-binaries job

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -11,6 +11,23 @@ jobs:
   goreleaser:
     runs-on: ubuntu-22.04
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Free additional space
+        shell: bash
+        run: |
+          # Remove tools/caches that aren't required for this run.
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/CodeQL
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/Ruby
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"/Java_Temurin-Hotspot_jdk
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description
The release-binaries job is failing [consistently](https://github.com/canonical/jimm/actions/runs/19494919491/job/55796610484) with an issue that seems to be related to disk space because logs abruptly stop, which I've normally seen due to low disk space. It's also happening during compilation/download for a `go build` another indicator this is likely due to disk space.

We can either, 
- Free up space on the Github hosted runner.
- Switch to a self-hosted runner with more disk.
- Avoid building for multiple architectures.

I've opted to go with the 1st option but would also be happy with the second.