### PR TITLE
feat: add can_addmodel permission to controllers

### DIFF
--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -632,7 +632,7 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 		return err
 	}
 
-	allowedAddModel, err := user.IsAllowedAddModel(ctx, region.Cloud.ResourceTag())
+	allowedAddModel, err := user.IsAllowedAddModelToCloud(ctx, region.Cloud.ResourceTag())
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -150,7 +150,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 
 	// at this point we know which cloud will host the model and
 	// we must check the user has add-model permission on the cloud
-	canAddModel, err := openfga.NewUser(owner, j.OpenFGAClient).IsAllowedAddModel(ctx, builder.cloud.ResourceTag())
+	canAddModel, err := openfga.NewUser(owner, j.OpenFGAClient).IsAllowedAddModelToCloud(ctx, builder.cloud.ResourceTag())
 	if err != nil {
 		return nil, errors.E(op, "permission check failed")
 	}

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -34,9 +34,19 @@ type User struct {
 	JimmAdmin bool
 }
 
-// IsAllowedAddModed returns true if the user is allowed to add a model on the
+// IsAllowedAddModelToController returns true if the user is allowed to add a model on the
+// specified controller.
+func (u *User) IsAllowedAddModelToController(ctx context.Context, resource names.ControllerTag) (bool, error) {
+	allowed, err := checkRelation(ctx, u, resource, ofganames.CanAddModelRelation)
+	if err != nil {
+		return false, errors.E(err)
+	}
+	return allowed, nil
+}
+
+// IsAllowedAddModelToCloud returns true if the user is allowed to add a model on the
 // specified cloud.
-func (u *User) IsAllowedAddModel(ctx context.Context, resource names.CloudTag) (bool, error) {
+func (u *User) IsAllowedAddModelToCloud(ctx context.Context, resource names.CloudTag) (bool, error) {
 	allowed, err := checkRelation(ctx, u, resource, ofganames.CanAddModelRelation)
 	if err != nil {
 		return false, errors.E(err)
@@ -108,7 +118,7 @@ func (u *User) GetCloudAccess(ctx context.Context, resource names.CloudTag) Rela
 	if isCloudAdmin {
 		return ofganames.AdministratorRelation
 	}
-	userAccess, err := u.IsAllowedAddModel(ctx, resource)
+	userAccess, err := u.IsAllowedAddModelToCloud(ctx, resource)
 	if err != nil {
 		zapctx.Error(ctx, "openfga check failed", zap.Error(err))
 		return ofganames.NoRelation

--- a/internal/openfga/user_test.go
+++ b/internal/openfga/user_test.go
@@ -350,20 +350,31 @@ func (s *userTestSuite) TestControllerAccess(c *gc.C) {
 func (s *userTestSuite) TestCanAddModelToController(c *gc.C) {
 	ctx := context.Background()
 
+	groupUUID := uuid.NewString()
+	group := jimmnames.NewGroupTag(groupUUID)
+
 	controllerUUID, err := uuid.NewRandom()
 	c.Assert(err, gc.IsNil)
 	controller := names.NewControllerTag(controllerUUID.String())
 
+	// eve has addmodel access via group membership
 	eve := names.NewUserTag("eve")
+	// alice has addmodel access set directly
 	alice := names.NewUserTag("alice")
+	// mike does not have access
+	mike := names.NewUserTag("mike")
 
 	tuples := []openfga.Tuple{{
 		Object:   ofganames.ConvertTag(eve),
-		Relation: ofganames.AdministratorRelation,
+		Relation: ofganames.MemberRelation,
+		Target:   ofganames.ConvertTag(jimmnames.NewGroupTag(groupUUID)),
+	}, {
+		Object:   ofganames.ConvertTagWithRelation(group, ofganames.MemberRelation),
+		Relation: ofganames.CanAddModelRelation,
 		Target:   ofganames.ConvertTag(controller),
 	}, {
 		Object:   ofganames.ConvertTag(alice),
-		Relation: ofganames.AuditLogViewerRelation,
+		Relation: ofganames.CanAddModelRelation,
 		Target:   ofganames.ConvertTag(controller),
 	}}
 	err = s.ofgaClient.AddRelation(ctx, tuples...)
@@ -373,15 +384,22 @@ func (s *userTestSuite) TestCanAddModelToController(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	aliceIdentity, err := dbmodel.NewIdentity(alice.Id())
 	c.Assert(err, gc.IsNil)
+	mikeIdentity, err := dbmodel.NewIdentity(mike.Id())
+	c.Assert(err, gc.IsNil)
 
 	eveUser := openfga.NewUser(eveIdentity, s.ofgaClient)
 	aliceUser := openfga.NewUser(aliceIdentity, s.ofgaClient)
+	mikeUser := openfga.NewUser(mikeIdentity, s.ofgaClient)
 
 	canAddModel, err := eveUser.IsAllowedAddModelToController(ctx, controller)
 	c.Assert(err, gc.IsNil)
 	c.Assert(canAddModel, gc.Equals, true)
 
 	canAddModel, err = aliceUser.IsAllowedAddModelToController(ctx, controller)
+	c.Assert(err, gc.IsNil)
+	c.Assert(canAddModel, gc.Equals, true)
+
+	canAddModel, err = mikeUser.IsAllowedAddModelToController(ctx, controller)
 	c.Assert(err, gc.IsNil)
 	c.Assert(canAddModel, gc.Equals, false)
 }

--- a/internal/openfga/user_test.go
+++ b/internal/openfga/user_test.go
@@ -347,6 +347,45 @@ func (s *userTestSuite) TestControllerAccess(c *gc.C) {
 	c.Assert(relation, gc.DeepEquals, ofganames.NoRelation)
 }
 
+func (s *userTestSuite) TestCanAddModelToController(c *gc.C) {
+	ctx := context.Background()
+
+	controllerUUID, err := uuid.NewRandom()
+	c.Assert(err, gc.IsNil)
+	controller := names.NewControllerTag(controllerUUID.String())
+
+	eve := names.NewUserTag("eve")
+	alice := names.NewUserTag("alice")
+
+	tuples := []openfga.Tuple{{
+		Object:   ofganames.ConvertTag(eve),
+		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(controller),
+	}, {
+		Object:   ofganames.ConvertTag(alice),
+		Relation: ofganames.AuditLogViewerRelation,
+		Target:   ofganames.ConvertTag(controller),
+	}}
+	err = s.ofgaClient.AddRelation(ctx, tuples...)
+	c.Assert(err, gc.IsNil)
+
+	eveIdentity, err := dbmodel.NewIdentity(eve.Id())
+	c.Assert(err, gc.IsNil)
+	aliceIdentity, err := dbmodel.NewIdentity(alice.Id())
+	c.Assert(err, gc.IsNil)
+
+	eveUser := openfga.NewUser(eveIdentity, s.ofgaClient)
+	aliceUser := openfga.NewUser(aliceIdentity, s.ofgaClient)
+
+	canAddModel, err := eveUser.IsAllowedAddModelToController(ctx, controller)
+	c.Assert(err, gc.IsNil)
+	c.Assert(canAddModel, gc.Equals, true)
+
+	canAddModel, err = aliceUser.IsAllowedAddModelToController(ctx, controller)
+	c.Assert(err, gc.IsNil)
+	c.Assert(canAddModel, gc.Equals, false)
+}
+
 func (s *userTestSuite) TestSetControllerAccess(c *gc.C) {
 	ctx := context.Background()
 	controllerUUID, err := uuid.NewRandom()

--- a/openfga/authorisation_model.fga
+++ b/openfga/authorisation_model.fga
@@ -16,6 +16,7 @@ type controller
     define controller: [controller]
     define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
     define audit_log_viewer: [user, user:*, group#member, role#assignee] or administrator
+    define can_addmodel: [user, user:*, group#member, role#assignee] or administrator
 
 type model
   relations

--- a/openfga/tests.fga.yaml
+++ b/openfga/tests.fga.yaml
@@ -102,6 +102,15 @@ tuples:
     - user: group:co-group-2#member
       relation: audit_log_viewer
       object: controller:co-controller-2
+    - user: user:co-user-5
+      relation: can_addmodel
+      object: controller:co-controller-1
+    - user: user:co-user-6
+      relation: member
+      object: group:co-group-3
+    - user: group:co-group-3#member
+      relation: can_addmodel
+      object: controller:co-controller-2
 
     # Model (mo)
     - user: user:mo-user-1
@@ -294,7 +303,7 @@ tests:
     # Checks whether:
     # - all or invididual users, or group members can become administators and audit_log_viewers of a controller
     # - controllers can be related to each other with correct inheritance of administrators
-    # - proper hierarchy of relations is upheld: administrator > audit_log_viewer
+    # - proper hierarchy of relations is upheld: administrator > audit_log_viewer, administrator > can_addmodel
     - name: Controller
       list_objects:
          - user: user:co-user-1
@@ -306,12 +315,17 @@ tests:
              audit_log_viewer:
                - controller:co-controller-1
                - controller:co-controller-2
+             can_addmodel:
+               - controller:co-controller-1
+               - controller:co-controller-2
          - user: group:co-group-1#member
            type: controller
            assertions:
              administrator:
                - controller:co-controller-2
              audit_log_viewer:
+               - controller:co-controller-2
+             can_addmodel:
                - controller:co-controller-2
          - user: user:co-user-3
            type: controller
@@ -323,6 +337,22 @@ tests:
            assertions:
              audit_log_viewer:
                - controller:co-controller-2
+         - user: user:co-user-5
+           type: controller
+           assertions:
+             can_addmodel:
+               - controller:co-controller-1
+               - controller:co-controller-2
+         - user: group:co-group-3#member
+           type: controller
+           assertions:
+             can_addmodel:
+               - controller:co-controller-2
+         - user: user:co-user-6
+           type: controller
+           assertions:
+             can_addmodel:
+               - controller:co-controller-2
 
       check:
         - user: user:co-user-2
@@ -330,6 +360,7 @@ tests:
           assertions:
             audit_log_viewer: true
             administrator: false
+            can_addmodel: false
 
     # Ensures:
     # - all or individual users, as well as group members can take part in appropriate relations


### PR DESCRIPTION
## Description
This PR adds a new permission to our authorization model. Specifically, `can_addmodel` on the controller type, this fields dictates whether a user has been granted access to create models on a specific controller, much like the `can_addmodel` permission on clouds. 

This is the first step in a series of upcoming changes to allow clients to select the controller where their model will be created in JAAS.

Resolves [JUJU-8813](https://warthogs.atlassian.net/browse/JUJU-8813)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
I've updated the openfga auth model tests.


[JUJU-8813]: https://warthogs.atlassian.net/browse/JUJU-8813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ