### PR TITLE
chore: remove double logging and improve error handling

### DIFF
--- a/cmd/jaas/cmd/group_test.go
+++ b/cmd/jaas/cmd/group_test.go
@@ -42,7 +42,7 @@ func (s *groupSuite) TestAddGroup(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewAddGroupCommandForTesting(s.ClientStore(), bClient), "test-group")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add group: unauthorized \(unauthorized access\)`)
 }
 
 func (s *groupSuite) TestRenameGroupSuperuser(c *gc.C) {
@@ -67,7 +67,7 @@ func (s *groupSuite) TestRenameGroup(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRenameGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "renamed-group")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to rename group: unauthorized \(unauthorized access\)`)
 }
 
 func (s *groupSuite) TestRemoveGroupSuperuser(c *gc.C) {
@@ -97,7 +97,7 @@ func (s *groupSuite) TestRemoveGroup(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveGroupCommandForTesting(s.ClientStore(), bClient), "test-group", "-y")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to remove group: unauthorized \(unauthorized access\)`)
 }
 
 func (s *groupSuite) TestListGroupsSuperuser(c *gc.C) {
@@ -145,5 +145,5 @@ func (s *groupSuite) TestListGroups(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewListGroupsCommandForTesting(s.ClientStore(), bClient))
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to list groups: unauthorized \(unauthorized access\)`)
 }

--- a/cmd/jaas/cmd/permission_test.go
+++ b/cmd/jaas/cmd/permission_test.go
@@ -151,7 +151,7 @@ func (s *relationSuite) TestAddRelationViaFileSuperuser(c *gc.C) {
 func (s *relationSuite) TestAddRelationRejectsUnauthorisedUsers(c *gc.C) {
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewAddRelationCommandForTesting(s.ClientStore(), bClient), "test-group1", "member", "test-group2")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add relation: unauthorized \(unauthorized access\)`)
 }
 
 func (s *relationSuite) TestRemoveRelationSuperuser(c *gc.C) {
@@ -250,7 +250,7 @@ func (s *relationSuite) TestRemoveRelation(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRemovePermissionCommandForTesting(s.ClientStore(), bClient), "group-testGroup1#member", "member", "group-testGroup2")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to remove relation: unauthorized \(unauthorized access\)`)
 }
 
 type environment struct {
@@ -655,5 +655,5 @@ func (s *relationSuite) TestCheckRelation(c *gc.C) {
 		"reader",
 		"controller-jimm",
 	)
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to check relation: unauthorized \(unauthorized access\)`)
 }

--- a/cmd/jaas/cmd/registercontroller_test.go
+++ b/cmd/jaas/cmd/registercontroller_test.go
@@ -279,7 +279,7 @@ func (s *registerControllerSuite) TestRegisterControllerNotAuthorised(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRegisterControllerCommandForTesting(store, bClient), "controller-1")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add controller: unauthorized \(unauthorized access\)`)
 }
 
 func writeYAMLTempFile(c *gc.C, payload interface{}) (string, string) {

--- a/cmd/jaas/cmd/role_test.go
+++ b/cmd/jaas/cmd/role_test.go
@@ -42,7 +42,7 @@ func (s *roleSuite) TestAddRole(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewAddRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add role: unauthorized \(unauthorized access\)`)
 }
 
 func (s *roleSuite) TestRenameRoleSuperuser(c *gc.C) {
@@ -67,7 +67,7 @@ func (s *roleSuite) TestRenameRole(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRenameRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "renamed-role")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to rename role: unauthorized \(unauthorized access\)`)
 }
 
 func (s *roleSuite) TestRemoveRoleSuperuser(c *gc.C) {
@@ -97,7 +97,7 @@ func (s *roleSuite) TestRemoveRole(c *gc.C) {
 	// bob is not superuser
 	bClient := s.SetupCLIAccess(c, "bob")
 	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "-y")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to remove role: unauthorized \(unauthorized access\)`)
 }
 
 func (s *roleSuite) TestListRolesSuperuser(c *gc.C) {

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -94,19 +94,16 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 
 	if parsedIssuerURL.Scheme == "" {
-		zapctx.Error(ctx, "oauth issuer url has no scheme")
 		return errors.E("oauth issuer url has no scheme")
 	}
 
 	clientID := os.Getenv("JIMM_OAUTH_CLIENT_ID")
 	if clientID == "" {
-		zapctx.Error(ctx, "no oauth client id")
 		return errors.E("no oauth client id")
 	}
 
 	clientSecret := os.Getenv("JIMM_OAUTH_CLIENT_SECRET")
 	if clientSecret == "" {
-		zapctx.Error(ctx, "no oauth client secret")
 		return errors.E("no oauth client secret")
 	}
 
@@ -117,7 +114,6 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 	zapctx.Info(ctx, "oauth scopes", zap.Any("scopes", scopesParsed))
 	if len(scopesParsed) == 0 {
-		zapctx.Error(ctx, "no oauth client scopes present")
 		return errors.E("no oauth client scopes present")
 	}
 

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -424,8 +424,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	)
 	jimmParameters.OAuthAuthenticator = authSvc
 	if err != nil {
-		zapctx.Error(ctx, "failed to setup authentication service", zap.Error(err))
-		return nil, errors.E(op, err, "failed to setup authentication service")
+		return nil, errors.E(op, fmt.Errorf("failed to setup authentication service: %w", err))
 	}
 
 	if p.JWTExpiryDuration == 0 {
@@ -504,8 +503,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
 		})
 		if err != nil {
-			zapctx.Error(ctx, "failed to setup authentication handler", zap.Error(err))
-			return nil, errors.E(op, err, "failed to setup authentication handler")
+			return nil, errors.E(op, fmt.Errorf("failed to setup authentication handler: %w", err))
 		}
 		mountHandler(
 			jimmhttp.AuthResourceBasePath,
@@ -637,8 +635,7 @@ func (s *Service) setupSessionStore(ctx context.Context, sessionSecret []byte, d
 
 	store, err := pgstore.NewPGStoreFromPool(sqlDb, sessionSecret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to create session store", zap.Error(err))
-		return nil, errors.E(op, err, "failed to create session store")
+		return nil, errors.E(op, fmt.Errorf("failed to create session store: %w", err))
 	}
 
 	// Cleanup expired session every 30 minutes
@@ -682,8 +679,7 @@ func (s *Service) setupCredentialStore(ctx context.Context, p Params, db *db.Dat
 
 	vs, err := newVaultStore(ctx, p)
 	if err != nil {
-		zapctx.Error(ctx, "Vault Store error", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("vault store error: %v", err))
 	}
 	if vs != nil {
 		return vs, nil

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/juju/schema v1.2.0 // indirect
 	github.com/juju/txn/v3 v3.0.2 // indirect
 	github.com/juju/usso v1.0.1 // indirect
-	github.com/juju/utils/v3 v3.2.3
+	github.com/juju/utils/v3 v3.2.3 // indirect
 	github.com/juju/viddy v0.0.0-beta5 // indirect
 	github.com/juju/webbrowser v1.0.0 // indirect
 	github.com/juju/worker/v3 v3.5.0 // indirect

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -5,12 +5,11 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil/zapctx"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"go.uber.org/zap"
 	"gorm.io/gorm/clause"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -129,14 +128,12 @@ func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, nil
 		}
-		zapctx.Error(ctx, "failed to get secret data", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to get secret data: %w", err))
 	}
 	var attr map[string]string
 	err = json.Unmarshal(secret.Data, &attr)
 	if err != nil {
-		zapctx.Error(ctx, "failed to unmarshal secret data", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to unmarshal secret data: %w", err))
 	}
 	return attr, nil
 }
@@ -155,8 +152,7 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 
 	dataJson, err := json.Marshal(attr)
 	if err != nil {
-		zapctx.Error(ctx, "failed to marshal secret data", zap.Error(err))
-		return errors.E(op, err, "failed to marshal secret data")
+		return errors.E(op, fmt.Errorf("failed to marshal secret data: %w", err))
 	}
 	secret := dbmodel.NewSecret(tag.Kind(), tag.String(), dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -181,14 +177,12 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 		return "", "", nil
 	}
 	if err != nil {
-		zapctx.Error(ctx, "failed to get secret data", zap.Error(err))
-		return "", "", errors.E(op, err)
+		return "", "", errors.E(op, fmt.Errorf("failed to get secret data: %w", err))
 	}
 	var secretData map[string]string
 	err = json.Unmarshal(secret.Data, &secretData)
 	if err != nil {
-		zapctx.Error(ctx, "failed to unmarshal secret data", zap.Error(err))
-		return "", "", errors.E(op, err)
+		return "", "", errors.E(op, fmt.Errorf("failed to unmarshal secret data: %w", err))
 	}
 	username, ok := secretData[usernameKey]
 	if !ok {
@@ -218,8 +212,7 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 	secretData[passwordKey] = password
 	dataJson, err := json.Marshal(secretData)
 	if err != nil {
-		zapctx.Error(ctx, "failed to unmarshal secret data", zap.Error(err))
-		return errors.E(op, err, "failed to marshal secret data")
+		return errors.E(op, fmt.Errorf("failed to marshal secret data: %w", err))
 	}
 	secret := dbmodel.NewSecret(names.ControllerTagKind, controllerName, dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -240,20 +233,17 @@ func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to cleanup jwks public key", zap.Error(err))
-		return errors.E(op, err, "failed to cleanup jwks public key")
+		return errors.E(op, fmt.Errorf("failed to cleanup jwks public key: %w", err))
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to cleanup jwks private key", zap.Error(err))
-		return errors.E(op, err, "failed to cleanup jwks private key")
+		return errors.E(op, fmt.Errorf("failed to cleanup jwks private key: %w", err))
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to cleanup jwks expiry info", zap.Error(err))
-		return errors.E(op, err, "failed to cleanup jwks expiry info")
+		return errors.E(op, fmt.Errorf("failed to cleanup jwks expiry info: %w", err))
 	}
 	return nil
 }
@@ -273,13 +263,11 @@ func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to get jwks data", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to get jwks data: %w", err))
 	}
 	ks, err := jwk.ParseString(string(secret.Data))
 	if err != nil {
-		zapctx.Error(ctx, "failed to parse jwk data", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to parse jwk data: %w", err))
 	}
 	return ks, nil
 }
@@ -299,14 +287,12 @@ func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) 
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to get jwks jwks private key", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to get jwks private key: %w", err))
 	}
 	var pem []byte
 	err = json.Unmarshal(secret.Data, &pem)
 	if err != nil {
-		zapctx.Error(ctx, "failed to unmarshal pem data data", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("failed to unmarshal pem data: %w", err))
 	}
 	return pem, nil
 }
@@ -326,14 +312,12 @@ func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		zapctx.Error(ctx, "failed to get jwks expiry", zap.Error(err))
-		return time.Time{}, errors.E(op, err)
+		return time.Time{}, errors.E(op, fmt.Errorf("failed to get jwks expiry: %w", err))
 	}
 	var expiryTime time.Time
 	err = json.Unmarshal(secret.Data, &expiryTime)
 	if err != nil {
-		zapctx.Error(ctx, "failed to unmarshal jwks expiry data", zap.Error(err))
-		return time.Time{}, errors.E(op, err)
+		return time.Time{}, errors.E(op, fmt.Errorf("failed to unmarshal jwks expiry data: %w", err))
 	}
 	return expiryTime, nil
 }
@@ -352,8 +336,7 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
-		zapctx.Error(ctx, "failed to marshal jwks", zap.Error(err))
-		return errors.E(op, err, "failed to marshal jwks data")
+		return errors.E(op, fmt.Errorf("failed to marshal jwks data: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, jwksJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -374,8 +357,7 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 
 	privateKeyJson, err := json.Marshal(pem)
 	if err != nil {
-		zapctx.Error(ctx, "failed to marshal pem data", zap.Error(err))
-		return errors.E(op, err, "failed to marshal jwks private key")
+		return errors.E(op, fmt.Errorf("failed to marshal jwks private key: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, privateKeyJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -395,8 +377,7 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 
 	expiryJson, err := json.Marshal(expiry)
 	if err != nil {
-		zapctx.Error(ctx, "failed to marshal jwks expiry data", zap.Error(err))
-		return errors.E(op, err, "failed to marshal jwks data")
+		return errors.E(op, fmt.Errorf("failed to marshal jwks expiry data: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, expiryJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -416,13 +397,11 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 
 	secret := dbmodel.NewSecret(oauthKind, oauthKeyTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		zapctx.Error(ctx, "failed to cleanup OAuth key", zap.Error(err))
-		return errors.E(op, err, "failed to cleanup OAuth key")
+		return errors.E(op, fmt.Errorf("failed to cleanup OAuth key: %w", err))
 	}
 	secret = dbmodel.NewSecret(oauthKind, oauthSessionStoreSecretTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		zapctx.Error(ctx, "failed to cleanup OAuth session store secret", zap.Error(err))
-		return errors.E(op, err, "failed to cleanup OAuth session store secret")
+		return errors.E(op, fmt.Errorf("failed to cleanup OAuth session store secret: %w", err))
 	}
 	return nil
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -154,19 +154,33 @@ const (
 )
 
 // ErrorCode returns the error code from the given error.
+// It unwraps the error chain to find the first error that implements
+// the ErrorCode() string method that also has a non-empty code. If no
+// such error is found, an empty Code is returned.
 func ErrorCode(err error) Code {
-	var errCode interface{ ErrorCode() string }
-	if stderr.As(err, &errCode) {
-		return Code(errCode.ErrorCode())
+	for err != nil {
+		if v, ok := err.(interface{ ErrorCode() string }); ok {
+			if code := v.ErrorCode(); code != "" {
+				return Code(code)
+			}
+		}
+		err = stderr.Unwrap(err)
 	}
 	return ""
 }
 
 // ErrorInfo returns additional information about the error.
+// It unwraps the error chain to find the first error that implements
+// the ErrorInfo() map[string]any method that also has non-nil info.
+// If no such error is found, nil is returned.
 func ErrorInfo(err error) map[string]any {
-	var errInfo interface{ ErrorInfo() map[string]any }
-	if stderr.As(err, &errInfo) {
-		return errInfo.ErrorInfo()
+	for err != nil {
+		if v, ok := err.(interface{ ErrorInfo() map[string]any }); ok {
+			if info := v.ErrorInfo(); info != nil {
+				return info
+			}
+		}
+		err = stderr.Unwrap(err)
 	}
 	return nil
 }

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -5,6 +5,7 @@ package auditlog
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -106,8 +107,7 @@ func (j *auditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, bef
 	}
 	count, err := j.store.DeleteAuditLogsBefore(ctx, before)
 	if err != nil {
-		zapctx.Error(ctx, "failed to purge logs", zap.Error(err))
-		return 0, errors.E(op, "failed to purge logs", err)
+		return 0, errors.E(op, fmt.Errorf("failed to purge logs: %w", err))
 	}
 	return count, nil
 }

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -334,11 +334,6 @@ func (b *bootstrapManager) BootstrapJob(
 		// Lock the bootstrap for the same length the process is allowed to run for
 		// before being killed.
 		if err := b.store.LockBootstrap(jobCtx, jujucommands.CommandKillDelay); err != nil {
-			zapctx.Error(
-				jobCtx,
-				"failed to acquire bootstrap lock",
-				zap.Error(err),
-			)
 			return errors.E(fmt.Errorf("failed to acquire bootstrap lock: %w", err))
 		}
 
@@ -454,7 +449,6 @@ func (b *bootstrapManager) runBootstrap(
 
 		zapctx.Error(jobCtx, "failed to cleanup controller after failing to add it to JIMM",
 			zap.NamedError("BootstrapError", err), zap.NamedError("CleanupError", cleanupErr))
-
 		return errors.E(fmt.Errorf("error post-bootstrap: %w\n"+
 			"automatic cleanup of the controller also failed: %w\n"+
 			"\n"+
@@ -599,11 +593,6 @@ func (b *bootstrapManager) DestroyControllerJob(
 		// Lock the bootstrap for the same length the process is allowed to run for
 		// before being killed.
 		if err := b.store.LockBootstrap(jobCtx, jujucommands.CommandKillDelay); err != nil {
-			zapctx.Error(
-				jobCtx,
-				"failed to acquire bootstrap lock",
-				zap.Error(err),
-			)
 			return errors.E(fmt.Errorf("failed to acquire bootstrap lock: %w", err))
 		}
 

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -56,8 +55,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 
 	isAdmin, err := openfga.IsAdministrator(ctx, user, model.ResourceTag())
 	if err != nil {
-		zapctx.Error(ctx, "failed administraor check", zap.Error(err))
-		return errors.E(op, "failed administrator check", err)
+		return errors.E(op, fmt.Errorf("failed administrator check: %w", err))
 	}
 	if !isAdmin {
 		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
@@ -116,8 +114,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	err = api.GetApplicationOffer(ctx, &offerDetails)
 	if err != nil {
-		zapctx.Error(ctx, "failed to fetch details of the created application offer", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to fetch details of the created application offer: %w", err))
 	}
 
 	doc := dbmodel.ApplicationOffer{
@@ -133,8 +130,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return nil
 	})
 	if err != nil {
-		zapctx.Error(ctx, "failed to store the created application offer", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to store the created application offer: %w", err))
 	}
 
 	if err := j.OpenFGAClient.AddModelApplicationOffer(
@@ -424,24 +420,21 @@ func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offe
 func (j *JujuManager) getUserOfferAccess(ctx context.Context, user *openfga.User, offerTag names.ApplicationOfferTag) (string, error) {
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offerTag)
 	if err != nil {
-		zapctx.Error(ctx, "openfga check failed", zap.Error(err))
-		return "", errors.E(err)
+		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
 	}
 	if isOfferAdmin {
 		return string(jujuparams.OfferAdminAccess), nil
 	}
 	isOfferConsumer, err := user.IsApplicationOfferConsumer(ctx, offerTag)
 	if err != nil {
-		zapctx.Error(ctx, "openfga check failed", zap.Error(err))
-		return "", errors.E(err)
+		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
 	}
 	if isOfferConsumer {
 		return string(jujuparams.OfferConsumeAccess), nil
 	}
 	isOfferReader, err := user.IsApplicationOfferReader(ctx, offerTag)
 	if err != nil {
-		zapctx.Error(ctx, "openfga check failed", zap.Error(err))
-		return "", errors.E(err)
+		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
 	}
 	if isOfferReader {
 		return string(jujuparams.OfferReadAccess), nil

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -1152,7 +1152,7 @@ func TestOffer(t *testing.T) {
 			offer := dbmodel.ApplicationOffer{}
 
 			return *u, offerParams, offer, func(c *qt.C, err error) {
-				c.Assert(err, qt.ErrorMatches, "a silly error")
+				c.Assert(err, qt.ErrorMatches, "failed to fetch details of the created application offer: a silly error")
 			}
 		},
 	}, {

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -11,8 +11,6 @@ import (
 
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -231,12 +229,10 @@ func (j *JujuManager) updateCredential(ctx context.Context, credential *dbmodel.
 	const op = errors.Op("jimm.updateCredential")
 
 	if err := j.Database.SetCloudCredential(ctx, credential); err != nil {
-		zapctx.Error(ctx, "failed to store credential id", zap.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to store credential id: %w", err))
 	}
 	if err := j.CredentialStore.Put(ctx, credential.ResourceTag(), attr); err != nil {
-		zapctx.Error(ctx, "failed to store credentials", zap.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to store credentials: %w", err))
 	}
 
 	return nil

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -277,12 +277,11 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 	}
 
 	if err := addControllerTx(ctx, j, dbClouds, ctl); err != nil {
-		zapctx.Error(ctx, "failed to add controller", zaputil.Error(err))
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 			return errors.E(op, err, fmt.Sprintf("controller %q already exists", ctl.Name))
 		}
 
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to add controller: %w", err))
 	}
 
 	for _, cloud := range dbClouds {
@@ -648,8 +647,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	model.InternalMigrationSuccess(targetController.ID)
 	err = j.Database.UpdateModel(ctx, &model)
 	if err != nil {
-		zapctx.Error(ctx, "failed to update model", zap.String("model", model.UUID.String), zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to update model: %w", err))
 	}
 
 	return nil

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -12,8 +12,6 @@ import (
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/canonical/jimm/v3/internal/db"
@@ -318,14 +316,12 @@ func (j *JujuManager) PrepareModelMigration(
 		return nil
 	})
 	if err != nil {
-		zapctx.Error(ctx, "failed to add incoming model migration details", zap.Error(err))
-		return "", errors.E(op, err)
+		return "", errors.E(op, fmt.Errorf("failed to add incoming model migration details: %w", err))
 	}
 
 	migrationToken, err := j.migrationTokenGenerator.NewMigrationToken(ctx, user.Name)
 	if err != nil {
-		zapctx.Error(ctx, "failed to generate migration token", zap.Error(err))
-		return "", errors.E(op, err)
+		return "", errors.E(op, fmt.Errorf("failed to generate migration token: %w", err))
 	}
 
 	return migrationToken, nil

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -768,7 +768,7 @@ func TestPrepareModelMigration_ControllerDoesNotExist(t *testing.T) {
 		targetControllerName,
 		userMapping,
 	)
-	c.Assert(err, qt.ErrorMatches, "controller not found")
+	c.Assert(err, qt.ErrorMatches, "failed to add incoming model migration details: controller not found")
 }
 
 func TestPrepareModelMigration_Success(t *testing.T) {

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -10,6 +10,7 @@ package jujuauth
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/juju/names/v5"
@@ -126,8 +127,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	ctl.SetTag(auth.ct)
 	err := auth.database.GetController(ctx, &ctl)
 	if err != nil {
-		zapctx.Error(ctx, "failed to fetch controller", zap.Error(err))
-		return nil, errors.E(op, "failed to fetch controller", err)
+		return nil, errors.E(op, fmt.Errorf("failed to fetch controller: %w", err))
 	}
 	clouds := make(map[names.CloudTag]bool)
 	for _, cloudRegion := range ctl.CloudRegions {
@@ -136,8 +136,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	for cloudTag := range clouds {
 		accessLevel, err := auth.accessChecker.GetUserCloudAccess(ctx, auth.user, cloudTag)
 		if err != nil {
-			zapctx.Error(ctx, "cloud access check failed", zap.Error(err))
-			return nil, errors.E(op, "failed to check user's cloud access", err)
+			return nil, errors.E(op, fmt.Errorf("failed to check user's cloud access: %w", err))
 		}
 		auth.accessMapCache[cloudTag.String()] = accessLevel
 	}

--- a/internal/jimm/jujuauth/logintokens_test.go
+++ b/internal/jimm/jujuauth/logintokens_test.go
@@ -181,7 +181,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 				ct.String(): "superuser",
 			},
 		},
-		expectedError: "failed to fetch controller",
+		expectedError: "failed to fetch controller: a test error",
 	}, {
 		about:    "cloud access check fails",
 		username: "eve@canonical.com",
@@ -205,7 +205,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 			},
 			cloudAccessCheckErr: errors.E("a test error"),
 		},
-		expectedError: "failed to check user's cloud access",
+		expectedError: "failed to check user's cloud access: a test error",
 	}, {
 		about:    "jwt service errors out",
 		username: "eve@canonical.com",

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -251,8 +251,7 @@ func (j *permissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Check if the user is jimm administrator.
 	isAdmin, err := openfga.IsAdministrator(ctx, targetUserTag, j.jimmTag)
 	if err != nil {
-		zapctx.Error(ctx, "failed to check access rights", zap.Error(err))
-		return "", errors.E(op, err)
+		return "", errors.E(op, fmt.Errorf("failed to check access rights: %w", err))
 	}
 	if isAdmin {
 		return "superuser", nil

--- a/internal/jimmhttp/rebac_admin/backend.go
+++ b/internal/jimmhttp/rebac_admin/backend.go
@@ -39,8 +39,7 @@ func SetupBackend(ctx context.Context, jimm jujuapi.JIMM) (*rebac_handlers.ReBAC
 		RolesErrorMapper:        securityEventLogger,
 	})
 	if err != nil {
-		zapctx.Error(ctx, "failed to create rebac admin backend", zap.Error(err))
-		return nil, errors.E(op, err, "failed to create rebac admin backend")
+		return nil, errors.E(op, fmt.Errorf("failed to create rebac admin backend: %w", err))
 	}
 
 	return rebacBackend, nil

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -95,7 +96,7 @@ func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTim
 			if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
 				zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
 			}
-			return errors.E(err)
+			return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
 		}
 	} else {
 		// Check it has expired.
@@ -108,7 +109,7 @@ func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTim
 				if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
 					zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
 				}
-				return errors.E(err)
+				return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
 			}
 			zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
 		}
@@ -133,8 +134,7 @@ func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequir
 	credStore := jwks.credentialStore
 
 	if err := rotateJWKS(ctx, credStore, initialRotateRequiredTime); err != nil {
-		zapctx.Error(ctx, "Rotate JWKS error", zap.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("rotate jwks: %w", err))
 	}
 
 	// The rotation method is as follows, if an expiry is not present, we know

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -122,7 +122,6 @@ func (j *JWTService) NewJWT(ctx context.Context, params JWTParams) ([]byte, erro
 
 	pubKey, ok := jwkSet.Key(jwkSet.Len() - 1)
 	if !ok {
-		zapctx.Error(ctx, "no jwk found")
 		return nil, errors.E("no jwk found")
 	}
 	pkeyPem, err := j.Store.GetJWKSPrivateKey(ctx)

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -4,10 +4,10 @@ package jujuapi
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
-	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -35,8 +35,7 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 
 	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
 	if err != nil {
-		zapctx.Error(ctx, "failed to add group", zaputil.Error(err))
-		return resp, errors.E(op, err)
+		return resp, errors.E(op, fmt.Errorf("failed to add group: %w", err))
 	}
 	resp = apiparams.AddGroupResponse{Group: apiparams.Group{
 		Name:      groupEntry.Name,
@@ -65,8 +64,7 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 		return apiparams.Group{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		zapctx.Error(ctx, "failed to get group", zaputil.Error(err))
-		return apiparams.Group{}, errors.E(op, err)
+		return apiparams.Group{}, errors.E(op, fmt.Errorf("failed to get group: %w", err))
 	}
 
 	return apiparams.Group{
@@ -86,8 +84,7 @@ func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGr
 	}
 
 	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {
-		zapctx.Error(ctx, "failed to rename group", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to rename group: %w", err))
 	}
 	return nil
 }
@@ -97,8 +94,7 @@ func (r *controllerRoot) RemoveGroup(ctx context.Context, req apiparams.RemoveGr
 	const op = errors.Op("jujuapi.RemoveGroup")
 
 	if err := r.jimm.GroupManager().RemoveGroup(ctx, r.user, req.Name); err != nil {
-		zapctx.Error(ctx, "failed to remove group", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to remove group: %w", err))
 	}
 	return nil
 }
@@ -110,7 +106,7 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
 	groups, err := r.jimm.GroupManager().ListGroups(ctx, r.user, pagination, "")
 	if err != nil {
-		return apiparams.ListGroupResponse{}, errors.E(op, err)
+		return apiparams.ListGroupResponse{}, errors.E(op, fmt.Errorf("failed to list groups: %w", err))
 	}
 	groupsResponse := make([]apiparams.Group, len(groups))
 	for i, g := range groups {
@@ -131,8 +127,7 @@ func (r *controllerRoot) AddRelation(ctx context.Context, req apiparams.AddRelat
 	const op = errors.Op("jujuapi.AddRelation")
 
 	if err := r.jimm.PermissionManager().AddRelation(ctx, r.user, req.Tuples); err != nil {
-		zapctx.Error(ctx, "failed to add relation", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to add relation: %w", err))
 	}
 	return nil
 }
@@ -144,8 +139,7 @@ func (r *controllerRoot) RemoveRelation(ctx context.Context, req apiparams.Remov
 
 	err := r.jimm.PermissionManager().RemoveRelation(ctx, r.user, req.Tuples)
 	if err != nil {
-		zapctx.Error(ctx, "failed to delete tuple(s)", zap.NamedError("remove-relation-error", err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to remove relation: %w", err))
 	}
 	return nil
 }
@@ -159,9 +153,8 @@ func (r *controllerRoot) CheckRelation(ctx context.Context, req apiparams.CheckR
 
 	allowed, err := r.jimm.PermissionManager().CheckRelation(ctx, r.user, req.Tuple, false)
 	if err != nil {
-		zapctx.Error(ctx, "failed to check relation", zap.NamedError("check-relation-error", err))
 		checkResp.Error = err.Error()
-		return checkResp, errors.E(op, err)
+		return checkResp, errors.E(op, fmt.Errorf("failed to check relation: %w", err))
 	}
 	checkResp.Allowed = allowed
 	zapctx.Debug(ctx, "check request", zap.String("allowed", strconv.FormatBool(allowed)))
@@ -176,8 +169,7 @@ func (r *controllerRoot) CheckRelations(ctx context.Context, req apiparams.Check
 
 	results, err := r.jimm.PermissionManager().CheckRelations(ctx, r.user, req.Tuples)
 	if err != nil {
-		zapctx.Error(ctx, "failed to check relation", zap.NamedError("check-relation-error", err))
-		return checksResp, errors.E(op, err)
+		return checksResp, errors.E(op, fmt.Errorf("failed to check relations: %w", err))
 	}
 	for _, result := range results {
 		resp := apiparams.CheckRelationResponse{
@@ -198,7 +190,7 @@ func (r *controllerRoot) ListRelationshipTuples(ctx context.Context, req apipara
 
 	responseTuples, ct, err := r.jimm.PermissionManager().ListRelationshipTuples(ctx, r.user, req.Tuple, req.PageSize, req.ContinuationToken)
 	if err != nil {
-		return apiparams.ListRelationshipTuplesResponse{}, errors.E(op, err)
+		return apiparams.ListRelationshipTuplesResponse{}, errors.E(op, fmt.Errorf("failed to list relations: %w", err))
 	}
 	errors := []string{}
 	tuples := make([]apiparams.RelationshipTuple, len(responseTuples))

--- a/internal/jujuapi/access_control_test.go
+++ b/internal/jujuapi/access_control_test.go
@@ -870,7 +870,7 @@ func (s *accessControlSuite) TestListRelationshipTuples(c *gc.C) {
 		},
 		ResolveUUIDs: true,
 	})
-	c.Assert(err, gc.ErrorMatches, "failed to parse tuple target object key applicationoffer-fake-offer: application offer not found.*")
+	c.Assert(err, gc.ErrorMatches, "failed to list relations: failed to parse tuple target object key applicationoffer-fake-offer: application offer not found.*")
 }
 
 func (s *accessControlSuite) TestListRelationshipTuplesNoUUIDResolution(c *gc.C) {
@@ -1012,7 +1012,7 @@ func (s *accessControlSuite) TestCheckRelationAsNonAdmin(c *gc.C) {
 	}
 	req := apiparams.CheckRelationRequest{Tuple: input}
 	_, err := client.CheckRelation(&req)
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to check relation: unauthorized \(unauthorized access\)`)
 	// Verify Bob can check for his own permission.
 	input = apiparams.RelationshipTuple{
 		Object:       userBobKey,

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -15,8 +15,6 @@ import (
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
-	"github.com/juju/zaputil"
-	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -227,8 +225,7 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 		AdminPassword:     req.Password,
 	}
 	if err := r.jimm.JujuManager().AddController(ctx, r.user, &ctl, ctlCreds); err != nil {
-		zapctx.Error(ctx, "failed to add controller", zaputil.Error(err))
-		return apiparams.ControllerInfo{}, errors.E(op, err)
+		return apiparams.ControllerInfo{}, errors.E(op, fmt.Errorf("failed to add controller: %w", err))
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -171,7 +171,7 @@ func (s *jimmSuite) TestAddController(c *gc.C) {
 	})
 
 	_, err = client.AddController(&acr)
-	c.Assert(err, gc.ErrorMatches, `controller "controller-2" already exists \(already exists\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add controller: controller "controller-2" already exists \(already exists\)`)
 	c.Assert(jujuparams.IsCodeAlreadyExists(err), gc.Equals, true)
 
 	conn = s.open(c, nil, "bob")
@@ -179,7 +179,7 @@ func (s *jimmSuite) TestAddController(c *gc.C) {
 	client = api.NewClient(conn)
 	acr.Name = "controller-2"
 	_, err = client.AddController(&acr)
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(err, gc.ErrorMatches, `failed to add controller: unauthorized \(unauthorized access\)`)
 	c.Assert(jujuparams.IsCodeUnauthorized(err), gc.Equals, true)
 
 	acr.Name = "jimm"
@@ -232,7 +232,7 @@ func (s *jimmSuite) TestAddControllerCustomTLSHostname(c *gc.C) {
 	}
 
 	_, err := client.AddController(&acr)
-	c.Assert(err, gc.ErrorMatches, "failed to dial the controller.*")
+	c.Assert(err, gc.ErrorMatches, "failed to add controller: failed to dial the controller.*")
 	acr.TLSHostname = "juju-apiserver"
 	ci, err := client.AddController(&acr)
 	c.Assert(err, gc.IsNil)

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -29,7 +29,7 @@ func (s *migrationTargetSuite) TestAbort(c *gc.C) {
 	modelUUID := "00000001-0000-0000-0000-000000000001"
 	client := migrationtarget.NewClient(conn)
 	err := client.Abort(modelUUID)
-	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found.*`)
 }
 
 func (s *migrationTargetSuite) TestCheckMachines(c *gc.C) {
@@ -39,7 +39,7 @@ func (s *migrationTargetSuite) TestCheckMachines(c *gc.C) {
 	modelUUID := "00000001-0000-0000-0000-000000000001"
 	client := migrationtarget.NewClient(conn)
 	_, err := client.CheckMachines(modelUUID)
-	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found.*`)
 }
 
 func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
@@ -75,7 +75,7 @@ func (s *migrationTargetSuite) TestPrechecks(c *gc.C) {
 	}
 	client := migrationtarget.NewClient(conn)
 	err := client.Prechecks(model)
-	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found.*`)
 
 	prepareModelMigration := params.PrepareModelMigrationRequest{
 		ModelTag:              names.NewModelTag(modelUUID).String(),
@@ -108,7 +108,7 @@ func (s *migrationTargetSuite) TestAdoptResources(c *gc.C) {
 	modelUUID := "00000001-0000-0000-0000-000000000001"
 	client := migrationtarget.NewClient(conn)
 	err := client.AdoptResources(modelUUID)
-	c.Assert(err, gc.ErrorMatches, `.*model not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model not found.*`)
 }
 
 func (s *migrationTargetSuite) TestActivate(c *gc.C) {
@@ -123,7 +123,7 @@ func (s *migrationTargetSuite) TestActivate(c *gc.C) {
 
 	client := migrationtarget.NewClient(conn)
 	err := client.Activate(modelUUID, sourceInfo, relatedModels)
-	c.Assert(err, gc.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, gc.ErrorMatches, `.*model migration not found.*`)
 }
 
 func (s *migrationTargetSuite) TestLatestLogTime(c *gc.C) {

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -4,10 +4,8 @@ package jujuapi
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/juju/zaputil"
-	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -27,8 +25,7 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 
 	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
 	if err != nil {
-		zapctx.Error(ctx, "failed to add role", zaputil.Error(err))
-		return resp, errors.E(op, err)
+		return resp, errors.E(op, fmt.Errorf("failed to add role: %w", err))
 	}
 	resp = apiparams.AddRoleResponse{Role: apiparams.Role{
 		Name:      roleEntry.Name,
@@ -59,8 +56,7 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		zapctx.Error(ctx, "failed to get role", zaputil.Error(err))
-		return apiparams.Role{}, errors.E(op, err)
+		return apiparams.Role{}, errors.E(op, fmt.Errorf("failed to get role: %w", err))
 	}
 
 	return apiparams.Role{
@@ -80,8 +76,7 @@ func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRol
 	}
 
 	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
-		zapctx.Error(ctx, "failed to rename role", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to rename role: %w", err))
 	}
 	return nil
 }
@@ -95,8 +90,7 @@ func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRol
 	}
 
 	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {
-		zapctx.Error(ctx, "failed to remove role", zaputil.Error(err))
-		return errors.E(op, err)
+		return errors.E(op, fmt.Errorf("failed to remove role: %w", err))
 	}
 	return nil
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -214,8 +214,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 		zapctx.Debug(ctx, "grabbing model info from path", zap.String("path", path))
 		uuid, finalPath, err := modelInfoFromPath(path)
 		if err != nil {
-			zapctx.Error(ctx, "error parsing path", zap.Error(err))
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(op, err)
+			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(op, fmt.Errorf("error parsing path: %w", err))
 		}
 		m := dbmodel.Model{
 			UUID: sql.NullString{
@@ -224,8 +223,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 			},
 		}
 		if err := s.jimm.Database.GetModel(context.Background(), &m); err != nil {
-			zapctx.Error(ctx, "failed to find model", zap.String("uuid", uuid), zap.Error(err))
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(err, errors.CodeNotFound)
+			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(fmt.Errorf("failed to find model: %w", err), errors.CodeNotFound)
 		}
 		jwtGenerator.SetTags(m.ResourceTag(), m.Controller.ResourceTag())
 		mt := m.ResourceTag()

--- a/internal/jujuapi/websocket_test.go
+++ b/internal/jujuapi/websocket_test.go
@@ -258,7 +258,7 @@ func (s *apiProxySuite) TestAgentLoginModelDoesNotExist(c *gc.C) {
 	}
 	_, err = api.Open(&info, dialOpts)
 	c.Assert(err, gc.NotNil)
-	c.Check(err.Error(), gc.Matches, `model not found.*`)
+	c.Check(err.Error(), gc.Matches, `failed to find model: model not found.*`)
 }
 
 type logger struct{}

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -350,7 +350,6 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 	}
 	ok = names.IsValidUser(user)
 	if !ok {
-		zapctx.Error(c.ctx, "invalid controller credentials", zap.String("user", user))
 		return nil, errors.E(op, "invalid/missing controller credentials")
 	}
 	requestHeader := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -46,8 +46,7 @@ func (d Dialer) DialWebsocket(ctx context.Context, url string, headers http.Head
 	}
 	conn, resp, err := dialer.DialContext(ctx, url, headers)
 	if err != nil {
-		zapctx.Error(ctx, "BasicDial failed", zap.Error(err))
-		return nil, errors.E(op, err)
+		return nil, errors.E(op, fmt.Errorf("basic dial failed: %w", err))
 	}
 	defer resp.Body.Close()
 	return conn, nil

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -113,20 +113,16 @@ type ProxyHelpers struct {
 func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 	const op = errors.Op("rpc.ProxySockets")
 	if helpers.ConnectController == nil {
-		zapctx.Error(ctx, "Missing controller connect function")
-		return errors.E(op, "Missing controller connect function")
+		return errors.E(op, "missing controller connect function")
 	}
 	if helpers.AuditLog == nil {
-		zapctx.Error(ctx, "Missing audit log function")
-		return errors.E(op, "Missing audit log function")
+		return errors.E(op, "missing audit log function")
 	}
 	if helpers.LoginService == nil {
-		zapctx.Error(ctx, "Missing login service function")
-		return errors.E(op, "Missing login service function")
+		return errors.E(op, "missing login service function")
 	}
 	if helpers.RedirectInfo == nil {
-		zapctx.Error(ctx, "Missing redirect info function")
-		return errors.E(op, "Missing redirect info function")
+		return errors.E(op, "missing redirect info function")
 	}
 	errChan := make(chan error, 2)
 	msgInFlight := inflightMsgs{messages: make(map[uint64]*message)}
@@ -333,8 +329,7 @@ func (p *modelProxy) auditLogMessage(msg *message, isResponse bool) error {
 		if msg.Response != nil {
 			err := json.Unmarshal(msg.Response, &allErrors)
 			if err != nil {
-				zapctx.Error(context.Background(), "failed to unmarshal message response", zap.Error(err), zap.Any("message", msg))
-				return errors.E(err, "failed to unmarshal message response")
+				return errors.E(fmt.Errorf("failed to unmarshal message response: %w", err))
 			}
 		}
 		singleError := params.ErrorResult{Error: &params.Error{Message: msg.Error, Code: msg.ErrorCode, Info: msg.ErrorInfo}}
@@ -651,7 +646,6 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 
 	jwt, err := tokenGen.MakeToken(ctx, permissions)
 	if err != nil {
-		zapctx.Error(ctx, "failed to make token", zap.Error(err))
 		return errors.E(op, err)
 	}
 

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -4,7 +4,6 @@ package jimmtest
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 )
@@ -56,24 +53,20 @@ func CreateRandomKeycloakUser() (*KeycloakUser, error) {
 
 	adminCLIToken, err := getAdminCLIAccessToken()
 	if err != nil {
-		zapctx.Error(context.Background(), "failed to authenticate admin CLI user", zap.Error(err))
-		return nil, errors.E(err, "failed to authenticate admin CLI user")
+		return nil, errors.E(fmt.Errorf("failed to authenticate admin CLI user: %w", err))
 	}
 
 	if err := addKeycloakUser(adminCLIToken, email, username); err != nil {
-		zapctx.Error(context.Background(), "failed to add keycloak user", zap.Error(err))
-		return nil, errors.E(err, fmt.Sprintf("failed to add keycloak user (%q, %q)", email, username))
+		return nil, errors.E(fmt.Errorf("failed to add keycloak user (%q, %q): %w", email, username, err))
 	}
 
 	id, err := getKeycloakUserId(adminCLIToken, username)
 	if err != nil {
-		zapctx.Error(context.Background(), "failed to get keycloak user ID", zap.Error(err))
-		return nil, errors.E(err, fmt.Sprintf("failed to retrieve ID for newly added keycloak user (%q, %q)", email, username))
+		return nil, errors.E(fmt.Errorf("failed to retrieve ID for newly added keycloak user (%q, %q): %w", email, username, err))
 	}
 
 	if err := setKeycloakUserPassword(adminCLIToken, id, password); err != nil {
-		zapctx.Error(context.Background(), "failed to set keycloak user password", zap.Error(err))
-		return nil, errors.E(err, fmt.Sprintf("failed to set password for newly added keycloak user (%q, %q, %q)", email, username, password))
+		return nil, errors.E(fmt.Errorf("failed to set password for newly added keycloak user (%q, %q, %q): %w", email, username, password, err))
 	}
 	return &KeycloakUser{
 		Id:       id,

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	goerr "errors"
 	"net/http"
 	"path"
@@ -17,7 +18,6 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
@@ -480,14 +480,12 @@ func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
 		roleSecretID,
 	)
 	if err != nil {
-		zapctx.Error(ctx, "unable to initialize approle auth method", zap.Error(err))
-		return nil, errors.E(op, err, "unable to initialize approle auth method")
+		return nil, errors.E(op, fmt.Errorf("unable to initialize approle auth method: %w", err))
 	}
 
 	authInfo, err := s.Client.Auth().Login(ctx, appRoleAuth)
 	if err != nil {
-		zapctx.Error(ctx, "unable to login to approle auth method", zap.Error(err))
-		return nil, errors.E(op, err, "unable to login to approle auth method")
+		return nil, errors.E(op, fmt.Errorf("unable to login to approle auth method: %w", err))
 	}
 	if authInfo == nil {
 		return nil, errors.E(op, "no auth info was returned after login")


### PR DESCRIPTION
## Description
This PR removes many instances where we log an error and return it up the call stack (where it is almost always logged again). Note that this may not be all instances of double logging, I asked copilot to fix things then I manually cleaned things up.

I've also ensured we don't mask errors in the places that were fixed. In these places I've changed `errors.E(op, err)` -> `errors.E(op, fmt.Errorf("message: %w", err))`, noting specifically the `%w` flag instead of `%v`. This is necessary for cases where we are inspecting one of the errors in the chain for a specific code/message. Initially this caused some test failures because there is a subtle error replacing,

`errors.E(op, err)` -> `errors.E(op, fmt.Errorf("message: %w", err))`

Namely that we lose the error code. `errors.E()` takes the provided error and extracts its error code (if one exists) and places it on the newly created error, persisting the error code up the call stack. If we wrap the error if `fmt.Errorf` the error passed into `errors.E()` has no error code. And at the end an API request, our `ErrorCode()` function only inspects the top-level error, ignoring any wrapped errors. 

To resolve this I've reworked the `ErrorCode()` and `ErrorInfo()` functions to iteratively unwrap errors until the first non-empty error code is obtained. Doing this made me realise this is also a good step towards making it easier to refactor our `errors.E` API.
