### PR TITLE
chore: remove opcode from errors

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -336,7 +336,6 @@ func (s *Service) AddCleanup(f func() error) {
 //
 //nolint:gocognit // NewService function to be ignored.
 func NewService(ctx context.Context, p Params) (*Service, error) {
-	const op = errors.Op("NewService")
 
 	s := new(Service)
 
@@ -354,21 +353,21 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	if p.AuditLogRetentionPeriodInDays != "" {
 		retentionPeriod, err := strconv.Atoi(p.AuditLogRetentionPeriodInDays)
 		if err != nil {
-			return nil, errors.E(op, "failed to parse audit log retention period")
+			return nil, errors.E("failed to parse audit log retention period")
 		}
 		if retentionPeriod < 0 {
-			return nil, errors.E(op, "retention period cannot be less than 0")
+			return nil, errors.E("retention period cannot be less than 0")
 		}
 		jimmParameters.AuditLogRetentionDays = retentionPeriod
 	}
 
 	if p.DSN == "" {
-		return nil, errors.E(op, "missing DSN")
+		return nil, errors.E("missing DSN")
 	}
 
 	database, err := openDB(ctx, p.DSN, p.LogSQL)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	db := &db.Database{
 		DB: database,
@@ -377,23 +376,23 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	openFGAclient, err := newOpenFGAClient(ctx, p.OpenFGAParams)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	jimmParameters.OpenFGAClient = openFGAclient
 
 	if err := ensureControllerAdministrators(ctx, openFGAclient, p.ControllerUUID, p.ControllerAdmins); err != nil {
-		return nil, errors.E(op, err, "failed to ensure controller admins")
+		return nil, errors.E(err, "failed to ensure controller admins")
 	}
 
 	credentialStore, err := s.setupCredentialStore(ctx, p, db)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	jimmParameters.CredentialStore = credentialStore
 
 	sessionStore, err := s.setupSessionStore(ctx, p.CookieSessionKey, db)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	s.AddCleanup(func() error {
 		sessionStore.Close()
@@ -424,7 +423,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	)
 	jimmParameters.OAuthAuthenticator = authSvc
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to setup authentication service: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to setup authentication service: %w", err))
 	}
 
 	if p.JWTExpiryDuration == 0 {
@@ -444,14 +443,14 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	jimmParameters.MigrationTokenGenerator = authSvc
 
 	if _, err := url.Parse(p.DashboardFinalRedirectURL); err != nil {
-		return nil, errors.E(op, err, "failed to parse final redirect url for the dashboard")
+		return nil, errors.E(err, "failed to parse final redirect url for the dashboard")
 	}
 
 	jimmParameters.BootstrapLoginTokenRefreshURL = p.BootstrapLoginTokenRefreshURL
 
 	s.jimm, err = jimm.New(jimmParameters)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	s.mux = chi.NewRouter()
@@ -475,7 +474,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	rebacBackend, err := rebac_admin.SetupBackend(ctx, s.jimm)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	s.mux.Mount("/rebac", middleware.AuthenticateRebac("/rebac", rebacBackend.Handler(""), s.jimm.LoginManager()))
@@ -503,7 +502,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
 		})
 		if err != nil {
-			return nil, errors.E(op, fmt.Errorf("failed to setup authentication handler: %w", err))
+			return nil, errors.E(fmt.Errorf("failed to setup authentication handler: %w", err))
 		}
 		mountHandler(
 			jimmhttp.AuthResourceBasePath,
@@ -513,13 +512,13 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	macaroonDischarger, err := s.setupDischarger(p)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to set up discharger: %v", err))
+		return nil, errors.E(fmt.Errorf("failed to set up discharger: %v", err))
 	}
 	s.mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
 
 	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to parse public DNS name: %v", err))
+		return nil, errors.E(fmt.Errorf("failed to parse public DNS name: %v", err))
 	}
 	params := jujuapi.Params{
 		ControllerUUID: p.ControllerUUID,
@@ -626,16 +625,15 @@ func (s *Service) setupDischarger(p Params) (*discharger.MacaroonDischarger, err
 }
 
 func (s *Service) setupSessionStore(ctx context.Context, sessionSecret []byte, db *db.Database) (*pgstore.PGStore, error) {
-	const op = errors.Op("setupSessionStore")
 
 	sqlDb, err := db.DB.DB()
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	store, err := pgstore.NewPGStoreFromPool(sqlDb, sessionSecret)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to create session store: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to create session store: %w", err))
 	}
 
 	// Cleanup expired session every 30 minutes
@@ -669,7 +667,6 @@ func openDB(ctx context.Context, dsn string, logSQL bool) (*gorm.DB, error) {
 }
 
 func (s *Service) setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmcreds.CredentialStore, error) {
-	const op = errors.Op("newSecretStore")
 
 	// Only enable Postgres storage for secrets if explicitly enabled.
 	if p.InsecureSecretStorage {
@@ -679,13 +676,13 @@ func (s *Service) setupCredentialStore(ctx context.Context, p Params, db *db.Dat
 
 	vs, err := newVaultStore(ctx, p)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("vault store error: %v", err))
+		return nil, errors.E(fmt.Errorf("vault store error: %v", err))
 	}
 	if vs != nil {
 		return vs, nil
 	}
 
-	return nil, errors.E(op, "jimm cannot start without a credential store")
+	return nil, errors.E("jimm cannot start without a credential store")
 }
 
 func newVaultStore(ctx context.Context, p Params) (jimmcreds.CredentialStore, error) {
@@ -717,7 +714,7 @@ func newVaultStore(ctx context.Context, p Params) (jimmcreds.CredentialStore, er
 }
 
 func newOpenFGAClient(ctx context.Context, p OpenFGAParams) (*openfga.OFGAClient, error) {
-	const op = errors.Op("newOpenFGAClient")
+
 	cofgaClient, err := cofga.NewClient(ctx, cofga.OpenFGAParams{
 		Scheme:      p.Scheme,
 		Host:        p.Host,
@@ -727,7 +724,7 @@ func newOpenFGAClient(ctx context.Context, p OpenFGAParams) (*openfga.OFGAClient
 		AuthModelID: p.AuthModel,
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return openfga.NewOpenFGAClient(cofgaClient), nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -171,11 +171,10 @@ type AuthenticationServiceParams struct {
 // NewAuthenticationService returns a new authentication service for handling
 // authentication within JIMM.
 func NewAuthenticationService(ctx context.Context, params AuthenticationServiceParams) (*AuthenticationService, error) {
-	const op = errors.Op("auth.NewAuthenticationService")
 
 	provider, err := oidc.NewProvider(ctx, params.IssuerURL)
 	if err != nil {
-		return nil, errors.E(op, errors.CodeServerConfiguration, fmt.Errorf("failed to create oidc provider: %v", err))
+		return nil, errors.E(errors.CodeServerConfiguration, fmt.Errorf("failed to create oidc provider: %v", err))
 	}
 
 	authSvc := &AuthenticationService{
@@ -220,11 +219,11 @@ func (as *AuthenticationService) AuthCodeURL() (string, string, error) {
 	// A good reference is https://spring.io/blog/2011/11/30/cross-site-request-forgery-and-oauth2
 	// Because Hydra only accepts return addresses that have been pre-registered
 	// the risk of csrf attacks is largely eliminated, but this may not be the case with other IdPs.
-	const op = errors.Op("AuthenticationService.AuthCodeURL")
+
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", "", errors.E(op, fmt.Sprintf("failed to generate state secret: %s", err.Error()))
+		return "", "", errors.E(fmt.Sprintf("failed to generate state secret: %s", err.Error()))
 	}
 	state := base64.RawURLEncoding.EncodeToString(b)
 	return as.oauthConfig.AuthCodeURL(state), state, nil
@@ -237,7 +236,6 @@ func (as *AuthenticationService) AuthCodeURL() (string, string, error) {
 // just testing the library. The handler test essentially covers this so perhaps
 // its ok to leave it as is?
 func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
-	const op = errors.Op("auth.AuthenticationService.Exchange")
 
 	t, err := as.oauthConfig.Exchange(
 		ctx,
@@ -245,7 +243,7 @@ func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oa
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("authorisation code exchange failed: %v", err))
+		return nil, errors.E(fmt.Errorf("authorisation code exchange failed: %v", err))
 	}
 
 	return t, nil
@@ -266,14 +264,13 @@ func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oa
 //
 // The interval, expiry and device code and used to poll the token endpoint for completion.
 func (as *AuthenticationService) Device(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
-	const op = errors.Op("auth.AuthenticationService.Device")
 
 	resp, err := as.oauthConfig.DeviceAuth(
 		ctx,
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("device auth call failed: %v", err))
+		return nil, errors.E(fmt.Errorf("device auth call failed: %v", err))
 	}
 
 	return resp, nil
@@ -284,7 +281,6 @@ func (as *AuthenticationService) Device(ctx context.Context) (*oauth2.DeviceAuth
 //
 // See Device(...) godoc for more info pertaining to the flow.
 func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oauth2.DeviceAuthResponse) (*oauth2.Token, error) {
-	const op = errors.Op("auth.AuthenticationService.DeviceAccessToken")
 
 	t, err := as.oauthConfig.DeviceAccessToken(
 		ctx,
@@ -292,7 +288,7 @@ func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oau
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("device access token call failed: %v", err))
+		return nil, errors.E(fmt.Errorf("device access token call failed: %v", err))
 	}
 
 	return t, nil
@@ -301,12 +297,11 @@ func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oau
 // ExtractAndVerifyIDToken extracts the id token from the extras claims of an oauth2 token
 // and performs signature verification of the token.
 func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oauth2Token *oauth2.Token) (*oidc.IDToken, error) {
-	const op = errors.Op("auth.AuthenticationService.ExtractAndVerifyIDToken")
 
 	// Extract the ID Token from oauth2 token.
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		return nil, errors.E(op, "failed to extract id token")
+		return nil, errors.E("failed to extract id token")
 	}
 
 	verifier := as.provider.Verifier(&oidc.Config{
@@ -315,7 +310,7 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to verify id token: %v", err))
+		return nil, errors.E(fmt.Errorf("failed to verify id token: %v", err))
 	}
 
 	return token, nil
@@ -323,18 +318,17 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 
 // Email retrieves the users email from an id token via the email claim
 func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
-	const op = errors.Op("auth.AuthenticationService.Email")
 
 	var claims struct {
 		Email         string `json:"email"`
 		EmailVerified bool   `json:"email_verified"` // TODO(ale8k): Add verification logic
 	}
 	if idToken == nil {
-		return "", errors.E(op, "id token is nil")
+		return "", errors.E("id token is nil")
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to extract claims: %v", err))
+		return "", errors.E(fmt.Errorf("failed to extract claims: %v", err))
 	}
 
 	return claims.Email, nil
@@ -343,19 +337,18 @@ func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
 // MintSessionToken mints a session token to be used when logging into JIMM
 // via an access token. The token only contains the user's email for authentication.
 func (as *AuthenticationService) MintSessionToken(email string) (string, error) {
-	const op = errors.Op("auth.AuthenticationService.MintAccessToken")
 
 	token, err := jwt.NewBuilder().
 		Subject(email).
 		Expiration(time.Now().Add(as.sessionTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to build access token: %v", err))
+		return "", errors.E(fmt.Errorf("failed to build access token: %v", err))
 	}
 
 	freshToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to sign access token: %v", err))
+		return "", errors.E(fmt.Errorf("failed to sign access token: %v", err))
 	}
 
 	return base64.StdEncoding.EncodeToString(freshToken), nil
@@ -369,19 +362,18 @@ func (as *AuthenticationService) MintSessionToken(email string) (string, error) 
 // this as a separate method from `MintSessionToken` allows for future changes to
 // the migration token without affecting the session token.
 func (as *AuthenticationService) NewMigrationToken(ctx context.Context, username string) (string, error) {
-	const op = errors.Op("auth.AuthenticationService.MintMigrationToken")
 
 	token, err := jwt.NewBuilder().
 		Subject(username).
 		Expiration(time.Now().Add(migrationTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to mint migration token: %v", err))
+		return "", errors.E(fmt.Errorf("failed to mint migration token: %v", err))
 	}
 
 	migrationToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to sign migration token: %v", err))
+		return "", errors.E(fmt.Errorf("failed to sign migration token: %v", err))
 	}
 
 	return base64.StdEncoding.EncodeToString(migrationToken), nil
@@ -396,9 +388,9 @@ func (as *AuthenticationService) NewMigrationToken(ctx context.Context, username
 // The error code returned here is used by the Juju CLI to know when to start a
 // device login flow, prompting the user to login again.
 func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, err error) {
-	const op = errors.Op("auth.AuthenticationService.VerifySessionToken")
+
 	errorFn := func(message string) error {
-		return errors.E(op, message, errors.CodeSessionTokenInvalid)
+		return errors.E(message, errors.CodeSessionTokenInvalid)
 	}
 	defer func() {
 		if err != nil {
@@ -435,14 +427,13 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 // UpdateIdentity updates the database with the display name and access token set for the user.
 // And, if present, a refresh token.
 func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email string, token *oauth2.Token) error {
-	const op = errors.Op("auth.UpdateIdentity")
 
 	db := as.db
 
 	// TODO(ale8k): Add test case for this
 	u, err := dbmodel.NewIdentity(email)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// TODO(babakks): If user does not exist, we will create one with an empty
@@ -451,7 +442,7 @@ func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email strin
 	// this should be changed and split apart so it is intentional what entities
 	// we are creating or fetching.
 	if err := db.GetIdentity(ctx, u); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	u.AccessToken = token.AccessToken
@@ -459,7 +450,7 @@ func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email strin
 	u.AccessTokenExpiry = token.Expiry
 	u.AccessTokenType = token.TokenType
 	if err := db.UpdateIdentity(ctx, u); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -509,11 +500,10 @@ func (as *AuthenticationService) CreateBrowserSession(
 	r *http.Request,
 	email string,
 ) error {
-	const op = errors.Op("auth.AuthenticationService.CreateBrowserSession")
 
 	session, err := as.sessionStore.Get(r, SessionName)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	session.IsNew = true                            // Sets cookie to a fresh new cookie
@@ -522,7 +512,7 @@ func (as *AuthenticationService) CreateBrowserSession(
 
 	session.Values[SessionIdentityKey] = email
 	if err = session.Save(r, w); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -531,7 +521,7 @@ func (as *AuthenticationService) CreateBrowserSession(
 // retrieving new access tokens upon expiry. If this cannot be done, the cookie
 // is deleted and an error is returned.
 func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context, w http.ResponseWriter, req *http.Request) (_ context.Context, err error) {
-	const op = errors.Op("auth.AuthenticationService.AuthenticateBrowserSession")
+
 	defer func() {
 		if err != nil {
 			servermon.AuthenticationFailCount.WithLabelValues("AuthenticateBrowserSession").Inc()
@@ -542,26 +532,26 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return ctx, errors.E(op, fmt.Errorf("failed to retrieve session: %v", err))
+		return ctx, errors.E(fmt.Errorf("failed to retrieve session: %v", err))
 	}
 	session = sessionCrossOriginSafe(session, as.secureCookies)
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		return ctx, errors.E(op, errors.CodeForbidden, "session is missing identity key")
+		return ctx, errors.E(errors.CodeForbidden, "session is missing identity key")
 	}
 
 	err = as.validateAndUpdateAccessToken(ctx, identityId)
 	if err != nil {
 		// If the user's access token AND refresh token have expired
 		// then we will fail authentication here.
-		return ctx, errors.E(op, fmt.Errorf("failed to validate and update status token: %v", err))
+		return ctx, errors.E(fmt.Errorf("failed to validate and update status token: %v", err))
 	}
 
 	ctx = ContextWithSessionIdentity(ctx, identityId)
 
 	if err := as.extendSession(session, w, req); err != nil {
-		return ctx, errors.E(op, err)
+		return ctx, errors.E(err)
 	}
 
 	return ctx, nil
@@ -573,25 +563,24 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 //     the expired session upon next run.
 //   - It resets the access tokens for this user
 func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
-	const op = errors.Op("auth.AuthenticationService.Logout")
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to retrieve session: %v", err))
+		return errors.E(fmt.Errorf("failed to retrieve session: %v", err))
 	}
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		return errors.E(op, "session is missing identity key")
+		return errors.E("session is missing identity key")
 	}
 
 	identityIdStr, ok := identityId.(string)
 	if !ok {
-		return errors.E(op, fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
+		return errors.E(fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
-		return errors.E(op, fmt.Errorf("failed to delete session: %v", err))
+		return errors.E(fmt.Errorf("failed to delete session: %v", err))
 	}
 
 	if err := as.UpdateIdentity(ctx, identityIdStr, &oauth2.Token{
@@ -600,7 +589,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 		Expiry:       time.Now(),
 		TokenType:    "",
 	}); err != nil {
-		return errors.E(op, fmt.Errorf("failed to update identity: %v", err))
+		return errors.E(fmt.Errorf("failed to update identity: %v", err))
 	}
 
 	return nil
@@ -610,21 +599,20 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 // according to the current database schema for identities. This is likely subject
 // to change in the future.
 func (as *AuthenticationService) Whoami(ctx context.Context) (*params.WhoamiResponse, error) {
-	const op = errors.Op("auth.AuthenticationService.Whoami")
 
 	identityId := SessionIdentityFromContext(ctx)
 	if identityId == "" {
-		return nil, errors.E(op, "no identity in context")
+		return nil, errors.E("no identity in context")
 	}
 
 	// TODO(ale8k) CSS-8227: Add test case for this
 	u, err := dbmodel.NewIdentity(identityId)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	if err := as.db.GetIdentity(ctx, u); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return &params.WhoamiResponse{
@@ -637,11 +625,10 @@ func (as *AuthenticationService) Whoami(ctx context.Context) (*params.WhoamiResp
 // validateAndUpdateAccessToken validates the access tokens expiry, and if it cannot, then
 // it attempts to refresh the access token.
 func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Context, email any) error {
-	const op = errors.Op("auth.AuthenticationService.validateAndUpdateAccessToken")
 
 	emailStr, ok := email.(string)
 	if !ok {
-		return errors.E(op, fmt.Sprintf("failed to cast email: got %T, expected %T", email, emailStr))
+		return errors.E(fmt.Sprintf("failed to cast email: got %T, expected %T", email, emailStr))
 	}
 
 	db := as.db
@@ -649,11 +636,11 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 	// TODO(ale8k) CSS-8228: Add test case for this
 	u, err := dbmodel.NewIdentity(emailStr)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := db.GetIdentity(ctx, u); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	t := &oauth2.Token{
@@ -670,7 +657,7 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 	}
 
 	if err := as.refreshIdentitiesToken(ctx, emailStr, t); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -681,50 +668,46 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 //
 // This is to be called only when a token is expired.
 func (as *AuthenticationService) refreshIdentitiesToken(ctx context.Context, email string, t *oauth2.Token) error {
-	const op = errors.Op("auth.AuthenticationService.refreshIdentitiesToken")
 
 	tSrc := as.oauthConfig.TokenSource(ctx, t)
 
 	// Get a new access and refresh token (token source only has Token())
 	newToken, err := tSrc.Token()
 	if err != nil {
-		return errors.E(op, err, fmt.Errorf("failed to refresh token: %w", err))
+		return errors.E(err, fmt.Errorf("failed to refresh token: %w", err))
 	}
 
 	if err := as.UpdateIdentity(ctx, email, newToken); err != nil {
-		return errors.E(op, err, fmt.Errorf("failed to update identity: %w", err))
+		return errors.E(err, fmt.Errorf("failed to update identity: %w", err))
 	}
 
 	return nil
 }
 
 func (as *AuthenticationService) deleteSession(session *sessions.Session, w http.ResponseWriter, req *http.Request) error {
-	const op = errors.Op("auth.AuthenticationService.deleteSession")
 
 	if err := as.modifySession(session, w, req, -1); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
 }
 
 func (as *AuthenticationService) extendSession(session *sessions.Session, w http.ResponseWriter, req *http.Request) error {
-	const op = errors.Op("auth.AuthenticationService.extendSession")
 
 	if err := as.modifySession(session, w, req, as.sessionCookieMaxAge); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
 }
 
 func (as *AuthenticationService) modifySession(session *sessions.Session, w http.ResponseWriter, req *http.Request, maxAge int) error {
-	const op = errors.Op("auth.AuthenticationService.modifySession")
 
 	session.Options.MaxAge = maxAge
 
 	if err := session.Save(req, w); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -18,9 +18,9 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -40,9 +40,9 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 	db := d.DB.WithContext(ctx)
 
 	switch {
@@ -73,9 +73,9 @@ func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.Ap
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -97,9 +97,9 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Table("application_offers AS offers")

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -12,10 +12,10 @@ import (
 
 // AddApplicationOffer stores the application offer information.
 func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
-	const op = errors.Op("db.AddApplicationOffer")
+	const op = "db.AddApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -26,7 +26,7 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 
 	result := db.Create(offer)
 	if result.Error != nil {
-		return errors.E(op, dbError(result.Error))
+		return errors.E(dbError(result.Error))
 	}
 	return nil
 }
@@ -34,10 +34,10 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 // GetApplicationOffer returns application offer information based on the
 // offer UUID or URL.
 func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
-	const op = errors.Op("db.GetApplicationOffer")
+	const op = "db.GetApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -51,26 +51,26 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	case offer.URL != "":
 		db = db.Where("url = ?", offer.URL)
 	default:
-		return errors.E(op, "missing offer UUID or URL")
+		return errors.E("missing offer UUID or URL")
 	}
 
 	db = db.Preload("Model").Preload("Model.Controller")
 	if err := db.First(&offer).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "application offer not found")
+			return errors.E(err, "application offer not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // DeleteApplicationOffer deletes the application offer.
 func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
-	const op = errors.Op("db.DeleteApplicationOffer")
+	const op = "db.DeleteApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -81,20 +81,20 @@ func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.Ap
 
 	result := db.Delete(offer)
 	if result.Error != nil {
-		return errors.E(op, dbError(result.Error))
+		return errors.E(dbError(result.Error))
 	}
 	return nil
 }
 
 // FindApplicationOffersByModel returns all application offers in a model specified by model name and owner.
 func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, modelOwner string) (_ []dbmodel.ApplicationOffer, err error) {
-	const op = errors.Op("db.FindApplicationOfferByModel")
+	const op = "db.FindApplicationOfferByModel"
 
 	if modelName == "" || modelOwner == "" {
-		return nil, errors.E(op, errors.CodeBadRequest, "model name or owner not specified")
+		return nil, errors.E(errors.CodeBadRequest, "model name or owner not specified")
 	}
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -111,14 +111,14 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 	var offers []dbmodel.ApplicationOffer
 	result := db.Preload("Model").Find(&offers)
 	if result.Error != nil {
-		return nil, errors.E(op, dbError(result.Error))
+		return nil, errors.E(dbError(result.Error))
 	}
 
 	for i, offer := range offers {
 		offer := offer
 		err := d.GetApplicationOffer(ctx, &offer)
 		if err != nil {
-			return nil, errors.E(op, dbError(err))
+			return nil, errors.E(dbError(err))
 		}
 		offers[i] = offer
 	}

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -19,9 +19,9 @@ func (d *Database) AddAuditLogEntry(ctx context.Context, ale *dbmodel.AuditLogEn
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Create(ale).Error; err != nil {
 		return errors.E(dbError(err))
@@ -75,9 +75,9 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx).Model(&dbmodel.AuditLogEntry{})
 	if !filter.Start.IsZero() {
@@ -134,9 +134,9 @@ func (d *Database) DeleteAuditLogsBefore(ctx context.Context, before time.Time) 
 		return 0, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	tx := d.DB.
 		WithContext(ctx).

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -13,10 +13,10 @@ import (
 
 // AddAuditLogEntry adds a new entry to the audit log.
 func (d *Database) AddAuditLogEntry(ctx context.Context, ale *dbmodel.AuditLogEntry) (err error) {
-	const op = errors.Op("db.AddAuditLogEntry")
+	const op = "db.AddAuditLogEntry"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -24,7 +24,7 @@ func (d *Database) AddAuditLogEntry(ctx context.Context, ale *dbmodel.AuditLogEn
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if err := d.DB.WithContext(ctx).Create(ale).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -70,9 +70,9 @@ type AuditLogFilter struct {
 // the given filter calling f for each entry. If f returns an error
 // iteration stops immediately and the error is retuned unmodified.
 func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilter, f func(*dbmodel.AuditLogEntry) error) (err error) {
-	const op = errors.Op("db.ForEachAuditLogEntry")
+	const op = "db.ForEachAuditLogEntry"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -107,20 +107,20 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 
 	rows, err := db.Rows()
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var ale dbmodel.AuditLogEntry
 		if err := db.ScanRows(rows, &ale); err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		if err := f(&ale); err != nil {
 			return err
 		}
 	}
 	if rows.Err() != nil {
-		return errors.E(op, rows.Err())
+		return errors.E(rows.Err())
 	}
 	return nil
 }
@@ -128,10 +128,10 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 // CleanupAuditLogs cleans up audit logs after the auditLogRetentionPeriodInDays,
 // HARD deleting them from the database.
 func (d *Database) DeleteAuditLogsBefore(ctx context.Context, before time.Time) (_ int64, err error) {
-	const op = errors.Op("db.DeleteAuditLogsBefore")
+	const op = "db.DeleteAuditLogsBefore"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -144,7 +144,7 @@ func (d *Database) DeleteAuditLogsBefore(ctx context.Context, before time.Time) 
 		Where("time < ?", before).
 		Delete(&dbmodel.AuditLogEntry{})
 	if tx.Error != nil {
-		return 0, errors.E(op, dbError(tx.Error))
+		return 0, errors.E(dbError(tx.Error))
 	}
 	return tx.RowsAffected, nil
 }

--- a/internal/db/bootstrap_lock.go
+++ b/internal/db/bootstrap_lock.go
@@ -17,7 +17,6 @@ import (
 // LockBootstrap acquires the bootstrap lock for controller bootstrap operations.
 // It returns an error if the lock cannot be acquired.
 func (d *Database) LockBootstrap(ctx context.Context, ttl time.Duration) error {
-	op := errors.Op("db.LockBootstrap")
 	err := d.Transaction(func(tx *Database) error {
 		lock := &dbmodel.BootstrapLock{}
 		// This is equivalent to a SELECT FOR UPDATE in SQL,
@@ -38,7 +37,7 @@ func (d *Database) LockBootstrap(ctx context.Context, ttl time.Duration) error {
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -46,7 +45,6 @@ func (d *Database) LockBootstrap(ctx context.Context, ttl time.Duration) error {
 // UnlockBootstrap releases the bootstrap lock for controller bootstrap operations.
 // It returns an error if the lock was not held or could not be released.
 func (d *Database) UnlockBootstrap(ctx context.Context) error {
-	op := errors.Op("db.LockBootstrap")
 	err := d.Transaction(func(tx *Database) error {
 		lock := &dbmodel.BootstrapLock{}
 		if err := tx.DB.First(lock).Error; err != nil {
@@ -63,7 +61,7 @@ func (d *Database) UnlockBootstrap(ctx context.Context) error {
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -17,9 +17,9 @@ import (
 // with a code of CodeAlreadyExists if there is already a cloud with the
 // same name.
 func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
-	const op = errors.Op("db.AddCloud")
+	const op = "db.AddCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -30,9 +30,9 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.Create(c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(op, fmt.Sprintf("cloud %q already exists", c.Name), err)
+			return errors.E(fmt.Sprintf("cloud %q already exists", c.Name), err)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -41,9 +41,9 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 // no cloud is found with the matching name then an error with a code of
 // CodeNotFound will be returned.
 func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
-	const op = errors.Op("db.GetCloud")
+	const op = "db.GetCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -56,18 +56,18 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.First(&c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, fmt.Sprintf("cloud %q not found", c.Name), err)
+			return errors.E(fmt.Sprintf("cloud %q not found", c.Name), err)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // GetClouds retrieves all the clouds from the database.
 func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error) {
-	const op = errors.Op("db.GetClouds")
+	const op = "db.GetClouds"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -78,7 +78,7 @@ func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error)
 	db := d.DB.WithContext(ctx)
 	db = preloadCloud("", db)
 	if err := db.Find(&clouds).Error; err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return clouds, nil
 }
@@ -87,9 +87,9 @@ func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error)
 // given cloud. UpdateCloud does not update any user information, nor does
 // it remove any information - this is an additive method.
 func (d *Database) UpdateCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
-	const op = errors.Op("db.UpdateCloud")
+	const op = "db.UpdateCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -115,7 +115,7 @@ func (d *Database) UpdateCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -132,9 +132,9 @@ func preloadCloud(prefix string, db *gorm.DB) *gorm.DB {
 // returns an error with a code of CodeAlreadyExists if there is already a
 // region with the same name on the cloud.
 func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) (err error) {
-	const op = errors.Op("db.AddCloudRegion")
+	const op = "db.AddCloudRegion"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -145,9 +145,9 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 	if err := db.Create(cr).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(op, fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
+			return errors.E(fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -155,9 +155,9 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 // FindRegionByCloudType finds a region with the given name on a cloud with the given
 // cloud type.
 func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regionName string) (_ *dbmodel.CloudRegion, err error) {
-	const op = errors.Op("db.FindRegion")
+	const op = "db.FindRegion"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -170,7 +170,7 @@ func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regi
 
 	var region dbmodel.CloudRegion
 	if err := db.First(&region).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return &region, nil
 }
@@ -178,9 +178,9 @@ func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regi
 // FindRegionByCloudName finds a region with the given name on a cloud with the given
 // name.
 func (d *Database) FindRegionByCloudName(ctx context.Context, cloudName, regionName string) (_ *dbmodel.CloudRegion, err error) {
-	const op = errors.Op("db.FindRegion")
+	const op = "db.FindRegion"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -193,17 +193,17 @@ func (d *Database) FindRegionByCloudName(ctx context.Context, cloudName, regionN
 
 	var region dbmodel.CloudRegion
 	if err := db.First(&region).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return &region, nil
 }
 
 // DeleteCloud deletes the given cloud.
 func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
-	const op = errors.Op("db.DeleteCloud")
+	const op = "db.DeleteCloud"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -212,17 +212,17 @@ func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // DeleteCloudRegionControllerPriority deletes the given cloud region controller priority entry.
 func (d *Database) DeleteCloudRegionControllerPriority(ctx context.Context, c *dbmodel.CloudRegionControllerPriority) (err error) {
-	const op = errors.Op("db.DeleteCloudRegionControllerPriority")
+	const op = "db.DeleteCloudRegionControllerPriority"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -231,7 +231,7 @@ func (d *Database) DeleteCloudRegionControllerPriority(ctx context.Context, c *d
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -22,9 +22,9 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Create(c).Error; err != nil {
@@ -46,9 +46,9 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Where("name = ?", c.Name)
@@ -70,9 +70,9 @@ func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error)
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var clouds []dbmodel.Cloud
 	db := d.DB.WithContext(ctx)
@@ -92,9 +92,9 @@ func (d *Database) UpdateCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	err = d.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Save(c).Error; err != nil {
@@ -137,9 +137,9 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Create(cr).Error; err != nil {
@@ -160,9 +160,9 @@ func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regi
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("Cloud").Preload("Controllers").Preload("Controllers.Controller")
@@ -183,9 +183,9 @@ func (d *Database) FindRegionByCloudName(ctx context.Context, cloudName, regionN
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("Cloud").Preload("Controllers").Preload("Controllers.Controller")
@@ -206,9 +206,9 @@ func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {
@@ -225,9 +225,9 @@ func (d *Database) DeleteCloudRegionControllerPriority(ctx context.Context, c *d
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -20,9 +20,9 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
 		return errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
@@ -50,9 +50,9 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
 		return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
@@ -81,9 +81,9 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Model(dbmodel.CloudCredential{})
@@ -115,9 +115,9 @@ func (d *Database) DeleteCloudCredential(ctx context.Context, cred *dbmodel.Clou
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(cred).Error; err != nil {

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -15,9 +15,9 @@ import (
 
 // SetCloudCredential upserts the cloud credential information.
 func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCredential) (err error) {
-	const op = errors.Op("db.SetCloudCredential")
+	const op = "db.SetCloudCredential"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -25,7 +25,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -37,7 +37,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 		},
 		DoUpdates: clause.AssignmentColumns([]string{"auth_type", "label", "valid"}),
 	}).Create(&cred).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -45,9 +45,9 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 // GetCloudCredential returns cloud credential information based on the
 // cloud, owner and name.
 func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCredential) (err error) {
-	const op = errors.Op("db.GetCloudCredential")
+	const op = "db.GetCloudCredential"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -55,7 +55,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
+		return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
 	}
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("Cloud")
@@ -63,9 +63,9 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	if err := db.Where("cloud_name = ? AND owner_identity_name = ? AND name = ?", cred.CloudName, cred.OwnerIdentityName, cred.Name).First(&cred).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), err)
+			return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), err)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -75,10 +75,10 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 // specified then the cloud-credentials are filtered to only return
 // credentials for that cloud.
 func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, cloud string, f func(*dbmodel.CloudCredential) error) (err error) {
-	const op = errors.Op("db.ForEachCloudCredential")
+	const op = "db.ForEachCloudCredential"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -96,7 +96,7 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 
 	var creds []dbmodel.CloudCredential
 	if err := db.Find(&creds).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	for _, c := range creds {
 		if err := f(&c); err != nil {
@@ -109,10 +109,10 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 
 // DeleteCloudCredential removes the given CloudCredential from the database.
 func (d *Database) DeleteCloudCredential(ctx context.Context, cred *dbmodel.CloudCredential) (err error) {
-	const op = errors.Op("db.DeleteCloudCredential")
+	const op = "db.DeleteCloudCredential"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -122,7 +122,7 @@ func (d *Database) DeleteCloudCredential(ctx context.Context, cred *dbmodel.Clou
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(cred).Error; err != nil {
 		err = dbError(err)
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -21,9 +21,9 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	err = d.Transaction(func(d *Database) error {
 		db := d.DB.WithContext(ctx)
@@ -79,9 +79,9 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	err = d.Transaction(func(d *Database) error {
 		db := d.DB.WithContext(ctx)
@@ -130,9 +130,9 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -164,9 +164,9 @@ func (d *Database) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Iden
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -15,10 +15,10 @@ import (
 
 // SetCloudDefaults sets default model setting values for the specified cloud/region.
 func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.CloudDefaults) (err error) {
-	const op = errors.Op("db.SetCloudDefaults")
+	const op = "db.SetCloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -42,11 +42,11 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				// if defaults do not exist, we create them
 				if err := db.Create(&defaults).Error; err != nil {
-					return errors.E(op, dbError(err))
+					return errors.E(dbError(err))
 				}
 				return nil
 			}
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		// update defaults
@@ -61,22 +61,22 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 			},
 			DoUpdates: clause.AssignmentColumns([]string{"defaults"}),
 		}).Create(&dbDefaults).Error; err != nil {
-			return errors.E(op, dbError(err))
+			return errors.E(dbError(err))
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // UnsetCloudDefaults unsets default model setting values for the specified cloud/region.
 func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.CloudDefaults, keys []string) (err error) {
-	const op = errors.Op("db.UpsertCloudDefaults")
+	const op = "db.UpsertCloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -97,7 +97,7 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 		// try to fetch cloud defaults from the db
 		err := d.CloudDefaults(ctx, &dbDefaults)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		// update defaults
@@ -112,22 +112,22 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 			},
 			DoUpdates: clause.AssignmentColumns([]string{"defaults"}),
 		}).Create(&dbDefaults).Error; err != nil {
-			return errors.E(op, dbError(err))
+			return errors.E(dbError(err))
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // CloudDefaults fetches cloud defaults based on user, cloud name or id and region name.
 func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDefaults) (err error) {
-	const op = errors.Op("db.CloudDefaults")
+	const op = "db.CloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -149,19 +149,19 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 	if result.Error != nil {
 		err := dbError(result.Error)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, errors.CodeNotFound, "cloudregiondefaults not found", err)
+			return errors.E(errors.CodeNotFound, "cloudregiondefaults not found", err)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // ModelDefaultsForCloud returns the default config values for the specified cloud.
 func (d *Database) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloud names.CloudTag) (_ []dbmodel.CloudDefaults, err error) {
-	const op = errors.Op("db.ModelDefaultsForCloud")
+	const op = "db.ModelDefaultsForCloud"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -177,7 +177,7 @@ func (d *Database) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Iden
 	var defaults []dbmodel.CloudDefaults
 	result := db.Preload("Identity").Preload("Cloud").Find(&defaults)
 	if result.Error != nil {
-		return nil, errors.E(op, dbError(result.Error))
+		return nil, errors.E(dbError(result.Error))
 	}
 	return defaults, nil
 }

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -14,9 +14,9 @@ import (
 
 // AddController stores the controller information.
 func (d *Database) AddController(ctx context.Context, controller *dbmodel.Controller) (err error) {
-	const op = errors.Op("db.AddController")
+	const op = "db.AddController"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -26,7 +26,7 @@ func (d *Database) AddController(ctx context.Context, controller *dbmodel.Contro
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(controller).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -34,9 +34,9 @@ func (d *Database) AddController(ctx context.Context, controller *dbmodel.Contro
 // GetController returns controller information based on the
 // controller UUID or name.
 func (d *Database) GetController(ctx context.Context, controller *dbmodel.Controller) (err error) {
-	const op = errors.Op("db.GetController")
+	const op = "db.GetController"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -51,15 +51,15 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 	case controller.Name != "":
 		db = db.Where("name = ?", controller.Name)
 	default:
-		return errors.E(op, errors.CodeBadRequest, "controller UUID or name must be provided")
+		return errors.E(errors.CodeBadRequest, "controller UUID or name must be provided")
 	}
 	db = db.Preload("CloudRegions").Preload("CloudRegions.CloudRegion").Preload("CloudRegions.CloudRegion.Cloud")
 	if err := db.First(&controller).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "controller not found")
+			return errors.E(err, "controller not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -67,14 +67,14 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 // UpdateController updates the given controller record. UpdateController will not store any
 // changes to a controller's CloudRegions or Models.
 func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Controller) (err error) {
-	const op = errors.Op("db.UpdateController")
+	const op = "db.UpdateController"
 
 	if controller.ID == 0 {
-		return errors.E(op, errors.CodeNotFound, `controller not found`)
+		return errors.E(errors.CodeNotFound, `controller not found`)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -84,20 +84,20 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 	db := d.DB.WithContext(ctx)
 	db = db.Omit("CloudRegions").Omit("Models")
 	if err := db.Save(controller).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // DeleteController removes the specified controller from the database.
 func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Controller) (err error) {
-	const op = errors.Op("db.DeleteController")
+	const op = "db.DeleteController"
 	if controller.ID == 0 {
-		return errors.E(op, errors.CodeNotFound, `controller not found`)
+		return errors.E(errors.CodeNotFound, `controller not found`)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -108,12 +108,12 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 	if err := db.Delete(controller).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "controller not found")
+			return errors.E(err, "controller not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if err := db.Select(clause.Associations).Delete(controller).Error; err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -122,10 +122,10 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 // for each one. If the given function returns an error the iteration
 // will stop immediately and the error will be returned unmodified.
 func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Controller) error) (err error) {
-	const op = errors.Op("db.ForEachController")
+	const op = "db.ForEachController"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -137,7 +137,7 @@ func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Contro
 
 	var controllers []dbmodel.Controller
 	if err := db.Order("name asc").Find(&controllers).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	for _, c := range controllers {
 		if err := f(&c); err != nil {
@@ -152,10 +152,10 @@ func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Contro
 // function returns an error the iteration will stop immediately and the
 // error will be returned unmodified.
 func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Controller, f func(m *dbmodel.Model) error) (err error) {
-	const op = errors.Op("db.ForEachControllerModel")
+	const op = "db.ForEachControllerModel"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -165,7 +165,7 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 	var models []dbmodel.Model
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(ctl).Association("Models").Find(&models); err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	for _, m := range models {
 		if err := f(&m); err != nil {

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -19,9 +19,9 @@ func (d *Database) AddController(ctx context.Context, controller *dbmodel.Contro
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -39,9 +39,9 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -77,9 +77,9 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Omit("CloudRegions").Omit("Models")
@@ -100,9 +100,9 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(controller).Error; err != nil {
@@ -128,9 +128,9 @@ func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Contro
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("CloudRegions").Preload("CloudRegions.CloudRegion").Preload("CloudRegions.CloudRegion.Cloud")
@@ -158,9 +158,9 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var models []dbmodel.Model
 	db := d.DB.WithContext(ctx)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -67,7 +67,6 @@ func (d *Database) Transaction(f func(*Database) error) error {
 // by the current data model. If the database is not configured then an error
 // with a code of errors.CodeServerConfiguration will be returned.
 func (d *Database) Migrate(ctx context.Context) error {
-	const op = "db.Migrate"
 	if d == nil || d.DB == nil {
 		return errors.E(errors.CodeServerConfiguration, "database not configured")
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -67,14 +67,14 @@ func (d *Database) Transaction(f func(*Database) error) error {
 // by the current data model. If the database is not configured then an error
 // with a code of errors.CodeServerConfiguration will be returned.
 func (d *Database) Migrate(ctx context.Context) error {
-	const op = errors.Op("db.Migrate")
+	const op = "db.Migrate"
 	if d == nil || d.DB == nil {
-		return errors.E(op, errors.CodeServerConfiguration, "database not configured")
+		return errors.E(errors.CodeServerConfiguration, "database not configured")
 	}
 
 	err := d.migrateFromSource(ctx, dbmodel.SQL, path.Join("sql", d.DB.Name()))
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -16,9 +16,9 @@ var newUUID = uuid.NewString
 
 // AddGroup adds a new group.
 func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.GroupEntry, err error) {
-	const op = errors.Op("db.AddGroup")
+	const op = "db.AddGroup"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -31,16 +31,16 @@ func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.Group
 	}
 
 	if err := d.DB.WithContext(ctx).Create(ge).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return ge, nil
 }
 
 // CountGroups returns a count of the number of groups that exist.
 func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
-	const op = errors.Op("db.CountGroups")
+	const op = "db.CountGroups"
 	if err := d.ready(); err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
@@ -49,7 +49,7 @@ func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 	var c int64
 	var g dbmodel.GroupEntry
 	if err := d.DB.WithContext(ctx).Model(g).Count(&c).Error; err != nil {
-		return 0, errors.E(op, dbError(err))
+		return 0, errors.E(dbError(err))
 	}
 	count = int(c)
 	return count, nil
@@ -57,13 +57,13 @@ func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 
 // GetGroup returns a GroupEntry with the specified name.
 func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err error) {
-	const op = errors.Op("db.GetGroup")
+	const op = "db.GetGroup"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if group.UUID == "" && group.Name == "" {
-		return errors.E(op, "must specify uuid or name")
+		return errors.E("must specify uuid or name")
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -81,7 +81,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 		db = db.Where("name = ?", group.Name)
 	}
 	if err := db.First(&group).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -89,9 +89,9 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 // ListGroups returns a paginated list of groups defined by limit and offset.
 // match is used to fuzzy find based on entries' name or uuid using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
-	const op = errors.Op("db.ListGroups")
+	const op = "db.ListGroups"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -111,21 +111,21 @@ func (d *Database) ListGroups(ctx context.Context, limit, offset int, match stri
 	}
 	var groups []dbmodel.GroupEntry
 	if err := db.Find(&groups).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return groups, nil
 }
 
 // UpdateGroupName updates the name of the group identified by its UUID.
 func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err error) {
-	const op = errors.Op("db.UpdateGroup")
+	const op = "db.UpdateGroup"
 
 	if uuid == "" {
-		return errors.E(op, "uuid must be specified")
+		return errors.E("uuid must be specified")
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -135,21 +135,21 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 	model := d.DB.WithContext(ctx).Model(&dbmodel.GroupEntry{})
 	model.Where("uuid = ?", uuid)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, "group not found")
+		return errors.E(errors.CodeNotFound, "group not found")
 	}
 	return nil
 }
 
 // RemoveGroup removes the group identified by its ID.
 func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (err error) {
-	const op = errors.Op("db.RemoveGroup")
+	const op = "db.RemoveGroup"
 
 	if group.ID == 0 && group.UUID == "" {
 		return errors.E("neither UUID or ID specified", errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -157,7 +157,7 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if err := d.DB.WithContext(ctx).Delete(group).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -21,9 +21,9 @@ func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.Group
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	ge = &dbmodel.GroupEntry{
 		Name: name,
@@ -42,9 +42,9 @@ func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 	if err := d.ready(); err != nil {
 		return 0, errors.E(err)
 	}
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var c int64
 	var g dbmodel.GroupEntry
@@ -66,9 +66,9 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 		return errors.E("must specify uuid or name")
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if group.ID != 0 {
@@ -94,9 +94,9 @@ func (d *Database) ListGroups(ctx context.Context, limit, offset int, match stri
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
@@ -128,9 +128,9 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	model := d.DB.WithContext(ctx).Model(&dbmodel.GroupEntry{})
 	model.Where("uuid = ?", uuid)
@@ -152,9 +152,9 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Delete(group).Error; err != nil {
 		return errors.E(dbError(err))

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -34,9 +34,9 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	result := d.DB.WithContext(ctx).Clauses(clause.OnConflict{
 		DoNothing: true,
@@ -74,9 +74,9 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("name = ?", u.Name).First(&u).Error; err != nil {
@@ -97,9 +97,9 @@ func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if u.Name == "" {
 		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
@@ -125,9 +125,9 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var credentials []dbmodel.CloudCredential
 	db := d.DB.WithContext(ctx)
@@ -145,9 +145,9 @@ func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
@@ -175,9 +175,9 @@ func (d *Database) CountIdentities(ctx context.Context) (_ int, err error) {
 		return 0, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	var count int64

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -24,14 +24,14 @@ import (
 //
 // GetIdentity returns an error with CodeNotFound if the identity name is invalid.
 func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err error) {
-	const op = errors.Op("db.GetIdentity")
+	const op = "db.GetIdentity"
 
 	if u.Name == "" {
-		return errors.E(op, errors.CodeNotFound, `invalid identity name ""`)
+		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -42,7 +42,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 		DoNothing: true,
 	}).Create(&u)
 	if result.Error != nil {
-		return errors.E(op, result.Error)
+		return errors.E(result.Error)
 	}
 
 	// Check if a new identity was created.
@@ -53,7 +53,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 
 	// If we didn't create it, it must exist (or we raced and lost). Fetch it.
 	if err = d.DB.WithContext(ctx).Where("name = ?", u.Name).First(&u).Error; err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -64,14 +64,14 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 //
 // FetchIdentity returns an error with CodeNotFound if the identity name is invalid.
 func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err error) {
-	const op = errors.Op("db.FetchIdentity")
+	const op = "db.FetchIdentity"
 
 	if u.Name == "" {
-		return errors.E(op, errors.CodeNotFound, `invalid identity name ""`)
+		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -80,7 +80,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("name = ?", u.Name).First(&u).Error; err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -92,9 +92,9 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 // UpdateIdentity returns an error with CodeNotFound if the identity name is
 // invalid.
 func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err error) {
-	const op = errors.Op("db.UpdateIdentity")
+	const op = "db.UpdateIdentity"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -102,27 +102,27 @@ func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if u.Name == "" {
-		return errors.E(op, errors.CodeNotFound, `invalid identity name ""`)
+		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	db := d.DB.WithContext(ctx)
 	db = db.Omit("ApplicationOffers").Omit("Clouds").Omit("CloudCredentials").Omit("Models")
 	if err := db.Save(u).Error; err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // GetIdentityCloudCredentials fetches identity's cloud credentials for the specified cloud.
 func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.Identity, cloud string) (_ []dbmodel.CloudCredential, err error) {
-	const op = errors.Op("db.GetIdentityCloudCredentials")
+	const op = "db.GetIdentityCloudCredentials"
 
 	if u.Name == "" || cloud == "" {
-		return nil, errors.E(op, errors.CodeNotFound, `cloudcredential not found`)
+		return nil, errors.E(errors.CodeNotFound, `cloudcredential not found`)
 	}
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -132,7 +132,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 	var credentials []dbmodel.CloudCredential
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(u).Where("cloud_name = ?", cloud).Association("CloudCredentials").Find(&credentials); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return credentials, nil
 }
@@ -140,9 +140,9 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 // ListIdentities returns a paginated list of identities defined by limit and offset.
 // match is used to fuzzy find based on entries' name using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match string) (_ []dbmodel.Identity, err error) {
-	const op = errors.Op("db.ListIdentities")
+	const op = "db.ListIdentities"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -162,17 +162,17 @@ func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match 
 	}
 	var identities []dbmodel.Identity
 	if err := db.Find(&identities).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return identities, nil
 }
 
 // CountIdentities counts the number of identities.
 func (d *Database) CountIdentities(ctx context.Context) (_ int, err error) {
-	const op = errors.Op("db.CountIdentities")
+	const op = "db.CountIdentities"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -182,7 +182,7 @@ func (d *Database) CountIdentities(ctx context.Context) (_ int, err error) {
 	db := d.DB.WithContext(ctx)
 	var count int64
 	if err := db.Model(&dbmodel.Identity{}).Count(&count).Error; err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	return int(count), nil
 }

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -19,16 +19,16 @@ var (
 
 // AddJobLog adds a job log entry to the store.
 func (d *Database) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine string) (err error) {
-	const op = errors.Op("db.AddJobLog")
+	const op = "db.AddJobLog"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return d.Transaction(func(d *Database) error {
 		// Blocks all other operations, including reads, writes, and other locks.
 		if err := d.DB.Exec(jobLoglockQuery).Error; err != nil {
-			return errors.E(op, "failed to lock job_logs table", err)
+			return errors.E("failed to lock job_logs table", err)
 		}
 
 		// Get the current line number for this job.
@@ -39,18 +39,18 @@ func (d *Database) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine strin
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error
 		if err != nil {
-			return errors.E(op, "failed to get current line number", err)
+			return errors.E("failed to get current line number", err)
 		}
 
 		nextLineNumber := currentLineNumber + 1
 
 		log, err := dbmodel.NewJobLog(jobId, nextLineNumber, logLine)
 		if err != nil {
-			return errors.E(op, "failed to construct job log", err)
+			return errors.E("failed to construct job log", err)
 		}
 
 		if err := d.DB.WithContext(ctx).Create(log).Error; err != nil {
-			return errors.E(op, dbError(err))
+			return errors.E(dbError(err))
 		}
 		return nil
 	})
@@ -62,10 +62,10 @@ func (d *Database) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine strin
 // as the one initially presented / previously returned. This means no new logs have
 // come in, but they may later, and the client should query again for logs after some time.
 func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int) (loggies []string, nextOffsetValue int, err error) {
-	const op = errors.Op("db.QueryJobLog")
+	const op = "db.QueryJobLog"
 
 	if err := d.ready(); err != nil {
-		return loggies, nextOffsetValue, errors.E(op, err)
+		return loggies, nextOffsetValue, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -76,7 +76,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int)
 	err = d.Transaction(func(d *Database) error {
 		// Make sure job exists, if it doesn't, there's no point running the query
 		if err := d.DB.WithContext(ctx).First(&dbmodel.JobTrackerEntry{JobID: jobId}, "job_id = ?", jobId).Error; err != nil {
-			return errors.E(op, "job not found", dbError(err))
+			return errors.E("job not found", dbError(err))
 		}
 
 		query := d.DB.WithContext(ctx).
@@ -85,7 +85,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int)
 
 		var count int64
 		if err := query.Count(&count).Error; err != nil {
-			return errors.E(op, dbError(err))
+			return errors.E(dbError(err))
 		}
 
 		if count == 0 {
@@ -94,7 +94,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int)
 
 		result := query.Offset(offset).Order("line_number ASC").Find(&logs)
 		if result.Error != nil {
-			return errors.E(op, dbError(result.Error))
+			return errors.E(dbError(result.Error))
 		}
 
 		// Get the next line number
@@ -105,7 +105,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int)
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error
 		if err != nil {
-			return errors.E(op, "failed to get current line number", err)
+			return errors.E("failed to get current line number", err)
 		}
 
 		nextOffsetValue = currentLineNumber

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -25,6 +25,10 @@ func (d *Database) AddJobLog(ctx context.Context, jobId uuid.UUID, logLine strin
 		return errors.E(err)
 	}
 
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
 	return d.Transaction(func(d *Database) error {
 		// Blocks all other operations, including reads, writes, and other locks.
 		if err := d.DB.Exec(jobLoglockQuery).Error; err != nil {
@@ -68,9 +72,9 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId uuid.UUID, offset int)
 		return loggies, nextOffsetValue, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var logs []dbmodel.JobLog
 	err = d.Transaction(func(d *Database) error {

--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -18,9 +18,9 @@ import (
 // AddJob adds a new job to the job tracker.
 // It returns the job ID and an error if the job already exists or if the creation fails
 func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID, err error) {
-	const op = errors.Op("db.AddJob")
+	const op = "db.AddJob"
 	if err := d.ready(); err != nil {
-		return jobId, errors.E(op, err)
+		return jobId, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -31,15 +31,15 @@ func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID,
 
 	entry, err := dbmodel.NewJobTrackerEntry(jobType)
 	if err != nil {
-		return jobId, errors.E(op, fmt.Sprintf("failed to create new job tracker entry: %v", err))
+		return jobId, errors.E(fmt.Sprintf("failed to create new job tracker entry: %v", err))
 	}
 	if err := db.Create(entry).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 			zapctx.Debug(ctx, "job already exists", zap.String("jobID", entry.JobID.String()))
-			return jobId, errors.E(op, fmt.Sprintf("job %s already exists", entry.JobID), err)
+			return jobId, errors.E(fmt.Sprintf("job %s already exists", entry.JobID), err)
 		}
-		return jobId, errors.E(op, err)
+		return jobId, errors.E(err)
 	}
 
 	jobId = entry.JobID
@@ -48,10 +48,10 @@ func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID,
 
 // GetJob retrieves a job entry by its ID.
 func (d *Database) GetJob(ctx context.Context, job *dbmodel.JobTrackerEntry) error {
-	const op = errors.Op("db.GetJob")
+	const op = "db.GetJob"
 	var err error
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -59,7 +59,7 @@ func (d *Database) GetJob(ctx context.Context, job *dbmodel.JobTrackerEntry) err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if job.JobID == uuid.Nil {
-		return errors.E(op, errors.CodeBadRequest, "job ID cannot be empty")
+		return errors.E(errors.CodeBadRequest, "job ID cannot be empty")
 	}
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("job_id = ?", job.JobID).First(&job).Error; err != nil {
@@ -72,9 +72,9 @@ func (d *Database) GetJob(ctx context.Context, job *dbmodel.JobTrackerEntry) err
 // GetJobStopSignal retrieves the stop signal for a job by its ID.
 // It returns true if the stop signal is set, false otherwise, and an error if the job does not exist or if the query fails.
 func (d *Database) GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopSignal bool, err error) {
-	const op = errors.Op("db.GetJobStopSignal")
+	const op = "db.GetJobStopSignal"
 	if err := d.ready(); err != nil {
-		return false, errors.E(op, err)
+		return false, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -93,9 +93,9 @@ func (d *Database) GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopS
 // StopJob marks a job as stopped.
 // It returns an error if the job does not exist or if the update fails.
 func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {
-	const op = errors.Op("db.StopJob")
+	const op = "db.StopJob"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -110,7 +110,7 @@ func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {
 	}
 
 	if result.RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("job %s not found", jobId))
+		return errors.E(errors.CodeNotFound, fmt.Sprintf("job %s not found", jobId))
 	}
 
 	return nil
@@ -139,21 +139,21 @@ func (d *Database) SetJobSuccessful(ctx context.Context, jobId uuid.UUID) (err e
 // SetJobFailed sets the job status to failed and records the error message.
 // It returns an error if the job does not exist or if the update fails.
 func (d *Database) SetJobFailed(ctx context.Context, jobId uuid.UUID, jobErr error) (err error) {
-	const op = errors.Op("db.SetJobFailed")
+	const op = "db.SetJobFailed"
 	entry := dbmodel.JobTrackerEntry{
 		JobID: jobId,
 	}
 	if err := entry.SetFailed(jobErr); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return d.updateJob(ctx, entry)
 }
 
 func (d *Database) updateJob(ctx context.Context, entry dbmodel.JobTrackerEntry) (err error) {
-	const op = errors.Op("db.updateJobStatus")
+	const op = "db.updateJobStatus"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -167,7 +167,7 @@ func (d *Database) updateJob(ctx context.Context, entry dbmodel.JobTrackerEntry)
 	}
 
 	if result.RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, fmt.Sprintf("job %s not found", entry.JobID))
+		return errors.E(errors.CodeNotFound, fmt.Sprintf("job %s not found", entry.JobID))
 	}
 
 	return nil
@@ -176,9 +176,9 @@ func (d *Database) updateJob(ctx context.Context, entry dbmodel.JobTrackerEntry)
 // GetJobStatus retrieves the status of a job by its ID.
 // It returns the job status and an error if the job does not exist or if the query fails.
 func (d *Database) GetJobStatus(ctx context.Context, jobId uuid.UUID) (status dbmodel.JobStatus, err error) {
-	const op = errors.Op("db.GetJobStatus")
+	const op = "db.GetJobStatus"
 	if err := d.ready(); err != nil {
-		return status, errors.E(op, err)
+		return status, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))

--- a/internal/db/job_tracker.go
+++ b/internal/db/job_tracker.go
@@ -23,9 +23,9 @@ func (d *Database) AddJob(ctx context.Context, jobType string) (jobId uuid.UUID,
 		return jobId, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -54,9 +54,9 @@ func (d *Database) GetJob(ctx context.Context, job *dbmodel.JobTrackerEntry) err
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if job.JobID == uuid.Nil {
 		return errors.E(errors.CodeBadRequest, "job ID cannot be empty")
@@ -77,9 +77,9 @@ func (d *Database) GetJobStopSignal(ctx context.Context, jobId uuid.UUID) (stopS
 		return false, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	var entry dbmodel.JobTrackerEntry
@@ -98,9 +98,9 @@ func (d *Database) StopJob(ctx context.Context, jobId uuid.UUID) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -139,7 +139,6 @@ func (d *Database) SetJobSuccessful(ctx context.Context, jobId uuid.UUID) (err e
 // SetJobFailed sets the job status to failed and records the error message.
 // It returns an error if the job does not exist or if the update fails.
 func (d *Database) SetJobFailed(ctx context.Context, jobId uuid.UUID, jobErr error) (err error) {
-	const op = "db.SetJobFailed"
 	entry := dbmodel.JobTrackerEntry{
 		JobID: jobId,
 	}
@@ -156,9 +155,9 @@ func (d *Database) updateJob(ctx context.Context, entry dbmodel.JobTrackerEntry)
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	result := db.Model(&entry).Select("status", "error").Updates(entry)
@@ -181,9 +180,9 @@ func (d *Database) GetJobStatus(ctx context.Context, jobId uuid.UUID) (status db
 		return status, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	entry := &dbmodel.JobTrackerEntry{}

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -21,9 +21,9 @@ func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err erro
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -41,9 +41,9 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.ready(); err != nil {
 		return errors.E(err)
@@ -86,9 +86,9 @@ func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID ui
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	var models []dbmodel.Model
@@ -106,9 +106,9 @@ func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err e
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Save(model).Error; err != nil {
@@ -124,9 +124,9 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 	db := d.DB.WithContext(ctx)
 	switch {
 	case model.UUID.Valid:
@@ -153,9 +153,9 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	db = preloadModel("", db)
@@ -184,9 +184,9 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var models []dbmodel.Model
 	db := d.DB.WithContext(ctx)
@@ -220,13 +220,17 @@ func preloadModel(prefix string, db *gorm.DB) *gorm.DB {
 
 // GetModelsByController retrieves a list of models hosted on the specified controller.
 // Note that because we do not preload here, foreign key references will be empty.
-func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Controller) ([]dbmodel.Model, error) {
+func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Controller) (models []dbmodel.Model, err error) {
 	const op = "db.GetModelsByController"
 
 	if err := d.ready(); err != nil {
 		return nil, errors.E(err)
 	}
-	var models []dbmodel.Model
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(ctl).Association("Models").Find(&models); err != nil {
 		return nil, errors.E(dbError(err))
@@ -235,17 +239,22 @@ func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Contro
 }
 
 // CountModelsByController counts the number of models hosted on a controller.
-func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Controller) (int, error) {
+func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Controller) (count int, err error) {
 	const op = "db.CountModelsByController"
 
 	if err := d.ready(); err != nil {
 		return 0, errors.E(err)
 	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
 	db := d.DB.WithContext(ctx)
 	asc := db.Model(ctl).Association("Models")
-	count := asc.Count()
+	count = int(asc.Count())
 	if err := asc.Error; err != nil {
 		return 0, errors.E(dbError(err))
 	}
-	return int(count), nil
+	return count, nil
 }

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -16,9 +16,9 @@ import (
 //   - returns an error with code errors.CodeAlreadyExists if
 //     model with the same name already exists.
 func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err error) {
-	const op = errors.Op("db.AddModel")
+	const op = "db.AddModel"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -28,7 +28,7 @@ func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err erro
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(model).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -36,9 +36,9 @@ func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err erro
 // GetModel returns model information based on the
 // model UUID.
 func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err error) {
-	const op = errors.Op("db.GetModel")
+	const op = "db.GetModel"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -72,18 +72,18 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 	if err := db.First(&model).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "model not found")
+			return errors.E(err, "model not found")
 		}
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // GetModelsUsingCredential returns all models that use the specified credentials.
 func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID uint) (_ []dbmodel.Model, err error) {
-	const op = errors.Op("db.GetModelsUsingCredential")
+	const op = "db.GetModelsUsingCredential"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -94,16 +94,16 @@ func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID ui
 	var models []dbmodel.Model
 	result := db.Where("cloud_credential_id = ?", credentialID).Preload("Controller").Find(&models)
 	if result.Error != nil {
-		return nil, errors.E(op, dbError(result.Error))
+		return nil, errors.E(dbError(result.Error))
 	}
 	return models, nil
 }
 
 // UpdateModel updates the model information.
 func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err error) {
-	const op = errors.Op("db.UpdateModel")
+	const op = "db.UpdateModel"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -112,16 +112,16 @@ func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err e
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Save(model).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // DeleteModel removes the model information from the database. It supports deletion by ID or UUID.
 func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err error) {
-	const op = errors.Op("db.DeleteModel")
+	const op = "db.DeleteModel"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -134,11 +134,11 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 	case model.ID != 0:
 		db = db.Where("id = ?", model.ID)
 	default:
-		return errors.E(op, "missing id or uuid", errors.CodeBadRequest)
+		return errors.E("missing id or uuid", errors.CodeBadRequest)
 	}
 
 	if err := db.Delete(model).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -147,10 +147,10 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 // for each one. If the given function returns an error the iteration
 // will stop immediately and the error will be returned unmodified.
 func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) error) (err error) {
-	const op = errors.Op("db.ForEachModel")
+	const op = "db.ForEachModel"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -162,7 +162,7 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 
 	var models []dbmodel.Model
 	if err := db.Find(&models).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	for _, m := range models {
 		if err := f(&m); err != nil {
@@ -178,10 +178,10 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 // If the UUID cannot be resolved to a model, it is skipped from the result and
 // no error is returned.
 func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ []dbmodel.Model, err error) {
-	const op = errors.Op("db.GetModelsByUUID")
+	const op = "db.GetModelsByUUID"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -195,9 +195,9 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 	if err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(op, err, "model not found")
+			return nil, errors.E(err, "model not found")
 		}
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return models, nil
 }
@@ -221,31 +221,31 @@ func preloadModel(prefix string, db *gorm.DB) *gorm.DB {
 // GetModelsByController retrieves a list of models hosted on the specified controller.
 // Note that because we do not preload here, foreign key references will be empty.
 func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Controller) ([]dbmodel.Model, error) {
-	const op = errors.Op("db.GetModelsByController")
+	const op = "db.GetModelsByController"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	var models []dbmodel.Model
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(ctl).Association("Models").Find(&models); err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return models, nil
 }
 
 // CountModelsByController counts the number of models hosted on a controller.
 func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Controller) (int, error) {
-	const op = errors.Op("db.CountModelsByController")
+	const op = "db.CountModelsByController"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	db := d.DB.WithContext(ctx)
 	asc := db.Model(ctl).Association("Models")
 	count := asc.Count()
 	if err := asc.Error; err != nil {
-		return 0, errors.E(op, dbError(err))
+		return 0, errors.E(dbError(err))
 	}
 	return int(count), nil
 }

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -16,9 +16,9 @@ import (
 // AddOrUpdateIncomingModelMigration stores information about an incoming model migration
 // if it does not already exist, or updates it if it does.
 func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.AddOrUpdateIncomingModelMigration")
+	const op = "db.AddOrUpdateIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -36,13 +36,13 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 			// If the model migration already exists, update it.
 			modelMigration.ID = lookup.ID
 		} else if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		db := d.DB.WithContext(ctx)
 
 		if err := db.Save(modelMigration).Error; err != nil {
-			return errors.E(op, dbError(err))
+			return errors.E(dbError(err))
 		}
 
 		return nil
@@ -54,7 +54,7 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 // This must be run within a transaction for the lock to be effective.
 // if `noWait` is true, the function will return an error if the lock cannot be acquired immediately.
 func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration, noWait bool) (err error) {
-	const op = errors.Op("db.GetIncomingMigrationWithLock")
+	const op = "db.GetIncomingMigrationWithLock"
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
@@ -65,7 +65,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.E(op, "missing uuid", errors.CodeBadRequest)
+		return errors.E("missing uuid", errors.CodeBadRequest)
 	}
 
 	lockingClause := clause.Locking{Strength: "UPDATE"}
@@ -76,18 +76,18 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "model migration not found")
+			return errors.E(err, "model migration not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // GetIncomingModelMigration returns model migration information based on the model UUID.
 func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.GetIncomingModelMigration")
+	const op = "db.GetIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -99,24 +99,24 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.E(op, "missing uuid", errors.CodeBadRequest)
+		return errors.E("missing uuid", errors.CodeBadRequest)
 	}
 
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "model migration not found")
+			return errors.E(err, "model migration not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // DeleteIncomingModelMigration removes a model migration entry from the database.
 func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
-	const op = errors.Op("db.DeleteIncomingModelMigration")
+	const op = "db.DeleteIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -125,16 +125,16 @@ func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigrat
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(modelMigration).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // GetIncomingModelMigrationsCreatedBefore returns all incoming model migrations created before the specified time.
 func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, createBefore time.Time) (migrations []dbmodel.IncomingModelMigration, err error) {
-	const op = errors.Op("db.GetIncomingModelMigrations")
+	const op = "db.GetIncomingModelMigrations"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -144,7 +144,7 @@ func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, 
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Where("created_at < ?", createBefore).Find(&migrations).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return migrations, nil
 }

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -21,9 +21,9 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	err = d.Transaction(func(d *Database) error {
 		lookup := dbmodel.IncomingModelMigration{
@@ -56,9 +56,9 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration, noWait bool) (err error) {
 	const op = "db.GetIncomingMigrationWithLock"
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	switch {
@@ -90,9 +90,9 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	switch {
@@ -119,9 +119,9 @@ func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigrat
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(modelMigration).Error; err != nil {
@@ -137,9 +137,9 @@ func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -77,9 +77,9 @@ func (d *Database) ListResources(ctx context.Context, limit, offset int, namePre
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	query, err := buildQuery(db, offset, limit, namePrefixFilter, typeFilter)

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -72,9 +72,9 @@ type Resource struct {
 // ListResources returns a list of models, clouds, controllers, and application offers, with its respective parents.
 // It has been implemented with a raw query because this is a specific implementation for the ReBAC Admin UI.
 func (d *Database) ListResources(ctx context.Context, limit, offset int, namePrefixFilter, typeFilter string) (_ []Resource, err error) {
-	const op = errors.Op("db.ListResources")
+	const op = "db.ListResources"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -89,7 +89,7 @@ func (d *Database) ListResources(ctx context.Context, limit, offset int, namePre
 
 	var resources []Resource
 	if err := query.Find(&resources).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return resources, nil
 }

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -12,9 +12,9 @@ import (
 
 // AddRole adds a new role.
 func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEntry, err error) {
-	const op = errors.Op("db.AddRole")
+	const op = "db.AddRole"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -27,16 +27,16 @@ func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEn
 	}
 
 	if err := d.DB.WithContext(ctx).Create(re).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return re, nil
 }
 
 // GetRole populates the provided *dbmodel.RoleEntry based on name or UUID.
 func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err error) {
-	const op = errors.Op("db.GetRole")
+	const op = "db.GetRole"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -44,7 +44,7 @@ func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err er
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if role.UUID == "" && role.Name == "" {
-		return errors.E(op, "must specify uuid or name")
+		return errors.E("must specify uuid or name")
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -58,21 +58,21 @@ func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err er
 		db = db.Where("name = ?", role.Name)
 	}
 	if err := db.First(&role).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // UpdateRoleName updates the name of a role identified by name.
 func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (err error) {
-	const op = errors.Op("db.UpdateRole")
+	const op = "db.UpdateRole"
 
 	if oldName == "" {
-		return errors.E(op, "name must be specified")
+		return errors.E("name must be specified")
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -82,7 +82,7 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 	model := d.DB.WithContext(ctx).Model(&dbmodel.RoleEntry{})
 	model.Where("name = ?", oldName)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, "role not found")
+		return errors.E(errors.CodeNotFound, "role not found")
 	}
 
 	return nil
@@ -90,14 +90,14 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 
 // RemoveRole removes the role identified by its ID or UUID.
 func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err error) {
-	const op = errors.Op("db.RemoveRole")
+	const op = "db.RemoveRole"
 
 	if role.ID == 0 && role.UUID == "" {
 		return errors.E("neither role UUID or ID specified", errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -105,7 +105,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
 
 	if err := d.DB.WithContext(ctx).Delete(role).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
@@ -113,9 +113,9 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 // ListRoles returns a paginated list of Roles defined by limit and offset.
 // match is used to fuzzy find based on entries' name or uuid using the LIKE operator (ex. LIKE %<match>%).
 func (d *Database) ListRoles(ctx context.Context, limit, offset int, match string) (_ []dbmodel.RoleEntry, err error) {
-	const op = errors.Op("db.ListRoles")
+	const op = "db.ListRoles"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -135,16 +135,16 @@ func (d *Database) ListRoles(ctx context.Context, limit, offset int, match strin
 	}
 	var Roles []dbmodel.RoleEntry
 	if err := db.Find(&Roles).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 	return Roles, nil
 }
 
 // CountRoles returns a count of the number of Roles that exist.
 func (d *Database) CountRoles(ctx context.Context) (count int, err error) {
-	const op = errors.Op("db.CountRoles")
+	const op = "db.CountRoles"
 	if err := d.ready(); err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
 	defer durationObserver()
@@ -153,7 +153,7 @@ func (d *Database) CountRoles(ctx context.Context) (count int, err error) {
 	var c int64
 	var g dbmodel.RoleEntry
 	if err := d.DB.WithContext(ctx).Model(g).Count(&c).Error; err != nil {
-		return 0, errors.E(op, dbError(err))
+		return 0, errors.E(dbError(err))
 	}
 	count = int(c)
 	return count, nil

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -17,9 +17,9 @@ func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEn
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	re = &dbmodel.RoleEntry{
 		Name: name,
@@ -39,9 +39,9 @@ func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if role.UUID == "" && role.Name == "" {
 		return errors.E("must specify uuid or name")
@@ -75,9 +75,9 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	model := d.DB.WithContext(ctx).Model(&dbmodel.RoleEntry{})
 	model.Where("name = ?", oldName)
@@ -100,9 +100,9 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Delete(role).Error; err != nil {
 		return errors.E(dbError(err))
@@ -118,9 +118,9 @@ func (d *Database) ListRoles(ctx context.Context, limit, offset int, match strin
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if match != "" {
@@ -146,9 +146,9 @@ func (d *Database) CountRoles(ctx context.Context) (count int, err error) {
 	if err := d.ready(); err != nil {
 		return 0, errors.E(err)
 	}
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var c int64
 	var g dbmodel.RoleEntry

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -16,7 +16,7 @@ import (
 
 // GetKey implements Backing.GetKey.
 func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
-	const op = errors.Op("db.FindLatestKey")
+	const op = "db.FindLatestKey"
 
 	if err := d.ready(); err != nil {
 		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
@@ -33,7 +33,7 @@ func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
 		if err == gorm.ErrRecordNotFound {
 			return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 		}
-		return dbrootkeystore.RootKey{}, errors.E(op, err)
+		return dbrootkeystore.RootKey{}, errors.E(err)
 	}
 	return dbrootkeystore.RootKey{
 		Id:      rk.ID,
@@ -45,7 +45,7 @@ func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
 
 // FindLatestKey implements Backing.FindLatestKey.
 func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (_ dbrootkeystore.RootKey, err error) {
-	const op = errors.Op("db.FindLatestKey")
+	const op = "db.FindLatestKey"
 
 	if err := d.ready(); err != nil {
 		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
@@ -63,7 +63,7 @@ func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.
 		if err == gorm.ErrRecordNotFound {
 			return dbrootkeystore.RootKey{}, nil
 		}
-		return dbrootkeystore.RootKey{}, errors.E(op, dbError(err))
+		return dbrootkeystore.RootKey{}, errors.E(dbError(err))
 	}
 	return dbrootkeystore.RootKey{
 		Id:      rk.ID,
@@ -75,10 +75,10 @@ func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.
 
 // InsertKey implements Backing.InsertKey.
 func (d *Database) InsertKey(key dbrootkeystore.RootKey) (err error) {
-	const op = errors.Op("db.InsertKey")
+	const op = "db.InsertKey"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -92,7 +92,7 @@ func (d *Database) InsertKey(key dbrootkeystore.RootKey) (err error) {
 		RootKey:   key.RootKey,
 	}
 	if err := d.DB.Create(&rk).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package db
 
@@ -22,9 +22,9 @@ func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
 		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	rk := dbmodel.RootKey{
 		ID: id,
@@ -51,9 +51,9 @@ func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.
 		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.Where("created_at > ?", createdAfter)
 	db = db.Where("expires BETWEEN ? AND ?", expiresAfter, expiresBefore)
@@ -81,9 +81,9 @@ func (d *Database) InsertKey(key dbrootkeystore.RootKey) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	rk := dbmodel.RootKey{
 		ID:        key.Id,

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -36,9 +36,9 @@ const (
 // UpsertSecret stores secret information.
 //   - updates the secret's time and data if it already exists
 func (d *Database) UpsertSecret(ctx context.Context, secret *dbmodel.Secret) (err error) {
-	const op = errors.Op("db.AddSecret")
+	const op = "db.AddSecret"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -51,21 +51,21 @@ func (d *Database) UpsertSecret(ctx context.Context, secret *dbmodel.Secret) (er
 		DoUpdates: clause.AssignmentColumns([]string{"time", "data"}),
 	})
 	if err := db.Create(secret).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // GetSecret gets the secret with the specified type and tag.
 func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err error) {
-	const op = errors.Op("db.GetSecret")
+	const op = "db.GetSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.E(op, "missing secret tag and type", errors.CodeBadRequest)
+		return errors.E("missing secret tag and type", errors.CodeBadRequest)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -79,23 +79,23 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	if err := db.First(&secret).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "secret not found")
+			return errors.E(err, "secret not found")
 		}
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // Delete secret deletes the secret with the specified type and tag.
 func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (err error) {
-	const op = errors.Op("db.DeleteSecret")
+	const op = "db.DeleteSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.E(op, "missing secret tag and type", errors.CodeBadRequest)
+		return errors.E("missing secret tag and type", errors.CodeBadRequest)
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -105,17 +105,17 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Unscoped().Where("tag = ? AND type = ?", secret.Tag, secret.Type).Delete(&dbmodel.Secret{}).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // Get retrieves the attributes for the given cloud credential from the DB.
 func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map[string]string, err error) {
-	const op = errors.Op("database.Get")
+	const op = "database.Get"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -128,22 +128,22 @@ func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, nil
 		}
-		return nil, errors.E(op, fmt.Errorf("failed to get secret data: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to get secret data: %w", err))
 	}
 	var attr map[string]string
 	err = json.Unmarshal(secret.Data, &attr)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to unmarshal secret data: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to unmarshal secret data: %w", err))
 	}
 	return attr, nil
 }
 
 // Put stores the attributes associated with a cloud-credential in the DB.
 func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr map[string]string) (err error) {
-	const op = errors.Op("database.Put")
+	const op = "database.Put"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -152,7 +152,7 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 
 	dataJson, err := json.Marshal(attr)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to marshal secret data: %w", err))
+		return errors.E(fmt.Errorf("failed to marshal secret data: %w", err))
 	}
 	secret := dbmodel.NewSecret(tag.Kind(), tag.String(), dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -161,10 +161,10 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 // GetControllerCredentials retrieves the credentials for the given controller from the DB.
 // It is expected for this interface that a non-existent controller credential return empty username/password.
 func (d *Database) GetControllerCredentials(ctx context.Context, controllerName string) (_ string, _ string, err error) {
-	const op = errors.Op("database.GetControllerCredentials")
+	const op = "database.GetControllerCredentials"
 
 	if err := d.ready(); err != nil {
-		return "", "", errors.E(op, err)
+		return "", "", errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -177,30 +177,30 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 		return "", "", nil
 	}
 	if err != nil {
-		return "", "", errors.E(op, fmt.Errorf("failed to get secret data: %w", err))
+		return "", "", errors.E(fmt.Errorf("failed to get secret data: %w", err))
 	}
 	var secretData map[string]string
 	err = json.Unmarshal(secret.Data, &secretData)
 	if err != nil {
-		return "", "", errors.E(op, fmt.Errorf("failed to unmarshal secret data: %w", err))
+		return "", "", errors.E(fmt.Errorf("failed to unmarshal secret data: %w", err))
 	}
 	username, ok := secretData[usernameKey]
 	if !ok {
-		return "", "", errors.E(op, "missing username")
+		return "", "", errors.E("missing username")
 	}
 	password, ok := secretData[passwordKey]
 	if !ok {
-		return "", "", errors.E(op, "missing password")
+		return "", "", errors.E("missing password")
 	}
 	return username, password, nil
 }
 
 // PutControllerCredentials stores the controller credentials in the DB.
 func (d *Database) PutControllerCredentials(ctx context.Context, controllerName string, username string, password string) (err error) {
-	const op = errors.Op("database.PutControllerCredentials")
+	const op = "database.PutControllerCredentials"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -212,7 +212,7 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 	secretData[passwordKey] = password
 	dataJson, err := json.Marshal(secretData)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to marshal secret data: %w", err))
+		return errors.E(fmt.Errorf("failed to marshal secret data: %w", err))
 	}
 	secret := dbmodel.NewSecret(names.ControllerTagKind, controllerName, dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -220,10 +220,10 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 
 // CleanupJWKS removes all secrets associated with the JWKS process.
 func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
-	const op = errors.Op("database.CleanupJWKS")
+	const op = "database.CleanupJWKS"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -233,27 +233,27 @@ func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to cleanup jwks public key: %w", err))
+		return errors.E(fmt.Errorf("failed to cleanup jwks public key: %w", err))
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to cleanup jwks private key: %w", err))
+		return errors.E(fmt.Errorf("failed to cleanup jwks private key: %w", err))
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to cleanup jwks expiry info: %w", err))
+		return errors.E(fmt.Errorf("failed to cleanup jwks expiry info: %w", err))
 	}
 	return nil
 }
 
 // GetJWKS returns the current key set stored within the DB.
 func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
-	const op = errors.Op("database.GetJWKS")
+	const op = "database.GetJWKS"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -263,21 +263,21 @@ func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to get jwks data: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to get jwks data: %w", err))
 	}
 	ks, err := jwk.ParseString(string(secret.Data))
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to parse jwk data: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to parse jwk data: %w", err))
 	}
 	return ks, nil
 }
 
 // GetJWKSPrivateKey returns the current private key for the active JWKS
 func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) {
-	const op = errors.Op("database.GetJWKSPrivateKey")
+	const op = "database.GetJWKSPrivateKey"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -287,22 +287,22 @@ func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) 
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to get jwks private key: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to get jwks private key: %w", err))
 	}
 	var pem []byte
 	err = json.Unmarshal(secret.Data, &pem)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to unmarshal pem data: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to unmarshal pem data: %w", err))
 	}
 	return pem, nil
 }
 
 // GetJWKSExpiry returns the expiry of the active JWKS.
 func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
-	const op = errors.Op("database.GetJWKSExpiry")
+	const op = "database.GetJWKSExpiry"
 
 	if err := d.ready(); err != nil {
-		return time.Time{}, errors.E(op, err)
+		return time.Time{}, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -312,22 +312,22 @@ func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return time.Time{}, errors.E(op, fmt.Errorf("failed to get jwks expiry: %w", err))
+		return time.Time{}, errors.E(fmt.Errorf("failed to get jwks expiry: %w", err))
 	}
 	var expiryTime time.Time
 	err = json.Unmarshal(secret.Data, &expiryTime)
 	if err != nil {
-		return time.Time{}, errors.E(op, fmt.Errorf("failed to unmarshal jwks expiry data: %w", err))
+		return time.Time{}, errors.E(fmt.Errorf("failed to unmarshal jwks expiry data: %w", err))
 	}
 	return expiryTime, nil
 }
 
 // PutJWKS puts a JWKS into the DB.
 func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
-	const op = errors.Op("database.PutJWKS")
+	const op = "database.PutJWKS"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -336,7 +336,7 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to marshal jwks data: %w", err))
+		return errors.E(fmt.Errorf("failed to marshal jwks data: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, jwksJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -345,10 +345,10 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 // PutJWKSPrivateKey persists the private key associated with the current JWKS within the DB.
 func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error) {
-	const op = errors.Op("database.PutJWKSPrivateKey")
+	const op = "database.PutJWKSPrivateKey"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -357,7 +357,7 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 
 	privateKeyJson, err := json.Marshal(pem)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to marshal jwks private key: %w", err))
+		return errors.E(fmt.Errorf("failed to marshal jwks private key: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, privateKeyJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -365,10 +365,10 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 
 // PutJWKSExpiry sets the expiry time for the current JWKS within the DB.
 func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err error) {
-	const op = errors.Op("database.PutJWKSExpiry")
+	const op = "database.PutJWKSExpiry"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -377,7 +377,7 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 
 	expiryJson, err := json.Marshal(expiry)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to marshal jwks expiry data: %w", err))
+		return errors.E(fmt.Errorf("failed to marshal jwks expiry data: %w", err))
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, expiryJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -385,10 +385,10 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 
 // CleanupOAuthSecrets removes all secrets associated with OAuth.
 func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
-	const op = errors.Op("database.CleanupOAuthSecrets")
+	const op = "database.CleanupOAuthSecrets"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -397,11 +397,11 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 
 	secret := dbmodel.NewSecret(oauthKind, oauthKeyTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		return errors.E(op, fmt.Errorf("failed to cleanup OAuth key: %w", err))
+		return errors.E(fmt.Errorf("failed to cleanup OAuth key: %w", err))
 	}
 	secret = dbmodel.NewSecret(oauthKind, oauthSessionStoreSecretTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		return errors.E(op, fmt.Errorf("failed to cleanup OAuth session store secret: %w", err))
+		return errors.E(fmt.Errorf("failed to cleanup OAuth session store secret: %w", err))
 	}
 	return nil
 }

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -41,9 +41,9 @@ func (d *Database) UpsertSecret(ctx context.Context, secret *dbmodel.Secret) (er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	// On conflict perform an upset to make the operation resemble a Put.
 	db := d.DB.WithContext(ctx).Clauses(clause.OnConflict{
@@ -68,9 +68,9 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -98,9 +98,9 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -118,9 +118,9 @@ func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(tag.Kind(), tag.String(), nil)
 	err = d.GetSecret(ctx, &secret)
@@ -146,9 +146,9 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	dataJson, err := json.Marshal(attr)
 	if err != nil {
@@ -167,9 +167,9 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 		return "", "", errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(names.ControllerTagKind, controllerName, nil)
 	err = d.GetSecret(ctx, &secret)
@@ -203,9 +203,9 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secretData := make(map[string]string)
 	secretData[usernameKey] = username
@@ -226,9 +226,9 @@ func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
@@ -256,9 +256,9 @@ func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
@@ -280,9 +280,9 @@ func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
@@ -305,9 +305,9 @@ func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
 		return time.Time{}, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.GetSecret(ctx, &secret)
@@ -330,9 +330,9 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
@@ -351,9 +351,9 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	privateKeyJson, err := json.Marshal(pem)
 	if err != nil {
@@ -371,9 +371,9 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	expiryJson, err := json.Marshal(expiry)
 	if err != nil {
@@ -391,9 +391,9 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	secret := dbmodel.NewSecret(oauthKind, oauthKeyTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -17,9 +17,9 @@ func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err e
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Create(sshKey).Error; err != nil {
 		dbErr := dbError(err)
@@ -40,9 +40,9 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	query := d.DB.Where("identity_name = ?", identityName).
 		Where("model_uuid = ?", model.ModelUUID).
@@ -68,9 +68,9 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	query := d.DB.Where("key_comment = ?", comment).
 		Where("model_uuid = ?", model.ModelUUID).
@@ -94,9 +94,9 @@ func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, 
 		return nil, errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 	query := d.DB.Where("identity_name = ?", identityName)
 	if !model.All {
 		query = query.Where("model_uuid = ?", model.ModelUUID)

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -12,9 +12,9 @@ import (
 
 // AddSSHKey adds a new SSH key.
 func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err error) {
-	const op = errors.Op("db.AddSSHKey")
+	const op = "db.AddSSHKey"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -27,17 +27,17 @@ func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err e
 			// we don't return an error if a user tries to add the same key twice.
 			return nil
 		}
-		return errors.E(op, dbErr)
+		return errors.E(dbErr)
 	}
 	return nil
 }
 
 // RemoveSSHKeyByFingerprint removes a user's ssh key identified by its fingerprint.
 func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName string, model SSHKeyModelFilter, fingerprint string) (err error) {
-	const op = errors.Op("db.RemoveSSHKeyByFingerprint")
+	const op = "db.RemoveSSHKeyByFingerprint"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -50,11 +50,11 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 		Delete(&dbmodel.SSHKey{})
 
 	if err := query.Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, "key not found")
+		return errors.E(errors.CodeNotFound, "key not found")
 	}
 
 	return nil
@@ -62,10 +62,10 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 
 // RemoveSSHKeyByComment removes a user's ssh key identified by its comment.
 func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName string, model SSHKeyModelFilter, comment string) (err error) {
-	const op = errors.Op("db.RemoveSSHKeyByComment")
+	const op = "db.RemoveSSHKeyByComment"
 
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -76,11 +76,11 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 		Where("model_uuid = ?", model.ModelUUID).
 		Delete(&dbmodel.SSHKey{})
 	if err := query.Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.E(op, errors.CodeNotFound, "key not found")
+		return errors.E(errors.CodeNotFound, "key not found")
 	}
 
 	return nil
@@ -88,10 +88,10 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 
 // ListSSHKeysForUser lists all user's SSH keys per model.
 func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, model SSHKeyModelFilter) (keys []dbmodel.SSHKey, err error) {
-	const op = errors.Op("db.ListSSHKeysForUser")
+	const op = "db.ListSSHKeysForUser"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -103,7 +103,7 @@ func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, 
 	}
 	if err := query.
 		Find(&keys).Error; err != nil {
-		return nil, errors.E(op, dbError(err))
+		return nil, errors.E(dbError(err))
 	}
 
 	return keys, nil

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -17,9 +17,9 @@ func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.User
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 
@@ -36,9 +36,9 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	switch {
@@ -69,9 +69,9 @@ func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.U
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(userMapping).Error; err != nil {
@@ -87,9 +87,9 @@ func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID 
 		return errors.E(err)
 	}
 
-	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("model_uuid = ?", modelUUID).Delete(&dbmodel.UserMapping{}).Error; err != nil {

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -12,9 +12,9 @@ import (
 
 // AddUserMapping stores information mapping a local user to an external user.
 func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
-	const op = errors.Op("db.AddUserMapping")
+	const op = "db.AddUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -24,16 +24,16 @@ func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.User
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(userMapping).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // GetUserMapping returns user mapping info based on the model UUID and local user.
 func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
-	const op = errors.Op("db.GetUserMapping")
+	const op = "db.GetUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -45,28 +45,28 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 	case userMapping.ModelUUID.Valid && userMapping.LocalUser != "":
 		db = db.Where("model_uuid = ? AND local_user = ?", userMapping.ModelUUID.String, userMapping.LocalUser)
 	case !userMapping.ModelUUID.Valid:
-		return errors.E(op, "missing model UUID", errors.CodeBadRequest)
+		return errors.E("missing model UUID", errors.CodeBadRequest)
 	case userMapping.LocalUser == "":
-		return errors.E(op, "missing local user", errors.CodeBadRequest)
+		return errors.E("missing local user", errors.CodeBadRequest)
 	default:
-		return errors.E(op, "invalid parameters", errors.CodeBadRequest)
+		return errors.E("invalid parameters", errors.CodeBadRequest)
 	}
 
 	if err := db.First(&userMapping).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "user mapping not found")
+			return errors.E(err, "user mapping not found")
 		}
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // DeleteUserMapping removes a user mapping from the database.
 func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
-	const op = errors.Op("db.DeleteUserMapping")
+	const op = "db.DeleteUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -75,16 +75,16 @@ func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.U
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(userMapping).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }
 
 // DeleteUserMappingsByModelUUID removes all user mappings for a given model UUID.
 func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID string) (err error) {
-	const op = errors.Op("db.DeleteUserMappingsByModelUUID")
+	const op = "db.DeleteUserMappingsByModelUUID"
 	if err := d.ready(); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, string(op))
@@ -93,7 +93,7 @@ func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID 
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("model_uuid = ?", modelUUID).Delete(&dbmodel.UserMapping{}).Error; err != nil {
-		return errors.E(op, dbError(err))
+		return errors.E(dbError(err))
 	}
 	return nil
 }

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -33,20 +33,19 @@ type MacaroonDischargerConfig struct {
 
 // NewMacaroonDischarger creates a new MacaroonDischarger instance with the provided configuration, database, and offer authorizer.
 func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, offerAuthorizer jimm.OfferAuthorizer) (*MacaroonDischarger, error) {
-	op := errors.Op("discharger.NewMacaroonDischarger")
 	var kp bakery.KeyPair
 	if cfg.PublicKey == "" || cfg.PrivateKey == "" {
 		return nil, errors.E("missing bakery private/public key")
 	} else {
 		if err := kp.Private.UnmarshalText([]byte(cfg.PrivateKey)); err != nil {
-			return nil, errors.E(op, err, "cannot unmarshal private key")
+			return nil, errors.E(err, "cannot unmarshal private key")
 		}
 		if err := kp.Public.UnmarshalText([]byte(cfg.PublicKey)); err != nil {
-			return nil, errors.E(op, err, "cannot unmarshal public key")
+			return nil, errors.E(err, "cannot unmarshal public key")
 		}
 	}
 	if offerAuthorizer == nil {
-		return nil, errors.E(op, "userMappingManager cannot be nil")
+		return nil, errors.E("userMappingManager cannot be nil")
 	}
 
 	checker := checkers.New(jjmacaroon.MacaroonNamespace)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -16,9 +16,6 @@ import (
 
 // An Error is an error in the JIMM system.
 type Error struct {
-	// Op is the operation that errored.
-	Op Op
-
 	// Code is a code attached to the error.
 	Code Code
 
@@ -82,8 +79,6 @@ func E(args ...interface{}) error {
 	var e Error
 	for _, arg := range args {
 		switch v := arg.(type) {
-		case Op:
-			e.Op = v
 		case Code:
 			setCode = true
 			e.Code = v
@@ -119,9 +114,6 @@ func E(args ...interface{}) error {
 	}
 	return &e
 }
-
-// An Op describes the operation being performed that caused the error.
-type Op string
 
 // A Code is a code which describes the class of error. Where possible
 // these codes are identical to the codes returned in the juju API.

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -29,11 +29,11 @@ func TestE(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
-	err := errors.E(errors.Op("test.op"), code, "an error happened")
+	err := errors.E(code, "an error happened")
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 
-	err = errors.E(errors.Op("test.op2"), err)
+	err = errors.E(err)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 }
@@ -43,7 +43,7 @@ func TestEWithInfo(t *testing.T) {
 
 	code := errors.Code("test code")
 	info := map[string]any{"key": "value"}
-	err := errors.E(errors.Op("test.op"), code, "an error happened", info)
+	err := errors.E(code, "an error happened", info)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 	c.Check(err.(*errors.Error).Info, qt.DeepEquals, info)

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -78,11 +78,10 @@ func redactSensitiveParams(ale *dbmodel.AuditLogEntry) {
 
 // FindAuditEvents returns audit events matching the given filter.
 func (j *auditLogManager) FindAuditEvents(ctx context.Context, user *openfga.User, filter db.AuditLogFilter) ([]dbmodel.AuditLogEntry, error) {
-	const op = errors.Op("jimm.FindAuditEvents")
 
 	access := user.GetAuditLogViewerAccess(ctx, j.jimmTag)
 	if access != ofganames.AuditLogViewerRelation {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var entries []dbmodel.AuditLogEntry
@@ -91,7 +90,7 @@ func (j *auditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return entries, nil
@@ -101,13 +100,12 @@ func (j *auditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 // administrators can perform this operation. The number of logs purged is
 // returned.
 func (j *auditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, before time.Time) (int64, error) {
-	op := errors.Op("jimm.PurgeLogs")
 	if !user.JimmAdmin {
-		return 0, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := j.store.DeleteAuditLogsBefore(ctx, before)
 	if err != nil {
-		return 0, errors.E(op, fmt.Errorf("failed to purge logs: %w", err))
+		return 0, errors.E(fmt.Errorf("failed to purge logs: %w", err))
 	}
 	return count, nil
 }

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -147,16 +147,15 @@ func NewBootstrapManager(
 // It requires the user to be an admin and returns the status, error message, logs,
 // and a watermark for pagination.
 func (b *bootstrapManager) GetJobInfo(ctx context.Context, _ *openfga.User, jobId uuid.UUID, offset int) (params.GetJobInfoResponse, error) {
-	const op = errors.Op("jimm.GetJobInfo")
 
 	job, err := b.tracker.GetJob(ctx, jobId)
 	if err != nil {
-		return params.GetJobInfoResponse{}, errors.E(op, "failed to get job info", err)
+		return params.GetJobInfoResponse{}, errors.E("failed to get job info", err)
 	}
 
 	loggies, newOffset, err := b.store.QueryJobLog(ctx, jobId, offset)
 	if err != nil {
-		return params.GetJobInfoResponse{}, errors.E(op, "failed to query job logs", err)
+		return params.GetJobInfoResponse{}, errors.E("failed to query job logs", err)
 	}
 	return params.GetJobInfoResponse{
 		Status:    params.JobStatus(job.Status),
@@ -168,19 +167,18 @@ func (b *bootstrapManager) GetJobInfo(ctx context.Context, _ *openfga.User, jobI
 
 // StopJob stops a bootstrap job by its ID.
 func (b *bootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobId uuid.UUID) error {
-	const op = errors.Op("jimm.StopJob")
 
 	if user == nil {
-		return errors.E(op, "user cannot be nil")
+		return errors.E("user cannot be nil")
 	}
 
 	if jobId == uuid.Nil {
-		return errors.E(op, "job ID cannot be nil")
+		return errors.E("job ID cannot be nil")
 	}
 
 	err := b.tracker.StopJob(ctx, jobId)
 	if err != nil {
-		return errors.E(op, "failed to stop job", err)
+		return errors.E("failed to stop job", err)
 	}
 
 	return nil
@@ -188,19 +186,18 @@ func (b *bootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobI
 
 // StartBootstrap starts a bootstrap job with the provided parameters.
 func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params BootstrapParams) (string, error) {
-	const op = errors.Op("jimm.StartBootstrapJob")
 
 	if b.jimmWellknownJWKSEndpoint == "" {
-		return "", errors.E(op, "bootstrap login token refresh URL is not configured. Cannot proceed with bootstrap. Please configure it and try again.")
+		return "", errors.E("bootstrap login token refresh URL is not configured. Cannot proceed with bootstrap. Please configure it and try again.")
 	}
 
 	if err := params.validate(); err != nil {
-		return "", errors.E(op, fmt.Errorf("invalid bootstrap parameters: %v", err))
+		return "", errors.E(fmt.Errorf("invalid bootstrap parameters: %v", err))
 	}
 
 	temp, err := os.MkdirTemp("", "juju-data-dir")
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
+		return "", errors.E(fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
 	}
 
 	jobId, err := b.tracker.Run(
@@ -228,7 +225,7 @@ func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		maxJobDuration,
 	)
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to start bootstrap job: %w", err))
+		return "", errors.E(fmt.Errorf("failed to start bootstrap job: %w", err))
 	}
 
 	return jobId.String(), nil
@@ -547,11 +544,10 @@ func (b *bootstrapManager) writeJobLog(ctx context.Context, jobId uuid.UUID, log
 
 // StartDestroyControllerJob starts a destroy-controller job
 func (b *bootstrapManager) StartDestroyControllerJob(ctx context.Context, user *openfga.User, params DestroyControllerParams) (string, error) {
-	const op = errors.Op("jimm.StartDestroyControllerJob")
 
 	jujuDataDir, err := os.MkdirTemp("", "juju-data-dir")
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
+		return "", errors.E(fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
 	}
 
 	jobId, err := b.tracker.Run(
@@ -561,7 +557,7 @@ func (b *bootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 		maxJobDuration,
 	)
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to start bootstrap job: %w", err))
+		return "", errors.E(fmt.Errorf("failed to start bootstrap job: %w", err))
 	}
 
 	return jobId.String(), nil

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -33,42 +33,39 @@ func NewGroupManager(store *db.Database, authSvc *openfga.OFGAClient) (*groupMan
 
 // AddGroup creates a group within JIMMs DB for reference by OpenFGA.
 func (j *groupManager) AddGroup(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
-	const op = errors.Op("jimm.GetGroupManager().AddGroup")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ge, err := j.store.AddGroup(ctx, name)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return ge, nil
 }
 
 // CountGroups returns the number of groups that exist.
 func (j *groupManager) CountGroups(ctx context.Context, user *openfga.User) (int, error) {
-	const op = errors.Op("jimm.CountGroups")
 
 	if !user.JimmAdmin {
-		return 0, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := j.store.CountGroups(ctx)
 	if err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	return count, nil
 }
 
 // getGroup returns a group based on the provided UUID or name.
 func (j *groupManager) getGroup(ctx context.Context, user *openfga.User, group *dbmodel.GroupEntry) (*dbmodel.GroupEntry, error) {
-	const op = errors.Op("jimm.getGroup")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := j.store.GetGroup(ctx, group); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return group, nil
 }
@@ -85,10 +82,9 @@ func (j *groupManager) GetGroupByName(ctx context.Context, user *openfga.User, n
 
 // RenameGroup renames a group in JIMM's DB.
 func (j *groupManager) RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error {
-	const op = errors.Op("jimm.GetGroupManager().RenameGroup")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -107,7 +103,7 @@ func (j *groupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -115,10 +111,9 @@ func (j *groupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 
 // RemoveGroup removes a group within JIMMs DB for reference by OpenFGA.
 func (j *groupManager) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {
-	const op = errors.Op("jimm.GetGroupManager().RemoveGroup")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -135,12 +130,12 @@ func (j *groupManager) RemoveGroup(ctx context.Context, user *openfga.User, name
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	err = j.authSvc.RemoveGroup(ctx, group.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -148,15 +143,14 @@ func (j *groupManager) RemoveGroup(ctx context.Context, user *openfga.User, name
 // ListGroups returns a list of groups known to JIMM.
 // `match` will filter the list fuzzy matching group's name or uuid.
 func (j *groupManager) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
-	const op = errors.Op("jimm.GetGroupManager().ListGroups")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	groups, err := j.store.ListGroups(ctx, pagination.Limit(), pagination.Offset(), match)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return groups, nil
 }

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -32,11 +32,10 @@ func NewIdentityManager(store *db.Database, authSvc *openfga.OFGAClient) (*ident
 // FetchIdentity fetches the user specified by the username and returns the user if it is found.
 // Or error "record not found".
 func (j *identityManager) FetchIdentity(ctx context.Context, id string) (*openfga.User, error) {
-	const op = errors.Op("jimm.FetchIdentity")
 
 	identity, err := dbmodel.NewIdentity(id)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	if err := j.store.FetchIdentity(ctx, identity); err != nil {
@@ -49,10 +48,9 @@ func (j *identityManager) FetchIdentity(ctx context.Context, id string) (*openfg
 // ListIdentities lists a page of users in our database and parse them into openfga entities.
 // `match` will filter the list for fuzzy find on identity name.
 func (j *identityManager) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
-	const op = errors.Op("jimm.ListIdentities")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	identities, err := j.store.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), match)
 	var users []openfga.User
@@ -61,22 +59,21 @@ func (j *identityManager) ListIdentities(ctx context.Context, user *openfga.User
 		users = append(users, *openfga.NewUser(&id, j.authSvc))
 	}
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return users, nil
 }
 
 // CountIdentities returns the count of all the identities in our database.
 func (j *identityManager) CountIdentities(ctx context.Context, user *openfga.User) (int, error) {
-	const op = errors.Op("jimm.CountIdentities")
 
 	if !user.JimmAdmin {
-		return 0, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	count, err := j.store.CountIdentities(ctx)
 	if err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	return count, nil
 }

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -38,7 +38,6 @@ type AddApplicationOfferParams struct {
 
 // Offer creates a new application offer.
 func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddApplicationOfferParams) error {
-	const op = errors.Op("jimm.Offer")
 
 	model := dbmodel.Model{
 		UUID: sql.NullString{
@@ -48,17 +47,17 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	if err := j.Database.GetModel(ctx, &model); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "model not found")
+			return errors.E(err, "model not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isAdmin, err := openfga.IsAdministrator(ctx, user, model.ResourceTag())
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed administrator check: %w", err))
+		return errors.E(fmt.Errorf("failed administrator check: %w", err))
 	}
 	if !isAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	offerURL := crossmodel.OfferURL{
@@ -77,12 +76,12 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return errors.E(fmt.Sprintf("offer %s already exists, please use a different name", offerURL.String()), errors.CodeAlreadyExists)
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 
@@ -102,9 +101,9 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		})
 	if err != nil {
 		if strings.Contains(err.Error(), "application offer already exists") {
-			return errors.E(op, err, errors.CodeAlreadyExists)
+			return errors.E(err, errors.CodeAlreadyExists)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	offerDetails := jujuparams.ApplicationOfferAdminDetailsV5{
@@ -114,7 +113,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	err = api.GetApplicationOffer(ctx, &offerDetails)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to fetch details of the created application offer: %w", err))
+		return errors.E(fmt.Errorf("failed to fetch details of the created application offer: %w", err))
 	}
 
 	doc := dbmodel.ApplicationOffer{
@@ -130,7 +129,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to store the created application offer: %w", err))
+		return errors.E(fmt.Errorf("failed to store the created application offer: %w", err))
 	}
 
 	if err := j.OpenFGAClient.AddModelApplicationOffer(
@@ -152,7 +151,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 
 	identity, err := dbmodel.NewIdentity(ownerId)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	owner := openfga.NewUser(
@@ -182,32 +181,31 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 // specified by details.ApplicationOfferDetails.OfferURL and completes
 // the rest of the details.
 func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, user *openfga.User, details *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
-	const op = errors.Op("jimm.GetApplicationOfferConsumeDetails")
 
 	offer := dbmodel.ApplicationOffer{
 		URL: details.Offer.OfferURL,
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, err, "application offer not found")
+			return errors.E(err, "application offer not found")
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	accessLevel, err := j.getUserOfferAccess(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	switch accessLevel {
 	case string(jujuparams.OfferAdminAccess):
 	case string(jujuparams.OfferConsumeAccess):
 	case string(jujuparams.OfferReadAccess):
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	default:
 		// TODO (ashipika)
 		//   - think about the returned error code
-		return errors.E(op, errors.CodeNotFound)
+		return errors.E(errors.CodeNotFound)
 	}
 
 	api, err := j.dial(
@@ -221,19 +219,19 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		},
 	)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 
 	if err := api.GetApplicationOfferConsumeDetails(ctx, user.ResourceTag(), details, v); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// Fix the consume details from the controller to be correct for JAAS.
 	// Filter out any juju local users.
 	users, err := j.listApplicationOfferUsers(ctx, offer.ResourceTag(), user.Identity, accessLevel == string(jujuparams.OfferAdminAccess))
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	details.Offer.Users = users
 
@@ -332,7 +330,6 @@ func (j *JujuManager) enrichOfferDetails(ctx context.Context, user *openfga.User
 
 // GetApplicationOffer returns details of the offer with the specified URL.
 func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.User, offerURL string) (*jujuparams.ApplicationOfferAdminDetailsV5, error) {
-	const op = errors.Op("jimm.GetApplicationOffer")
 
 	offer := dbmodel.ApplicationOffer{
 		URL: offerURL,
@@ -340,20 +337,20 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	err := j.Database.GetApplicationOffer(ctx, &offer)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(op, err, "application offer not found")
+			return nil, errors.E(err, "application offer not found")
 		}
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	reader, err := user.IsApplicationOfferReader(ctx, offer.ResourceTag())
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	// if this user does not have access to this application offer
 	// we return a not found error.
 	if !reader {
-		return nil, errors.E(op, errors.CodeNotFound, "application offer not found")
+		return nil, errors.E(errors.CodeNotFound, "application offer not found")
 	}
 
 	// Always collect application-offer admin details from the
@@ -367,19 +364,19 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 		nil,
 	)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	defer api.Close()
 
 	var offerDetails jujuparams.ApplicationOfferAdminDetailsV5
 	offerDetails.OfferURL = offerURL
 	if err := api.GetApplicationOffer(ctx, &offerDetails); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	offerDetails, err = j.enrichOfferDetails(ctx, user, offerDetails)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return &offerDetails, nil
@@ -387,7 +384,6 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 
 // DestroyOffer removes the application offer.
 func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offerURL string, force bool) error {
-	const op = errors.Op("jimm.DestroyOffer")
 
 	err := j.doApplicationOfferAdmin(ctx, user, offerURL, func(offer *dbmodel.ApplicationOffer, api API) error {
 		if err := api.DestroyApplicationOffer(ctx, offerURL, force); err != nil {
@@ -409,7 +405,7 @@ func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offe
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -456,10 +452,9 @@ func (o *offers) addOffer(offer jujuparams.ApplicationOfferAdminDetailsV5) {
 
 // FindApplicationOffers returns details of offers matching the specified filter.
 func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
-	const op = errors.Op("jimm.FindApplicationOffers")
 
 	if len(filters) == 0 {
-		return nil, errors.E(op, errors.CodeBadRequest, "at least one filter must be specified")
+		return nil, errors.E(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
@@ -468,30 +463,29 @@ func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.U
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
 		return api.FindApplicationOffers(ctx, filters)
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return offers, nil
 }
 
 // ListApplicationOffers returns details of offers matching the specified filter.
 func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
-	const op = errors.Op("jimm.ListApplicationOffers")
 
 	if len(filters) == 0 {
-		return nil, errors.E(op, errors.CodeBadRequest, "at least one filter must be specified")
+		return nil, errors.E(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
 	for _, f := range filters {
 		if f.ModelName == "" {
-			return nil, errors.E(op, "application offer filter must specify a model name")
+			return nil, errors.E("application offer filter must specify a model name")
 		}
 		if f.OwnerName == "" {
 			f.OwnerName = user.Name
@@ -502,7 +496,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 			OwnerIdentityName: f.OwnerName,
 		}
 		if err := j.Database.GetModel(ctx, &m); err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 		controllers[m.Controller.ID] = &m.Controller
 	}
@@ -511,7 +505,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 		return api.ListApplicationOffers(ctx, filters)
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return offers, nil
 }
@@ -561,21 +555,20 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 // As long as they are model admins or controller superusers they can also
 // manipulate the application offer as admins.
 func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga.User, offerURL string, f func(offer *dbmodel.ApplicationOffer, api API) error) error {
-	const op = errors.Op("jimm.doApplicationOfferAdmin")
 
 	offer := dbmodel.ApplicationOffer{
 		URL: offerURL,
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isOfferAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	// add offer admin claim
 	api, err := j.dial(
@@ -585,11 +578,11 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		nil,
 	)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 	if err := f(&offer, api); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -28,23 +28,22 @@ import (
 // add-model access to the cloud then the returned Users field will only
 // contain the authentcated user.
 func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error) {
-	const op = errors.Op("jimm.GetCloud")
 
 	var cl dbmodel.Cloud
 	cl.SetTag(tag)
 
 	if err := j.Database.GetCloud(ctx, &cl); err != nil {
-		return cl, errors.E(op, err)
+		return cl, errors.E(err)
 	}
 
 	accessLevel, err := j.permissionManager.GetUserCloudAccess(ctx, user, tag)
 	if err != nil {
-		return dbmodel.Cloud{}, errors.E(op, err)
+		return dbmodel.Cloud{}, errors.E(err)
 	}
 
 	switch accessLevel {
 	case "":
-		return dbmodel.Cloud{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return dbmodel.Cloud{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	case "admin":
 		return cl, nil
 	default:
@@ -61,11 +60,10 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 // an error then iteration will stop immediately and the error will be
 // returned unchanged. The given function should not update the database.
 func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
-	const op = errors.Op("jimm.ForEachUserCloud")
 
 	clouds, err := j.Database.GetClouds(ctx)
 	if err != nil {
-		return errors.E(op, err, "cannot load clouds")
+		return errors.E(err, "cannot load clouds")
 	}
 	for _, cloud := range clouds {
 		userAccess := permissions.ToCloudAccessString(user.GetCloudAccess(ctx, cloud.ResourceTag()))
@@ -88,15 +86,14 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 // superuser then an error with the code CodeUnauthorized is returned. The
 // given function should not update the database.
 func (j *JujuManager) ForEachCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
-	const op = errors.Op("jimm.ForEachCloud")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	clds, err := j.Database.GetClouds(ctx)
 	if err != nil {
-		return errors.E(op, "cannot load clouds", err)
+		return errors.E("cannot load clouds", err)
 	}
 
 	for i := range clds {
@@ -140,34 +137,33 @@ var DefaultReservedCloudNames = []string{
 // will be returned. If there is an error returned by the controller when
 // creating the cloud then that error code will be preserved.
 func (j *JujuManager) AddCloudToController(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error {
-	const op = errors.Op("jimm.AddCloudToController")
 
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := j.checkControllerAdminAccess(ctx, user, controller); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := checkReservedCloudNames(tag, j.ReservedCloudNames); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := validateCloudRegion(ctx, j.Database, user, cloud, controllerName); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	dbCloud, err := j.addCloudToDatabase(ctx, controller, user, tag, cloud, force)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// TODO(ale8k): We've added the cloud to the db, but the access failed.
 	// This call needs to be idempotent.
 	if err := j.addCloudControllerRelation(ctx, dbCloud, *controller); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -236,7 +232,6 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 //   - If there is an error returned by the controller when creating the cloud
 //     then that error code will be preserved.
 func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error {
-	const op = errors.Op("jimm.AddHostedCloud")
 
 	// NOTE (alesstimec) The default JIMM access right for every user is
 	// "login". Previously the code checked:
@@ -250,27 +245,27 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	}
 	for _, n := range reservedNames {
 		if tag.Id() == n {
-			return errors.E(op, errors.CodeAlreadyExists, fmt.Sprintf("cloud %q already exists", tag.Id()))
+			return errors.E(errors.CodeAlreadyExists, fmt.Sprintf("cloud %q already exists", tag.Id()))
 		}
 	}
 
 	// Validate that the requested cloud is valid.
 	if cloud.Type != "kubernetes" {
-		return errors.E(op, errors.CodeIncompatibleClouds, fmt.Sprintf("unsupported cloud type %q", cloud.Type))
+		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("unsupported cloud type %q", cloud.Type))
 	}
 	if cloud.HostCloudRegion == "" {
-		return errors.E(op, errors.CodeCloudRegionRequired, "cloud host region not specified")
+		return errors.E(errors.CodeCloudRegionRequired, "cloud host region not specified")
 	}
 
 	region, err := j.determineHostCloudRegion(ctx, cloud.HostCloudRegion)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if region.Cloud.HostCloudRegion != "" {
 		// Do not support creating a new cloud on an already hosted
 		// cloud.
-		return errors.E(op, errors.CodeIncompatibleClouds, fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion))
+		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion))
 	}
 
 	// Create the cloud locally, to reserve the name.
@@ -278,7 +273,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	dbCloud.FromJujuCloud(cloud)
 	dbCloud.Name = tag.Id()
 	if err := j.Database.AddCloud(ctx, &dbCloud); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// Create the cloud on a host.
@@ -288,7 +283,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	ccloud, err := j.addControllerCloud(ctx, &controller, user.ResourceTag(), tag, cloud, force)
 	if err != nil {
 		// TODO(mhilton) remove the added cloud if adding it to the controller failed.
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	// Update the cloud in the database.
 	dbCloud.FromJujuCloud(*ccloud)
@@ -305,7 +300,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 		// At this point the cloud has been created on the
 		// controller and we know something about it. Trying to
 		// undo that will probably make things worse.
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	err = j.OpenFGAClient.AddCloudController(ctx, dbCloud.ResourceTag(), controller.ResourceTag())
@@ -338,21 +333,20 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 // the controller. No error will be returned if the cloud already exists on
 // the controller or the user already has access to the cloud.
 func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, ut names.UserTag, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
-	const op = errors.Op("jimm.addControllerCloud")
 
 	api, err := j.dial(ctx, ctl, names.ModelTag{}, nil)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	defer api.Close()
 	if err := api.AddCloud(tag, cloud, force); err != nil {
 		if !jujuparams.IsCodeAlreadyExists(err) {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 	}
 	var result jujucloud.Cloud
 	if err := api.Cloud(tag, &result); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return &result, nil
@@ -371,23 +365,22 @@ func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Contr
 // returned from the dial operation. If the given function returns an error
 // that error will be returned with the code unmasked.
 func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct names.CloudTag, f func(*dbmodel.Cloud, API) error) error {
-	const op = errors.Op("jimm.doCloudAdmin")
 
 	var c dbmodel.Cloud
 	c.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &c); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, c.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	// Ensure we always have at least 1 region for the cloud with at least 1 controller
 	// managing that region.
@@ -396,15 +389,15 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		if len(c.Regions) > 0 {
 			zapctx.Error(ctx, "number of controllers available for cloud/region", zap.Int("controllers", len(c.Regions[0].Controllers)))
 		}
-		return errors.E(op, fmt.Sprintf("cloud administration not available for %s", ct.Id()))
+		return errors.E(fmt.Sprintf("cloud administration not available for %s", ct.Id()))
 	}
 	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 	if err := f(&c, api); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -415,7 +408,6 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 // with the code CodeUnauthorized is returned. If the RemoveClouds API call
 // returns an error the error code is not masked.
 func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct names.CloudTag) error {
-	const op = errors.Op("jimm.RemoveCloud")
 
 	err := j.doCloudAdmin(ctx, user, ct, func(c *dbmodel.Cloud, api API) error {
 		// Note: JIMM doesn't attempt to determine if the cloud is
@@ -427,7 +419,7 @@ func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct na
 		}
 
 		if err := j.Database.DeleteCloud(ctx, c); err != nil {
-			return errors.E(op, err, "cannot update database after updating controller")
+			return errors.E(err, "cannot update database after updating controller")
 		}
 
 		if err := j.OpenFGAClient.RemoveCloud(ctx, ct); err != nil {
@@ -436,7 +428,7 @@ func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct na
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -447,22 +439,21 @@ func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct na
 // CodeUnauthorized. If the cloud with the given name cannot be found then
 // an error with the code CodeNotFound is returned.
 func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct names.CloudTag, cloud jujucloud.Cloud) error {
-	const op = errors.Op("jimm.UpdateCloud")
 
 	var c dbmodel.Cloud
 	c.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &c); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	cloudAccess, err := j.permissionManager.GetUserCloudAccess(ctx, user, c.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if cloudAccess != "admin" {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var controllers []dbmodel.Controller
@@ -481,7 +472,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 		return api.UpdateCloud(ct, cloud)
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -509,7 +500,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 	})
 
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -520,23 +511,22 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 // access to the cloud then an error with the code CodeUnauthorized is returned.
 // If the RemoveClouds API call returns an error the error code is not masked.
 func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openfga.User, controllerName string, ct names.CloudTag) error {
-	const op = errors.Op("jimm.RemoveCloudFromController")
 
 	var cloud dbmodel.Cloud
 	cloud.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &cloud); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(op, err, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(err, errors.CodeUnauthorized, "unauthorized")
 	}
 	if !isAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	controllers := make(map[string]dbmodel.Controller)
@@ -548,12 +538,12 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	controller, ok := controllers[controllerName]
 	if !ok {
-		return errors.E(op, "cloud not hosted by controller", errors.CodeNotFound)
+		return errors.E("cloud not hosted by controller", errors.CodeNotFound)
 	}
 
 	api, err := j.dial(ctx, &controller, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 
@@ -562,7 +552,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	// relies on the controller failing the RemoveClouds API
 	// request if the cloud is in use.
 	if err := api.RemoveCloud(ct); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	delete(controllers, controllerName)
@@ -570,7 +560,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	// if this was the only cloud controller, we delete the cloud
 	if len(controllers) == 0 {
 		if err := j.Database.DeleteCloud(ctx, &cloud); err != nil {
-			return errors.E(op, err, "failed to delete cloud after updating controller")
+			return errors.E(err, "failed to delete cloud after updating controller")
 		}
 		return nil
 	}
@@ -581,7 +571,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 		for _, crp := range cr.Controllers {
 			crp := crp
 			if err := j.Database.DeleteCloudRegionControllerPriority(ctx, &crp); err != nil {
-				return errors.E(op, err, "cannot update database after updating controller")
+				return errors.E(err, "cannot update database after updating controller")
 			}
 		}
 	}
@@ -670,7 +660,6 @@ func checkReservedCloudNames(tag names.CloudTag, reservedCloudNames []string) er
 // addCloudToDatabase adds the cloud to the database for this controller.
 // Additionally, it sets the cloud to controller access relation.
 func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmodel.Controller, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (dbmodel.Cloud, error) {
-	const op = errors.Op("jimm.addCloudToDatabase")
 
 	var dbCloud dbmodel.Cloud
 	dbCloud.FromJujuCloud(cloud)
@@ -678,7 +667,7 @@ func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmode
 
 	ccloud, err := j.addControllerCloud(ctx, controller, user.ResourceTag(), tag, cloud, force)
 	if err != nil {
-		return dbCloud, errors.E(op, err)
+		return dbCloud, errors.E(err)
 	}
 
 	dbCloud.FromJujuCloud(*ccloud)
@@ -689,7 +678,7 @@ func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmode
 		}}
 	}
 	if err := j.Database.AddCloud(ctx, &dbCloud); err != nil {
-		return dbCloud, errors.E(op, err)
+		return dbCloud, errors.E(err)
 	}
 
 	return dbCloud, nil

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -26,10 +26,9 @@ import (
 // superuser or the owner of the credentials then an error with a code of
 // CodeUnauthorized will be returned.
 func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error) {
-	const op = errors.Op("jimm.GetCloudCredential")
 
 	if !user.JimmAdmin && user.Name != tag.Owner().Id() {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var credential dbmodel.CloudCredential
@@ -37,7 +36,7 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return &credential, nil
@@ -46,10 +45,9 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 // RevokeCloudCredential checks that the credential with the given path
 // can be revoked  and revokes the credential.
 func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
-	const op = errors.Op("jimm.RevokeCloudCredential")
 
 	if user.Name != tag.Owner().Id() {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var credential dbmodel.CloudCredential
@@ -61,7 +59,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 			// It is not an error to revoke an non-existent credential
 			return nil
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	credential.Valid = sql.NullBool{
@@ -71,20 +69,20 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 
 	models, err := j.Database.GetModelsUsingCredential(ctx, credential.ID)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	// Before we accepted the force flag to remove the credential regardless of the references count.
 	// Now we want to ensure that the credential is not used by any models before removing it to maintain
 	// referential integrity.
 	if len(models) > 0 {
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("cloud credential still used by %d model(s)", len(models)))
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("cloud credential still used by %d model(s)", len(models)))
 	}
 
 	cloud := dbmodel.Cloud{
 		Name: credential.CloudName,
 	}
 	if err = j.Database.GetCloud(ctx, &cloud); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	var controllers []dbmodel.Controller
@@ -108,12 +106,12 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 	})
 
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	err = j.Database.DeleteCloudCredential(ctx, &credential)
 	if err != nil {
-		return errors.E(op, err, "failed to revoke credential in local database")
+		return errors.E(err, "failed to revoke credential in local database")
 	}
 	return nil
 }
@@ -130,19 +128,18 @@ type UpdateCloudCredentialArgs struct {
 // and updates it in the local database and all controllers
 // to which it is deployed.
 func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.User, args UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error) {
-	const op = errors.Op("jimm.UpdateCloudCredential")
 
 	var resultMu sync.Mutex
 	var result []jujuparams.UpdateCredentialModelResult
 	if user.Tag() != args.CredentialTag.Owner() {
 		if !user.JimmAdmin {
-			return result, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+			return result, errors.E(errors.CodeUnauthorized, "unauthorized")
 		}
 		// ensure the user we are adding the credential for exists.
 		var u2 dbmodel.Identity
 		u2.SetTag(args.CredentialTag.Owner())
 		if err := j.Database.GetIdentity(ctx, &u2); err != nil {
-			return result, errors.E(op, err)
+			return result, errors.E(err)
 		}
 	}
 
@@ -151,19 +148,19 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 
 	// Confirm the cloud exists.
 	var cloud dbmodel.Cloud
 	cloud.SetTag(names.NewCloudTag(credential.CloudName))
 	if err = j.Database.GetCloud(ctx, &cloud); err != nil {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 
 	models, err := j.Database.GetModelsUsingCredential(ctx, credential.ID)
 	if err != nil {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 	var controllers []dbmodel.Controller
 	seen := make(map[uint]bool)
@@ -186,7 +183,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 			return err
 		})
 		if err != nil {
-			return result, errors.E(op, err)
+			return result, errors.E(err)
 		}
 	}
 	var modelsErr bool
@@ -203,7 +200,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 	}
 
 	if err := j.updateCredential(ctx, &credential, args.Credential.Attributes); err != nil {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 
 	err = j.forEachController(ctx, controllers, func(ctl *dbmodel.Controller, api API) error {
@@ -219,20 +216,19 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 		return nil
 	})
 	if err != nil {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 	return result, nil
 }
 
 // updateCredential updates the credential stored in JIMM's database.
 func (j *JujuManager) updateCredential(ctx context.Context, credential *dbmodel.CloudCredential, attr map[string]string) error {
-	const op = errors.Op("jimm.updateCredential")
 
 	if err := j.Database.SetCloudCredential(ctx, credential); err != nil {
-		return errors.E(op, fmt.Errorf("failed to store credential id: %w", err))
+		return errors.E(fmt.Errorf("failed to store credential id: %w", err))
 	}
 	if err := j.CredentialStore.Put(ctx, credential.ResourceTag(), attr); err != nil {
-		return errors.E(op, fmt.Errorf("failed to store credentials: %w", err))
+		return errors.E(fmt.Errorf("failed to store credentials: %w", err))
 	}
 
 	return nil
@@ -243,11 +239,10 @@ func (j *JujuManager) updateControllerCloudCredential(
 	cred *dbmodel.CloudCredential,
 	f func(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error),
 ) ([]jujuparams.UpdateCredentialModelResult, error) {
-	const op = errors.Op("jimm.updateControllerCloudCredential")
 
 	attr, err := j.getCloudCredentialAttributes(ctx, cred)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	models, err := f(ctx, jujuparams.TaggedCredential{
@@ -258,7 +253,7 @@ func (j *JujuManager) updateControllerCloudCredential(
 		},
 	})
 	if err != nil {
-		return models, errors.E(op, err)
+		return models, errors.E(err)
 	}
 	return models, nil
 }
@@ -270,7 +265,6 @@ func (j *JujuManager) updateControllerCloudCredential(
 // GetCloudCredentialAttributes should be used to retrive the credential
 // attributes if needed. The given function should not update the database.
 func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel.Identity, ct names.CloudTag, f func(cred *dbmodel.CloudCredential) error) error {
-	const op = errors.Op("jimm.ForEachUserCloudCredential")
 
 	var cloud string
 	if ct != (names.CloudTag{}) {
@@ -289,7 +283,7 @@ func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel
 	if err == errStop {
 		err = iterErr
 	} else if err != nil {
-		err = errors.E(op, err)
+		err = errors.E(err)
 	}
 	return err
 }
@@ -301,22 +295,21 @@ func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel
 // other user, including controller superusers, will receive an error with
 // the code CodeUnauthorized.
 func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, user *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error) {
-	const op = errors.Op("jimm.GetCloudCredentialAttributes")
 
 	if hidden {
 		// Controller superusers cannot read hidden credential attributes.
 		if user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+			return nil, nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 		}
 	} else {
 		if !user.JimmAdmin && user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+			return nil, nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 		}
 	}
 
 	attrs, err = j.getCloudCredentialAttributes(ctx, cred)
 	if err != nil {
-		err = errors.E(op, err)
+		err = errors.E(err)
 		return
 	}
 	if len(attrs) == 0 {
@@ -340,32 +333,29 @@ func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, user *op
 
 // getCloudCredentialAttributes retrieves the attributes for a cloud credential.
 func (j *JujuManager) getCloudCredentialAttributes(ctx context.Context, cred *dbmodel.CloudCredential) (map[string]string, error) {
-	const op = errors.Op("jimm.getCloudCredentialAttributes")
 
 	attr, err := j.CredentialStore.Get(ctx, cred.ResourceTag())
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return attr, nil
 }
 
 // CopyCredential copies a cloud credential from one user to another.
 func (j *JujuManager) CopyCredential(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error) {
-	op := errors.Op("jimm.CopyCredential")
-
 	credential, err := j.GetCloudCredential(ctx, originalUser, cred)
 	if err != nil {
-		return names.CloudCredentialTag{}, nil, errors.E(op, err)
+		return names.CloudCredentialTag{}, nil, errors.E(err)
 	}
 
 	attr, err := j.getCloudCredentialAttributes(ctx, credential)
 	if err != nil {
-		return names.CloudCredentialTag{}, nil, errors.E(op, err)
+		return names.CloudCredentialTag{}, nil, errors.E(err)
 	}
 
 	newCredID := fmt.Sprintf("%s/%s/%s", cred.Cloud().Id(), newUser.Name, cred.Name())
 	if !names.IsValidCloudCredential(newCredID) {
-		return names.CloudCredentialTag{}, nil, errors.E(op, fmt.Sprintf("new credential ID %s is not a valid cloud credential tag", newCredID))
+		return names.CloudCredentialTag{}, nil, errors.E(fmt.Sprintf("new credential ID %s is not a valid cloud credential tag", newCredID))
 	}
 
 	newCredential := jujuparams.CloudCredential{

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -19,7 +19,6 @@ const (
 
 // SetModelDefaults writes new default model setting values for the specified cloud/region.
 func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error {
-	const op = errors.Op("jimm.SetModelDefaults")
 
 	var keys strings.Builder
 	var needComma bool
@@ -33,7 +32,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 
 	for k := range configs {
 		if k == agentVersionKey {
-			return errors.E(op, errors.CodeBadRequest, `agent-version cannot have a default value`)
+			return errors.E(errors.CodeBadRequest, `agent-version cannot have a default value`)
 		}
 	}
 
@@ -42,7 +41,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 	}
 	err := j.Database.GetCloud(ctx, &cloud)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if region != "" {
 		found := false
@@ -52,7 +51,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 			}
 		}
 		if !found {
-			return errors.E(op, errors.CodeNotFound, "region not found")
+			return errors.E(errors.CodeNotFound, "region not found")
 		}
 	}
 	err = j.Database.SetCloudDefaults(ctx, &dbmodel.CloudDefaults{
@@ -62,14 +61,13 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 		Defaults:     configs,
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // UnsetModelDefaults resets  default model setting values for the specified cloud/region.
 func (j *JujuManager) UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error {
-	const op = errors.Op("jimm.UnsetModelDefaults")
 
 	defaults := dbmodel.CloudDefaults{
 		IdentityName: user.Name,
@@ -80,14 +78,14 @@ func (j *JujuManager) UnsetModelDefaults(ctx context.Context, user *dbmodel.Iden
 	}
 	err := j.Database.UnsetCloudDefaults(ctx, &defaults, keys)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // ModelDefaultsForCloud returns the default config values for the specified cloud.
 func (j *JujuManager) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error) {
-	const op = errors.Op("jimm.ModelDefaultsForCloud")
+
 	result := jujuparams.ModelDefaultsResult{
 		Config: make(map[string]jujuparams.ModelDefaults),
 	}
@@ -97,7 +95,7 @@ func (j *JujuManager) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.I
 			Message: err.Error(),
 			Code:    string(errors.ErrorCode(err)),
 		}
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 
 	for _, cloudDefaults := range defaults {

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -221,7 +221,6 @@ func addControllerTx(ctx context.Context, j *JujuManager, jujuClouds []dbmodel.C
 // contacted then an error with a code of CodeConnectionFailed will be
 // returned.
 func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, creds ControllerCreds) error {
-	const op = errors.Op("jimm.AddController")
 
 	if err := j.checkJimmAdmin(user); err != nil {
 		return err
@@ -229,18 +228,18 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	api, err := j.dialController(ctx, ctl)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial the controller: %v", err))
+		return errors.E(fmt.Errorf("failed to dial the controller: %v", err))
 	}
 	defer api.Close()
 
 	modelSummary, err := getControllerModelSummary(ctx, api)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get model summary: %v", err))
+		return errors.E(fmt.Errorf("failed to get model summary: %v", err))
 	}
 
 	cloudName, err := getCloudNameFromModelSummary(modelSummary)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to parse the cloud tag: %v", err))
+		return errors.E(fmt.Errorf("failed to parse the cloud tag: %v", err))
 	}
 
 	ctl.CloudName = cloudName
@@ -249,7 +248,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	clouds, err := api.Clouds()
 	if err != nil {
-		return errors.E(op, err, "failed to fetch controller clouds")
+		return errors.E(err, "failed to fetch controller clouds")
 	}
 
 	dbClouds := convertJujuCloudsToDbClouds(clouds)
@@ -273,15 +272,15 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	err = j.CredentialStore.PutControllerCredentials(ctx, ctl.Name, creds.AdminIdentityName, creds.AdminPassword)
 	if err != nil {
-		return errors.E(op, err, "failed to store controller credentials")
+		return errors.E(err, "failed to store controller credentials")
 	}
 
 	if err := addControllerTx(ctx, j, dbClouds, ctl); err != nil {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(op, err, fmt.Sprintf("controller %q already exists", ctl.Name))
+			return errors.E(err, fmt.Sprintf("controller %q already exists", ctl.Name))
 		}
 
-		return errors.E(op, fmt.Errorf("failed to add controller: %w", err))
+		return errors.E(fmt.Errorf("failed to add controller: %w", err))
 	}
 
 	for _, cloud := range dbClouds {
@@ -325,7 +324,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 // If there are no available controllers or none of their versions are
 // known, it returns the zero version.
 func (j *JujuManager) EarliestControllerVersion(ctx context.Context) (version.Number, error) {
-	const op = errors.Op("jimm.EarliestControllerVersion")
+
 	var v *version.Number
 
 	err := j.Database.ForEachController(ctx, func(controller *dbmodel.Controller) error {
@@ -349,7 +348,7 @@ func (j *JujuManager) EarliestControllerVersion(ctx context.Context) (version.Nu
 		return nil
 	})
 	if err != nil {
-		return version.Number{}, errors.E(op, err)
+		return version.Number{}, errors.E(err)
 	}
 	if v == nil {
 		return version.Number{}, nil
@@ -554,7 +553,6 @@ func (m *modelImporter) save(ctx context.Context) error {
 // ImportModel imports a model and existing offers into JIMM.  A new owner  must be set to
 // represent the external user who will own this model (if the original owner is a local user).
 func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
-	const op = errors.Op("jimm.ImportModel")
 
 	if err := j.checkJimmAdmin(user); err != nil {
 		return err
@@ -562,19 +560,19 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 
 	importer, err := newModelImporter(j, newOwner)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := importer.fetchModelInfo(ctx, controllerName, modelTag); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := importer.setModelOwner(ctx); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := importer.addPermissions(ctx); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// TODO(CSS-5458): Remove the below section on cloud credentials once we no longer persist the relation between
@@ -582,15 +580,15 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 	// Update: We need to investigate this further, if a user updates their cloud-credential it will update the credential
 	// on this model.
 	if err := importer.setCloudCredential(ctx); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := importer.setModelCloud(ctx); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := importer.save(ctx); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -599,10 +597,9 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 // UpdateMigratedModel asserts that the model has been migrated to the
 // specified controller and updates the internal model representation.
 func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error {
-	const op = errors.Op("jimm.UpdateMigratedModel")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	model := dbmodel.Model{
@@ -614,9 +611,9 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, "model not found", errors.CodeModelNotFound)
+			return errors.E("model not found", errors.CodeModelNotFound)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	targetController := dbmodel.Controller{
@@ -625,15 +622,15 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err = j.Database.GetController(ctx, &targetController)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(op, "controller not found", errors.CodeNotFound)
+			return errors.E("controller not found", errors.CodeNotFound)
 		}
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// check the model is known to the controller
 	api, err := j.dial(ctx, &targetController, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 
@@ -641,13 +638,13 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 		UUID: modelTag.Id(),
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	model.InternalMigrationSuccess(targetController.ID)
 	err = j.Database.UpdateModel(ctx, &model)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to update model: %w", err))
+		return errors.E(fmt.Errorf("failed to update model: %w", err))
 	}
 
 	return nil
@@ -664,37 +661,37 @@ func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User,
 // It is used for both internal migrations (migrating a model to another
 // controller managed by JIMM) and migrations away from JIMM.
 func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec, internalMigration bool) (jujuparams.InitiateMigrationResult, error) {
-	const op = errors.Op("jimm.initiateMigration")
+
 	result := jujuparams.InitiateMigrationResult{
 		ModelTag: spec.ModelTag,
 	}
 	mt, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
-		return result, errors.E(op, err, errors.CodeBadRequest)
+		return result, errors.E(err, errors.CodeBadRequest)
 	}
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, mt)
 	if err != nil {
-		return result, errors.E(op, err, errors.CodeOpenFGARequestFailed)
+		return result, errors.E(err, errors.CodeOpenFGARequestFailed)
 	}
 	if !isAdministrator {
-		return result, errors.E(op, errors.CodeUnauthorized)
+		return result, errors.E(errors.CodeUnauthorized)
 	}
 
 	targetControllerTag, err := names.ParseControllerTag(spec.TargetInfo.ControllerTag)
 	if err != nil {
-		return result, errors.E(op, err, errors.CodeBadRequest)
+		return result, errors.E(err, errors.CodeBadRequest)
 	}
 
 	targetUserTag, err := names.ParseUserTag(spec.TargetInfo.AuthTag)
 	if err != nil {
-		return result, errors.E(op, err, errors.CodeBadRequest)
+		return result, errors.E(err, errors.CodeBadRequest)
 	}
 
 	var targetMacaroons []macaroon.Slice
 	if spec.TargetInfo.Macaroons != "" {
 		err = json.Unmarshal([]byte(spec.TargetInfo.Macaroons), &targetMacaroons)
 		if err != nil {
-			return result, errors.E(op, err, "failed to unmarshal macaroons", errors.CodeBadRequest)
+			return result, errors.E(err, "failed to unmarshal macaroons", errors.CodeBadRequest)
 		}
 	}
 
@@ -703,11 +700,11 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	err = j.Database.Transaction(func(tx *db.Database) error {
 		err := tx.ForUpdate().GetModel(ctx, &model)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		if model.MigrationMode != dbmodel.MigrationModeNone {
-			return errors.E(op, fmt.Errorf("model is already in migration mode %q", model.MigrationMode))
+			return errors.E(fmt.Errorf("model is already in migration mode %q", model.MigrationMode))
 		}
 
 		if internalMigration {
@@ -719,7 +716,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		return tx.UpdateModel(ctx, &model)
 	})
 	if err != nil {
-		return result, errors.E(op, fmt.Errorf("failed to update the model's migration mode: %v", err))
+		return result, errors.E(fmt.Errorf("failed to update the model's migration mode: %v", err))
 	}
 
 	// Until we have better handling for partial failures we try to revert
@@ -734,7 +731,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
 		rollbackMigrationMode()
-		return result, errors.E(op, "failed to dial the controller", err)
+		return result, errors.E("failed to dial the controller", err)
 	}
 
 	client := newControllerClient(api)
@@ -752,7 +749,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	})
 	if err != nil {
 		rollbackMigrationMode()
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 
 	return result, nil
@@ -760,22 +757,21 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 
 // ControllerConfig returns the controller config for the specified controller.
 func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName string) (jujucontroller.Config, error) {
-	const op = errors.Op("jimm.ControllerConfig")
 
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
-		return jujucontroller.Config{}, errors.E(op, err)
+		return jujucontroller.Config{}, errors.E(err)
 	}
 
 	api, err := j.dialController(ctx, controller)
 	if err != nil {
-		return jujucontroller.Config{}, errors.E(op, err)
+		return jujucontroller.Config{}, errors.E(err)
 	}
 	defer api.Close()
 
 	cfg, err := api.ControllerConfig(ctx)
 	if err != nil {
-		return jujucontroller.Config(cfg.Config), errors.E(op, err)
+		return jujucontroller.Config(cfg.Config), errors.E(err)
 	}
 	return jujucontroller.Config(cfg.Config), nil
 }
@@ -783,7 +779,6 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName strin
 // ControllerDetailsForModel returns the controller details for the specified model
 // including the controller, and the admin credentials (username and password) for the controller.
 func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID string) (ControllerConnectionDetails, error) {
-	const op = errors.Op("jimm.ControllerDetailsForModel")
 
 	model := dbmodel.Model{
 		UUID: sql.NullString{
@@ -794,18 +789,18 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerConnectionDetails{}, errors.E(op, err)
+		return ControllerConnectionDetails{}, errors.E(err)
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
 	if err != nil {
-		return ControllerConnectionDetails{}, errors.E(op, err)
+		return ControllerConnectionDetails{}, errors.E(err)
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
+		return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
 	}
 
 	return toControllerConnectionDetails(model.Controller, username, password), nil

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -54,22 +54,21 @@ func (j *JujuManager) forEachController(ctx context.Context, controllers []dbmod
 
 // ControllerInfo returns info about a controller connected to JIMM.
 func (j *JujuManager) ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error) {
-	const op = errors.Op("jimm.ListControllers")
+
 	ctl := dbmodel.Controller{
 		Name: name,
 	}
 	if err := j.Database.GetController(ctx, &ctl); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return &ctl, nil
 }
 
 // ListControllers returns a list of controllers the user has access to.
 func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error) {
-	const op = errors.Op("jimm.ListControllers")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var controllers []dbmodel.Controller
@@ -78,7 +77,7 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return controllers, nil
@@ -87,10 +86,9 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 // SetControllerDeprecated records if the controller is to be deprecated.
 // No new models or clouds can be added to a deprecated controller.
 func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error {
-	const op = errors.Op("jimm.SetControllerDeprecated")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -107,7 +105,7 @@ func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga
 		return db.UpdateController(ctx, &c)
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -115,10 +113,9 @@ func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga
 
 // RemoveController removes a controller.
 func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, controllerName string, force bool) error {
-	const op = errors.Op("jimm.RemoveController")
 
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -155,7 +152,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 		return db.DeleteController(ctx, &c)
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -163,10 +160,9 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 
 // FullModelStatus returns the full status of the juju model.
 func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error) {
-	const op = errors.Op("jimm.RemoveController")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	model := dbmodel.Model{
@@ -177,17 +173,17 @@ func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, m
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	api, err := j.dial(ctx, &model.Controller, modelTag, nil)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	status, err := api.Status(ctx, patterns)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return status, nil
@@ -230,11 +226,10 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 
 // InitiateInternalMigration initiates a model migration between two controllers within JIMM.
 func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error) {
-	const op = errors.Op("jimm.InitiateInternalMigration")
 
 	migrationTarget, _, err := fillMigrationTarget(j.Database, j.CredentialStore, targetController)
 	if err != nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(op, err)
+		return jujuparams.InitiateMigrationResult{}, errors.E(err)
 	}
 
 	model := dbmodel.Model{}
@@ -243,15 +238,15 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 	if err != nil {
 		s := strings.Split(modelNameOrUUID, "/")
 		if len(s) != 2 {
-			return jujuparams.InitiateMigrationResult{}, errors.E(op, "invalid model target")
+			return jujuparams.InitiateMigrationResult{}, errors.E("invalid model target")
 		}
 
 		owner, name := s[0], s[1]
 		if !names.IsValidUser(owner) {
-			return jujuparams.InitiateMigrationResult{}, errors.E(op, "invalid user name")
+			return jujuparams.InitiateMigrationResult{}, errors.E("invalid user name")
 		}
 		if !names.IsValidModelName(name) {
-			return jujuparams.InitiateMigrationResult{}, errors.E(op, "invalid model name")
+			return jujuparams.InitiateMigrationResult{}, errors.E("invalid model name")
 		}
 
 		model.Name = name
@@ -265,12 +260,12 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 
 	err = j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(op, err)
+		return jujuparams.InitiateMigrationResult{}, errors.E(err)
 	}
 	spec := jujuparams.MigrationSpec{ModelTag: model.ResourceTag().String(), TargetInfo: migrationTarget}
 	result, err := initiateInternalMigration(ctx, j, user, spec)
 	if err != nil {
-		return result, errors.E(op, err)
+		return result, errors.E(err)
 	}
 	return result, nil
 }
@@ -284,7 +279,6 @@ func (j *JujuManager) PrepareModelMigration(
 	targetControllerName string,
 	userMapping map[string]string,
 ) (string, error) {
-	const op = errors.Op("jujumanager.PrepareModelMigration")
 
 	err := j.Database.Transaction(func(d *db.Database) error {
 		ctl := dbmodel.Controller{Name: targetControllerName}
@@ -300,7 +294,7 @@ func (j *JujuManager) PrepareModelMigration(
 		}
 		err := d.GetModel(ctx, model)
 		if err == nil {
-			return errors.E(op, "model migration for the specified model is already in progress/completed")
+			return errors.E("model migration for the specified model is already in progress/completed")
 		} else if errors.ErrorCode(err) != errors.CodeNotFound {
 			return err
 		}
@@ -316,12 +310,12 @@ func (j *JujuManager) PrepareModelMigration(
 		return nil
 	})
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to add incoming model migration details: %w", err))
+		return "", errors.E(fmt.Errorf("failed to add incoming model migration details: %w", err))
 	}
 
 	migrationToken, err := j.migrationTokenGenerator.NewMigrationToken(ctx, user.Name)
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to generate migration token: %w", err))
+		return "", errors.E(fmt.Errorf("failed to generate migration token: %w", err))
 	}
 
 	return migrationToken, nil
@@ -331,33 +325,32 @@ func (j *JujuManager) PrepareModelMigration(
 // model could be migrated to. This includes controllers that support the model's
 // cloud region and version, but excludes the controller the model is already on.
 func (j *JujuManager) ListMigrationTargets(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error) {
-	const op = errors.Op("jimm.ListMigrationTargets")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var model dbmodel.Model
 	model.SetTag(modelTag)
 	if err := j.Database.GetModel(ctx, &model); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	currentVersion, err := version.Parse(model.Controller.AgentVersion)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	cloudRegion, err := j.Database.FindRegionByCloudName(ctx, model.CloudRegion.CloudName, model.CloudRegion.Name)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	var controllers []dbmodel.Controller
 	for _, ctl := range cloudRegion.Controllers {
 		candidateVersion, err := version.Parse(ctl.Controller.AgentVersion)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 
 		if model.Controller.ID != ctl.Controller.ID &&

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -36,7 +36,6 @@ const TIMEOUT_PENDING_MIGRATION = 24 * time.Hour
 // It also deletes the migration record from the database, but does not return an error
 // if the deletion fails, as the migration has already been aborted on the target controller.
 func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
-	const op = errors.Op("jimm.Abort")
 
 	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -46,18 +45,18 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+		return errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	err = api.Abort(modelUUID)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to abort migration: %w", err))
+		return errors.E(fmt.Errorf("failed to abort migration: %w", err))
 	}
 
 	err = j.Database.DeleteIncomingModelMigration(ctx, &incomingModel)
@@ -90,7 +89,6 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 // and compares them with the ones reported by the provider.
 // It calls the CheckMachines method on the target Juju controller.
 func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
-	const op = errors.Op("jimm.CheckMachines")
 
 	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -100,18 +98,18 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+		return nil, errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	machineErrors, err := api.CheckMachines(modelUUID)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to check machines: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to check machines: %w", err))
 	}
 	return machineErrors, nil
 }
@@ -119,7 +117,6 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 // ControllerDetailsForIncomingModel retrieves the target controller details for a model that is being migrated.
 // It returns the controller information, username, and password for the target controller.
 func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (ControllerConnectionDetails, error) {
-	const op = errors.Op("jimm.ControllerDetailsForIncomingModel")
 
 	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -131,9 +128,9 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerConnectionDetails{}, errors.E(op, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
+		return ControllerConnectionDetails{}, errors.E(fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, incomingModel.TargetController.Name)
@@ -142,7 +139,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.E(op, errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
+		return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
 	}
 
 	return toControllerConnectionDetails(incomingModel.TargetController, username, password), nil
@@ -154,7 +151,6 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 // As part of all model migrations passing through JIMM, it modifies the model description
 // to replace any local user references with their external mapping.
 func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model migration.ModelInfo) error {
-	const op = errors.Op("jimm.Prechecks")
 
 	incomingModel := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -164,22 +160,22 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
+		return errors.E(fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
 	}
 
 	err = j.validateUserMapping(model.ModelDescription, incomingModel.UserMapping)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to validate user mapping: %w", err))
+		return errors.E(fmt.Errorf("failed to validate user mapping: %w", err))
 	}
 
 	err = j.modifyMigrationInfo(&model, incomingModel.UserMapping)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to modify migration info: %w", err))
+		return errors.E(fmt.Errorf("failed to modify migration info: %w", err))
 	}
 
 	_, err = j.Database.FindRegionByCloudName(ctx, model.ModelDescription.CloudCredential().Cloud(), model.ModelDescription.CloudRegion())
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to find region for cloud %q: %w", model.ModelDescription.CloudCredential().Cloud(), err))
+		return errors.E(fmt.Errorf("failed to find region for cloud %q: %w", model.ModelDescription.CloudCredential().Cloud(), err))
 	}
 
 	cloudCredential := &dbmodel.CloudCredential{
@@ -190,18 +186,18 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model m
 
 	err = j.Database.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	err = api.Prechecks(model)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to run pre-checks for migration: %w", err))
+		return errors.E(fmt.Errorf("failed to run pre-checks for migration: %w", err))
 	}
 	return nil
 }
@@ -248,7 +244,6 @@ func (j *JujuManager) validateUserMapping(modelDescription description.Model, us
 // Adopt resources is called after the model has been activated so the
 // incoming model migration does not exist and the model is used instead.
 func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
-	const op = errors.Op("jimm.AdoptResources")
 
 	model := dbmodel.Model{
 		UUID: sql.NullString{
@@ -258,18 +253,18 @@ func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, mo
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
+		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
 	}
 
 	api, err := j.dialController(ctx, &model.Controller)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	err = api.AdoptResources(modelUUID, sourceControllerVersion)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to adopt resources: %w", err))
+		return errors.E(fmt.Errorf("failed to adopt resources: %w", err))
 	}
 	return nil
 }
@@ -353,7 +348,6 @@ func modifyModelDescription(modelDescription description.Model, userMapping dbmo
 // LatestLogTime asks the target controller for the time of the latest
 // log record it has seen.
 func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error) {
-	const op = errors.Op("jimm.LatestLogTime")
 
 	model := dbmodel.Model{
 		UUID: sql.NullString{
@@ -363,18 +357,18 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return time.Time{}, errors.E(op, fmt.Errorf("failed to get model %q: %w", modelUUID, err))
+		return time.Time{}, errors.E(fmt.Errorf("failed to get model %q: %w", modelUUID, err))
 	}
 
 	api, err := j.dialController(ctx, &model.Controller)
 	if err != nil {
-		return time.Time{}, errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return time.Time{}, errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	t, err := api.LatestLogTime(modelUUID)
 	if err != nil {
-		return time.Time{}, errors.E(op, fmt.Errorf("failed to get latest log time for model %q: %w", modelUUID, err))
+		return time.Time{}, errors.E(fmt.Errorf("failed to get latest log time for model %q: %w", modelUUID, err))
 	}
 	return t, nil
 }
@@ -382,7 +376,6 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time
 // Activate gets the model migration, proxies the Activate call to the target controller,
 // and then deletes the model migration from the database.
 func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error {
-	const op = errors.Op("jimm.Activate")
 
 	modelMigration := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -392,17 +385,17 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err))
+		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err))
 	}
 	api, err := j.dialController(ctx, &modelMigration.TargetController)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	err = api.Activate(modelTag.Id(), migrationInfo, relatedModels)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+		return errors.E(fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
 	}
 
 	// This is done in a transaction to ensure that the model migration is only deleted
@@ -421,7 +414,7 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 			}
 			err = db.AddUserMapping(ctx, userMapping)
 			if err != nil {
-				return errors.E(op, fmt.Errorf("failed to add user mapping for model %q: %w", modelTag.Id(), err))
+				return errors.E(fmt.Errorf("failed to add user mapping for model %q: %w", modelTag.Id(), err))
 			}
 		}
 		model := dbmodel.Model{
@@ -432,24 +425,24 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 		}
 		err = db.GetModel(ctx, &model)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to get model %q: %w", modelTag.Id(), err))
+			return errors.E(fmt.Errorf("failed to get model %q: %w", modelTag.Id(), err))
 		}
 		model.MigrationMode = dbmodel.MigrationModeNone
 		model.Life = state.Alive.String()
 
 		err = db.UpdateModel(ctx, &model)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to update model %q: %w", modelTag.Id(), err))
+			return errors.E(fmt.Errorf("failed to update model %q: %w", modelTag.Id(), err))
 		}
 
 		err = db.DeleteIncomingModelMigration(ctx, &modelMigration)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to delete model migration for model %q: %w", modelTag.Id(), err))
+			return errors.E(fmt.Errorf("failed to delete model migration for model %q: %w", modelTag.Id(), err))
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+		return errors.E(fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
 	}
 	return nil
 }
@@ -462,11 +455,10 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 //   - Adds permissions for the model and application offers.
 //   - Calls the import method on the target Juju controller to import the model.
 func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized params.SerializedModel) error {
-	const op = errors.Op("jimm.Import")
 
 	modelDescription, err := description.Deserialize(serialized.Bytes)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to deserialize model description: %w", err))
+		return errors.E(fmt.Errorf("failed to deserialize model description: %w", err))
 	}
 
 	var (
@@ -488,17 +480,17 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		noWait := false
 		err = d.GetIncomingModelMigrationWithLock(ctx, incomingMigration, noWait)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to get incoming model migration: %w", err))
+			return errors.E(fmt.Errorf("failed to get incoming model migration: %w", err))
 		}
 
 		err = modifyModelDescription(modelDescription, incomingMigration.UserMapping)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to modify model description: %w", err))
+			return errors.E(fmt.Errorf("failed to modify model description: %w", err))
 		}
 
 		model, offers, err = importFromDescription(ctx, d, incomingMigration.TargetController.ID, modelDescription)
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to import model from description: %w", err))
+			return errors.E(fmt.Errorf("failed to import model from description: %w", err))
 		}
 		return nil
 	})
@@ -511,24 +503,24 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	controllerTag := incomingMigration.TargetController.ResourceTag()
 	err = j.addModelAndOfferPermissions(ctx, user, model, offers, controllerTag)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to add resource permissions: %w", err))
+		return errors.E(fmt.Errorf("failed to add resource permissions: %w", err))
 	}
 
 	// Call the import method on the target controller to import the model.
 	api, err := j.dialController(ctx, &incomingMigration.TargetController)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to dial controller: %w", err))
+		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
 	defer api.Close()
 
 	serializedDescrition, err := description.Serialize(modelDescription)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to serialize model description: %w", err))
+		return errors.E(fmt.Errorf("failed to serialize model description: %w", err))
 	}
 	err = api.Import(serializedDescrition)
 	if err != nil {
 		// TODO: handle migration failure in a cleanup routine.
-		return errors.E(op, fmt.Errorf("failed to import model: %w", err))
+		return errors.E(fmt.Errorf("failed to import model: %w", err))
 	}
 
 	return nil
@@ -540,20 +532,18 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 // Application offers are created for any offers in the model description.
 // It also ensures that the cloud credential and region are present in the database.
 func importFromDescription(ctx context.Context, tx *db.Database, targetControllerID uint, description description.Model) (*dbmodel.Model, []*dbmodel.ApplicationOffer, error) {
-	op := errors.Op("jimm.importFromDescription")
-
 	modelNameStr, ok := description.Config()[config.NameKey].(string)
 	if !ok {
-		return nil, nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
+		return nil, nil, errors.E(fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
 	}
 
 	modelUUIDStr, ok := description.Config()[config.UUIDKey].(string)
 	if !ok {
-		return nil, nil, errors.E(op, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+		return nil, nil, errors.E(fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
 	}
 
 	if description.CloudCredential() == nil {
-		return nil, nil, errors.E(op, fmt.Errorf("model description must contain a cloud credential"))
+		return nil, nil, errors.E(fmt.Errorf("model description must contain a cloud credential"))
 	}
 	cloudCredential := &dbmodel.CloudCredential{
 		CloudName:         description.CloudCredential().Cloud(),
@@ -563,11 +553,11 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 
 	err := tx.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 	region, err := tx.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	var importedModel *dbmodel.Model
@@ -587,7 +577,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 	}
 	err = tx.AddModel(ctx, &model)
 	if err != nil {
-		return nil, nil, errors.E(op, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
+		return nil, nil, errors.E(fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
 	}
 	importedModel = &model
 
@@ -606,7 +596,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 					return nil, nil, fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
 				}
-				return nil, nil, errors.E(op, fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err))
+				return nil, nil, errors.E(fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err))
 			}
 
 			importedOffers = append(importedOffers, &dbOffer)
@@ -619,17 +609,16 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 // addModelAndOfferPermissions grants the user access to the model
 // and adds the necesary relations between the model and app offers.
 func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *openfga.User, model *dbmodel.Model, offers []*dbmodel.ApplicationOffer, ct names.ControllerTag) error {
-	const op = errors.Op("jimm.addResourcePermissions")
 
 	modelTag := model.ResourceTag()
 	if err := j.addModelPermissions(ctx, user, modelTag, ct); err != nil {
-		return errors.E(op, fmt.Errorf("failed to add model permissions: %w", err))
+		return errors.E(fmt.Errorf("failed to add model permissions: %w", err))
 	}
 
 	for _, offer := range offers {
 		err := j.OpenFGAClient.AddModelApplicationOffer(ctx, modelTag, offer.ResourceTag())
 		if err != nil {
-			return errors.E(op, fmt.Errorf("failed to add application offer permissions: %w", err))
+			return errors.E(fmt.Errorf("failed to add application offer permissions: %w", err))
 		}
 	}
 	return nil
@@ -639,12 +628,11 @@ func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *ope
 // It deletes the incoming model migration record, deletes the user mappings for the model,
 // and deletes the model record from JIMM's state.
 func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
-	const op = errors.Op("jimm.CleanupPartialModelMigrations")
 
 	// Get all incoming model migrations that have exceeded the timeout.
 	migrations, err := j.Database.GetIncomingModelMigrationsCreatedBefore(ctx, time.Now().Add(-TIMEOUT_PENDING_MIGRATION))
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get incoming model migrations: %w", err))
+		return errors.E(fmt.Errorf("failed to get incoming model migrations: %w", err))
 	}
 	var errs []error
 	for _, migration := range migrations {
@@ -659,19 +647,18 @@ func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
 // cleanupPartialModelMigration cleans up a partial model migration by deleting the incoming model migration record,
 // deleting the user mappings for the model, and deleting the model record from JIMM's state.
 func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migration dbmodel.IncomingModelMigration) error {
-	const op = errors.Op("jimm.cleanupPartialModelMigration")
 
 	return j.Database.Transaction(func(db *db.Database) error {
 		// Delete the incoming model migration record.
 		err := j.Database.DeleteIncomingModelMigration(ctx, &migration)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		// Delete user mappings for the model.
 		err = j.Database.DeleteUserMappingsByModelUUID(ctx, migration.ModelUUID.String)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		// Delete the model record from JIMM's state.
@@ -683,7 +670,7 @@ func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migratio
 		}
 		err = j.Database.DeleteModel(ctx, &model)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		return nil
 	})

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -91,39 +91,36 @@ func (a *ModelCreateArgs) FromJujuModelCreateArgs(args *jujuparams.ModelCreateAr
 
 // AddModel adds the specified model to JIMM.
 func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *ModelCreateArgs) (_ *jujuparams.ModelInfo, err error) {
-	const op = errors.Op("jimm.AddModel")
-	zapctx.Info(ctx, string(op))
-
 	owner, err := dbmodel.NewIdentity(args.Owner.Id())
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	err = j.Database.GetIdentity(ctx, owner)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	// Only JIMM admins are able to add models on behalf of other users.
 	if owner.Name != user.Name && !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	builder := newModelBuilder(ctx, j)
 	builder = builder.WithOwner(owner)
 	builder = builder.WithName(args.Name)
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	builder = builder.WithCloud(user, args.Cloud)
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	builder = builder.WithCloudRegion(args.CloudRegion)
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	// fetch cloud defaults
 	cloudDefaults := dbmodel.CloudDefaults{
@@ -132,7 +129,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	}
 	err = j.Database.CloudDefaults(ctx, &cloudDefaults)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return nil, errors.E(op, "failed to fetch cloud defaults")
+		return nil, errors.E("failed to fetch cloud defaults")
 	}
 	builder = builder.WithConfig(cloudDefaults.Defaults)
 
@@ -144,7 +141,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	}
 	err = j.Database.CloudDefaults(ctx, &cloudRegionDefaults)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return nil, errors.E(op, "failed to fetch cloud defaults")
+		return nil, errors.E("failed to fetch cloud defaults")
 	}
 	builder = builder.WithConfig(cloudRegionDefaults.Defaults)
 
@@ -152,10 +149,10 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	// we must check the user has add-model permission on the cloud
 	canAddModel, err := openfga.NewUser(owner, j.OpenFGAClient).IsAllowedAddModelToCloud(ctx, builder.cloud.ResourceTag())
 	if err != nil {
-		return nil, errors.E(op, "permission check failed")
+		return nil, errors.E("permission check failed")
 	}
 	if !canAddModel {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// last but not least, use the provided config values
@@ -165,23 +162,23 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	if args.CloudCredential != (names.CloudCredentialTag{}) {
 		builder = builder.WithCloudCredential(args.CloudCredential)
 		if err := builder.Error(); err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 	}
 	builder = builder.CreateDatabaseModel()
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	defer builder.Cleanup()
 
 	builder = builder.CreateControllerModel()
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	builder = builder.UpdateDatabaseModel()
 	if err := builder.Error(); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	mi := builder.JujuModelInfo()
@@ -191,7 +188,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	controllerTag := builder.controller.ResourceTag()
 
 	if err := j.addModelPermissions(ctx, ownerUser, modelTag, controllerTag); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return mi, nil
 }
@@ -242,28 +239,25 @@ func (j *JujuManager) addModelPermissions(ctx context.Context, owner *openfga.Us
 // access to the model then the returned error will have the code
 // CodeUnauthorized.
 func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt names.ModelTag) (*jujuparams.ModelInfo, error) {
-	const op = errors.Op("jimm.ModelInfo")
-	zapctx.Info(ctx, string(op))
-
 	var m dbmodel.Model
 	m.SetTag(mt)
 	if err := j.Database.GetModel(ctx, &m); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	if ok, err := user.IsModelReader(ctx, mt); !ok || err != nil {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, nil)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	defer api.Close()
 
 	modelInfo, err := j.modelInfo(ctx, &m, api)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return j.mergeModelInfo(ctx, user, modelInfo, m)
@@ -359,7 +353,6 @@ func (m *modelSummariesMap) addModelSummary(summary jujuparams.ModelSummaryResul
 // ListModelSummaries returns the list of modelsummary the user has access to.
 // It queries the controllers and then merge the info from the JIMM db.
 func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) (jujuparams.ModelSummaryResults, error) {
-	const op = errors.Op("jimm.ListModelSummaries")
 
 	modelSummariesSafeMap := modelSummariesMap{}
 	modelSummaryResults := []jujuparams.ModelSummaryResult{}
@@ -385,7 +378,7 @@ func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User
 		return nil
 	})
 	if err != nil {
-		return jujuparams.ModelSummaryResults{}, errors.E(op, err)
+		return jujuparams.ModelSummaryResults{}, errors.E(err)
 	}
 
 	// we query the model summaries for each controller
@@ -431,9 +424,6 @@ func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User
 // mergeModelInfo replaces fields on the juju model info object with
 // information from JIMM where JIMM specific information should be used.
 func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, modelInfo *jujuparams.ModelInfo, jimmModel dbmodel.Model) (*jujuparams.ModelInfo, error) {
-	const op = errors.Op("jimm.mergeModelInfo")
-	zapctx.Info(ctx, string(op))
-
 	modelInfo.CloudCredentialTag = jimmModel.CloudCredential.Tag().String()
 	modelInfo.ControllerUUID = jimmModel.Controller.UUID
 	modelInfo.OwnerTag = jimmModel.Owner.Tag().String()
@@ -449,7 +439,7 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 	} {
 		usersWithSpecifiedRelation, err := openfga.ListUsersWithAccess(ctx, j.OpenFGAClient, jimmModel.ResourceTag(), relation)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 		for _, u := range usersWithSpecifiedRelation {
 			// Since we are checking user relations in decreasing level of
@@ -463,7 +453,7 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 
 	modelAccess, err := j.permissionManager.GetUserModelAccess(ctx, user, jimmModel.ResourceTag())
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	users := make([]jujuparams.ModelUserInfo, 0, len(userAccess))
@@ -497,9 +487,6 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 // CodeNotFound, If the given user does not have admin access to the model
 // then the returned error will have the code CodeUnauthorized.
 func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt names.ModelTag) (*jujuparams.ModelStatus, error) {
-	const op = errors.Op("jimm.ModelStatus")
-	zapctx.Info(ctx, string(op))
-
 	var ms jujuparams.ModelStatus
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		ms.OwnerTag = m.Owner.Tag().String()
@@ -519,7 +506,7 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return &ms, nil
 }
@@ -555,9 +542,6 @@ func (j *JujuManager) deleteModel(ctx context.Context, mt names.ModelTag) error 
 // returned unmodified and iteration will stop immediately. The given
 // function should not update the database.
 func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error {
-	const op = errors.Op("jimm.ForEachUserModel")
-	zapctx.Info(ctx, string(op))
-
 	errStop := errors.E("stop")
 	var iterErr error
 	err := j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
@@ -565,7 +549,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 
 		access, err := j.permissionManager.GetUserModelAccess(ctx, user, model.ResourceTag())
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		if access == "read" || access == "write" || access == "admin" {
 			if err := f(&model, jujuparams.UserAccessPermission(access)); err != nil {
@@ -582,7 +566,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 	case errStop:
 		return iterErr
 	default:
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 }
 
@@ -594,11 +578,8 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 // error the error will be returned unmodified and iteration will stop
 // immediately. The given function should not update the database.
 func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error {
-	const op = errors.Op("jimm.ForEachModel")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	errStop := errors.E("stop")
@@ -616,7 +597,7 @@ func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f fu
 	case errStop:
 		return iterErr
 	default:
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 }
 
@@ -625,9 +606,6 @@ func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f fu
 // with a code of CodeUnauthorized is returned. Any error returned from
 // the juju API will not have it's code masked.
 func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
-	const op = errors.Op("jimm.DestroyModel")
-	zapctx.Info(ctx, string(op))
-
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		m.Life = state.Dying.String()
 		if err := j.Database.UpdateModel(ctx, m); err != nil {
@@ -647,7 +625,7 @@ func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt n
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// NOTE (alesstimec) If we remove OpenFGA relation now, the user
@@ -663,9 +641,6 @@ func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt n
 // If the given user is not a controller superuser or a model admin an
 // error with the code CodeUnauthorized is returned.
 func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt names.ModelTag, simplified bool) (string, error) {
-	const op = errors.Op("jimm.DumpModel")
-	zapctx.Info(ctx, string(op))
-
 	var dump string
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		var err error
@@ -673,7 +648,7 @@ func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt name
 		return err
 	})
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 	return dump, nil
 }
@@ -682,9 +657,6 @@ func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt name
 // controller. If the given user is not a controller superuser or a model
 // admin an error with the code CodeUnauthorized is returned.
 func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt names.ModelTag) (map[string]interface{}, error) {
-	const op = errors.Op("jimm.DumpModelDB")
-	zapctx.Info(ctx, string(op))
-
 	var dump map[string]interface{}
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		var err error
@@ -692,7 +664,7 @@ func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt na
 		return err
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return dump, nil
 }
@@ -704,14 +676,11 @@ func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt na
 // the controller doesn't support the ValidateModelUpgrades command the
 // CodeNotImplemented error code will be propagated back to the client.
 func (j *JujuManager) ValidateModelUpgrade(ctx context.Context, user *openfga.User, mt names.ModelTag, force bool) error {
-	const op = errors.Op("jimm.ValidateModelUpgrade")
-	zapctx.Info(ctx, string(op))
-
 	err := j.doModelAdmin(ctx, user, mt, func(_ *dbmodel.Model, api API) error {
 		return api.ValidateModelUpgrade(ctx, mt, force)
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -733,34 +702,31 @@ func (j *JujuManager) doModelAdmin(ctx context.Context, user *openfga.User, mt n
 }
 
 func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.ModelTag, requireRelation openfga.Relation, f func(*dbmodel.Model, API) error) error {
-	const op = errors.Op("jimm.doModel")
-	zapctx.Info(ctx, string(op))
-
 	var m dbmodel.Model
 	m.SetTag(mt)
 
 	if err := j.Database.GetModel(ctx, &m); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	hasAccess, err := user.HasModelRelation(ctx, mt, requireRelation)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if !hasAccess {
 		// If the user doesn't have correct access on the model return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 	if err := f(&m, api); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -768,11 +734,8 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 // ChangeModelCredential changes the credential used with a model on both
 // the controller and the local database.
 func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error {
-	const op = errors.Op("jimm.ChangeModelCredential")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin && user.Tag() != cloudCredentialTag.Owner() {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	credential := dbmodel.CloudCredential{}
@@ -780,32 +743,32 @@ func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.U
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	var m *dbmodel.Model
 	err = j.doModelAdmin(ctx, user, modelTag, func(model *dbmodel.Model, api API) error {
 		_, err = j.updateControllerCloudCredential(ctx, &credential, api.UpdateCredential)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 
 		err = api.ChangeModelCredential(ctx, modelTag, cloudCredentialTag)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		m = model
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	m.CloudCredential = credential
 	m.CloudCredentialID = credential.ID
 	err = j.Database.UpdateModel(ctx, m)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -814,19 +777,16 @@ func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.U
 // ListModels list the models that the user has access to. It intentionally excludes the
 // controller model as this call is used within the context of login and register commands.
 func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]base.UserModel, error) {
-	const op = errors.Op("jimm.ListModels")
-	zapctx.Info(ctx, string(op))
-
 	// Get uuids of models the user has access to
 	uuids, err := user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return nil, errors.E(op, fmt.Sprintf("failed to list user models: %v", err))
+		return nil, errors.E(fmt.Sprintf("failed to list user models: %v", err))
 	}
 
 	// Get the models from the database
 	models, err := j.Database.GetModelsByUUID(ctx, uuids)
 	if err != nil {
-		return nil, errors.E(op, fmt.Sprintf("failed to get models by uuid: %v", err))
+		return nil, errors.E(fmt.Sprintf("failed to get models by uuid: %v", err))
 	}
 
 	// Create map for lookup later
@@ -875,7 +835,7 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(op, fmt.Sprintf("failed to list models: %v", err))
+		return nil, errors.E(fmt.Sprintf("failed to list models: %v", err))
 	}
 
 	return userModels, nil

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -20,9 +20,9 @@ import (
 // If the model exists in JIMM's database, but not on the controller,
 // it is deleted from JIMM's database.
 func (j *JujuManager) PollModels(ctx context.Context) (err error) {
-	const op = errors.Op("jimm.PollModels")
-	zapctx.Info(ctx, string(op))
-	durationObserver := servermon.DurationObserver(servermon.JimmMethodsDurationHistogram, string(op))
+	const op = "jimm.PollModels"
+
+	durationObserver := servermon.DurationObserver(servermon.JimmMethodsDurationHistogram, op)
 	defer durationObserver()
 
 	// Step 1: Group models by controller
@@ -33,7 +33,7 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 		return nil
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// Step 2: Loop over controllers and process their models
@@ -70,39 +70,38 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 // checkModelMigratedInternal checks if the model has been migrated from
 // one controller managed by JIMM to another controller managed by JIMM.
 func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI error, m *dbmodel.Model) error {
-	const op = errors.Op("jimm.checkModelMigratedInternal")
 
 	// Expect a redirect error if the model successfully migrated.
 	// This is the error that Juju controllers return when a model has been migrated.
 	isRedirectErr := errors.ErrorCode(errFromAPI) == params.CodeRedirect
 	if !isRedirectErr {
-		return errors.E(op, errFromAPI)
+		return errors.E(errFromAPI)
 	}
 
 	// Parse the redirect error to get the new controller details.
 	errInfo := errors.ErrorInfo(errFromAPI)
 	if errInfo == nil {
-		return errors.E(op, fmt.Errorf("missing error info in redirect error: %w", errFromAPI))
+		return errors.E(fmt.Errorf("missing error info in redirect error: %w", errFromAPI))
 	}
 
 	var redirectInfo params.RedirectErrorInfo
 	err := params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("cannot unmarshal redirect error info: %w", err))
+		return errors.E(fmt.Errorf("cannot unmarshal redirect error info: %w", err))
 	}
 
 	// We expect this controller will be known to JIMM.
 	controller := dbmodel.Controller{Name: redirectInfo.ControllerAlias}
 	err = j.Database.GetController(ctx, &controller)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI))
+		return errors.E(fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI))
 	}
 
 	m.InternalMigrationSuccess(controller.ID)
 
 	err = j.Database.UpdateModel(ctx, m)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to update model after migration: %w", errFromAPI))
+		return errors.E(fmt.Errorf("failed to update model after migration: %w", errFromAPI))
 	}
 	zapctx.Info(ctx, "model successfully migrated to controller", zap.String("model", m.UUID.String), zap.String("controller_name", controller.Name))
 	return nil
@@ -113,12 +112,12 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI
 // the API (since the deletion of a model is not immediate) and handles
 // cases where the model was deleted directly on the underlying controller.
 func (j *JujuManager) maybeCleanupModel(ctx context.Context, errFromAPI error, m *dbmodel.Model) error {
-	const op = errors.Op("jimm.maybeCleanupModel")
+
 	// Some versions of juju return unauthorized for models that cannot be found.
 	modelDeleted := (errors.ErrorCode(errFromAPI) == errors.CodeNotFound || errors.ErrorCode(errFromAPI) == errors.CodeUnauthorized)
 	if modelDeleted {
 		if err := j.deleteModel(ctx, m.ResourceTag()); err != nil {
-			return errors.E(op, fmt.Errorf("failed to delete model: %w", err))
+			return errors.E(fmt.Errorf("failed to delete model: %w", err))
 		}
 	}
 	return nil

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -29,7 +29,6 @@ import (
 // Errors will contain a map from model UUID -> []error. Otherwise, the Results field
 // will contain model UUID -> []Jq result.
 func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jqQuery string) (params.CrossModelQueryResponse, error) {
-	op := errors.Op("QueryModels")
 	results := params.CrossModelQueryResponse{
 		Results: make(map[string][]any),
 		Errors:  make(map[string][]string),
@@ -37,7 +36,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 
 	query, err := gojq.Parse(jqQuery)
 	if err != nil {
-		return results, errors.E(op, "failed to parse jq query", err)
+		return results, errors.E("failed to parse jq query", err)
 	}
 
 	// Set up a formatterParamsRetriever to handle the heavy lifting
@@ -46,7 +45,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 
 	models, err := j.Database.GetModelsByUUID(ctx, modelUUIDs)
 	if err != nil {
-		return results, errors.E(op, "failed to get models for user")
+		return results, errors.E("failed to get models for user")
 	}
 
 	for _, model := range models {
@@ -79,7 +78,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 		}
 		tempMap := make(map[string]any)
 		if err := json.Unmarshal(fb, &tempMap); err != nil {
-			return results, errors.E(op, err)
+			return results, errors.E(err)
 		}
 
 		queryCtx, cancel := context.WithTimeout(ctx, j.crossModelQueryTimeout)
@@ -97,7 +96,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			// both erreoneous and valid query results.
 			if err, ok := v.(error); ok {
 				if stderrors.Is(err, context.DeadlineExceeded) {
-					return results, errors.E(op, fmt.Sprintf("jq query timed out after %.2f seconds", j.crossModelQueryTimeout.Seconds()), err)
+					return results, errors.E(fmt.Sprintf("jq query timed out after %.2f seconds", j.crossModelQueryTimeout.Seconds()), err)
 				}
 				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())
 				continue
@@ -164,7 +163,7 @@ func (f *formatterParamsRetriever) GetParams(ctx context.Context, model dbmodel.
 func (f *formatterParamsRetriever) dialModel(ctx context.Context) error {
 	modelTag, ok := f.model.Tag().(names.ModelTag)
 	if !ok {
-		return errors.E(errors.Op("failed to parse model tag"))
+		return errors.E("failed to parse model tag")
 	}
 	api, err := f.jujuManager.dial(ctx, &f.model.Controller, modelTag, nil)
 	if err != nil {

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -46,7 +46,6 @@ type Watcher struct {
 // until either the given context is closed, or there is an error querying
 // the database.
 func (w *Watcher) WatchAllModelSummaries(ctx context.Context, interval time.Duration) error {
-	const op = errors.Op("jimm.WatchAllModelSummaries")
 
 	r := newRunner()
 	// Ensure that all started goroutines are completed before we return.
@@ -72,7 +71,7 @@ func (w *Watcher) WatchAllModelSummaries(ctx context.Context, interval time.Dura
 		if err != nil {
 			// Ignore temporary database errors.
 			if errors.ErrorCode(err) != errors.CodeDatabaseLocked {
-				return errors.E(op, err)
+				return errors.E(err)
 			}
 			zapctx.Warn(ctx, "temporary error polling for controllers", zap.Error(err))
 		}
@@ -86,7 +85,6 @@ func (w *Watcher) WatchAllModelSummaries(ctx context.Context, interval time.Dura
 }
 
 func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (api API, err error) {
-	const op = errors.Op("jimm.dialController")
 
 	updateController := false
 	defer func() {
@@ -111,7 +109,7 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 		ctl.UnavailableSince = db.Now()
 		updateController = true
 
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	if ctl.UnavailableSince.Valid {
 		ctl.UnavailableSince = sql.NullTime{}
@@ -123,23 +121,22 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 // watchAllModelSummaries connects to the given controller and watches the
 // summary updates.
 func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Controller) error {
-	const op = errors.Op("jimm.watchAllModelSummaries")
 
 	// connect to the controller
 	api, err := w.dialController(ctx, ctl)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer api.Close()
 
 	if !api.SupportsModelSummaryWatcher() {
-		return errors.E(op, errors.CodeNotSupported)
+		return errors.E(errors.CodeNotSupported)
 	}
 
 	// start the model summary watcher
 	id, err := api.WatchAllModelSummaries(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	defer func() {
 		if err := api.ModelSummaryWatcherStop(ctx, id); err != nil {
@@ -150,13 +147,13 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.E(op, ctx.Err(), "context cancelled")
+			return errors.E(ctx.Err(), "context cancelled")
 		default:
 		}
 		// wait for updates from the all model summary watcher.
 		modelSummaries, err := api.ModelSummaryWatcherNext(ctx, id)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		// Sanitize the model abstracts.
 		for _, summary := range modelSummaries {

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -88,13 +88,12 @@ func (auth *LoginTokenGenerator) GetUser() names.UserTag {
 // a JWT containing claims about user's access to the controller, model (if applicable)
 // and all clouds that the controller knows about.
 func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.User) ([]byte, error) {
-	const op = errors.Op("jimm.MakeLoginToken")
 
 	auth.mu.Lock()
 	defer auth.mu.Unlock()
 
 	if user == nil {
-		return nil, errors.E(op, "user not specified")
+		return nil, errors.E("user not specified")
 	}
 	auth.user = user
 
@@ -104,7 +103,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 
 	var modelAccess string
 	if auth.mt.Id() == "" {
-		return nil, errors.E(op, "model not set")
+		return nil, errors.E("model not set")
 	}
 	modelAccess, authErr = auth.accessChecker.GetUserModelAccess(ctx, auth.user, auth.mt)
 	if authErr != nil {
@@ -114,7 +113,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	auth.accessMapCache[auth.mt.String()] = modelAccess
 
 	if auth.ct.Id() == "" {
-		return nil, errors.E(op, "controller not set")
+		return nil, errors.E("controller not set")
 	}
 	var controllerAccess string
 	controllerAccess, authErr = auth.accessChecker.GetUserControllerAccess(ctx, auth.user, auth.ct)
@@ -127,7 +126,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	ctl.SetTag(auth.ct)
 	err := auth.database.GetController(ctx, &ctl)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to fetch controller: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to fetch controller: %w", err))
 	}
 	clouds := make(map[names.CloudTag]bool)
 	for _, cloudRegion := range ctl.CloudRegions {
@@ -136,7 +135,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	for cloudTag := range clouds {
 		accessLevel, err := auth.accessChecker.GetUserCloudAccess(ctx, auth.user, cloudTag)
 		if err != nil {
-			return nil, errors.E(op, fmt.Errorf("failed to check user's cloud access: %w", err))
+			return nil, errors.E(fmt.Errorf("failed to check user's cloud access: %w", err))
 		}
 		auth.accessMapCache[cloudTag.String()] = accessLevel
 	}
@@ -152,17 +151,16 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 // specified in the permissionMap. If the logged in user has all those permissions
 // a JWT will be returned with assertions confirming all those permissions.
 func (auth *LoginTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
-	const op = errors.Op("jimm.MakeToken")
 
 	auth.mu.Lock()
 	defer auth.mu.Unlock()
 
 	if auth.callCount >= 10 {
-		return nil, errors.E(op, "Permission check limit exceeded")
+		return nil, errors.E("Permission check limit exceeded")
 	}
 	auth.callCount++
 	if auth.user == nil {
-		return nil, errors.E(op, "User authorization missing.")
+		return nil, errors.E("User authorization missing.")
 	}
 	if permissionMap != nil {
 		var err error

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -105,10 +105,10 @@ func NewLoginManager(store *db.Database, authSvc *openfga.OFGAClient, oAuthAuthe
 
 // LoginDevice starts the device login flow.
 func (j *loginManager) LoginDevice(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
-	const op = errors.Op("jimm.LoginDevice")
+
 	resp, err := j.oAuthAuthenticator.Device(ctx)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return resp, nil
 }
@@ -120,30 +120,29 @@ func (j *loginManager) AuthenticateBrowserSession(ctx context.Context, w http.Re
 
 // GetDeviceSessionToken polls an OIDC server while a user logs in and returns a session token scoped to the user's identity.
 func (j *loginManager) GetDeviceSessionToken(ctx context.Context, deviceOAuthResponse *oauth2.DeviceAuthResponse) (string, error) {
-	const op = errors.Op("jimm.GetDeviceSessionToken")
 
 	token, err := j.oAuthAuthenticator.DeviceAccessToken(ctx, deviceOAuthResponse)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 
 	idToken, err := j.oAuthAuthenticator.ExtractAndVerifyIDToken(ctx, token)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 
 	email, err := j.oAuthAuthenticator.Email(idToken)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 
 	if err := j.oAuthAuthenticator.UpdateIdentity(ctx, email, token); err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 
 	encToken, err := j.oAuthAuthenticator.MintSessionToken(email)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err)
 	}
 
 	return string(encToken), nil
@@ -151,24 +150,24 @@ func (j *loginManager) GetDeviceSessionToken(ctx context.Context, deviceOAuthRes
 
 // LoginClientCredentials verifies a user's client ID and secret before the user is logged in.
 func (j *loginManager) LoginClientCredentials(ctx context.Context, clientID string, clientSecret string) (*openfga.User, error) {
-	const op = errors.Op("jimm.LoginClientCredentials")
+
 	// We expect the client to send the service account ID "as-is" and because we know that this is a clientCredentials login,
 	// we can append the @serviceaccount domain to the clientID (if not already present).
 	// TODO(Kian): Consider inlining the function below and removing the dependency on jimmnames.
 	clientIdWithDomain, err := jimmnames.EnsureValidServiceAccountId(clientID)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	err = j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	user, err := j.UserLogin(ctx, clientIdWithDomain)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	logger.LogSuccessfulLogin(ctx, clientIdWithDomain)
 	return user, nil
@@ -176,18 +175,18 @@ func (j *loginManager) LoginClientCredentials(ctx context.Context, clientID stri
 
 // LoginWithSessionToken verifies a user's session token before the user is logged in.
 func (j *loginManager) LoginWithSessionToken(ctx context.Context, sessionToken string) (*openfga.User, error) {
-	const op = errors.Op("jimm.LoginWithSessionToken")
+
 	jwtToken, err := j.oAuthAuthenticator.VerifySessionToken(sessionToken)
 	if err != nil {
 		logger.LogFailedLogin(ctx, "unknown session token")
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	email := jwtToken.Subject()
 	user, err := j.UserLogin(ctx, email)
 	if err != nil {
 		logger.LogFailedLogin(ctx, email)
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	logger.LogSuccessfulLogin(ctx, email)
 	return user, nil
@@ -200,14 +199,14 @@ func (j *loginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 // and passed to this function with the assumption that the cookie contained a valid session. This function is far from
 // the session cookie logic due to the separation between the HTTP layer and Juju's RPC mechanism.
 func (j *loginManager) LoginWithSessionCookie(ctx context.Context, identityID string) (*openfga.User, error) {
-	const op = errors.Op("jimm.LoginWithSessionCookie")
+
 	if identityID == "" {
-		return nil, errors.E(op, "missing cookie identity")
+		return nil, errors.E("missing cookie identity")
 	}
 	user, err := j.UserLogin(ctx, identityID)
 	if err != nil {
 		logger.LogFailedLogin(ctx, identityID)
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	logger.LogSuccessfulLogin(ctx, identityID)
 	return user, nil
@@ -218,24 +217,23 @@ func (j *loginManager) LoginWithSessionCookie(ctx context.Context, identityID st
 // It will create a new identity if one does not exist.
 // The identity's last login time is updated.
 func (j *loginManager) UserLogin(ctx context.Context, identifier string) (*openfga.User, error) {
-	const op = errors.Op("jimm.UpdateLastLogin")
+
 	ofgaUser, err := j.getOrCreateIdentity(ctx, identifier)
 	if err != nil {
-		return nil, errors.E(op, err, errors.CodeUnauthorized)
+		return nil, errors.E(err, errors.CodeUnauthorized)
 	}
 	err = j.updateLastLogin(ctx, ofgaUser.Identity)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return ofgaUser, nil
 }
 
 func (j *loginManager) getOrCreateIdentity(ctx context.Context, identifier string) (*openfga.User, error) {
-	const op = errors.Op("jimm.getOrCreateIdentity")
 
 	identity, err := dbmodel.NewIdentity(identifier)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	if err := j.store.GetIdentity(ctx, identity); err != nil {
@@ -245,7 +243,7 @@ func (j *loginManager) getOrCreateIdentity(ctx context.Context, identifier strin
 
 	isJimmAdmin, err := openfga.IsAdministrator(ctx, ofgaUser, j.jimmTag)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	ofgaUser.JimmAdmin = isJimmAdmin
 

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -145,46 +145,44 @@ func (j *permissionManager) GetUserModelAccess(ctx context.Context, user *openfg
 
 // GrantAuditLogAccess grants audit log access for the target user.
 func (j *permissionManager) GrantAuditLogAccess(ctx context.Context, user *openfga.User, targetUserTag names.UserTag) error {
-	const op = errors.Op("jimm.GrantAuditLogAccess")
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
 	targetUser.SetTag(targetUserTag)
 	err := j.store.GetIdentity(ctx, targetUser)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	err = openfga.NewUser(targetUser, j.authSvc).SetControllerAccess(ctx, j.jimmTag, ofganames.AuditLogViewerRelation)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // RevokeAuditLogAccess revokes audit log access for the target user.
 func (j *permissionManager) RevokeAuditLogAccess(ctx context.Context, user *openfga.User, targetUserTag names.UserTag) error {
-	const op = errors.Op("jimm.RevokeAuditLogAccess")
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
 	targetUser.SetTag(targetUserTag)
 	err := j.store.GetIdentity(ctx, targetUser)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	err = openfga.NewUser(targetUser, j.authSvc).UnsetAuditLogViewerAccess(ctx, j.jimmTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -194,27 +192,27 @@ func (j *permissionManager) RevokeAuditLogAccess(ctx context.Context, user *open
 // error is returned.
 // Note that cachedPerms map is modified and returned.
 func (j *permissionManager) CheckPermission(ctx context.Context, user *openfga.User, cachedPerms map[string]string, desiredPerms map[string]interface{}) (map[string]string, error) {
-	const op = errors.Op("jimm.CheckPermission")
+
 	for key, val := range desiredPerms {
 		if _, ok := cachedPerms[key]; !ok {
 			stringVal, ok := val.(string)
 			if !ok {
-				return nil, errors.E(op, fmt.Sprintf("failed to get permission assertion: expected %T, got %T", stringVal, val))
+				return nil, errors.E(fmt.Sprintf("failed to get permission assertion: expected %T, got %T", stringVal, val))
 			}
 			tag, err := names.ParseTag(key)
 			if err != nil {
-				return cachedPerms, errors.E(op, fmt.Sprintf("failed to parse tag %s", key))
+				return cachedPerms, errors.E(fmt.Sprintf("failed to parse tag %s", key))
 			}
 			relation, err := ofganames.ConvertJujuRelation(stringVal)
 			if err != nil {
-				return cachedPerms, errors.E(op, fmt.Sprintf("failed to parse relation %s", stringVal), err)
+				return cachedPerms, errors.E(fmt.Sprintf("failed to parse relation %s", stringVal), err)
 			}
 			check, err := openfga.CheckRelation(ctx, user, tag, relation)
 			if err != nil {
-				return cachedPerms, errors.E(op, err)
+				return cachedPerms, errors.E(err)
 			}
 			if !check {
-				return cachedPerms, errors.E(op, fmt.Sprintf("Missing permission for %s:%s", key, val))
+				return cachedPerms, errors.E(fmt.Sprintf("Missing permission for %s:%s", key, val))
 			}
 			cachedPerms[key] = stringVal
 		}
@@ -225,7 +223,6 @@ func (j *permissionManager) CheckPermission(ctx context.Context, user *openfga.U
 // GetJimmControllerAccess returns the JIMM controller access level for the
 // requested user.
 func (j *permissionManager) GetJimmControllerAccess(ctx context.Context, user *openfga.User, tag names.UserTag) (string, error) {
-	const op = errors.Op("jimm.GetJIMMControllerAccess")
 
 	// If the authenticated user is requesting the access level
 	// for him/her-self then we return that - either the user
@@ -241,7 +238,7 @@ func (j *permissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Only JIMM administrators are allowed to see the access
 	// level of somebody else.
 	if !user.JimmAdmin {
-		return "", errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return "", errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var targetUser dbmodel.Identity
@@ -251,7 +248,7 @@ func (j *permissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Check if the user is jimm administrator.
 	isAdmin, err := openfga.IsAdministrator(ctx, targetUserTag, j.jimmTag)
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf("failed to check access rights: %w", err))
+		return "", errors.E(fmt.Errorf("failed to check access rights: %w", err))
 	}
 	if isAdmin {
 		return "superuser", nil
@@ -266,7 +263,6 @@ func (j *permissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 // access to the cloud then an error with the code CodeUnauthorized is
 // returned.
 func (j *permissionManager) GrantCloudAccess(ctx context.Context, user *openfga.User, ct names.CloudTag, ut names.UserTag, access string) error {
-	const op = errors.Op("jimm.GrantCloudAccess")
 
 	targetRelation, err := ToCloudRelation(access)
 	if err != nil {
@@ -276,17 +272,17 @@ func (j *permissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -324,7 +320,7 @@ func (j *permissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zap.String("cloud", string(ct.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, fmt.Errorf("failed to set cloud access: %w", err))
+		return errors.E(fmt.Errorf("failed to set cloud access: %w", err))
 	}
 	return nil
 }
@@ -335,7 +331,6 @@ func (j *permissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 // access to the cloud then an error with the code CodeUnauthorized is
 // returned.
 func (j *permissionManager) RevokeCloudAccess(ctx context.Context, user *openfga.User, ct names.CloudTag, ut names.UserTag, access string) error {
-	const op = errors.Op("jimm.RevokeCloudAccess")
 
 	targetRelation, err := ToCloudRelation(access)
 	if err != nil {
@@ -345,17 +340,17 @@ func (j *permissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -403,7 +398,7 @@ func (j *permissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zap.String("cloud", string(ct.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, fmt.Errorf("failed to unset cloud access: %w", err))
+		return errors.E(fmt.Errorf("failed to unset cloud access: %w", err))
 	}
 
 	return nil
@@ -415,9 +410,6 @@ func (j *permissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 // admin access to the model then an error with the code CodeUnauthorized
 // is returned.
 func (j *permissionManager) GrantModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error {
-	const op = errors.Op("jimm.GrantModelAccess")
-	zapctx.Info(ctx, string(op))
-
 	targetRelation, err := ToModelRelation(string(access))
 	if err != nil {
 		zapctx.Debug(
@@ -426,15 +418,15 @@ func (j *permissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
 	}
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !modelAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -479,7 +471,7 @@ func (j *permissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zap.String("model", string(mt.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, fmt.Errorf("failed to set model access: %w", err))
+		return errors.E(fmt.Errorf("failed to set model access: %w", err))
 	}
 	return nil
 }
@@ -490,9 +482,6 @@ func (j *permissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 // access to the model, and is not attempting to revoke their own access,
 // then an error with the code CodeUnauthorized is returned.
 func (j *permissionManager) RevokeModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error {
-	const op = errors.Op("jimm.RevokeModelAccess")
-	zapctx.Info(ctx, string(op))
-
 	targetRelation, err := ToModelRelation(string(access))
 	if err != nil {
 		zapctx.Debug(
@@ -501,7 +490,7 @@ func (j *permissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
 	}
 
 	requiredAccess := ofganames.AdministratorRelation
@@ -512,10 +501,10 @@ func (j *permissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, requiredAccess)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !modelAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -571,18 +560,17 @@ func (j *permissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zap.String("model", string(mt.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(op, fmt.Errorf("failed to unset model access: %w", err))
+		return errors.E(fmt.Errorf("failed to unset model access: %w", err))
 	}
 	return nil
 }
 
 // GrantOfferAccess grants rights for an application offer.
 func (j *permissionManager) GrantOfferAccess(ctx context.Context, user *openfga.User, offerURL string, ut names.UserTag, access jujuparams.OfferAccessPermission) error {
-	const op = errors.Op("jimm.GrantOfferAccess")
 
 	identity, err := dbmodel.NewIdentity(ut.Id())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	offer := dbmodel.ApplicationOffer{
@@ -590,15 +578,15 @@ func (j *permissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 	}
 	if err := j.store.GetApplicationOffer(ctx, &offer); err != nil {
 		// If the offer is not found, we leak information about the existence of offers that do exist.
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isOfferAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)
@@ -611,11 +599,11 @@ func (j *permissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 	if targetAccessLevel != currentAccessLevel {
 		relation, err := ToOfferRelation(targetAccessLevel)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		err = targetUser.SetApplicationOfferAccess(ctx, offer.ResourceTag(), relation)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 	}
 
@@ -649,11 +637,10 @@ func determineAccessLevelAfterGrant(currentAccessLevel, grantAccessLevel string)
 
 // RevokeOfferAccess revokes rights for an application offer.
 func (j *permissionManager) RevokeOfferAccess(ctx context.Context, user *openfga.User, offerURL string, ut names.UserTag, access jujuparams.OfferAccessPermission) (err error) {
-	const op = errors.Op("jimm.RevokeOfferAccess")
 
 	identity, err := dbmodel.NewIdentity(ut.Id())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	offer := dbmodel.ApplicationOffer{
@@ -661,25 +648,25 @@ func (j *permissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	}
 	if err := j.store.GetApplicationOffer(ctx, &offer); err != nil {
 		// If the offer is not found, we leak information about the existence of offers that do exist.
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	if !isOfferAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)
 	targetRelation, err := ToOfferRelation(string(access))
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	err = targetUser.UnsetApplicationOfferAccess(ctx, offer.ResourceTag(), targetRelation)
 	if err != nil {
-		return errors.E(op, err, "failed to unset given access")
+		return errors.E(err, "failed to unset given access")
 	}
 
 	// Checking if the target user still has the given access to the
@@ -705,7 +692,7 @@ func (j *permissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	}
 
 	if stillHasAccess {
-		return errors.E(op, "unable to completely revoke given access due to other relations; try to remove them as well")
+		return errors.E("unable to completely revoke given access due to other relations; try to remove them as well")
 	}
 	return nil
 }

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -28,9 +28,9 @@ const BATCH_SIZE_OPENFGA = 100
 // AddRelation checks user permission and add given relations tuples.
 // At the moment user is required be admin.
 func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
-	const op = errors.Op("jimm.AddRelation")
+
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
@@ -45,7 +45,7 @@ func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User,
 
 		err = j.authSvc.AddRelation(ctx, batch...)
 		if err != nil {
-			return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+			return errors.E(errors.CodeOpenFGARequestFailed, err)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -55,13 +55,13 @@ func (j *permissionManager) AddRelation(ctx context.Context, user *openfga.User,
 // RemoveRelation checks user permission and remove given relations tuples.
 // At the moment user is required be admin.
 func (j *permissionManager) RemoveRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
-	const op = errors.Op("jimm.RemoveRelation")
+
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
 		end := i + BATCH_SIZE_OPENFGA
@@ -72,7 +72,7 @@ func (j *permissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 
 		err = j.authSvc.RemoveRelation(ctx, batch...)
 		if err != nil {
-			return errors.E(op, errors.CodeOpenFGARequestFailed, err)
+			return errors.E(errors.CodeOpenFGARequestFailed, err)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -82,21 +82,21 @@ func (j *permissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 // CheckRelation checks user permission and return true if the given tuple exists.
 // At the moment user is required be admin or checking its own relations.
 func (j *permissionManager) CheckRelation(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, trace bool) (_ bool, err error) {
-	const op = errors.Op("jimm.CheckRelation")
+
 	allowed := false
 	parsedTuple, err := j.parseTuple(ctx, tuple)
 	if err != nil {
-		return false, errors.E(op, err)
+		return false, errors.E(err)
 	}
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
 	// Admins can check any relation, non-admins can only check their own.
 	if !(user.JimmAdmin || userCheckingSelf) {
-		return allowed, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return allowed, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace)
 	if err != nil {
-		return allowed, errors.E(op, errors.CodeOpenFGARequestFailed, err)
+		return allowed, errors.E(errors.CodeOpenFGARequestFailed, err)
 	}
 	return allowed, nil
 }
@@ -123,9 +123,9 @@ func (j *permissionManager) CheckRelations(ctx context.Context, user *openfga.Us
 // ListRelationshipTuples checks user permission and lists relationship tuples based of tuple struct with pagination.
 // Listing filters can be relaxed: optionally exclude tuple.Relation or tuple.Object or specify only tuple.TargetObject.Kind.
 func (j *permissionManager) ListRelationshipTuples(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, pageSize int32, continuationToken string) ([]openfga.Tuple, string, error) {
-	const op = errors.Op("jimm.ListRelationshipTuples")
+
 	if !user.JimmAdmin {
-		return nil, "", errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, "", errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	// if targetObject is not specified returns all tuples.
 	parsedTuple := &openfga.Tuple{}
@@ -133,15 +133,15 @@ func (j *permissionManager) ListRelationshipTuples(ctx context.Context, user *op
 	if tuple.TargetObject != "" {
 		parsedTuple, err = j.parseTuple(ctx, tuple)
 		if err != nil {
-			return nil, "", errors.E(op, err)
+			return nil, "", errors.E(err)
 		}
 	} else if tuple.Object != "" {
-		return nil, "", errors.E(op, errors.CodeBadRequest, "it is invalid to pass an object without a target object.")
+		return nil, "", errors.E(errors.CodeBadRequest, "it is invalid to pass an object without a target object.")
 	}
 
 	responseTuples, ct, err := j.authSvc.ReadRelatedObjects(ctx, *parsedTuple, pageSize, continuationToken)
 	if err != nil {
-		return nil, "", errors.E(op, err)
+		return nil, "", errors.E(err)
 	}
 	return responseTuples, ct, nil
 }
@@ -151,20 +151,20 @@ func (j *permissionManager) ListRelationshipTuples(ctx context.Context, user *op
 //
 // This functions provides a slightly higher-level abstraction in favor of ListRelationshipTuples.
 func (j *permissionManager) ListObjectRelations(ctx context.Context, user *openfga.User, object string, pageSize int32, entitlementToken pagination.EntitlementToken) ([]openfga.Tuple, pagination.EntitlementToken, error) {
-	const op = errors.Op("jimm.ListObjectRelations")
+
 	var e pagination.EntitlementToken
 	if !user.JimmAdmin {
-		return nil, e, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, e, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	responseTuples, nextToken, err := j.getObjectRelationsPage(ctx, object, pageSize, entitlementToken)
 	if err != nil {
-		return nil, e, errors.E(op, err)
+		return nil, e, errors.E(err)
 	}
 	// verify next page contains some entries. Otherwise return empty nextToken.
 	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
 		responseTuples, _, err := j.getObjectRelationsPage(ctx, object, 1, nextToken)
 		if err != nil {
-			return nil, e, errors.E(op, "error getting next page to verify it cointains something", err)
+			return nil, e, errors.E("error getting next page to verify it cointains something", err)
 		}
 		if len(responseTuples) == 0 {
 			nextToken = pagination.EntitlementToken{}
@@ -175,10 +175,9 @@ func (j *permissionManager) ListObjectRelations(ctx context.Context, user *openf
 
 // ListResources returns a list of resources known to JIMM with a pagination filter.
 func (j *permissionManager) ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error) {
-	const op = errors.Op("jimm.ListResources")
 
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	return j.store.ListResources(ctx, filter.Limit(), filter.Offset(), namePrefixFilter, typeFilter)
@@ -241,11 +240,10 @@ func (j *permissionManager) parseTuples(ctx context.Context, tuples []apiparams.
 // whatever format, be it JAAS or Juju tag, is resolved to the correct identifier
 // to be persisted within OpenFGA.
 func (j *permissionManager) parseTuple(ctx context.Context, tuple apiparams.RelationshipTuple) (*openfga.Tuple, error) {
-	const op = errors.Op("jujuapi.parseTuple")
 
 	relation, err := ofganames.ParseRelation(tuple.Relation)
 	if err != nil {
-		return nil, errors.E(op, err, errors.CodeBadRequest)
+		return nil, errors.E(err, errors.CodeBadRequest)
 	}
 	t := openfga.Tuple{
 		Relation: relation,
@@ -256,11 +254,11 @@ func (j *permissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 	// to be specific to the erroneous offender.
 	parseTagError := func(msg string, key string, err error) error {
 		zapctx.Debug(ctx, msg, zap.String("key", key), zap.Error(err))
-		return errors.E(op, errors.CodeFailedToParseTupleKey, fmt.Sprintf("%s %s: %s", msg, key, err.Error()))
+		return errors.E(errors.CodeFailedToParseTupleKey, fmt.Sprintf("%s %s: %s", msg, key, err.Error()))
 	}
 
 	if tuple.TargetObject == "" {
-		return nil, errors.E(op, errors.CodeBadRequest, "target object not specified")
+		return nil, errors.E(errors.CodeBadRequest, "target object not specified")
 	}
 	t.Target, err = j.parseAndValidateTag(ctx, tuple.TargetObject)
 	if err != nil {

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -344,12 +344,11 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 //
 // This key may be in the form of either a JIMM tag string or Juju tag string.
 func (j *permissionManager) parseAndValidateTag(ctx context.Context, key string) (*ofganames.Tag, error) {
-	op := errors.Op("jimm.parseAndValidateTag")
 	tupleKeySplit := strings.SplitN(key, "-", 2)
 	if len(tupleKeySplit) == 1 {
 		tag, err := ofganames.BlankKindTag(tupleKeySplit[0])
 		if err != nil {
-			return nil, errors.E(op, errors.CodeFailedToParseTupleKey, err)
+			return nil, errors.E(errors.CodeFailedToParseTupleKey, err)
 		}
 		return tag, nil
 	}
@@ -357,7 +356,7 @@ func (j *permissionManager) parseAndValidateTag(ctx context.Context, key string)
 	tag, err := resolveTag(j.jimmUUID, j.store, tagString)
 	if err != nil {
 		zapctx.Debug(ctx, "failed to resolve tuple object", zap.Error(err))
-		return nil, errors.E(op, errors.CodeFailedToResolveTupleResource, err)
+		return nil, errors.E(errors.CodeFailedToResolveTupleResource, err)
 	}
 	zapctx.Debug(ctx, "resolved JIMM tag", zap.String("tag", tag.String()))
 

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package role
 

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -5,8 +5,6 @@ package role
 import (
 	"context"
 
-	"github.com/juju/zaputil/zapctx"
-
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -33,43 +31,31 @@ func NewRoleManager(store *db.Database, authSvc *openfga.OFGAClient) (*roleManag
 
 // AddRole adds a role to JIMM.
 func (rm *roleManager) AddRole(ctx context.Context, user *openfga.User, roleName string) (*dbmodel.RoleEntry, error) {
-	const op = errors.Op("role.AddRole")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	re, err := rm.store.AddRole(ctx, roleName)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return re, nil
 }
 
 // GetRoleByUUID returns a role based on the provided UUID.
 func (rm *roleManager) GetRoleByUUID(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.RoleEntry, error) {
-	const op = errors.Op("role.GetRoleByUUID")
-	zapctx.Info(ctx, string(op))
-
 	return rm.getRole(ctx, user, &dbmodel.RoleEntry{UUID: uuid})
 }
 
 // GetRoleByName returns a role based on the provided name.
 func (rm *roleManager) GetRoleByName(ctx context.Context, user *openfga.User, name string) (*dbmodel.RoleEntry, error) {
-	const op = errors.Op("role.GetRoleByName")
-	zapctx.Info(ctx, string(op))
-
 	return rm.getRole(ctx, user, &dbmodel.RoleEntry{Name: name})
 }
 
 // RemoveRole removes the role from JIMM in both the store and authorisation store.
 func (rm *roleManager) RemoveRole(ctx context.Context, user *openfga.User, roleName string) error {
-	const op = errors.Op("role.RemoveRole")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	re := &dbmodel.RoleEntry{
@@ -77,18 +63,18 @@ func (rm *roleManager) RemoveRole(ctx context.Context, user *openfga.User, roleN
 	}
 	err := rm.store.GetRole(ctx, re)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	// TODO(ale8k):
 	// Would be nice to have a way to create a transaction to get, remove tuples, if successful, delete role
 	// somehow. We could pass a callback and change the db methods?
 	if err := rm.authSvc.RemoveRole(ctx, re.ResourceTag()); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err := rm.store.RemoveRole(ctx, re); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -96,16 +82,13 @@ func (rm *roleManager) RemoveRole(ctx context.Context, user *openfga.User, roleN
 
 // RenameRole renames a role in JIMM's DB.
 func (rm *roleManager) RenameRole(ctx context.Context, user *openfga.User, oldName, newName string) error {
-	const op = errors.Op("role.RenameRole")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := rm.store.UpdateRoleName(ctx, oldName, newName)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -114,46 +97,37 @@ func (rm *roleManager) RenameRole(ctx context.Context, user *openfga.User, oldNa
 // ListRoles returns a list of roles known to JIMM.
 // `match` will filter the list fuzzy matching role's name or uuid.
 func (rm *roleManager) ListRoles(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.RoleEntry, error) {
-	const op = errors.Op("role.ListRoles")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	res, err := rm.store.ListRoles(ctx, pagination.Limit(), pagination.Offset(), match)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return res, nil
 }
 
 // CountRoles returns the number of roles that exist.
 func (rm *roleManager) CountRoles(ctx context.Context, user *openfga.User) (int, error) {
-	const op = errors.Op("role.CountRoles")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return 0, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := rm.store.CountRoles(ctx)
 	if err != nil {
-		return 0, errors.E(op, err)
+		return 0, errors.E(err)
 	}
 	return count, nil
 }
 
 // getRole returns a role based on the provided UUID or name.
 func (rm *roleManager) getRole(ctx context.Context, user *openfga.User, role *dbmodel.RoleEntry) (*dbmodel.RoleEntry, error) {
-	const op = errors.Op("role.getRole")
-	zapctx.Info(ctx, string(op))
-
 	if !user.JimmAdmin {
-		return nil, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	if err := rm.store.GetRole(ctx, role); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return role, nil

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -29,10 +29,9 @@ func NewSSHKeyManager(store *db.Database) (*sshKeyManager, error) {
 
 // AddUserPublicKey saves a user's public key.
 func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey PublicKey) error {
-	const op = errors.Op("sshkeys.AddUserPublicKey")
 
 	if ok, reason := publicKey.valid(); !ok {
-		return errors.E(op, errors.CodeBadRequest, reason)
+		return errors.E(errors.CodeBadRequest, reason)
 	}
 
 	k := dbmodel.SSHKey{
@@ -44,27 +43,26 @@ func (sm *sshKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.Use
 	}
 	err := sm.store.AddSSHKey(ctx, &k)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // VerifyPublicKey lists the key for a user and compares the key to find a match.
 func (sm *sshKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
-	const op = errors.Op("sshkeys.VerifyPublicKey")
 
 	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, claimUser, db.SSHKeyModelFilter{All: true})
 	if err != nil {
-		return false, errors.E(op, err)
+		return false, errors.E(err)
 	}
 	publicKeyToCompare, err := gossh.ParsePublicKey(publicKey)
 	if err != nil {
-		return false, errors.E(op, err)
+		return false, errors.E(err)
 	}
 	for _, key := range dbKeys {
 		k, err := gossh.ParsePublicKey(key.PublicKey)
 		if err != nil {
-			return false, errors.E(op, err)
+			return false, errors.E(err)
 		}
 		if ssh.KeysEqual(k, publicKeyToCompare) {
 			return true, nil
@@ -76,17 +74,16 @@ func (sm *sshKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, 
 
 // ListUserPublicKeys lists a user's public keys.
 func (sm *sshKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]PublicKey, error) {
-	const op = errors.Op("sshkeys.ListUserPublicKeys")
 
 	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, user.Name, model)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	var pubKeys []PublicKey
 	for _, key := range dbKeys {
 		k, err := gossh.ParsePublicKey(key.PublicKey)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 		pubKeys = append(pubKeys, PublicKey{PublicKey: k, Comment: key.KeyComment})
 	}
@@ -95,22 +92,20 @@ func (sm *sshKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.U
 
 // RemoveUserKeyByComment removes a user's public key(s) by the key comment.
 func (sm *sshKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
-	const op = errors.Op("sshkeys.RemoveUserKeyByComment")
 
 	err := sm.store.RemoveSSHKeyByComment(ctx, user.Name, model, comment)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // RemoveUserKeyByFingerprint removes a user's public key by the key fingerprint.
 func (sm *sshKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
-	const op = errors.Op("sshkeys.RemoveUserKeyByFingerprint")
 
 	err := sm.store.RemoveSSHKeyByFingerprint(ctx, user.Name, model, fingerprint)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }

--- a/internal/jimmhttp/rebac_admin/backend.go
+++ b/internal/jimmhttp/rebac_admin/backend.go
@@ -19,7 +19,6 @@ import (
 )
 
 func SetupBackend(ctx context.Context, jimm jujuapi.JIMM) (*rebac_handlers.ReBACAdminBackend, error) {
-	const op = errors.Op("rebac_admin.SetupBackend")
 
 	securityEventLogger := &securityEventLogger{}
 
@@ -39,7 +38,7 @@ func SetupBackend(ctx context.Context, jimm jujuapi.JIMM) (*rebac_handlers.ReBAC
 		RolesErrorMapper:        securityEventLogger,
 	})
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("failed to create rebac admin backend: %w", err))
+		return nil, errors.E(fmt.Errorf("failed to create rebac admin backend: %w", err))
 	}
 
 	return rebacBackend, nil

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -56,35 +56,35 @@ func (wkh *WellKnownHandler) SetupMiddleware() {
 // The JWKS is expected to be cached by the client, where the expiry time
 // is the expiry time persisted for this set in our credential store.
 func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
-	const op = errors.Op("wellknownapi.JWKS")
+
 	ctx := r.Context()
 	if wkh == nil || wkh.CredentialStore == nil {
 		zapctx.Error(ctx, "nil reference in JWKS handler")
 		w.WriteHeader(http.StatusInternalServerError)
-		render.JSON(w, r, errors.E(op, errors.CodeJWKSRetrievalFailed, "JWKS does not exist"))
+		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "JWKS does not exist"))
 		return
 	}
 	ks, err := wkh.CredentialStore.GetJWKS(ctx)
 
 	if err != nil && errors.ErrorCode(err) == errors.CodeNotFound {
 		w.WriteHeader(http.StatusNotFound)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(op, errors.CodeJWKSRetrievalFailed, "JWKS does not exist yet", err)))
-		render.JSON(w, r, errors.E(op, errors.CodeNotFound, "JWKS does not exist yet"))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "JWKS does not exist yet", err)))
+		render.JSON(w, r, errors.E(errors.CodeNotFound, "JWKS does not exist yet"))
 		return
 	}
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(op, errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS", err)))
-		render.JSON(w, r, errors.E(op, errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS"))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS", err)))
+		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS"))
 		return
 	}
 
 	expiry, err := wkh.CredentialStore.GetJWKSExpiry(ctx)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(op, errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS expiry", err)))
-		render.JSON(w, r, errors.E(op, errors.CodeJWKSRetrievalFailed, "something went wrong..."))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS expiry", err)))
+		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "something went wrong..."))
 		return
 	}
 

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -83,7 +83,6 @@ func TestWellknownAPIJWKSJSONHandles404(t *testing.T) {
 		"Err":     nil,
 		"Info":    nil,
 		"Message": "JWKS does not exist yet",
-		"Op":      "wellknownapi.JWKS",
 	})
 }
 
@@ -114,7 +113,6 @@ func TestWellknownAPIJWKSJSONHandles500(t *testing.T) {
 		"Info":    nil,
 		"Err":     nil,
 		"Message": "something went wrong...",
-		"Op":      "wellknownapi.JWKS",
 	})
 }
 

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -129,12 +129,11 @@ func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTim
 // to use e and n for validation.
 // https://stackoverflow.com/questions/61395261/how-to-validate-signature-of-jwt-from-jwks-without-x5c
 func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequired <-chan time.Time, initialRotateRequiredTime time.Time) error {
-	const op = errors.Op("vault.StartJWKSRotator")
 
 	credStore := jwks.credentialStore
 
 	if err := rotateJWKS(ctx, credStore, initialRotateRequiredTime); err != nil {
-		return errors.E(op, fmt.Errorf("rotate jwks: %w", err))
+		return errors.E(fmt.Errorf("rotate jwks: %w", err))
 	}
 
 	// The rotation method is as follows, if an expiry is not present, we know
@@ -147,7 +146,7 @@ func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequir
 			select {
 			case <-checkRotateRequired:
 				if err := rotateJWKS(ctx, credStore, initialRotateRequiredTime); err != nil {
-					zapctx.Error(ctx, "security failure", zap.Any("op", op), zap.NamedError("jwks-error", err))
+					zapctx.Error(ctx, "security failure", zap.NamedError("jwks-error", err))
 				}
 			case <-ctx.Done():
 				zapctx.Debug(ctx, "shutdown for JWKS rotator complete.")
@@ -164,13 +163,12 @@ func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequir
 // It will return a jwk.Set containing the public key
 // and a PEM encoded private key for JWT signing.
 func generateJWK(ctx context.Context) (jwk.Set, []byte, error) {
-	const op = errors.Op("vault.generateJWKS")
 
 	// Due to the sensitivity of controllers, it is best we allow a larger encryption bit size
 	// and accept any negligible wire cost.
 	keySet, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	privateKeyPEM := pem.EncodeToMemory(
@@ -183,32 +181,32 @@ func generateJWK(ctx context.Context) (jwk.Set, []byte, error) {
 	// We also use the same methodology of generating UUIDs for our KID
 	kid, err := uuid.NewRandom()
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	jwks, err := jwk.FromRaw(keySet.PublicKey)
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 	err = jwks.Set(jwk.KeyIDKey, kid.String())
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	err = jwks.Set(jwk.KeyUsageKey, "sig") // Couldn't find const for this...
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	err = jwks.Set(jwk.AlgorithmKey, jwa.RS256)
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	ks := jwk.NewSet()
 	err = ks.AddKey(jwks)
 	if err != nil {
-		return nil, nil, errors.E(op, err)
+		return nil, nil, errors.E(err)
 	}
 
 	return ks, privateKeyPEM, nil

--- a/internal/jobtracker/jobtracker.go
+++ b/internal/jobtracker/jobtracker.go
@@ -147,12 +147,11 @@ func (j *Tracker) monitorJob(id uuid.UUID, jobErrCh chan error, cancelJob contex
 
 // GetJob retrieves a Job via its jobId.
 func (j *Tracker) GetJob(ctx context.Context, jobId uuid.UUID) (dbmodel.JobTrackerEntry, error) {
-	const op = errors.Op("jimm.GetJobStatus")
 
 	job := dbmodel.JobTrackerEntry{JobID: jobId}
 	err := j.store.GetJob(ctx, &job)
 	if err != nil {
-		return job, errors.E(op, "failed to get job info", err)
+		return job, errors.E("failed to get job info", err)
 	}
 
 	return job, nil
@@ -160,10 +159,9 @@ func (j *Tracker) GetJob(ctx context.Context, jobId uuid.UUID) (dbmodel.JobTrack
 
 // StopJob stops a job by its ID.
 func (j *Tracker) StopJob(ctx context.Context, jobId uuid.UUID) error {
-	const op = errors.Op("jimm.StopJob")
 
 	if err := j.store.StopJob(ctx, jobId); err != nil {
-		return errors.E(op, "failed to stop job", err)
+		return errors.E("failed to stop job", err)
 	}
 
 	return nil

--- a/internal/jujuapi/access_control.go
+++ b/internal/jujuapi/access_control.go
@@ -26,16 +26,16 @@ const (
 
 // AddGroup creates a group within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupRequest) (apiparams.AddGroupResponse, error) {
-	const op = errors.Op("jujuapi.AddGroup")
+
 	resp := apiparams.AddGroupResponse{}
 
 	if !jimmnames.IsValidGroupName(req.Name) {
-		return resp, errors.E(op, errors.CodeBadRequest, "invalid group name")
+		return resp, errors.E(errors.CodeBadRequest, "invalid group name")
 	}
 
 	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
 	if err != nil {
-		return resp, errors.E(op, fmt.Errorf("failed to add group: %w", err))
+		return resp, errors.E(fmt.Errorf("failed to add group: %w", err))
 	}
 	resp = apiparams.AddGroupResponse{Group: apiparams.Group{
 		Name:      groupEntry.Name,
@@ -49,22 +49,21 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 
 // GetGroup returns group information based on a UUID or name.
 func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupRequest) (apiparams.Group, error) {
-	const op = errors.Op("jujuapi.GetGroup")
 
 	var groupEntry *dbmodel.GroupEntry
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Group{}, errors.E(op, errors.CodeBadRequest, "only one of UUID or Name should be provided")
+		return apiparams.Group{}, errors.E(errors.CodeBadRequest, "only one of UUID or Name should be provided")
 	case req.UUID != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Group{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
+		return apiparams.Group{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		return apiparams.Group{}, errors.E(op, fmt.Errorf("failed to get group: %w", err))
+		return apiparams.Group{}, errors.E(fmt.Errorf("failed to get group: %w", err))
 	}
 
 	return apiparams.Group{
@@ -77,36 +76,33 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 
 // RenameGroup renames a group within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGroupRequest) error {
-	const op = errors.Op("jujuapi.RenameGroup")
 
 	if !jimmnames.IsValidGroupName(req.NewName) {
-		return errors.E(op, errors.CodeBadRequest, "invalid group name")
+		return errors.E(errors.CodeBadRequest, "invalid group name")
 	}
 
 	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {
-		return errors.E(op, fmt.Errorf("failed to rename group: %w", err))
+		return errors.E(fmt.Errorf("failed to rename group: %w", err))
 	}
 	return nil
 }
 
 // RemoveGroup removes a group within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) RemoveGroup(ctx context.Context, req apiparams.RemoveGroupRequest) error {
-	const op = errors.Op("jujuapi.RemoveGroup")
 
 	if err := r.jimm.GroupManager().RemoveGroup(ctx, r.user, req.Name); err != nil {
-		return errors.E(op, fmt.Errorf("failed to remove group: %w", err))
+		return errors.E(fmt.Errorf("failed to remove group: %w", err))
 	}
 	return nil
 }
 
 // ListGroup lists relational access control groups within JIMMs DB.
 func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroupsRequest) (apiparams.ListGroupResponse, error) {
-	const op = errors.Op("jujuapi.ListGroups")
 
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
 	groups, err := r.jimm.GroupManager().ListGroups(ctx, r.user, pagination, "")
 	if err != nil {
-		return apiparams.ListGroupResponse{}, errors.E(op, fmt.Errorf("failed to list groups: %w", err))
+		return apiparams.ListGroupResponse{}, errors.E(fmt.Errorf("failed to list groups: %w", err))
 	}
 	groupsResponse := make([]apiparams.Group, len(groups))
 	for i, g := range groups {
@@ -124,10 +120,9 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 // AddRelation creates a tuple between two objects [if applicable]
 // within OpenFGA.
 func (r *controllerRoot) AddRelation(ctx context.Context, req apiparams.AddRelationRequest) error {
-	const op = errors.Op("jujuapi.AddRelation")
 
 	if err := r.jimm.PermissionManager().AddRelation(ctx, r.user, req.Tuples); err != nil {
-		return errors.E(op, fmt.Errorf("failed to add relation: %w", err))
+		return errors.E(fmt.Errorf("failed to add relation: %w", err))
 	}
 	return nil
 }
@@ -135,11 +130,10 @@ func (r *controllerRoot) AddRelation(ctx context.Context, req apiparams.AddRelat
 // RemoveRelation removes a tuple between two objects [if applicable]
 // within OpenFGA.
 func (r *controllerRoot) RemoveRelation(ctx context.Context, req apiparams.RemoveRelationRequest) error {
-	const op = errors.Op("jujuapi.RemoveRelation")
 
 	err := r.jimm.PermissionManager().RemoveRelation(ctx, r.user, req.Tuples)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to remove relation: %w", err))
+		return errors.E(fmt.Errorf("failed to remove relation: %w", err))
 	}
 	return nil
 }
@@ -148,13 +142,13 @@ func (r *controllerRoot) RemoveRelation(ctx context.Context, req apiparams.Remov
 // against another tuple within OpenFGA.
 // This corresponds directly to /stores/{store_id}/check.
 func (r *controllerRoot) CheckRelation(ctx context.Context, req apiparams.CheckRelationRequest) (apiparams.CheckRelationResponse, error) {
-	const op = errors.Op("jujuapi.CheckRelation")
+
 	checkResp := apiparams.CheckRelationResponse{Allowed: false}
 
 	allowed, err := r.jimm.PermissionManager().CheckRelation(ctx, r.user, req.Tuple, false)
 	if err != nil {
 		checkResp.Error = err.Error()
-		return checkResp, errors.E(op, fmt.Errorf("failed to check relation: %w", err))
+		return checkResp, errors.E(fmt.Errorf("failed to check relation: %w", err))
 	}
 	checkResp.Allowed = allowed
 	zapctx.Debug(ctx, "check request", zap.String("allowed", strconv.FormatBool(allowed)))
@@ -164,12 +158,12 @@ func (r *controllerRoot) CheckRelation(ctx context.Context, req apiparams.CheckR
 // CheckRelations performs an authorisation check for a list of tuples.
 // It returns a list of results, each with an Allowed boolean and an optional error message.
 func (r *controllerRoot) CheckRelations(ctx context.Context, req apiparams.CheckRelationsRequest) (apiparams.CheckRelationsResponse, error) {
-	const op = errors.Op("jujuapi.CheckRelations")
+
 	checksResp := apiparams.CheckRelationsResponse{}
 
 	results, err := r.jimm.PermissionManager().CheckRelations(ctx, r.user, req.Tuples)
 	if err != nil {
-		return checksResp, errors.E(op, fmt.Errorf("failed to check relations: %w", err))
+		return checksResp, errors.E(fmt.Errorf("failed to check relations: %w", err))
 	}
 	for _, result := range results {
 		resp := apiparams.CheckRelationResponse{
@@ -186,11 +180,10 @@ func (r *controllerRoot) CheckRelations(ctx context.Context, req apiparams.Check
 
 // ListRelationshipTuples returns a list of tuples matching the specified filter.
 func (r *controllerRoot) ListRelationshipTuples(ctx context.Context, req apiparams.ListRelationshipTuplesRequest) (apiparams.ListRelationshipTuplesResponse, error) {
-	const op = errors.Op("jujuapi.ListRelationshipTuples")
 
 	responseTuples, ct, err := r.jimm.PermissionManager().ListRelationshipTuples(ctx, r.user, req.Tuple, req.PageSize, req.ContinuationToken)
 	if err != nil {
-		return apiparams.ListRelationshipTuplesResponse{}, errors.E(op, fmt.Errorf("failed to list relations: %w", err))
+		return apiparams.ListRelationshipTuplesResponse{}, errors.E(fmt.Errorf("failed to list relations: %w", err))
 	}
 	errors := []string{}
 	tuples := make([]apiparams.RelationshipTuple, len(responseTuples))

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -44,12 +44,12 @@ var facadeInit = make(map[string]func(r *controllerRoot) []int)
 // Upon successful login, the user is then expected to retrieve an access token using
 // GetDeviceAccessToken.
 func (r *controllerRoot) LoginDevice(ctx context.Context) (params.LoginDeviceResponse, error) {
-	const op = errors.Op("jujuapi.LoginDevice")
+
 	response := params.LoginDeviceResponse{}
 
 	deviceResponse, err := r.jimm.LoginManager().LoginDevice(ctx)
 	if err != nil {
-		return response, errors.E(op, err, errors.CodeUnauthorized)
+		return response, errors.E(err, errors.CodeUnauthorized)
 	}
 	// NOTE: As this is on the controller root struct, and a new controller root
 	// is created per WS, it is EXPECTED that the subsequent call to GetDeviceSessionToken
@@ -68,12 +68,12 @@ func (r *controllerRoot) LoginDevice(ctx context.Context) (params.LoginDeviceRes
 // where the subject of the JWT contains the user's email - enabling identification
 // of the said user's session.
 func (r *controllerRoot) GetDeviceSessionToken(ctx context.Context) (params.GetDeviceSessionTokenResponse, error) {
-	const op = errors.Op("jujuapi.GetDeviceSessionToken")
+
 	response := params.GetDeviceSessionTokenResponse{}
 
 	token, err := r.jimm.LoginManager().GetDeviceSessionToken(ctx, r.deviceOAuthResponse)
 	if err != nil {
-		return response, errors.E(op, err, errors.CodeUnauthorized)
+		return response, errors.E(err, errors.CodeUnauthorized)
 	}
 
 	response.SessionToken = token
@@ -87,11 +87,10 @@ func (r *controllerRoot) GetDeviceSessionToken(ctx context.Context) (params.GetD
 // It may be misleading in that it does not interact with cookies at all, but this will only ever
 // be successful upon the http layer login being successful.
 func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams.LoginResult, error) {
-	const op = errors.Op("jujuapi.LoginWithSessionCookie")
 
 	user, err := r.jimm.LoginManager().LoginWithSessionCookie(ctx, r.identityId)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(op, err, errors.CodeUnauthorized)
+		return jujuparams.LoginResult{}, errors.E(err, errors.CodeUnauthorized)
 	}
 
 	r.mu.Lock()
@@ -101,7 +100,7 @@ func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(op, err)
+		return jujuparams.LoginResult{}, errors.E(err)
 	}
 
 	return jujuparams.LoginResult{
@@ -119,12 +118,11 @@ func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams
 // whether or not they're an admin and place the user on the controller root
 // such that subsequent facade method calls can access the authenticated user.
 func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.LoginWithSessionTokenRequest) (jujuparams.LoginResult, error) {
-	const op = errors.Op("jujuapi.LoginWithSessionToken")
 
 	user, err := r.jimm.LoginManager().LoginWithSessionToken(ctx, req.SessionToken)
 	if err != nil {
 		// Avoid masking the error code on err below. The Juju CLI uses it to determine when to initiate login see [OAuthAuthenticator.VerifySessionToken].
-		return jujuparams.LoginResult{}, errors.E(op, err)
+		return jujuparams.LoginResult{}, errors.E(err)
 	}
 
 	// TODO(ale8k): This isn't needed I don't think as controller roots are unique
@@ -136,7 +134,7 @@ func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.L
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(op, err)
+		return jujuparams.LoginResult{}, errors.E(err)
 	}
 
 	return jujuparams.LoginResult{
@@ -151,7 +149,6 @@ func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.L
 // LoginWithClientCredentials handles logging into the JIMM with the client ID
 // and secret created by the IdP.
 func (r *controllerRoot) LoginWithClientCredentials(ctx context.Context, req params.LoginWithClientCredentialsRequest) (jujuparams.LoginResult, error) {
-	const op = errors.Op("jujuapi.LoginWithClientCredentials")
 
 	user, err := r.jimm.LoginManager().LoginClientCredentials(ctx, req.ClientID, req.ClientSecret)
 	if err != nil {
@@ -165,7 +162,7 @@ func (r *controllerRoot) LoginWithClientCredentials(ctx context.Context, req par
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(op, err)
+		return jujuparams.LoginResult{}, errors.E(err)
 	}
 
 	return jujuparams.LoginResult{

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -52,15 +52,14 @@ func (r *controllerRoot) Offer(ctx context.Context, args jujuparams.AddApplicati
 }
 
 func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicationOffer) error {
-	const op = errors.Op("jujuapi.Offer")
 
 	mt, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(op, errors.CodeBadRequest, err)
+		return errors.E(errors.CodeBadRequest, err)
 	}
 	offerOwnerTag, err := names.ParseUserTag(args.OwnerTag)
 	if err != nil {
-		return errors.E(op, errors.CodeBadRequest, err)
+		return errors.E(errors.CodeBadRequest, err)
 	}
 	err = r.jimm.JujuManager().Offer(ctx, r.user, juju.AddApplicationOfferParams{
 		ModelTag:               mt,
@@ -71,7 +70,7 @@ func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicati
 		Endpoints:              args.Endpoints,
 	})
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -101,11 +100,10 @@ func (r *controllerRoot) GetConsumeDetails(ctx context.Context, args jujuparams.
 }
 
 func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.User, v bakery.Version, offerURL string) (jujuparams.ConsumeOfferDetails, error) {
-	const op = errors.Op("jujuapi.GetConsumeDetails")
 
 	ourl, err := crossmodel.ParseOfferURL(offerURL)
 	if err != nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.E(op, "cannot parse offer URL", errors.CodeBadRequest, err)
+		return jujuparams.ConsumeOfferDetails{}, errors.E("cannot parse offer URL", errors.CodeBadRequest, err)
 	}
 
 	// Ensure the path is normalised.
@@ -120,19 +118,19 @@ func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.Us
 		},
 	}
 	if err := r.jimm.JujuManager().GetApplicationOfferConsumeDetails(ctx, user, &details, v); err != nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.E(op, err)
+		return jujuparams.ConsumeOfferDetails{}, errors.E(err)
 	}
 	return details, nil
 }
 
 // ListApplicationOffers returns all offers matching the specified filters.
 func (r *controllerRoot) ListApplicationOffers(ctx context.Context, args jujuparams.OfferFilters) (jujuparams.QueryApplicationOffersResultsV5, error) {
-	const op = errors.Op("jujuapi.ListApplicationOffers")
+
 	results := jujuparams.QueryApplicationOffersResultsV5{}
 
 	offers, err := r.jimm.JujuManager().ListApplicationOffers(ctx, r.user, args.Filters...)
 	if err != nil {
-		return results, errors.E(op, err)
+		return results, errors.E(err)
 	}
 	results.Results = offers
 
@@ -143,12 +141,12 @@ func (r *controllerRoot) ListApplicationOffers(ctx context.Context, args jujupar
 // as long as the user has read access to each offer. It also omits details
 // on users and connections.
 func (r *controllerRoot) FindApplicationOffers(ctx context.Context, args jujuparams.OfferFilters) (jujuparams.QueryApplicationOffersResultsV5, error) {
-	const op = errors.Op("jujuapi.FindApplicationOffers")
+
 	results := jujuparams.QueryApplicationOffersResultsV5{}
 
 	offers, err := r.jimm.JujuManager().FindApplicationOffers(ctx, r.user, args.Filters...)
 	if err != nil {
-		return results, errors.E(op, err)
+		return results, errors.E(err)
 	}
 	results.Results = offers
 
@@ -168,11 +166,10 @@ func (r *controllerRoot) ModifyOfferAccess(ctx context.Context, args jujuparams.
 }
 
 func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparams.ModifyOfferAccess) error {
-	const op = errors.Op("jujuapi.ModifyOfferAccess")
 
 	ut, err := parseUserTag(change.UserTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
@@ -181,23 +178,23 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 		// releases of Juju.
 		if err := r.jimm.JujuManager().GrantOfferAccessOnController(ctx, r.user, ut, change.OfferURL, change.Access); err != nil {
 			if !strings.Contains(err.Error(), "user already has") {
-				return errors.E(op, err)
+				return errors.E(err)
 			}
 		}
 		if err := r.jimm.PermissionManager().GrantOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		return nil
 	case jujuparams.RevokeOfferAccess:
 		if err := r.jimm.PermissionManager().RevokeOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		if err := r.jimm.JujuManager().RevokeOfferAccessOnController(ctx, r.user, ut, change.OfferURL, change.Access); err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 		return nil
 	default:
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("unknown action %q", change.Action))
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("unknown action %q", change.Action))
 	}
 }
 

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -62,23 +62,22 @@ func init() {
 // DefaultCloud implements the DefaultCloud method of the Cloud facade.
 // It returns a default cloud if there is only one cloud available.
 func (r *controllerRoot) DefaultCloud(ctx context.Context) (jujuparams.StringResult, error) {
-	return jujuparams.StringResult{}, errors.E(errors.Op("jujuapi.DefaultCloud"), errors.CodeNotFound, "no default cloud")
+	return jujuparams.StringResult{}, errors.E(errors.CodeNotFound, "no default cloud")
 }
 
 // Cloud implements the Cloud method of the Cloud facade.
 func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (jujuparams.CloudResults, error) {
-	const op = errors.Op("jujuapi.Cloud")
 
 	cloudResults := make([]jujuparams.CloudResult, len(ents.Entities))
 	for i, ent := range ents.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			cloudResults[i].Error = r.mapError(ctx, errors.E(op, errors.CodeBadRequest, err))
+			cloudResults[i].Error = r.mapError(ctx, errors.E(errors.CodeBadRequest, err))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			cloudResults[i].Error = r.mapError(ctx, errors.E(op, err))
+			cloudResults[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		cloudResults[i].Cloud = new(jujuparams.Cloud)
@@ -91,7 +90,6 @@ func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (j
 
 // Clouds implements the Clouds method on the Cloud facade.
 func (r *controllerRoot) Clouds(ctx context.Context) (jujuparams.CloudsResult, error) {
-	const op = errors.Op("jujuapi.Clouds")
 
 	res := jujuparams.CloudsResult{
 		Clouds: make(map[string]jujuparams.Cloud),
@@ -101,25 +99,24 @@ func (r *controllerRoot) Clouds(ctx context.Context) (jujuparams.CloudsResult, e
 		return nil
 	})
 	if err != nil {
-		return res, errors.E(op, err)
+		return res, errors.E(err)
 	}
 	return res, nil
 }
 
 // UserCredentials implements the UserCredentials method of the Cloud facade.
 func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujuparams.UserClouds) (jujuparams.StringsResults, error) {
-	const op = errors.Op("jujuapi.UserCredentials")
 
 	results := make([]jujuparams.StringsResult, len(userclouds.UserClouds))
 	for i, ent := range userclouds.UserClouds {
 		user, err := r.masquerade(ctx, ent.UserTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		cld, err := names.ParseCloudTag(ent.CloudTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		err = r.jimm.JujuManager().ForEachUserCloudCredential(ctx, user.Identity, cld, func(c *dbmodel.CloudCredential) error {
@@ -127,7 +124,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 			return nil
 		})
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 		}
 	}
 
@@ -152,14 +149,13 @@ func (r *controllerRoot) RevokeCredentialsCheckModels(ctx context.Context, args 
 
 // RevokeCredentials revokes a set of cloud credentials.
 func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, _ bool) error {
-	const op = errors.Op("jujuapi.RevokeCredentialsCheckModels")
 
 	ct, err := names.ParseCloudCredentialTag(tag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -182,49 +178,47 @@ func (r *controllerRoot) Credential(ctx context.Context, args jujuparams.Entitie
 
 // credential retrieves the given credential.
 func (r *controllerRoot) credential(ctx context.Context, cloudCredentialTag string) (*jujuparams.CloudCredential, error) {
-	const op = errors.Op("jujuapi.Credential")
 
 	cct, err := names.ParseCloudCredentialTag(cloudCredentialTag)
 	if err != nil {
-		return nil, errors.E(op, err, errors.CodeBadRequest)
+		return nil, errors.E(err, errors.CodeBadRequest)
 	}
 
 	cred, err := r.jimm.JujuManager().GetCloudCredential(ctx, r.user, cct)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	cc := jujuparams.CloudCredential{
 		AuthType: cred.AuthType,
 	}
 	cc.Attributes, cc.Redacted, err = r.jimm.JujuManager().GetCloudCredentialAttributes(ctx, r.user, cred, false)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return &cc, nil
 }
 
 // AddCloud implements the AddCloud method of the Cloud (v2) facade.
 func (r *controllerRoot) AddCloud(ctx context.Context, args jujuparams.AddCloudArgs) error {
-	const op = errors.Op("jujuapi.AddCloud")
+
 	force := false
 	if args.Force != nil && *args.Force {
 		force = true
 	}
 	if err := r.jimm.JujuManager().AddHostedCloud(ctx, r.user, names.NewCloudTag(args.Name), cloudFromParams(args.Name, args.Cloud), force); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // AddCredentials implements the AddCredentials method of the Cloud (v2) facade.
 func (r *controllerRoot) AddCredentials(ctx context.Context, args jujuparams.TaggedCredentials) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.AddCredentials")
 
 	updateResults, err := r.UpdateCredentialsCheckModels(ctx, jujuparams.UpdateCredentialArgs{
 		Credentials: args.Credentials,
 	})
 	if err != nil {
-		return jujuparams.ErrorResults{}, errors.E(op, err)
+		return jujuparams.ErrorResults{}, errors.E(err)
 	}
 	results := collapseUpdateCredentialResults(args, updateResults)
 	return results, nil
@@ -285,7 +279,6 @@ func (r *controllerRoot) CredentialContents(ctx context.Context, args jujuparams
 }
 
 func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openfga.User, j JIMM, args jujuparams.CloudCredentialArgs) (jujuparams.CredentialContentResults, error) {
-	const op = errors.Op("jujuapi.CredentialContents")
 
 	credentialContents := func(c *dbmodel.CloudCredential) (*jujuparams.ControllerCredentialInfo, error) {
 		content := jujuparams.CredentialContent{
@@ -319,12 +312,12 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 		cct := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", arg.CloudName, user.Name, arg.CredentialName))
 		cred, err := j.JujuManager().GetCloudCredential(ctx, user, cct)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		results[i].Result, err = credentialContents(cred)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 		}
 	}
 	if len(results) > 0 {
@@ -336,13 +329,13 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 		var err error
 		result.Result, err = credentialContents(c)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(err))
 		}
 		results = append(results, result)
 		return nil
 	})
 	if err != nil {
-		return jujuparams.CredentialContentResults{}, errors.E(op, err)
+		return jujuparams.CredentialContentResults{}, errors.E(err)
 	}
 	return jujuparams.CredentialContentResults{Results: results}, nil
 }
@@ -350,7 +343,6 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 // RemoveClouds removes the specified clouds from the controller.
 // If a cloud is in use (has models deployed to it), the removal will fail.
 func (r *controllerRoot) RemoveClouds(ctx context.Context, args jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.RemoveClouds")
 
 	result := jujuparams.ErrorResults{
 		Results: make([]jujuparams.ErrorResult, len(args.Entities)),
@@ -358,12 +350,12 @@ func (r *controllerRoot) RemoveClouds(ctx context.Context, args jujuparams.Entit
 	for i, entity := range args.Entities {
 		tag, err := names.ParseCloudTag(entity.Tag)
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		err = r.jimm.JujuManager().RemoveCloud(ctx, r.user, tag)
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(err))
 		}
 	}
 	return result, nil
@@ -385,15 +377,14 @@ func (r *controllerRoot) ModifyCloudAccess(ctx context.Context, args jujuparams.
 }
 
 func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparams.ModifyCloudAccess) error {
-	const op = errors.Op("jujuapi.ModifyCloudAccess")
 
 	ut, err := parseUserTag(change.UserTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	ct, err := names.ParseCloudTag(change.CloudTag)
 	if err != nil {
-		return errors.E(op, errors.CodeBadRequest, err)
+		return errors.E(errors.CodeBadRequest, err)
 	}
 
 	var modifyf func(context.Context, *openfga.User, names.CloudTag, names.UserTag, string) error
@@ -403,10 +394,10 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 	case jujuparams.RevokeCloudAccess:
 		modifyf = r.jimm.PermissionManager().RevokeCloudAccess
 	default:
-		return errors.E(op, errors.CodeBadRequest, fmt.Sprintf("unsupported modify cloud action %q", change.Action))
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("unsupported modify cloud action %q", change.Action))
 	}
 	if err := modifyf(ctx, r.user, ct, ut, change.Access); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -471,18 +462,17 @@ func (r *controllerRoot) updateCloud() error {
 
 // CloudInfo implements the cloud facades CloudInfo method.
 func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities) (jujuparams.CloudInfoResults, error) {
-	const op = errors.Op("jujuapi.CloudInfo")
 
 	results := make([]jujuparams.CloudInfoResult, len(args.Entities))
 	for i, ent := range args.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 
@@ -496,7 +486,6 @@ func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities
 
 // ListCloudInfo implements the ListCloudInfo method on the cloud facade.
 func (r *controllerRoot) ListCloudInfo(ctx context.Context, args jujuparams.ListCloudsRequest) (jujuparams.ListCloudInfoResults, error) {
-	const op = errors.Op("jujuapi.ListCloudInfo")
 
 	listF := r.jimm.JujuManager().ForEachUserCloud
 	if args.All {
@@ -514,7 +503,7 @@ func (r *controllerRoot) ListCloudInfo(ctx context.Context, args jujuparams.List
 		return nil
 	})
 	if err != nil {
-		return jujuparams.ListCloudInfoResults{}, errors.E(op, err)
+		return jujuparams.ListCloudInfoResults{}, errors.E(err)
 	}
 
 	return jujuparams.ListCloudInfoResults{

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -85,11 +85,10 @@ func (r *controllerRoot) IdentityProviderURL(ctx context.Context) (jujuparams.St
 // ControllerVersion returns the version information associated with this
 // controller binary.
 func (r *controllerRoot) ControllerVersion(ctx context.Context) (jujuparams.ControllerVersionResults, error) {
-	const op = errors.Op("jujuapi.ControllerVersion")
 
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.ControllerVersionResults{}, errors.E(op, err)
+		return jujuparams.ControllerVersionResults{}, errors.E(err)
 	}
 	result := jujuparams.ControllerVersionResults{
 		Version:   srvVersion.String(),
@@ -101,11 +100,10 @@ func (r *controllerRoot) ControllerVersion(ctx context.Context) (jujuparams.Cont
 // WatchModelSummaries implements the WatchModelSummaries command on the
 // Controller facade.
 func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.SummaryWatcherID, error) {
-	const op = errors.Op("jujuapi.WatchModelSummaries")
 
 	err := r.setupUUIDGenerator()
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(op, err)
+		return jujuparams.SummaryWatcherID{}, errors.E(err)
 	}
 
 	id := fmt.Sprintf("%v", r.generator.Next())
@@ -123,7 +121,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 	}
 	watcher, err := newModelSummaryWatcher(ctx, id, r.jimm.PubSubHub(), getModels)
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(op, err)
+		return jujuparams.SummaryWatcherID{}, errors.E(err)
 	}
 	r.watchers.register(watcher)
 
@@ -135,15 +133,14 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 // WatchAllModelSummaries implements the WatchAllModelSummaries command on the
 // Controller facade.
 func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams.SummaryWatcherID, error) {
-	const op = errors.Op("jujuapi.WatchAllModelSummaries")
 
 	if !r.user.JimmAdmin {
-		return jujuparams.SummaryWatcherID{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return jujuparams.SummaryWatcherID{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := r.setupUUIDGenerator()
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(op, err)
+		return jujuparams.SummaryWatcherID{}, errors.E(err)
 	}
 
 	id := fmt.Sprintf("%v", r.generator.Next())
@@ -155,14 +152,14 @@ func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams
 			return nil
 		})
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 		return modelUUIDs, nil
 	}
 
 	watcher, err := newModelSummaryWatcher(ctx, id, r.jimm.PubSubHub(), getAllModels)
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(op, err)
+		return jujuparams.SummaryWatcherID{}, errors.E(err)
 	}
 	r.watchers.register(watcher)
 
@@ -178,7 +175,6 @@ func (r *controllerRoot) AllModels(ctx context.Context) (jujuparams.UserModelLis
 
 // allModels returns all the models the logged in user has access to.
 func (r *controllerRoot) allModels(ctx context.Context) (jujuparams.UserModelList, error) {
-	const op = errors.Op("jujuapi.AllModels")
 
 	var models []jujuparams.UserModel
 	err := r.jimm.JujuManager().ForEachUserModel(ctx, r.user, func(m *dbmodel.Model, _ jujuparams.UserAccessPermission) error {
@@ -189,7 +185,7 @@ func (r *controllerRoot) allModels(ctx context.Context) (jujuparams.UserModelLis
 		return nil
 	})
 	if err != nil {
-		return jujuparams.UserModelList{}, errors.E(op, err)
+		return jujuparams.UserModelList{}, errors.E(err)
 	}
 	return jujuparams.UserModelList{
 		UserModels: models,
@@ -198,7 +194,6 @@ func (r *controllerRoot) allModels(ctx context.Context) (jujuparams.UserModelLis
 
 // ModelStatus implements the ModelStatus command on the Controller facade.
 func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelStatusResults, error) {
-	const op = errors.Op("jujuapi.ModelStatus")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -206,12 +201,12 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 	for i, arg := range args.Entities {
 		mt, err := names.ParseModelTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		status, err := r.jimm.JujuManager().ModelStatus(ctx, r.user, mt)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		results[i] = *status
@@ -223,10 +218,10 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 
 // ControllerConfig returns the JIMM's controller configuration.
 func (r *controllerRoot) ControllerConfig(ctx context.Context) (jujuparams.ControllerConfigResult, error) {
-	const op = errors.Op("jujuapi.ControllerConfig")
+
 	config, err := r.jimm.ConfigManager().GetConfig()
 	if err != nil {
-		return jujuparams.ControllerConfigResult{}, errors.E(op, err)
+		return jujuparams.ControllerConfigResult{}, errors.E(err)
 	}
 	cfg := make(map[string]interface{})
 	cfg[jujucontroller.ControllerUUIDKey] = config.ControllerUUID
@@ -256,18 +251,17 @@ func (r *controllerRoot) ModelConfig() (jujuparams.ModelConfigResults, error) {
 // GetControllerAccess returns the access level on the controller for
 // users.
 func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparams.Entities) (jujuparams.UserAccessResults, error) {
-	const op = errors.Op("jujuapi.GetControllerAccess")
 
 	results := make([]jujuparams.UserAccessResult, len(args.Entities))
 	for i, arg := range args.Entities {
 		tag, err := names.ParseUserTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		access, err := r.jimm.PermissionManager().GetJimmControllerAccess(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		results[i].Result = &jujuparams.UserAccess{
@@ -284,13 +278,12 @@ func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparam
 // InitiateMigration attempts to begin the migration of one or
 // more models to other controllers.
 func (r *controllerRoot) InitiateMigration(ctx context.Context, args jujuparams.InitiateMigrationArgs) (jujuparams.InitiateMigrationResults, error) {
-	const op = errors.Op("jujuapi.InitiateMigration")
 
 	results := make([]jujuparams.InitiateMigrationResult, len(args.Specs))
 	for i, spec := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateMigration(ctx, r.user, spec)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(err))
 		}
 		results[i] = result
 	}

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -121,10 +121,9 @@ func init() {
 // with any model information is the UUID of the juju controller that is
 // hosting the model, and not JAAS.
 func (r *controllerRoot) DisableControllerUUIDMasking(ctx context.Context) error {
-	const op = errors.Op("jujuapi.DisableControllerUUIDMasking")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	r.controllerUUIDMasking = false
 	return nil
@@ -167,14 +166,14 @@ type LegacyControllerResponse struct {
 
 // AddCloudToController adds the specified cloud to a specific controller.
 func (r *controllerRoot) AddCloudToController(ctx context.Context, req apiparams.AddCloudToControllerRequest) error {
-	const op = errors.Op("jujuapi.AddCloudToController")
+
 	force := false
 	if req.Force != nil && *req.Force {
 		force = true
 	}
 	cloud := cloudFromParams(req.Name, req.Cloud)
 	if err := r.jimm.JujuManager().AddCloudToController(ctx, r.user, req.ControllerName, names.NewCloudTag(req.Name), cloud, force); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -182,27 +181,26 @@ func (r *controllerRoot) AddCloudToController(ctx context.Context, req apiparams
 // AddController allows adds a controller to the pool of controllers
 // available to JIMM.
 func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddControllerRequest) (apiparams.ControllerInfo, error) {
-	const op = errors.Op("jujuapi.AddController")
 
 	if req.Name == jimmControllerName {
-		return apiparams.ControllerInfo{}, errors.E(op, errors.CodeBadRequest, fmt.Sprintf("cannot add a controller with name %q", jimmControllerName))
+		return apiparams.ControllerInfo{}, errors.E(errors.CodeBadRequest, fmt.Sprintf("cannot add a controller with name %q", jimmControllerName))
 	}
 	if req.PublicAddress != "" {
 		host, port, err := net.SplitHostPort(req.PublicAddress)
 		if err != nil {
-			return apiparams.ControllerInfo{}, errors.E(op, err, errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.E(err, errors.CodeBadRequest)
 		}
 		if host == "" {
-			return apiparams.ControllerInfo{}, errors.E(op, fmt.Sprintf("address %s: host not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.E(fmt.Sprintf("address %s: host not specified in public address", req.PublicAddress), errors.CodeBadRequest)
 		}
 		if port == "" {
-			return apiparams.ControllerInfo{}, errors.E(op, fmt.Sprintf("address %s: port not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.E(fmt.Sprintf("address %s: port not specified in public address", req.PublicAddress), errors.CodeBadRequest)
 		}
 	}
 
 	nphps, err := network.ParseProviderHostPorts(req.APIAddresses...)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, errors.CodeBadRequest, err)
+		return apiparams.ControllerInfo{}, errors.E(errors.CodeBadRequest, err)
 	}
 	for i := range nphps {
 		// Mark all the unknown scopes public.
@@ -225,7 +223,7 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 		AdminPassword:     req.Password,
 	}
 	if err := r.jimm.JujuManager().AddController(ctx, r.user, &ctl, ctlCreds); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, fmt.Errorf("failed to add controller: %w", err))
+		return apiparams.ControllerInfo{}, errors.E(fmt.Errorf("failed to add controller: %w", err))
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
@@ -235,14 +233,13 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 // If the user is not an admin, they will only receive information about
 // JIMM itself - note that the controller name returned is "jaas".
 func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListControllersResponse, error) {
-	const op = errors.Op("jujuapi.ListControllersV3")
 
 	if !r.user.JimmAdmin {
 		// if the user isn't a controller admin return JAAS
 		// itself as the only controller.
 		srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 		if err != nil {
-			return apiparams.ListControllersResponse{}, errors.E(op, err)
+			return apiparams.ListControllersResponse{}, errors.E(err)
 		}
 		jimmCtl := params.ControllerInfo{
 			Name: "jaas",
@@ -258,7 +255,7 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 	}
 	dbControllers, err := r.jimm.JujuManager().ListControllers(ctx, r.user)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(op, err)
+		return apiparams.ListControllersResponse{}, errors.E(err)
 	}
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
@@ -271,29 +268,27 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 
 // RemoveController removes a controller.
 func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.RemoveControllerRequest) (apiparams.ControllerInfo, error) {
-	const op = errors.Op("jujuapi.RemoveController")
 
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, err)
+		return apiparams.ControllerInfo{}, errors.E(err)
 	}
 
 	if err := r.jimm.JujuManager().RemoveController(ctx, r.user, req.Name, req.Force); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, err)
+		return apiparams.ControllerInfo{}, errors.E(err)
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
 
 // SetControllerDeprecated sets the deprecated status of a controller.
 func (r *controllerRoot) SetControllerDeprecated(ctx context.Context, req apiparams.SetControllerDeprecatedRequest) (apiparams.ControllerInfo, error) {
-	const op = errors.Op("jujuapi.SetControllerDeprecated")
 
 	if err := r.jimm.JujuManager().SetControllerDeprecated(ctx, r.user, req.Name, req.Deprecated); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, err)
+		return apiparams.ControllerInfo{}, errors.E(err)
 	}
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(op, err)
+		return apiparams.ControllerInfo{}, errors.E(err)
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
@@ -348,14 +343,14 @@ func auditParamsToFilter(req apiparams.FindAuditEventsRequest) (db.AuditLogFilte
 
 // FindAuditEvents finds the audit-log entries that match the given filter.
 func (r *controllerRoot) FindAuditEvents(ctx context.Context, req apiparams.FindAuditEventsRequest) (apiparams.AuditEvents, error) {
-	const op = errors.Op("jujuapi.FindAuditEvents")
+
 	filter, err := auditParamsToFilter(req)
 	if err != nil {
-		return apiparams.AuditEvents{}, errors.E(op, err)
+		return apiparams.AuditEvents{}, errors.E(err)
 	}
 	entries, err := r.jimm.AuditLogManager().FindAuditEvents(ctx, r.user, filter)
 	if err != nil {
-		return apiparams.AuditEvents{}, errors.E(op, err)
+		return apiparams.AuditEvents{}, errors.E(err)
 	}
 
 	events := make([]apiparams.AuditEvent, len(entries))
@@ -371,16 +366,15 @@ func (r *controllerRoot) FindAuditEvents(ctx context.Context, req apiparams.Find
 // level to the specified user. The only currently supported level is
 // "read". Only controller admin users can grant access to the audit log.
 func (r *controllerRoot) GrantAuditLogAccess(ctx context.Context, req apiparams.AuditLogAccessRequest) error {
-	const op = errors.Op("jujuapi.GrantAuditLogAccess")
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.PermissionManager().GrantAuditLogAccess(ctx, r.user, ut)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -389,32 +383,30 @@ func (r *controllerRoot) GrantAuditLogAccess(ctx context.Context, req apiparams.
 // level from the specified user. The only currently supported level is
 // "read". Only controller admin users can revoke access to the audit log.
 func (r *controllerRoot) RevokeAuditLogAccess(ctx context.Context, req apiparams.AuditLogAccessRequest) error {
-	const op = errors.Op("jujuapi.RevokeAuditLogAccess")
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.PermissionManager().RevokeAuditLogAccess(ctx, r.user, ut)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // FullModelStatus returns the full status of the juju model.
 func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.FullModelStatusRequest) (jujuparams.FullStatus, error) {
-	const op = errors.Op("jujuapi.FullModelStatus")
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return jujuparams.FullStatus{}, errors.E(op, err, errors.CodeBadRequest)
+		return jujuparams.FullStatus{}, errors.E(err, errors.CodeBadRequest)
 	}
 
 	status, err := r.jimm.JujuManager().FullModelStatus(ctx, r.user, mt, req.Patterns)
 	if err != nil {
-		return jujuparams.FullStatus{}, errors.E(op, err)
+		return jujuparams.FullStatus{}, errors.E(err)
 	}
 
 	return *status, nil
@@ -423,19 +415,18 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 // UpdateMigratedModel checks that the model has been migrated to the specified controller
 // and updates internal representation of the model.
 func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.UpdateMigratedModelRequest) error {
-	const op = errors.Op("jujuapi.UpdateMigratedModel")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	err = r.jimm.JujuManager().UpdateMigratedModel(ctx, r.user, mt, req.TargetController)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -443,29 +434,28 @@ func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.
 // ImportModel imports a model already attached to a controller allowing
 // management of that model in JIMM.
 func (r *controllerRoot) ImportModel(ctx context.Context, req apiparams.ImportModelRequest) error {
-	const op = errors.Op("jujuapi.ImportModel")
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.JujuManager().ImportModel(ctx, r.user, req.Controller, mt, req.Owner)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // RemoveCloudFromController removes the specified cloud from a specific controller.
 func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apiparams.RemoveCloudFromControllerRequest) error {
-	const op = errors.Op("jujuapi.RemoveCloudFromController")
+
 	ct, err := names.ParseCloudTag(req.CloudTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RemoveCloudFromController(ctx, r.user, req.ControllerName, ct); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -474,30 +464,28 @@ func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apip
 //
 // The query will run against output exactly like "juju status --format json", but for each of their models.
 func (r *controllerRoot) CrossModelQuery(ctx context.Context, req apiparams.CrossModelQueryRequest) (apiparams.CrossModelQueryResponse, error) {
-	const op = errors.Op("jujuapi.CrossModelQuery")
 
 	modelUUIDs, err := r.user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return apiparams.CrossModelQueryResponse{}, errors.E(op, errors.Code("failed to list user's model access"))
+		return apiparams.CrossModelQueryResponse{}, errors.E(errors.Code("failed to list user's model access"))
 	}
 
 	switch strings.TrimSpace(strings.ToLower(req.Type)) {
 	case "jq":
 		return r.jimm.JujuManager().QueryModelsJq(ctx, modelUUIDs, req.Query)
 	case "jimmsql":
-		return apiparams.CrossModelQueryResponse{}, errors.E(op, errors.CodeNotImplemented)
+		return apiparams.CrossModelQueryResponse{}, errors.E(errors.CodeNotImplemented)
 	default:
-		return apiparams.CrossModelQueryResponse{}, errors.E(op, errors.Code("invalid query type"), "unable to query models")
+		return apiparams.CrossModelQueryResponse{}, errors.E(errors.Code("invalid query type"), "unable to query models")
 	}
 }
 
 // PurgeLogs removes all audit log entries older than the specified date.
 func (r *controllerRoot) PurgeLogs(ctx context.Context, req apiparams.PurgeLogsRequest) (apiparams.PurgeLogsResponse, error) {
-	const op = errors.Op("jujuapi.PurgeLogs")
 
 	deleted_count, err := r.jimm.AuditLogManager().PurgeLogs(ctx, r.user, req.Date)
 	if err != nil {
-		return apiparams.PurgeLogsResponse{}, errors.E(op, err)
+		return apiparams.PurgeLogsResponse{}, errors.E(err)
 	}
 	return apiparams.PurgeLogsResponse{
 		DeletedCount: deleted_count,
@@ -508,14 +496,13 @@ func (r *controllerRoot) PurgeLogs(ctx context.Context, req apiparams.PurgeLogsR
 // are already attached to JIMM. See InitiateMigration in controller.go to migrate a model
 // in a controller attached to JIMM to one not managed by JIMM.
 func (r *controllerRoot) MigrateModel(ctx context.Context, args apiparams.MigrateModelRequest) (jujuparams.InitiateMigrationResults, error) {
-	const op = errors.Op("jujuapi.MigrateModel")
 
 	results := make([]jujuparams.InitiateMigrationResult, len(args.Specs))
 
 	for i, arg := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateInternalMigration(ctx, r.user, arg.TargetModelNameOrUUID, arg.TargetController)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(op, err))
+			result.Error = r.mapError(ctx, errors.E(err))
 		}
 		results[i] = result
 	}
@@ -536,26 +523,26 @@ func (r *controllerRoot) Version(ctx context.Context) (apiparams.VersionResponse
 
 // PrepareModelMigration prepares JIMM for an incoming migration.
 func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apiparams.PrepareModelMigrationRequest) (apiparams.PrepareModelMigrationResponse, error) {
-	const op = errors.Op("jujuapi.PrepareModelMigration")
+
 	resp := apiparams.PrepareModelMigrationResponse{}
 
 	if !r.user.JimmAdmin {
-		return resp, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return resp, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return resp, errors.E(op, "invalid model tag", err)
+		return resp, errors.E("invalid model tag", err)
 	}
 
 	if !names.IsValidControllerName(args.BackingControllerName) {
-		return resp, errors.E(op, "invalid controller name")
+		return resp, errors.E("invalid controller name")
 	}
 
 	// Check each key is a valid local user and each value is a valid user and has a domain
 	for local, external := range args.UserMapping {
 		if !names.IsValidUserName(local) {
-			return resp, errors.E(op, fmt.Sprintf("%s is not a valid local user name", local))
+			return resp, errors.E(fmt.Sprintf("%s is not a valid local user name", local))
 		}
 
 		if external == "" {
@@ -565,13 +552,13 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 		}
 
 		if !names.IsValidUser(external) || !strings.Contains(external, "@") {
-			return resp, errors.E(op, fmt.Sprintf("%s is not a valid external user name", external))
+			return resp, errors.E(fmt.Sprintf("%s is not a valid external user name", external))
 		}
 	}
 
 	resp.Token, err = r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.BackingControllerName, args.UserMapping)
 	if err != nil {
-		return resp, errors.E(op, err)
+		return resp, errors.E(err)
 	}
 
 	return resp, nil
@@ -581,16 +568,15 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 // model could be migrated to. This includes controllers that support the model's
 // cloud region and version, but excludes the controller the model is already on.
 func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams.ListMigrationTargetsRequest) (apiparams.ListControllersResponse, error) {
-	const op = errors.Op("jujuapi.ListMigrationTargets")
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(op, err, errors.CodeBadRequest)
+		return apiparams.ListControllersResponse{}, errors.E(err, errors.CodeBadRequest)
 	}
 
 	dbControllers, err := r.jimm.JujuManager().ListMigrationTargets(ctx, r.user, mt)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(op, err)
+		return apiparams.ListControllersResponse{}, errors.E(err)
 	}
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
@@ -604,15 +590,14 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 // GetJobInfo retrieves the status of a job, its logs and the watermark
 // for the logs.
 func (r *controllerRoot) GetJobInfo(ctx context.Context, req apiparams.GetJobInfoRequest) (apiparams.GetJobInfoResponse, error) {
-	const op = errors.Op("jujuapi.GetJobInfo")
 
 	if !r.user.JimmAdmin {
-		return apiparams.GetJobInfoResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return apiparams.GetJobInfoResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobId, err := uuid.Parse(req.JobID)
 	if err != nil {
-		return apiparams.GetJobInfoResponse{}, errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
+		return apiparams.GetJobInfoResponse{}, errors.E(errors.CodeBadRequest, "invalid job ID", err)
 	}
 
 	return r.jimm.BootstrapManager().GetJobInfo(ctx, r.user, jobId, req.Watermark)
@@ -620,41 +605,39 @@ func (r *controllerRoot) GetJobInfo(ctx context.Context, req apiparams.GetJobInf
 
 // StopJob stops a job.
 func (r *controllerRoot) StopJob(ctx context.Context, req apiparams.StopJobRequest) error {
-	const op = errors.Op("jujuapi.StopJob")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobID, err := uuid.Parse(req.JobID)
 	if err != nil {
-		return errors.E(op, errors.CodeBadRequest, "invalid job ID", err)
+		return errors.E(errors.CodeBadRequest, "invalid job ID", err)
 	}
 
 	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to stop job: %v", err))
+		return errors.E(fmt.Errorf("failed to stop job: %v", err))
 	}
 	return nil
 }
 
 // StartBootstrapJob starts a bootstrap job.
 func (r *controllerRoot) StartBootstrapJob(ctx context.Context, req apiparams.BootstrapParams) (apiparams.StartJobResponse, error) {
-	const op = errors.Op("jujuapi.StartBootstrapJob")
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return apiparams.StartJobResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Check built in clouds like localhost (lxd).
 	builtinClouds, err := common.BuiltInClouds()
 	if err != nil {
-		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeIncompatibleClouds, "unauthorized")
+		return apiparams.StartJobResponse{}, errors.E(errors.CodeIncompatibleClouds, "unauthorized")
 	}
 
 	if _, isABuiltinCloud := builtinClouds[req.CloudName]; isABuiltinCloud {
 		return apiparams.StartJobResponse{},
-			errors.E(op, errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
+			errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
 	}
 
 	cloudNameAndRegion := req.CloudName
@@ -682,7 +665,7 @@ func (r *controllerRoot) StartBootstrapJob(ctx context.Context, req apiparams.Bo
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrapJob(ctx, r.user, params)
 	if err != nil {
-		return apiparams.StartJobResponse{}, errors.E(op, fmt.Errorf("failed to start bootstrap job: %v", err))
+		return apiparams.StartJobResponse{}, errors.E(fmt.Errorf("failed to start bootstrap job: %v", err))
 	}
 	return apiparams.StartJobResponse{
 		JobID: jobID,
@@ -691,19 +674,18 @@ func (r *controllerRoot) StartBootstrapJob(ctx context.Context, req apiparams.Bo
 
 // StartDestroyControllerJob starts a destroy-controller job.
 func (r *controllerRoot) StartDestroyControllerJob(ctx context.Context, req apiparams.DestroyControllerRequest) (apiparams.StartJobResponse, error) {
-	const op = errors.Op("jujuapi.StartDestroyControllerJob")
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return apiparams.StartJobResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.ControllerName)
 	if err != nil {
-		return apiparams.StartJobResponse{}, errors.E(op, fmt.Errorf("failed to fetch controller info: %w", err))
+		return apiparams.StartJobResponse{}, errors.E(fmt.Errorf("failed to fetch controller info: %w", err))
 	}
 
 	if len(ctrl.Models) != 0 {
-		return apiparams.StartJobResponse{}, errors.E(op, errors.CodeBadRequest, "cannot destroy controller with models")
+		return apiparams.StartJobResponse{}, errors.E(errors.CodeBadRequest, "cannot destroy controller with models")
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartDestroyControllerJob(ctx, r.user, bootstrap.DestroyControllerParams{
@@ -717,7 +699,7 @@ func (r *controllerRoot) StartDestroyControllerJob(ctx context.Context, req apip
 		CACertificate:  ctrl.CACertificate,
 	})
 	if err != nil {
-		return apiparams.StartJobResponse{}, errors.E(op, fmt.Errorf("failed to start destroy-controller job: %v", err))
+		return apiparams.StartJobResponse{}, errors.E(fmt.Errorf("failed to start destroy-controller job: %v", err))
 	}
 
 	return apiparams.StartJobResponse{

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -73,20 +73,19 @@ func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 }
 
 func (r *controllerRoot) CheckMachines(ctx context.Context, args params.ModelArgs) (params.ErrorResults, error) {
-	const op = errors.Op("jujuapi.CheckMachines")
 
 	if !r.user.JimmAdmin {
-		return params.ErrorResults{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return params.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return params.ErrorResults{}, errors.E(op, err)
+		return params.ErrorResults{}, errors.E(err)
 	}
 
 	results, err := r.jimm.JujuManager().CheckMachines(ctx, r.user, modelTag.Id())
 	if err != nil {
-		return params.ErrorResults{}, errors.E(op, err)
+		return params.ErrorResults{}, errors.E(err)
 	}
 	var errorResults []params.ErrorResult
 	for _, result := range results {
@@ -102,15 +101,14 @@ func (r *controllerRoot) CheckMachines(ctx context.Context, args params.ModelArg
 // Abort implements the Abort method of the MigrationTarget facade.
 // It is used by the source Juju controller to abort a model migration.
 func (r *controllerRoot) Abort(ctx context.Context, args params.ModelArgs) error {
-	const op = errors.Op("jujuapi.Abort")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return r.jimm.JujuManager().AbortMigration(ctx, r.user, modelTag.Id())
 }
@@ -121,15 +119,14 @@ func (r *controllerRoot) Abort(ctx context.Context, args params.ModelArgs) error
 // This prevents the resources from being destroyed if the source controller
 // is destroyed after the model is migrated away.
 func (r *controllerRoot) AdoptResources(ctx context.Context, args params.AdoptResourcesArgs) error {
-	const op = errors.Op("jujuapi.AdoptResources")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return r.jimm.JujuManager().AdoptResources(ctx, r.user, modelTag.Id(), args.SourceControllerVersion)
 }
@@ -138,40 +135,38 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args params.AdoptRe
 // It is used by the source Juju controller to retrieve the time of the
 // latest log record it has seen.
 func (r *controllerRoot) LatestLogTime(ctx context.Context, args params.ModelArgs) (time.Time, error) {
-	const op = errors.Op("jujuapi.LatestLogTime")
 
 	if !r.user.JimmAdmin {
-		return time.Time{}, errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return time.Time{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return time.Time{}, errors.E(op, err)
+		return time.Time{}, errors.E(err)
 	}
 
 	t, err := r.jimm.JujuManager().LatestLogTime(ctx, modelTag.Id())
 	if err != nil {
-		return time.Time{}, errors.E(op, err)
+		return time.Time{}, errors.E(err)
 	}
 	return t, nil
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.
 func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfo) error {
-	const op = errors.Op("jujuapi.Prechecks")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ownerTag, err := names.ParseUserTag(args.OwnerTag)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	modelDescription, err := description.Deserialize(args.ModelDescription)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to deserialize model description: %w", err))
+		return errors.E(fmt.Errorf("failed to deserialize model description: %w", err))
 	}
 
 	model := migration.ModelInfo{
@@ -184,22 +179,20 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 	}
 	err = r.jimm.JujuManager().Prechecks(ctx, r.user, model)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // Activate is the implementation of the Activate method of the MigrationTarget facade.
 func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModelArgs) error {
-	const op = errors.Op("jujuapi.Activate")
-
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("invalid model tag: %w", err))
+		return errors.E(fmt.Errorf("invalid model tag: %w", err))
 	}
 	// The controller tag is optional, so we parse it only if provided.
 	// It is only provided when args.CrossModelUUIDs is not empty.
@@ -208,7 +201,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModel
 		controllerTag, err = names.ParseControllerTag(args.ControllerTag)
 		if err != nil {
 
-			return errors.E(op, fmt.Errorf("invalid controller tag: %w", err))
+			return errors.E(fmt.Errorf("invalid controller tag: %w", err))
 		}
 	}
 
@@ -222,7 +215,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModel
 		},
 		args.CrossModelUUIDs)
 	if err != nil {
-		return errors.E(errors.Op("jujuapi.Activate"), err)
+		return err
 	}
 	return nil
 }
@@ -230,15 +223,14 @@ func (r *controllerRoot) Activate(ctx context.Context, args params.ActivateModel
 // Import implements the Import method of the MigrationTarget facade.
 // It imports resources into JIMM and proxies the import request to the target Juju controller.
 func (r *controllerRoot) Import(ctx context.Context, serialized params.SerializedModel) error {
-	const op = errors.Op("jujuapi.Import")
 
 	if !r.user.JimmAdmin {
-		return errors.E(op, errors.CodeUnauthorized, "unauthorized")
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := r.jimm.JujuManager().Import(ctx, r.user, serialized)
 	if err != nil {
-		return errors.E(op, fmt.Errorf("failed to import model: %w", err))
+		return errors.E(fmt.Errorf("failed to import model: %w", err))
 	}
 	return nil
 }

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -83,7 +83,6 @@ type ModelManager interface {
 // 3 onwards) facade. The model dump is passed back as-is from the
 // controller without any changes from JIMM.
 func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpModelRequest) jujuparams.StringResults {
-	const op = errors.Op("jujuapi.DumpModels")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -92,11 +91,11 @@ func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpMod
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModel(ctx, r.user, mt, args.Simplified)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 		}
 	}
 	return jujuparams.StringResults{
@@ -107,14 +106,14 @@ func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpMod
 // ListModelSummaries returns summaries for all the models that that
 // authenticated user has access to. The request parameter is ignored.
 func (r *controllerRoot) ListModelSummaries(ctx context.Context, _ jujuparams.ModelSummariesRequest) (jujuparams.ModelSummaryResults, error) {
-	const op = errors.Op("jujuapi.ListModelSummaries")
+
 	maskingControllerUUID := ""
 	if r.controllerUUIDMasking {
 		maskingControllerUUID = r.params.ControllerUUID
 	}
 	res, err := r.jimm.JujuManager().ListModelSummaries(ctx, r.user, maskingControllerUUID)
 	if err != nil {
-		return jujuparams.ModelSummaryResults{}, errors.E(op, err)
+		return jujuparams.ModelSummaryResults{}, errors.E(err)
 	}
 
 	return res, nil
@@ -123,9 +122,6 @@ func (r *controllerRoot) ListModelSummaries(ctx context.Context, _ jujuparams.Mo
 // ListModels returns the models that the authenticated user
 // has access to. The user parameter is ignored.
 func (r *controllerRoot) ListModels(ctx context.Context, _ jujuparams.Entity) (jujuparams.UserModelList, error) {
-	const op = errors.Op("jujuapi.ListModels")
-	zapctx.Info(ctx, string(op))
-
 	res := jujuparams.UserModelList{}
 
 	models, err := r.jimm.JujuManager().ListModels(ctx, r.user)
@@ -155,7 +151,6 @@ func (r *controllerRoot) ListModels(ctx context.Context, _ jujuparams.Entity) (j
 
 // ModelInfo implements the ModelManager facade's ModelInfo method.
 func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelInfoResults, error) {
-	const op = errors.Op("jujuapi.ModelInfo")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -164,7 +159,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 		mt, err := names.ParseModelTag(arg.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		results[i].Result, err = r.jimm.JujuManager().ModelInfo(ctx, r.user, mt)
@@ -172,9 +167,9 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				// Map not-found errors to unauthorized, this is what juju
 				// does.
-				err = errors.E(op, errors.CodeUnauthorized, "unauthorized")
+				err = errors.E(errors.CodeUnauthorized, "unauthorized")
 			}
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 		} else if r.controllerUUIDMasking {
 			results[i].Result.ControllerUUID = r.params.ControllerUUID
 		}
@@ -186,19 +181,18 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 
 // CreateModel implements the ModelManager facade's CreateModel method.
 func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelCreateArgs) (jujuparams.ModelInfo, error) {
-	const op = errors.Op("jujuapi.CreateModel")
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var mca juju.ModelCreateArgs
 	if err := mca.FromJujuModelCreateArgs(&args); err != nil {
-		return jujuparams.ModelInfo{}, errors.E(op, err)
+		return jujuparams.ModelInfo{}, errors.E(err)
 	}
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, &mca)
 	if err != nil {
 		servermon.ModelsCreatedFailCount.Inc()
-		return jujuparams.ModelInfo{}, errors.E(op, err)
+		return jujuparams.ModelInfo{}, errors.E(err)
 	}
 
 	servermon.ModelsCreatedCount.Inc()
@@ -211,7 +205,6 @@ func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelC
 // DestroyModels implements the ModelManager facade's DestroyModels
 // method used in version 4 onwards.
 func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.DestroyModelsParams) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.DestroyModel")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -221,7 +214,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 		mt, err := names.ParseModelTag(model.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 
@@ -229,7 +222,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 			if errors.ErrorCode(err) != errors.CodeNotFound {
 				// It isn't an error to try and destroy an already
 				// destroyed model.
-				results[i].Error = r.mapError(ctx, errors.E(op, err))
+				results[i].Error = r.mapError(ctx, errors.E(err))
 			}
 		}
 	}
@@ -241,7 +234,6 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 
 // ModifyModelAccess implements the ModelManager facade's ModifyModelAccess method.
 func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.ModifyModelAccessRequest) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.ModifyModelAccess")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -250,12 +242,12 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		mt, err := names.ParseModelTag(change.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		user, err := parseUserTag(change.UserTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		switch change.Action {
@@ -264,10 +256,10 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		case jujuparams.RevokeModelAccess:
 			err = r.jimm.PermissionManager().RevokeModelAccess(ctx, r.user, mt, user, change.Access)
 		default:
-			err = errors.E(op, errors.CodeBadRequest, fmt.Sprintf("invalid action %q", change.Action))
+			err = errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid action %q", change.Action))
 		}
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			err = errors.E(op, errors.CodeUnauthorized, "unauthorized")
+			err = errors.E(errors.CodeUnauthorized, "unauthorized")
 		}
 		results[i].Error = r.mapError(ctx, err)
 	}
@@ -280,7 +272,6 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 // model dump is passed back as-is from the controller without any
 // changes from JIMM.
 func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entities) jujuparams.MapResults {
-	const op = errors.Op("jujuapi.DumpModelsDB")
 
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -289,11 +280,11 @@ func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entit
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModelDB(ctx, r.user, mt)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 		}
 	}
 	return jujuparams.MapResults{
@@ -317,19 +308,18 @@ func (r *controllerRoot) ChangeModelCredential(ctx context.Context, args jujupar
 }
 
 func (r *controllerRoot) changeModelCredential(ctx context.Context, arg jujuparams.ChangeModelCredentialParams) error {
-	const op = errors.Op("jujuapi.ChangeModelCredential")
 
 	mt, err := names.ParseModelTag(arg.ModelTag)
 	ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	cct, err := names.ParseCloudCredentialTag(arg.CloudCredentialTag)
 	if err != nil {
-		return errors.E(op, err, errors.CodeBadRequest)
+		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().ChangeModelCredential(ctx, r.user, mt, cct); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -340,14 +330,13 @@ func (r *controllerRoot) changeModelCredential(ctx context.Context, arg jujupara
 // current status of the machine, so performing an upgrade-model can lead to
 // bad unintended errors down the line.
 func (r *controllerRoot) ValidateModelUpgrades(ctx context.Context, args jujuparams.ValidateModelUpgradeParams) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.ValidateModelUpgrades")
 
 	results := make([]jujuparams.ErrorResult, len(args.Models))
 	for i, arg := range args.Models {
 		modelTag, err := names.ParseModelTag(arg.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", modelTag.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
 			continue
 		}
 		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().ValidateModelUpgrade(ctx, r.user, modelTag, args.Force))
@@ -359,14 +348,13 @@ func (r *controllerRoot) ValidateModelUpgrades(ctx context.Context, args jujupar
 
 // SetModelDefaults writes new values for the specified default model settings.
 func (r *controllerRoot) SetModelDefaults(ctx context.Context, args jujuparams.SetModelDefaults) (jujuparams.ErrorResults, error) {
-	const op = errors.Op("jujuapi.ModelDefaultsForClouds")
 
 	results := make([]jujuparams.ErrorResult, len(args.Config))
 	for i, config := range args.Config {
 		cloudTag, err := names.ParseCloudTag(config.CloudTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", cloudTag.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(op, err))
+			results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().SetModelDefaults(ctx, r.user.Identity, cloudTag, config.CloudRegion, config.Config))
@@ -398,7 +386,6 @@ func (r *controllerRoot) UnsetModelDefaults(ctx context.Context, args jujuparams
 // ModelDefaultsForClouds returns the default config values for the specified
 // clouds.
 func (r *controllerRoot) ModelDefaultsForClouds(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelDefaultsResults, error) {
-	const op = errors.Op("jujuapi.ModelDefaultsForClouds")
 
 	result := jujuparams.ModelDefaultsResults{}
 	result.Results = make([]jujuparams.ModelDefaultsResult, len(args.Entities))
@@ -406,12 +393,12 @@ func (r *controllerRoot) ModelDefaultsForClouds(ctx context.Context, args jujupa
 		cloudTag, err := names.ParseCloudTag(entity.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", cloudTag.String()))
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		defaults, err := r.jimm.JujuManager().ModelDefaultsForCloud(ctx, r.user.Identity, cloudTag)
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(op, err))
+			result.Results[i].Error = r.mapError(ctx, errors.E(err))
 			continue
 		}
 		result.Results[i] = defaults

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -35,11 +35,10 @@ func init() {
 // ModelSummaryWatcher facade. It returns the next set of model summaries
 // when they are available.
 func (r *controllerRoot) ModelSummaryWatcherNext(ctx context.Context, objID string) (jujuparams.SummaryWatcherNextResults, error) {
-	const op = errors.Op("jujuapi.ModelSummaryWatcherNext")
 
 	w, err := r.watchers.get(objID)
 	if err != nil {
-		return jujuparams.SummaryWatcherNextResults{}, errors.E(op, err)
+		return jujuparams.SummaryWatcherNextResults{}, errors.E(err)
 	}
 	return w.Next()
 }
@@ -47,11 +46,10 @@ func (r *controllerRoot) ModelSummaryWatcherNext(ctx context.Context, objID stri
 // ModelSummaryWatcherStop implements the Stop method on the
 // ModelSummaryWatcher facade.
 func (r *controllerRoot) ModelSummaryWatcherStop(ctx context.Context, objID string) error {
-	const op = errors.Op("jujuapi.ModelSummaryWatcherStop")
 
 	w, err := r.watchers.get(objID)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return w.Stop()
@@ -101,7 +99,6 @@ func (r *watcherRegistry) get(id string) (*modelSummaryWatcher, error) {
 }
 
 func newModelSummaryWatcher(ctx context.Context, id string, pubsub *pubsub.Hub, modelGetterFunc func(context.Context) ([]string, error)) (*modelSummaryWatcher, error) {
-	const op = errors.Op("jujuapi.newModelSummaryWatcher")
 
 	ctx, cancelContext := context.WithCancel(ctx)
 
@@ -125,7 +122,7 @@ func newModelSummaryWatcher(ctx context.Context, id string, pubsub *pubsub.Hub, 
 	cleanupFunction, err := pubsub.SubscribeMatch(accessWatcher.match, watcher.pubsubHandler)
 	if err != nil {
 		cancelContext()
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	watcher.cleanup = func() {
 		cancelContext()

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -16,16 +16,16 @@ import (
 
 // AddRole creates a role within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleRequest) (apiparams.AddRoleResponse, error) {
-	const op = errors.Op("jujuapi.AddRole")
+
 	resp := apiparams.AddRoleResponse{}
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return resp, errors.E(op, errors.CodeBadRequest, "invalid role name")
+		return resp, errors.E(errors.CodeBadRequest, "invalid role name")
 	}
 
 	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
 	if err != nil {
-		return resp, errors.E(op, fmt.Errorf("failed to add role: %w", err))
+		return resp, errors.E(fmt.Errorf("failed to add role: %w", err))
 	}
 	resp = apiparams.AddRoleResponse{Role: apiparams.Role{
 		Name:      roleEntry.Name,
@@ -39,24 +39,23 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 
 // GetRole returns role information based on a UUID or name.
 func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleRequest) (apiparams.Role, error) {
-	const op = errors.Op("jujuapi.GetRole")
 
 	var roleEntry *dbmodel.RoleEntry
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "only one of UUID or Name should be provided")
+		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "only one of UUID or Name should be provided")
 	case req.Name != "" && !jimmnames.IsValidRoleName(req.Name):
-		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "invalid role name")
+		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "invalid role name")
 	case req.UUID != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Role{}, errors.E(op, errors.CodeBadRequest, "no UUID or Name provided")
+		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		return apiparams.Role{}, errors.E(op, fmt.Errorf("failed to get role: %w", err))
+		return apiparams.Role{}, errors.E(fmt.Errorf("failed to get role: %w", err))
 	}
 
 	return apiparams.Role{
@@ -69,40 +68,37 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 
 // RenameRole renames a role within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRoleRequest) error {
-	const op = errors.Op("jujuapi.RenameRole")
 
 	if !jimmnames.IsValidRoleName(req.NewName) {
-		return errors.E(op, errors.CodeBadRequest, "invalid role name")
+		return errors.E(errors.CodeBadRequest, "invalid role name")
 	}
 
 	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
-		return errors.E(op, fmt.Errorf("failed to rename role: %w", err))
+		return errors.E(fmt.Errorf("failed to rename role: %w", err))
 	}
 	return nil
 }
 
 // RemoveRole removes a role within JIMMs DB for reference by OpenFGA.
 func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRoleRequest) error {
-	const op = errors.Op("jujuapi.RemoveRole")
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return errors.E(op, errors.CodeBadRequest, "invalid role name")
+		return errors.E(errors.CodeBadRequest, "invalid role name")
 	}
 
 	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {
-		return errors.E(op, fmt.Errorf("failed to remove role: %w", err))
+		return errors.E(fmt.Errorf("failed to remove role: %w", err))
 	}
 	return nil
 }
 
 // ListRole lists access control roles within JIMMs DB.
 func (r *controllerRoot) ListRoles(ctx context.Context, req apiparams.ListRolesRequest) (apiparams.ListRoleResponse, error) {
-	const op = errors.Op("jujuapi.ListRoles")
 
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
 	roles, err := r.jimm.RoleManager().ListRoles(ctx, r.user, pagination, "")
 	if err != nil {
-		return apiparams.ListRoleResponse{}, errors.E(op, err)
+		return apiparams.ListRoleResponse{}, errors.E(err)
 	}
 	rolesResponse := make([]apiparams.Role, len(roles))
 	for i, g := range roles {

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -77,14 +77,13 @@ func (r *controllerRoot) UserInfo(ctx context.Context, req jujuparams.UserInfoRe
 }
 
 func (r *controllerRoot) userInfo(entity string) (*jujuparams.UserInfo, error) {
-	const op = errors.Op("jujuapi.UserInfo")
 
 	user, err := parseUserTag(entity)
 	if err != nil {
-		return nil, errors.E(op, err, errors.CodeBadRequest)
+		return nil, errors.E(err, errors.CodeBadRequest)
 	}
 	if r.user.Name != user.Id() {
-		return nil, errors.E(op, errors.CodeUnauthorized)
+		return nil, errors.E(errors.CodeUnauthorized)
 	}
 	ui := r.user.ToJujuUserInfo()
 	return &ui, nil

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -209,12 +209,12 @@ func (s apiModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn
 // connect to a controller when a client makes a request.
 func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTokenGenerator) func(context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
 	return func(ctx context.Context) (rpcproxy.WebsocketConnectionWithMetadata, error) {
-		const op = errors.Op("proxy.controllerConnectionFunc")
+
 		path := jimmhttp.PathElementFromContext(ctx)
 		zapctx.Debug(ctx, "grabbing model info from path", zap.String("path", path))
 		uuid, finalPath, err := modelInfoFromPath(path)
 		if err != nil {
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(op, fmt.Errorf("error parsing path: %w", err))
+			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(fmt.Errorf("error parsing path: %w", err))
 		}
 		m := dbmodel.Model{
 			UUID: sql.NullString{

--- a/internal/jujuclient/applicationoffers.go
+++ b/internal/jujuclient/applicationoffers.go
@@ -17,7 +17,7 @@ import (
 // Offer creates a new ApplicationOffer on the controller. Offer uses the
 // Offer procedure on the ApplicationOffers facade.
 func (c Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, offer jujuparams.AddApplicationOffer) error {
-	const op = errors.Op("jujuclient.Offer")
+
 	args := jujuparams.AddApplicationOffers{
 		Offers: []jujuparams.AddApplicationOffer{offer},
 	}
@@ -29,33 +29,33 @@ func (c Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, off
 		// created offer
 		err := c.Call(ctx, "ApplicationOffers", 4, "", "Offer", &args, &resp)
 		if err != nil {
-			return errors.E(op, jujuerrors.Cause(err))
+			return errors.E(jujuerrors.Cause(err))
 		}
 		if resp.Results[0].Error != nil {
-			return errors.E(op, resp.Results[0].Error)
+			return errors.E(resp.Results[0].Error)
 		}
 	} else {
 		ownerTag, err := names.ParseUserTag(offer.OwnerTag)
 		if err != nil {
-			return errors.E(op, errors.CodeBadRequest, err)
+			return errors.E(errors.CodeBadRequest, err)
 		}
 
 		// Facade call version 2 will not grant owner admin access, so
 		// we have to do it ourselves.
 		err = c.Call(ctx, "ApplicationOffers", 2, "", "Offer", &args, &resp)
 		if err != nil {
-			return errors.E(op, jujuerrors.Cause(err))
+			return errors.E(jujuerrors.Cause(err))
 		}
 		if len(resp.Results) == 0 {
-			return errors.E(op, "unknown error - no results returned")
+			return errors.E("unknown error - no results returned")
 		}
 		if resp.Results[0].Error != nil {
-			return errors.E(op, resp.Results[0].Error)
+			return errors.E(resp.Results[0].Error)
 		}
 
 		// Ensure the user creating the offer is an admin for the offer.
 		if err := c.GrantApplicationOfferAccess(ctx, offerURL.String(), ownerTag, jujuparams.OfferAdminAccess); err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 	}
 	return nil
@@ -65,7 +65,7 @@ func (c Connection) Offer(ctx context.Context, offerURL crossmodel.OfferURL, off
 // the given filters. ListApplicationOffers uses the ListApplicationOffers
 // procedure on the ApplicationOffers facade.
 func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
-	const op = errors.Op("jujuclient.ListApplicationOffers")
+
 	args := jujuparams.OfferFilters{
 		Filters: filters,
 	}
@@ -73,7 +73,7 @@ func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujupar
 	var resp jujuparams.QueryApplicationOffersResultsV5
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "ListApplicationOffers", &args, &resp)
 	if err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	return resp.Results, nil
 }
@@ -82,7 +82,7 @@ func (c Connection) ListApplicationOffers(ctx context.Context, filters []jujupar
 // the given filters. FindApplicationOffers uses the FindApplicationOffers
 // procedure on the ApplicationOffers facade.
 func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
-	const op = errors.Op("jujuclient.FindApplicationOffers")
+
 	args := jujuparams.OfferFilters{
 		Filters: filters,
 	}
@@ -90,7 +90,7 @@ func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujupar
 	var resp jujuparams.QueryApplicationOffersResultsV5
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "FindApplicationOffers", &args, &resp)
 	if err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	return resp.Results, nil
 }
@@ -101,7 +101,7 @@ func (c Connection) FindApplicationOffers(ctx context.Context, filters []jujupar
 // GetApplicationOffer uses the ApplicationOffers procedure on the
 // ApplicationOffers facade.
 func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.ApplicationOfferAdminDetailsV5) error {
-	const op = errors.Op("jujuclient.GetApplicationOffer")
+
 	args := jujuparams.OfferURLs{
 		OfferURLs: []string{info.OfferURL},
 	}
@@ -111,10 +111,10 @@ func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.Ap
 	}
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "ApplicationOffers", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	*info = *resp.Results[0].Result
 	return nil
@@ -124,7 +124,7 @@ func (c Connection) GetApplicationOffer(ctx context.Context, info *jujuparams.Ap
 // given user on the given application offer. GrantApplicationOfferAccess
 // uses the ModifyOfferAccess procedure on the ApplicationOffers facade..
 func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
-	const op = errors.Op("jujuclient.GrantApplicationOfferAccess")
+
 	args := jujuparams.ModifyOfferAccessRequest{
 		Changes: []jujuparams.ModifyOfferAccess{{
 			UserTag:  user.String(),
@@ -139,10 +139,10 @@ func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL st
 	}
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "ModifyOfferAccess", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -151,7 +151,7 @@ func (c Connection) GrantApplicationOfferAccess(ctx context.Context, offerURL st
 // given user on the given application offer. RevokeApplicationOfferAccess
 // uses the ModifyOfferAccess procedure on the ApplicationOffers facade.
 func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL string, user names.UserTag, access jujuparams.OfferAccessPermission) error {
-	const op = errors.Op("jujuclient.RevokeApplicationOfferAccess")
+
 	args := jujuparams.ModifyOfferAccessRequest{
 		Changes: []jujuparams.ModifyOfferAccess{{
 			UserTag:  user.String(),
@@ -166,10 +166,10 @@ func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL s
 	}
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "ModifyOfferAccess", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -178,7 +178,7 @@ func (c Connection) RevokeApplicationOfferAccess(ctx context.Context, offerURL s
 // DestroyApplicationOffer uses the DestroyOffers procedure
 // from the ApplicationOffers facade.
 func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, force bool) error {
-	const op = errors.Op("jujuclient.DestroyApplicationOffer")
+
 	args := jujuparams.DestroyApplicationOffers{
 		OfferURLs: []string{offer},
 		Force:     force,
@@ -189,10 +189,10 @@ func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, f
 	}
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "DestroyOffers", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -203,7 +203,7 @@ func (c Connection) DestroyApplicationOffer(ctx context.Context, offer string, f
 // filled in by the API call. GetApplicationOfferConsumeDetails uses the
 // GetConsumeDetails procedure on the ApplicationOffers facade.
 func (c Connection) GetApplicationOfferConsumeDetails(ctx context.Context, user names.UserTag, info *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
-	const op = errors.Op("jujuclient.GetApplicationOfferConsumeDetails")
+
 	args := jujuparams.ConsumeOfferDetailsArg{
 		OfferURLs: jujuparams.OfferURLs{
 			OfferURLs:     []string{info.Offer.OfferURL},
@@ -218,10 +218,10 @@ func (c Connection) GetApplicationOfferConsumeDetails(ctx context.Context, user 
 	}
 	err := c.CallHighestFacadeVersion(ctx, "ApplicationOffers", []int{5}, "", "GetConsumeDetails", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	*info = resp.Results[0].ConsumeOfferDetails
 	return nil

--- a/internal/jujuclient/client.go
+++ b/internal/jujuclient/client.go
@@ -13,7 +13,6 @@ import (
 
 // Status returns the status of the juju model.
 func (c Connection) Status(ctx context.Context, patterns []string) (*jujuparams.FullStatus, error) {
-	const op = errors.Op("jujuclient.Status")
 
 	p := jujuparams.StatusParams{
 		Patterns: patterns,
@@ -21,7 +20,7 @@ func (c Connection) Status(ctx context.Context, patterns []string) (*jujuparams.
 
 	out := jujuparams.FullStatus{}
 	if err := c.CallHighestFacadeVersion(ctx, "Client", []int{8}, "", "FullStatus", &p, &out); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 
 	return &out, nil

--- a/internal/jujuclient/cloud.go
+++ b/internal/jujuclient/cloud.go
@@ -20,7 +20,7 @@ import (
 // the Cloud. Any error that represents a Juju API
 // failure will be of type *APIError.
 func (c Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
-	const op = errors.Op("jujuclient.CheckCredentialModels")
+
 	in := jujuparams.TaggedCredentials{
 		Credentials: []jujuparams.TaggedCredential{cred},
 	}
@@ -29,10 +29,10 @@ func (c Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.T
 		Results: make([]jujuparams.UpdateCredentialResult, 1),
 	}
 	if err := c.CallHighestFacadeVersion(ctx, "Cloud", []int{7}, "", "CheckCredentialsModels", &in, &out); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	if out.Results[0].Error != nil {
-		return out.Results[0].Models, errors.E(op, out.Results[0].Error)
+		return out.Results[0].Models, errors.E(out.Results[0].Error)
 	}
 	return out.Results[0].Models, nil
 }
@@ -51,7 +51,7 @@ func (c Connection) CheckCredentialModels(ctx context.Context, cred jujuparams.T
 // Any error that represents a Juju API failure will be of type
 // *APIError.
 func (c Connection) UpdateCredential(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialModelResult, error) {
-	const op = errors.Op("jujuclient.UpdateCredential")
+
 	creds := jujuparams.TaggedCredentials{
 		Credentials: []jujuparams.TaggedCredential{cred},
 	}
@@ -71,10 +71,10 @@ func (c Connection) UpdateCredential(ctx context.Context, cred jujuparams.Tagged
 	// unmarshal correctly into the latter so there is no need to use
 	// a different response type.
 	if err := c.CallHighestFacadeVersion(ctx, "Cloud", []int{7}, "", "UpdateCredentialsCheckModels", &update, &out); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	if out.Results[0].Error != nil {
-		return out.Results[0].Models, errors.E(op, out.Results[0].Error)
+		return out.Results[0].Models, errors.E(out.Results[0].Error)
 	}
 	return out.Results[0].Models, nil
 }
@@ -92,7 +92,7 @@ func (c Connection) UpdateCredential(ctx context.Context, cred jujuparams.Tagged
 // Any error that represents a Juju API failure will be of type
 // *APIError.
 func (c Connection) RevokeCredential(ctx context.Context, cred names.CloudCredentialTag) error {
-	const op = errors.Op("jujuclient.RevokeCredential")
+
 	out := jujuparams.ErrorResults{
 		Results: make([]jujuparams.ErrorResult, 1),
 	}
@@ -103,11 +103,11 @@ func (c Connection) RevokeCredential(ctx context.Context, cred names.CloudCreden
 		}},
 	}
 	if err := c.CallHighestFacadeVersion(ctx, "Cloud", []int{7}, "", "RevokeCredentialsCheckModels", &in, &out); err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 
 	if out.Results[0].Error != nil {
-		return errors.E(op, out.Results[0].Error)
+		return errors.E(out.Results[0].Error)
 	}
 	return nil
 }

--- a/internal/jujuclient/controller.go
+++ b/internal/jujuclient/controller.go
@@ -13,13 +13,13 @@ import (
 
 // ControllerConfig retrieves the controller configuration.
 func (c Connection) ControllerConfig(ctx context.Context) (jujuparams.ControllerConfigResult, error) {
-	const op = errors.Op("jujuclient.ControllerConfig")
+
 	results := jujuparams.ControllerConfigResult{}
 	if err := c.CallHighestFacadeVersion(ctx, "Controller", []int{12}, "", "ControllerConfig", nil, &results); err != nil {
-		return jujuparams.ControllerConfigResult{}, errors.E(op, jujuerrors.Cause(err))
+		return jujuparams.ControllerConfigResult{}, errors.E(jujuerrors.Cause(err))
 	}
 	if results.Config == nil {
-		return jujuparams.ControllerConfigResult{}, errors.E(op, errors.CodeNotFound, "controller config not found")
+		return jujuparams.ControllerConfigResult{}, errors.E(errors.CodeNotFound, "controller config not found")
 	}
 	return results, nil
 }

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -114,14 +114,13 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 
 // Dial implements jimm.Dialer.
 func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (juju.API, error) {
-	const op = errors.Op("jujuclient.Dial")
 
 	conn, err := rpc.Dial(ctx, ctl, modelTag, "", nil)
 	if err != nil {
 		return nil, err
 	}
 	if conn == nil {
-		return nil, errors.E(op, errors.CodeConnectionFailed, err)
+		return nil, errors.E(errors.CodeConnectionFailed, err)
 	}
 	client := rpc.NewClient(conn)
 
@@ -133,20 +132,20 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	if user.Name == adminUser {
 		loginRequest, err = d.createAdminLoginRequest(ctx, ctl, modelTag, withPermissions)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 
 	} else {
 		loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user, withPermissions)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err)
 		}
 	}
 
 	var res jujuparams.LoginResult
 	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
 		client.Close()
-		return nil, errors.E(op, errors.CodeConnectionFailed, err)
+		return nil, errors.E(errors.CodeConnectionFailed, err)
 	}
 
 	ct, err := names.ParseControllerTag(res.ControllerTag)
@@ -338,25 +337,25 @@ func (c *Connection) Context() context.Context {
 // The given parameters are used as URL query values
 // when making the initial HTTP request.
 func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, error) {
-	const op = errors.Op("jujuclient.ConnectStream")
+
 	modelTag, ok := c.ModelTag()
 	if !ok {
-		return nil, errors.E(op, "no model found")
+		return nil, errors.E("no model found")
 	}
 
 	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	ok = names.IsValidUser(user)
 	if !ok {
-		return nil, errors.E(op, "invalid/missing controller credentials")
+		return nil, errors.E("invalid/missing controller credentials")
 	}
 	requestHeader := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
 
 	conn, err := rpc.Dial(c.ctx, c.ctl, modelTag, path, requestHeader)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	return conn, nil
 }
@@ -367,11 +366,10 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 // HTTP request. Headers passed in will be added to the HTTP
 // request.
 func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extraHeaders http.Header) (base.Stream, error) {
-	const op = errors.Op("jujuclient.ConnectControllerStream")
 
 	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	header := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
@@ -383,7 +381,7 @@ func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extr
 
 	conn, err := rpc.Dial(c.ctx, c.ctl, names.ModelTag{}, path, header)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return conn, nil

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -22,9 +22,9 @@ import (
 // of type *APIError. CreateModel uses the Create model procedure on the
 // ModelManager facade.
 func (c Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreateArgs, info *jujuparams.ModelInfo) error {
-	const op = errors.Op("jujuclient.CreateModel")
+
 	if err := c.Call(ctx, "ModelManager", 10, "", "CreateModel", args, info); err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	return nil
 }
@@ -36,7 +36,7 @@ func (c Connection) CreateModel(ctx context.Context, args *jujuparams.ModelCreat
 // will use the ModelInfo procedure from the ModelManager version 9
 // facade if it is available, falling back to version 3.
 func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) error {
-	const op = errors.Op("jujuclient.ModelInfo")
+
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
 			Tag: names.NewModelTag(info.UUID).String(),
@@ -50,10 +50,10 @@ func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) e
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "ModelInfo", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (c Connection) ModelInfo(ctx context.Context, info *jujuparams.ModelInfo) e
 // GrantJIMMModelAdmin uses the ModifyModelAccess procedure on the
 // ModelManager facade.
 func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
-	const op = errors.Op("jujuclient.GrantJIMMModelAdmin")
+
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
 			UserTag:  c.user.ResourceTag().String(),
@@ -79,10 +79,10 @@ func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag)
 		Results: make([]jujuparams.ErrorResult, 1),
 	}
 	if err := c.Call(ctx, "ModelManager", 10, "", "ModifyModelAccess", &args, &resp); err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -91,7 +91,7 @@ func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag)
 // dump is requested then a simplified dump is returned. DumpModel uses the
 // DumpModels method on the ModelManager facade.
 func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (string, error) {
-	const op = errors.Op("jujuclient.DumpModel")
+
 	args := jujuparams.DumpModelRequest{
 		Entities: []jujuparams.Entity{{
 			Tag: tag.String(),
@@ -103,10 +103,10 @@ func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplifie
 		Results: make([]jujuparams.StringResult, 1),
 	}
 	if err := c.Call(ctx, "ModelManager", 10, "", "DumpModels", &args, &resp); err != nil {
-		return "", errors.E(op, jujuerrors.Cause(err))
+		return "", errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return "", errors.E(op, resp.Results[0].Error)
+		return "", errors.E(resp.Results[0].Error)
 	}
 	return resp.Results[0].Result, nil
 }
@@ -114,7 +114,7 @@ func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplifie
 // DumpModelDB dumps the controller database entry given model.
 // DumpModelDB uses the DumpModelsDB method on the ModelManager facade..
 func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
-	const op = errors.Op("jujuclient.DumpModelDB")
+
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
 			Tag: tag.String(),
@@ -125,10 +125,10 @@ func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[st
 		Results: make([]jujuparams.MapResult, 1),
 	}
 	if err := c.Call(ctx, "ModelManager", 10, "", "DumpModelsDB", &args, &resp); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return nil, errors.E(op, resp.Results[0].Error)
+		return nil, errors.E(resp.Results[0].Error)
 	}
 	return resp.Results[0].Result, nil
 }
@@ -137,7 +137,7 @@ func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[st
 // given model. GrantModelAccess uses the ModifyModelAccess procedure
 // on the ModelManager facade.
 func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
-	const op = errors.Op("jujuclient.GrantModelAccess")
+
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
 			UserTag:  userTag.String(),
@@ -152,10 +152,10 @@ func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTa
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "ModifyModelAccess", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func (c Connection) GrantModelAccess(ctx context.Context, modelTag names.ModelTa
 // the given model. Revoke ModelAccess uses the ModifyModelAccess procedure
 // on the ModelManager facade.
 func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelTag, userTag names.UserTag, access jujuparams.UserAccessPermission) error {
-	const op = errors.Op("jujuclient.RevokeModelAccess")
+
 	args := jujuparams.ModifyModelAccessRequest{
 		Changes: []jujuparams.ModifyModelAccess{{
 			UserTag:  userTag.String(),
@@ -179,10 +179,10 @@ func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelT
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "ModifyModelAccess", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -191,7 +191,7 @@ func (c Connection) RevokeModelAccess(ctx context.Context, modelTag names.ModelT
 // model. ControllerModelSummary uses the ListModelSummaries procedure on
 // the ModelManager facade.
 func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.ModelSummary) error {
-	const op = errors.Op("jujuclient.ControllerModelSummary")
+
 	args := jujuparams.ModelSummariesRequest{
 		UserTag: c.user.ResourceTag().String(),
 		All:     true,
@@ -199,7 +199,7 @@ func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.M
 	var resp jujuparams.ModelSummaryResults
 	err := c.Call(ctx, "ModelManager", 10, "", "ListModelSummaries", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	for _, r := range resp.Results {
 		if r.Result != nil && r.Result.IsController {
@@ -207,12 +207,12 @@ func (c Connection) ControllerModelSummary(ctx context.Context, ms *jujuparams.M
 			return nil
 		}
 	}
-	return errors.E(op, "controller model not found", errors.CodeNotFound)
+	return errors.E("controller model not found", errors.CodeNotFound)
 }
 
 // ListModelSummaries retrieves the list of model summaries from the controler
 func (c Connection) ListModelSummaries(ctx context.Context, ms jujuparams.ModelSummariesRequest) (jujuparams.ModelSummaryResults, error) {
-	const op = errors.Op("jujuclient.ControllerModelSummary")
+
 	args := jujuparams.ModelSummariesRequest{
 		UserTag: c.user.ResourceTag().String(),
 		All:     ms.All,
@@ -220,7 +220,7 @@ func (c Connection) ListModelSummaries(ctx context.Context, ms jujuparams.ModelS
 	var resp jujuparams.ModelSummaryResults
 	err := c.Call(ctx, "ModelManager", 10, "", "ListModelSummaries", &args, &resp)
 	if err != nil {
-		return jujuparams.ModelSummaryResults{}, errors.E(op, jujuerrors.Cause(err))
+		return jujuparams.ModelSummaryResults{}, errors.E(jujuerrors.Cause(err))
 	}
 
 	return resp, nil
@@ -229,7 +229,7 @@ func (c Connection) ListModelSummaries(ctx context.Context, ms jujuparams.ModelS
 // ValidateModelUpgrade validates if a model is allowed to perform an upgrade. It
 // uses ValidateModelUpgrades on the ModelManager facade.
 func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelTag, force bool) error {
-	const op = errors.Op("jujuclient.ValidateModelUpgrade")
+
 	args := jujuparams.ValidateModelUpgradeParams{
 		Models: []jujuparams.ModelParam{{
 			ModelTag: model.String(),
@@ -241,10 +241,10 @@ func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelT
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "ValidateModelUpgrades", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -254,7 +254,7 @@ func (c Connection) ValidateModelUpgrade(ctx context.Context, model names.ModelT
 //
 //   - ModelManager(10).DestroyModels
 func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStorage *bool, force *bool, maxWait, timeout *time.Duration) error {
-	const op = errors.Op("jujuclient.DestroyModel")
+
 	args := jujuparams.DestroyModelsParams{
 		Models: []jujuparams.DestroyModelParams{{
 			ModelTag:       tag.String(),
@@ -270,10 +270,10 @@ func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destro
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "DestroyModels", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	return nil
 }
@@ -285,7 +285,7 @@ func (c Connection) DestroyModel(ctx context.Context, tag names.ModelTag, destro
 // ModelStatus will use the ModelStatus procedure from the ModelManager
 // version 4 facade if it is available, falling back to version 2.
 func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelStatus) error {
-	const op = errors.Op("jujuclient.ModelStatus")
+
 	args := jujuparams.Entities{
 		Entities: []jujuparams.Entity{{
 			Tag: status.ModelTag,
@@ -297,10 +297,10 @@ func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelSta
 	}
 	err := c.Call(ctx, "ModelManager", 10, "", "ModelStatus", &args, &resp)
 	if err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	if resp.Results[0].Error != nil {
-		return errors.E(op, resp.Results[0].Error)
+		return errors.E(resp.Results[0].Error)
 	}
 	*status = resp.Results[0]
 	return nil
@@ -308,7 +308,6 @@ func (c Connection) ModelStatus(ctx context.Context, status *jujuparams.ModelSta
 
 // ChangeModelCredential replaces cloud credential for a given model with the provided one.
 func (c Connection) ChangeModelCredential(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
-	const op = errors.Op("jujuclient.ChangeModelCredential")
 
 	var out jujuparams.ErrorResults
 	args := jujuparams.ChangeModelCredentialsParams{
@@ -320,7 +319,7 @@ func (c Connection) ChangeModelCredential(ctx context.Context, model names.Model
 
 	err := c.Call(ctx, "ModelManager", 10, "", "ChangeModelCredential", &args, &out)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return out.OneError()
 }

--- a/internal/jujuclient/modelsummarywatcher.go
+++ b/internal/jujuclient/modelsummarywatcher.go
@@ -22,10 +22,10 @@ func (c Connection) SupportsModelSummaryWatcher() bool {
 // of type *APIError. This uses the WatchAllModelSummaries method on the
 // Controller facade version 9.
 func (c Connection) WatchAllModelSummaries(ctx context.Context) (string, error) {
-	const op = errors.Op("jujuclient.WatchAllModelSummaries")
+
 	var resp jujuparams.SummaryWatcherID
 	if err := c.CallHighestFacadeVersion(ctx, "Controller", []int{11}, "", "WatchAllModelSummaries", nil, &resp); err != nil {
-		return "", errors.E(op, jujuerrors.Cause(err))
+		return "", errors.E(jujuerrors.Cause(err))
 	}
 	return resp.WatcherID, nil
 }
@@ -35,10 +35,10 @@ func (c Connection) WatchAllModelSummaries(ctx context.Context) (string, error) 
 // will be of type *APIError. This uses the Next method on the
 // ModelSummaryWatcher facade version 1.
 func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]jujuparams.ModelAbstract, error) {
-	const op = errors.Op("jujuclient.ModelSummaryWatcherNext")
+
 	var resp jujuparams.SummaryWatcherNextResults
 	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Next", nil, &resp); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 	return resp.Models, nil
 }
@@ -48,9 +48,9 @@ func (c Connection) ModelSummaryWatcherNext(ctx context.Context, id string) ([]j
 // will be of type *APIError. This uses the Stop method on the
 // ModelSummaryWatcher facade version 1.
 func (c Connection) ModelSummaryWatcherStop(ctx context.Context, id string) error {
-	const op = errors.Op("jujuclient.ModelSummaryWatcherStop")
+
 	if err := c.client.Call(ctx, "ModelSummaryWatcher", 1, id, "Stop", nil, nil); err != nil {
-		return errors.E(op, jujuerrors.Cause(err))
+		return errors.E(jujuerrors.Cause(err))
 	}
 	return nil
 }

--- a/internal/jujuclient/ping.go
+++ b/internal/jujuclient/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/ping.go
+++ b/internal/jujuclient/ping.go
@@ -11,11 +11,10 @@ import (
 // Ping sends a ping message across the connection and waits for a
 // response.
 func (c Connection) Ping(ctx context.Context) error {
-	const op = errors.Op("jujuclient.Ping")
 
 	err := c.Call(ctx, "Pinger", 1, "", "Ping", nil, nil)
 	if err != nil {
-		err = errors.E(op, err)
+		err = errors.E(err)
 	}
 	return err
 }

--- a/internal/jujuclient/storage.go
+++ b/internal/jujuclient/storage.go
@@ -15,7 +15,6 @@ import (
 // ListFilesystems lists filesystems for desired machines.
 // If no machines provided, a list of all filesystems is returned.
 func (c Connection) ListFilesystems(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
-	const op = errors.Op("jujuclient.ListFilesystems")
 
 	filters := make([]jujuparams.FilesystemFilter, len(machines))
 	for i, machine := range machines {
@@ -31,12 +30,11 @@ func (c Connection) ListFilesystems(ctx context.Context, machines []string) ([]j
 	var results jujuparams.FilesystemDetailsListResults
 
 	if err := c.CallHighestFacadeVersion(ctx, "Storage", []int{6}, "", "ListFilesystems", &args, &results); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 
 	if len(results.Results) != len(filters) {
 		return nil, errors.E(
-			op,
 			jujuerrors.Errorf(
 				"expected %d result(s), got %d",
 				len(filters), len(results.Results),
@@ -50,7 +48,6 @@ func (c Connection) ListFilesystems(ctx context.Context, machines []string) ([]j
 // ListVolumes lists volumes for desired machines.
 // If no machines provided, a list of all volumes is returned.
 func (c Connection) ListVolumes(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
-	const op = errors.Op("jujuclient.ListVolumes")
 
 	filters := make([]jujuparams.VolumeFilter, len(machines))
 	for i, machine := range machines {
@@ -63,12 +60,11 @@ func (c Connection) ListVolumes(ctx context.Context, machines []string) ([]jujup
 	var results jujuparams.VolumeDetailsListResults
 
 	if err := c.CallHighestFacadeVersion(ctx, "Storage", []int{6}, "", "ListVolumes", &args, &results); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 
 	if len(results.Results) != len(filters) {
 		return nil, errors.E(
-			op,
 			jujuerrors.Errorf(
 				"expected %d result(s), got %d",
 				len(filters), len(results.Results),
@@ -81,7 +77,6 @@ func (c Connection) ListVolumes(ctx context.Context, machines []string) ([]jujup
 
 // ListStorageDetails lists all storage.
 func (c Connection) ListStorageDetails(ctx context.Context) ([]jujuparams.StorageDetails, error) {
-	const op = errors.Op("jujuclient.ListStorageDetails")
 
 	args := jujuparams.StorageFilters{
 		Filters: []jujuparams.StorageFilter{{}}, // one empty filter
@@ -89,12 +84,11 @@ func (c Connection) ListStorageDetails(ctx context.Context) ([]jujuparams.Storag
 	var results jujuparams.StorageDetailsListResults
 
 	if err := c.CallHighestFacadeVersion(ctx, "Storage", []int{6}, "", "ListStorageDetails", &args, &results); err != nil {
-		return nil, errors.E(op, jujuerrors.Cause(err))
+		return nil, errors.E(jujuerrors.Cause(err))
 	}
 
 	if len(results.Results) != 1 {
 		return nil, errors.E(
-			op,
 			jujuerrors.Errorf(
 				"expected 1 result, got %d",
 				len(results.Results),
@@ -103,7 +97,6 @@ func (c Connection) ListStorageDetails(ctx context.Context) ([]jujuparams.Storag
 	}
 	if results.Results[0].Error != nil {
 		return nil, errors.E(
-			op,
 			jujuerrors.Trace(results.Results[0].Error),
 		)
 	}

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -122,7 +122,7 @@ func BlankKindTag(kind string) (*Tag, error) {
 // ConvertJujuRelation takes a juju relation string and converts it to
 // one appropriate for use with OpenFGA.
 func ConvertJujuRelation(relation string) (cofga.Relation, error) {
-	const op = errors.Op("ConvertJujuRelation")
+
 	switch relation {
 	case string(permission.AdminAccess):
 		return AdministratorRelation, nil
@@ -137,17 +137,17 @@ func ConvertJujuRelation(relation string) (cofga.Relation, error) {
 	// Below are controller specific permissions that
 	// are not represented in JIMM's OpenFGA model.
 	case string(permission.LoginAccess):
-		return NoRelation, errors.E(op, "login access unused")
+		return NoRelation, errors.E("login access unused")
 	case string(permission.SuperuserAccess):
-		return NoRelation, errors.E(op, "superuser access unused")
+		return NoRelation, errors.E("superuser access unused")
 	default:
-		return NoRelation, errors.E(op, "unknown relation")
+		return NoRelation, errors.E("unknown relation")
 	}
 }
 
 // ParseRelation parses the relation string
 func ParseRelation(relationString string) (cofga.Relation, error) {
-	const op = errors.Op("ParseRelation")
+
 	switch relationString {
 	case "":
 		return cofga.Relation(""), nil
@@ -172,7 +172,7 @@ func ParseRelation(relationString string) (cofga.Relation, error) {
 	case AssigneeRelation.String():
 		return AssigneeRelation, nil
 	default:
-		return cofga.Relation(""), errors.E(op, fmt.Sprintf("unknown relation %s", relationString))
+		return cofga.Relation(""), errors.E(fmt.Sprintf("unknown relation %s", relationString))
 
 	}
 }

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -180,33 +180,33 @@ func (o *OFGAClient) listObjects(ctx context.Context, user *Tag, relation Relati
 
 // AddRelation adds given relations (tuples).
 func (o *OFGAClient) AddRelation(ctx context.Context, tuples ...Tuple) (err error) {
-	op := errors.Op("openfga.AddRelation")
+	const op = "openfga.AddRelation"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	return o.cofgaClient.AddRelation(ctx, tuples...)
 }
 
 // RemoveRelation removes given relations (tuples).
 func (o *OFGAClient) RemoveRelation(ctx context.Context, tuples ...Tuple) (err error) {
-	op := errors.Op("openfga.RemoveRelation")
+	const op = "openfga.RemoveRelation"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	return o.cofgaClient.RemoveRelation(ctx, tuples...)
 }
 
 // ListObjects returns all object IDs of <objType> that a user has the relation <relation> to.
 func (o *OFGAClient) ListObjects(ctx context.Context, user *Tag, relation Relation, objType Kind, contextualTuples []Tuple) (_ []Tag, err error) {
-	op := errors.Op("openfga.ListObjects")
+	const op = "openfga.ListObjects"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	return o.listObjects(ctx, user, relation, objType, contextualTuples)
 }
@@ -217,11 +217,11 @@ func (o *OFGAClient) ListObjects(ctx context.Context, user *Tag, relation Relati
 //
 // You may read via pagination utilising the continuation token returned from the request.
 func (o *OFGAClient) ReadRelatedObjects(ctx context.Context, tuple Tuple, pageSize int32, continuationToken string) (_ []Tuple, _ string, err error) {
-	op := errors.Op("openfga.ReadRelatedObjects")
+	const op = "openfga.ReadRelatedObjects"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	return o.getRelatedObjects(ctx, tuple, pageSize, continuationToken)
 }
@@ -230,11 +230,11 @@ func (o *OFGAClient) ReadRelatedObjects(ctx context.Context, tuple Tuple, pageSi
 //
 // It will return a bool of simply true or false, denoting authorisation, and an error.
 func (o *OFGAClient) CheckRelation(ctx context.Context, tuple Tuple, trace bool) (_ bool, err error) {
-	op := errors.Op("openfga.CheckRelation")
+	const op = "openfga.CheckRelation"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	if trace {
 		return o.cofgaClient.CheckRelationWithTracing(ctx, tuple)
@@ -244,11 +244,11 @@ func (o *OFGAClient) CheckRelation(ctx context.Context, tuple Tuple, trace bool)
 
 // removeTuples iteratively reads through all the tuples with the parameters as supplied by tuple and deletes them.
 func (o *OFGAClient) removeTuples(ctx context.Context, tuple Tuple) (err error) {
-	op := errors.Op("openfga.removeTuples")
+	const op = "openfga.removeTuples"
 
-	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	// Note (babakks): an obvious improvement to this function is to make it work
 	// atomically and remove all the tuples in a transaction. At the moment, it's

--- a/internal/pubsub/hub.go
+++ b/internal/pubsub/hub.go
@@ -94,15 +94,15 @@ func (h *Hub) Subscribe(model string, handler HandlerFunc) (func(), error) {
 // while the modelMatcher function is called. Any DB lookups or other
 // long operations for the matcher should be done out-of-band.
 func (h *Hub) SubscribeMatch(modelMatcher func(string) bool, handler HandlerFunc) (func(), error) {
-	const op = errors.Op("pubsub.SubscribeMatch")
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	if handler == nil {
-		return func() {}, errors.E(op, "handler not specified")
+		return func() {}, errors.E("handler not specified")
 	}
 	if modelMatcher == nil {
-		return func() {}, errors.E(op, "model matcher not specified")
+		return func() {}, errors.E("model matcher not specified")
 	}
 	idx := h.idx
 	h.idx++

--- a/internal/pubsub/hub.go
+++ b/internal/pubsub/hub.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 // Package pubsub contains an implementation of a simple pubsub
 // mechanism that passes messages about models between

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -153,14 +153,13 @@ func (c *Client) handleResponse(msg *message) {
 // the server and waits for the response to be returned or the context to
 // be canceled.
 func (c *Client) Call(ctx context.Context, facade string, version int, id, method string, args, resp interface{}) error {
-	const op = errors.Op("rpc.Client.Call")
 
 	var argsb []byte
 	if args != nil {
 		var err error
 		argsb, err = json.Marshal(args)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err)
 		}
 	}
 	req := &message{
@@ -186,7 +185,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 	req.RequestID = c.reqID
 	if err := c.conn.WriteJSON(req); err != nil {
 		c.broken = true
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	ch := make(chan struct{})
 	//nolint:staticcheck // Not sure why Martin made this a **. Ignore for now.
@@ -212,7 +211,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 		}
 		if resp != nil {
 			if err := json.Unmarshal([]byte((*respMsg).Response), &resp); err != nil {
-				return errors.E(op, err)
+				return errors.E(err)
 			}
 		}
 		return nil
@@ -221,7 +220,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 		defer c.mu.Unlock()
 		return c.err
 	case <-ctx.Done():
-		return errors.E(op, ctx.Err())
+		return errors.E(ctx.Err())
 	}
 }
 
@@ -230,7 +229,6 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 // complete before gracefully shutting down. If for any reason sending the
 // close message fails Close will abruptly close the undelying connection.
 func (c *Client) Close() error {
-	const op = errors.Op("rpc.Client.Close")
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -244,7 +242,7 @@ func (c *Client) Close() error {
 	c.closing = true
 	cm := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
 	if err := c.conn.WriteControl(websocket.CloseMessage, cm, time.Time{}); err != nil {
-		c.err = errors.E(op, "error closing connection", err)
+		c.err = errors.E("error closing connection", err)
 		// If sending the close message failed then tear down the
 		// connection. Note that we don't need to clear up any
 		// outstanding messages here as the receiver will error and

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -39,14 +39,13 @@ func (d Dialer) Dial(ctx context.Context, url string, headers http.Header) (*Cli
 
 // DialWebsocket dials a url and returns a websocket.
 func (d Dialer) DialWebsocket(ctx context.Context, url string, headers http.Header) (*websocket.Conn, error) {
-	const op = errors.Op("rpc.BasicDial")
 
 	dialer := websocket.Dialer{
 		TLSClientConfig: d.TLSConfig,
 	}
 	conn, resp, err := dialer.DialContext(ctx, url, headers)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("basic dial failed: %w", err))
+		return nil, errors.E(fmt.Errorf("basic dial failed: %w", err))
 	}
 	defer resp.Body.Close()
 	return conn, nil

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -111,18 +111,18 @@ type ProxyHelpers struct {
 // tokenGen is used to authenticate the user and generate JWT token.
 // connectController provides the function to return a connection to the desired controller endpoint.
 func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
-	const op = errors.Op("rpc.ProxySockets")
+
 	if helpers.ConnectController == nil {
-		return errors.E(op, "missing controller connect function")
+		return errors.E("missing controller connect function")
 	}
 	if helpers.AuditLog == nil {
-		return errors.E(op, "missing audit log function")
+		return errors.E("missing audit log function")
 	}
 	if helpers.LoginService == nil {
-		return errors.E(op, "missing login service function")
+		return errors.E("missing login service function")
 	}
 	if helpers.RedirectInfo == nil {
-		return errors.E(op, "missing redirect info function")
+		return errors.E("missing redirect info function")
 	}
 	errChan := make(chan error, 2)
 	msgInFlight := inflightMsgs{messages: make(map[uint64]*message)}
@@ -155,7 +155,7 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 			zapctx.Debug(ctx, "Proxy error", zap.Error(err))
 		}
 	case <-ctx.Done():
-		err = errors.E(op, "Context cancelled")
+		err = errors.E("Context cancelled")
 		zapctx.Debug(ctx, "Context cancelled")
 	}
 	// Close the client connection to ensure everything is cleaned up.
@@ -434,13 +434,13 @@ func (p *clientProxy) start(ctx context.Context) error {
 // makeControllerConnection dials a controller and starts a go routine for
 // proxying requests from the controller to the client.
 func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
-	const op = errors.Op("rpc.makeControllerConnection")
+
 	var createConnErr error
 	// Create the controller connection once.
 	p.connectController.Do(func() {
 		connWithMetadata, err := p.createControllerConn(ctx)
 		if err != nil {
-			createConnErr = errors.E(op, err)
+			createConnErr = errors.E(err)
 			return
 		}
 
@@ -612,14 +612,13 @@ func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any
 // extra permission checks for an operation. If the client performed anonymous
 // login, an error is always returned since we cannot authorize an anonymous user.
 func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]any) error {
-	const op = errors.Op("rpc.redoLogin")
 
 	if p.anonymousLogin {
-		return errors.E(op, errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
+		return errors.E(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
 	}
 	loginMsg := p.msgs.getLoginMessage()
 	if loginMsg == nil {
-		return errors.E(op, errors.CodeUnauthorized, "Haven't received login yet")
+		return errors.E(errors.CodeUnauthorized, "Haven't received login yet")
 	}
 	err := addJWT(ctx, loginMsg, permissions, p.tokenGen)
 	if err != nil {
@@ -634,19 +633,19 @@ func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]
 
 // addJWT adds a JWT token to the the provided message.
 func addJWT(ctx context.Context, msg *message, permissions map[string]interface{}, tokenGen TokenGenerator) error {
-	const op = errors.Op("rpc.addJWT")
+
 	// First we unmarshal the existing LoginRequest.
 	if msg == nil {
-		return errors.E(op, "nil messsage")
+		return errors.E("nil messsage")
 	}
 	var lr params.LoginRequest
 	if err := json.Unmarshal(msg.Params, &lr); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	jwt, err := tokenGen.MakeToken(ctx, permissions)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	jwtString := base64.StdEncoding.EncodeToString(jwt)
@@ -655,7 +654,7 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 	// Marshal it again to JSON.
 	data, err := json.Marshal(lr)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	// And add it to the message.
 	msg.Params = data

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical.
+// Copyright 2025 Canonical.
 
 package jimmtest
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	goerr "errors"
+	"fmt"
 	"net/http"
 	"path"
 	"sync"
@@ -61,20 +61,20 @@ type VaultStore struct {
 // Get retrieves the attributes for the given cloud credential from a vault
 // service.
 func (s *VaultStore) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map[string]string, err error) {
-	const op = errors.Op("vault.Get")
+	const op = "vault.Get"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.path(tag))
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	if secret == nil || secret.Data == nil {
 		return nil, nil
@@ -99,15 +99,14 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 		return s.delete(ctx, tag)
 	}
 
-	const op = errors.Op("vault.Put")
-
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	const op = "vault.Put"
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	data := make(map[string]interface{}, len(attr))
@@ -116,7 +115,7 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 	}
 	_, err = client.KVv2(s.KVPath).Put(ctx, s.path(tag), data)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -124,15 +123,14 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 // delete removes the attributes associated with the cloud-credential in
 // the vault service.
 func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (err error) {
-	const op = errors.Op("vault.delete")
-
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	const op = "vault.delete"
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.path(tag))
 	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
@@ -140,7 +138,7 @@ func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (
 		err = nil
 	}
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -148,20 +146,20 @@ func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (
 // GetControllerCredentials retrieves the credentials for the given controller from a vault
 // service.
 func (s *VaultStore) GetControllerCredentials(ctx context.Context, controllerName string) (_ string, _ string, err error) {
-	const op = errors.Op("vault.GetControllerCredentials")
+	const op = "vault.GetControllerCredentials"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return "", "", errors.E(op, err)
+		return "", "", errors.E(err)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.controllerCredentialsPath(controllerName))
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return "", "", errors.E(op, err)
+		return "", "", errors.E(err)
 	}
 	if secret == nil || secret.Data == nil {
 		return "", "", nil
@@ -185,15 +183,14 @@ func (s *VaultStore) PutControllerCredentials(ctx context.Context, controllerNam
 		return s.deleteControllerCredentials(ctx, controllerName)
 	}
 
-	const op = errors.Op("vault.PutControllerCredentials")
-
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	const op = "vault.PutControllerCredentials"
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	data := map[string]interface{}{
@@ -202,54 +199,54 @@ func (s *VaultStore) PutControllerCredentials(ctx context.Context, controllerNam
 	}
 	_, err = client.KVv2(s.KVPath).Put(ctx, s.controllerCredentialsPath(controllerName), data)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // CleanupJWKS removes all secrets associated with the JWKS process.
 func (s *VaultStore) CleanupJWKS(ctx context.Context) (err error) {
-	const op = errors.Op("vault.CleanupJWKS")
+	const op = "vault.CleanupJWKS"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSExpiryPath()); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSPath()); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSPrivateKeyPath()); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // GetJWKS returns the current key set stored within the credential store.
 func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
-	const op = errors.Op("vault.GetJWKS")
+	const op = "vault.GetJWKS"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	// This is how the current version of vaults API Read works,
@@ -258,17 +255,17 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.E(op, errors.CodeNotFound, msg)
+		return nil, errors.E(errors.CodeNotFound, msg)
 	}
 
 	jsonString, ok := secret.Data[jwksKey].(string)
 	if !ok {
-		return nil, errors.E(op, "invalid type for jwks")
+		return nil, errors.E("invalid type for jwks")
 	}
 
 	ks, err := jwk.ParseString(jsonString)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return ks, nil
@@ -276,33 +273,33 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 
 // GetJWKSPrivateKey returns the current private key for the active JWKS
 func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) {
-	const op = errors.Op("vault.GetJWKSPrivateKey")
+	const op = "vault.GetJWKSPrivateKey"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPrivateKeyPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS private key exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.E(op, errors.CodeNotFound, msg)
+		return nil, errors.E(errors.CodeNotFound, msg)
 	}
 
 	keyPemB64 := secret.Data[jwksPrivateKey].(string)
 
 	keyPem, err := base64.StdEncoding.DecodeString(keyPemB64)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 
 	return keyPem, nil
@@ -310,37 +307,37 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 
 // GetJWKSExpiry returns the expiry of the active JWKS.
 func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
-	const op = errors.Op("vault.getJWKSExpiry")
+	const op = "vault.getJWKSExpiry"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	now := time.Now()
 	client, err := s.client(ctx)
 	if err != nil {
-		return now, errors.E(op, err)
+		return now, errors.E(err)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSExpiryPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return now, errors.E(op, err)
+		return now, errors.E(err)
 	}
 
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS expiry exists yet."
 		zapctx.Debug(ctx, msg)
-		return now, errors.E(op, errors.CodeNotFound, msg)
+		return now, errors.E(errors.CodeNotFound, msg)
 	}
 
 	expiry, ok := secret.Data[jwksExpiryKey].(string)
 	if !ok {
-		return now, errors.E(op, "failed to retrieve expiry")
+		return now, errors.E("failed to retrieve expiry")
 	}
 
 	t, err := time.Parse(time.RFC3339, expiry)
 	if err != nil {
-		return now, errors.E(op, err)
+		return now, errors.E(err)
 	}
 
 	return t, nil
@@ -351,25 +348,25 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 // The pathing is similar to the controllers credentials
 // in that we understand RS256 keys as credentials, rather than crytographic keys.
 func (s *VaultStore) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
-	const op = errors.Op("vault.PutJWKS")
+	const op = "vault.PutJWKS"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	jwksData := map[string]any{jwksKey: string(jwksJson)}
 	if _, err = client.KVv2(s.KVPath).Put(ctx, s.getJWKSPath(), jwksData); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	return nil
@@ -377,39 +374,39 @@ func (s *VaultStore) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 // PutJWKSPrivateKey persists the private key associated with the current JWKS within the store.
 func (s *VaultStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error) {
-	const op = errors.Op("vault.PutJWKSPrivateKey")
+	const op = "vault.PutJWKSPrivateKey"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 
 	privateKeyData := map[string]interface{}{jwksPrivateKey: pem}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSPrivateKeyPath(), privateKeyData); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
 
 // PutJWKSExpiry sets the expiry time for the current JWKS within the store.
 func (s *VaultStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err error) {
-	const op = errors.Op("vault.PutJWKSExpiry")
+	const op = "vault.PutJWKSExpiry"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	expiryData := map[string]interface{}{jwksExpiryKey: expiry}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSExpiryPath(), expiryData); err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -439,15 +436,15 @@ func (s *VaultStore) getJWKSExpiryPath() string {
 // deleteControllerCredentials removes the credentials associated with the controller in
 // the vault service.
 func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controllerName string) (err error) {
-	const op = errors.Op("vault.deleteControllerCredentials")
+	const op = "vault.deleteControllerCredentials"
 
-	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, string(op))
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
 	defer durationObserver()
-	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, string(op))
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.controllerCredentialsPath(controllerName))
 	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
@@ -455,7 +452,7 @@ func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controller
 		err = nil
 	}
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err)
 	}
 	return nil
 }
@@ -463,8 +460,6 @@ func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controller
 const ttlLeeway time.Duration = 5 * time.Second
 
 func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
-	const op = errors.Op("vault.client")
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now()
@@ -480,28 +475,28 @@ func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
 		roleSecretID,
 	)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("unable to initialize approle auth method: %w", err))
+		return nil, errors.E(fmt.Errorf("unable to initialize approle auth method: %w", err))
 	}
 
 	authInfo, err := s.Client.Auth().Login(ctx, appRoleAuth)
 	if err != nil {
-		return nil, errors.E(op, fmt.Errorf("unable to login to approle auth method: %w", err))
+		return nil, errors.E(fmt.Errorf("unable to login to approle auth method: %w", err))
 	}
 	if authInfo == nil {
-		return nil, errors.E(op, "no auth info was returned after login")
+		return nil, errors.E("no auth info was returned after login")
 	}
 
 	ttl, err := authInfo.TokenTTL()
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	tok, err := authInfo.TokenID()
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	s.client_, err = s.Client.Clone()
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err)
 	}
 	s.client_.SetToken(tok)
 	s.expires = now.Add(ttl - ttlLeeway)


### PR DESCRIPTION
## Description
This PR removes opcodes from the errors package. The opcodes were meant to supplement error info to indicate which function/method generated the error. This can be done better with tracing and stacktraces and since the opcode was not currently being used, I have dropped it.

In places where we were using opcodes as a monitoring label, I have converted the constants to strings.

I didn't use AI for this btw, just good old find and replace.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests