### PR TITLE
feat(upgrade-to-cmd): add `juju upgrade-to <model-uuid> <version>`

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -278,3 +278,10 @@ func NewMigrateModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.L
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
 }
+
+func NewUpgradeToCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) *upgradeToCommand {
+	return &upgradeToCommand{
+		store:    store,
+		dialOpts: cmdtest.TestDialOpts(lp),
+	}
+}

--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -13,4 +13,5 @@ type JIMMAPI interface {
 	StartDestroyControllerJob(req *params.DestroyControllerRequest) (*params.StartJobResponse, error)
 	ListMigrationTargets(req *params.ListMigrationTargetsRequest) ([]params.ControllerInfo, error)
 	PrepareModelMigration(req *params.PrepareModelMigrationRequest) (params.PrepareModelMigrationResponse, error)
+	UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error)
 }

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -310,3 +310,42 @@ func (c *MockJIMMAPIStopJobCall) DoAndReturn(f func(*params.StopJobRequest) erro
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// UpgradeTo mocks base method.
+func (m *MockJIMMAPI) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeTo", req)
+	ret0, _ := ret[0].(params.UpgradeToResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeTo indicates an expected call of UpgradeTo.
+func (mr *MockJIMMAPIMockRecorder) UpgradeTo(req any) *MockJIMMAPIUpgradeToCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeTo", reflect.TypeOf((*MockJIMMAPI)(nil).UpgradeTo), req)
+	return &MockJIMMAPIUpgradeToCall{Call: call}
+}
+
+// MockJIMMAPIUpgradeToCall wrap *gomock.Call
+type MockJIMMAPIUpgradeToCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIUpgradeToCall) Return(arg0 params.UpgradeToResponse, arg1 error) *MockJIMMAPIUpgradeToCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIUpgradeToCall) Do(f func(*params.UpgradeToRequest) (params.UpgradeToResponse, error)) *MockJIMMAPIUpgradeToCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIUpgradeToCall) DoAndReturn(f func(*params.UpgradeToRequest) (params.UpgradeToResponse, error)) *MockJIMMAPIUpgradeToCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	upgradeToDoc = `
+Upgrades a controller to a specified version.
+`
+	upgradeToExample = `
+    juju upgrade-to 2cb433a6-04eb-4ec4-9567-90426d20a004 3.6.11
+`
+)
+
+// NewUpgradeToCommand returns a command to upgrade a controller to a specified version.
+func NewUpgradeToCommand() cmd.Command {
+	cmd := &upgradeToCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+	cmd.jimmAPIFunc = cmd.newClient
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// upgradeToCommand upgrades a controller to a specified version.
+type upgradeToCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store       jujuclient.ClientStore
+	dialOpts    *jujuapi.DialOpts
+	version     string
+	modelUUID   string
+	jimmAPIFunc func() (JIMMAPI, error)
+}
+
+func (c *upgradeToCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "upgrade-to",
+		Args:     "<model-uuid> <version>",
+		Purpose:  "Upgrades a controller to a specified version",
+		Doc:      upgradeToDoc,
+		Examples: upgradeToExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *upgradeToCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *upgradeToCommand) Init(args []string) error {
+	if len(args) < 2 {
+		return errors.E("missing required arguments: model UUID and version")
+	}
+	if len(args) > 2 {
+		return errors.E("too many arguments")
+	}
+	c.modelUUID = args[0]
+	c.version = args[1]
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.jimmAPIFunc()
+	if err != nil {
+		return errors.E(err, "failed to create JIMM client")
+	}
+	defer client.Close()
+
+	resp, err := client.UpgradeTo(&apiparams.UpgradeToRequest{
+		TargetVersion: c.version,
+		ModelUUID:     c.modelUUID,
+	})
+	if err != nil {
+		return errors.E(err)
+	}
+
+	err = c.out.Write(ctxt, resp)
+	if err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+// newClient creates a new JIMM API client.
+func (c *upgradeToCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return nil, errors.E(err, "could not determine controller")
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
+}

--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -9,6 +9,8 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
+	"github.com/juju/names/v5"
+	jujuversion "github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
@@ -20,7 +22,7 @@ const (
 Upgrades a controller to a specified version.
 `
 	upgradeToExample = `
-    juju upgrade-to 2cb433a6-04eb-4ec4-9567-90426d20a004 3.6.11
+    juju upgrade-to 3.6.11 2cb433a6-04eb-4ec4-9567-90426d20a004
 `
 )
 
@@ -49,7 +51,7 @@ type upgradeToCommand struct {
 func (c *upgradeToCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:     "upgrade-to",
-		Args:     "<model-uuid> <version>",
+		Args:     "<version> <model-uuid>",
 		Purpose:  "Upgrades a controller to a specified version",
 		Doc:      upgradeToDoc,
 		Examples: upgradeToExample,
@@ -68,13 +70,24 @@ func (c *upgradeToCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *upgradeToCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("missing required arguments: model UUID and version")
+		return errors.E("missing required arguments: version and model UUID")
 	}
 	if len(args) > 2 {
 		return errors.E("too many arguments")
 	}
-	c.modelUUID = args[0]
-	c.version = args[1]
+	c.version = args[0]
+	c.modelUUID = args[1]
+
+	// Validate version format
+	if _, err := jujuversion.Parse(c.version); err != nil {
+		return errors.E("invalid version format: " + c.version)
+	}
+
+	// Validate model UUID format
+	if !names.IsValidModel(c.modelUUID) {
+		return errors.E("invalid model UUID: " + c.modelUUID)
+	}
+
 	return nil
 }
 
@@ -86,17 +99,19 @@ func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer client.Close()
 
+	modelTag := names.NewModelTag(c.modelUUID)
 	resp, err := client.UpgradeTo(&apiparams.UpgradeToRequest{
-		TargetVersion: c.version,
-		ModelUUID:     c.modelUUID,
+		TargetControllerVersion: c.version,
+		ModelTag:                modelTag.String(),
 	})
 	if err != nil {
 		return errors.E(err)
 	}
-
-	err = c.out.Write(ctxt, resp)
-	if err != nil {
-		return errors.E(err)
+	if !resp.Success {
+		err = c.out.Write(ctxt, resp.Error)
+		if err != nil {
+			return errors.E(err)
+		}
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Canonical.
+
+// Note that this file is not an integration test
+// because of limitations with the JujuConnSuite
+// so it is placed under the cmd package.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/gnuflag"
+	jjclient "github.com/juju/juju/jujuclient"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd/mocks"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+// upgradeToSuite is a test suite for the upgrade-to command.
+type upgradeToSuite struct {
+	jimmClient *mocks.MockJIMMAPI
+	writer     *mocks.MockWriter
+	store      *mocks.MockClientStore
+}
+
+var _ = gc.Suite(&upgradeToSuite{})
+
+func (s *upgradeToSuite) SetupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.jimmClient = mocks.NewMockJIMMAPI(ctrl)
+	s.writer = mocks.NewMockWriter(ctrl)
+	s.store = mocks.NewMockClientStore(ctrl)
+
+	return ctrl
+}
+
+func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
+	defer s.SetupMocks(c).Finish()
+
+	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testTargetVersion := "3.5.0"
+	testLogs := "Upgrade initiated successfully\nController is being upgraded to version 3.5.0"
+
+	upgradeToParams := &apiparams.UpgradeToRequest{
+		TargetVersion: testTargetVersion,
+		ModelUUID:     testModelUUID,
+	}
+
+	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
+		Logs: testLogs,
+	}, nil)
+	s.jimmClient.EXPECT().Close().Return(nil)
+
+	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		c.Check(strings.Contains(string(b), "Upgrade initiated successfully"), gc.Equals, true)
+		return len(b), nil
+	})
+
+	upgradeToCmd := &upgradeToCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.jimmClient, nil
+		},
+		store: s.store,
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	upgradeToCmd.SetFlags(f)
+
+	// Set args after setting flags to avoid resetting them.
+	upgradeToCmd.version = testTargetVersion
+	upgradeToCmd.modelUUID = testModelUUID
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+	err := upgradeToCmd.Run(ctx)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
+	defer s.SetupMocks(c).Finish()
+
+	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testTargetVersion := "3.5.0"
+
+	upgradeToParams := &apiparams.UpgradeToRequest{
+		TargetVersion: testTargetVersion,
+		ModelUUID:     testModelUUID,
+	}
+	errorToReturn := errors.New("failed to initiate upgrade")
+	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errorToReturn)
+	s.jimmClient.EXPECT().Close().Return(nil)
+
+	upgradeToCmd := &upgradeToCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.jimmClient, nil
+		},
+		store: s.store,
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	upgradeToCmd.SetFlags(f)
+
+	// Set args after setting flags to avoid resetting them.
+	upgradeToCmd.version = testTargetVersion
+	upgradeToCmd.modelUUID = testModelUUID
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+	err := upgradeToCmd.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, ".*failed to initiate upgrade.*")
+}
+
+func (s *upgradeToSuite) TestCommandsFailsWithMissingArgs(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil))
+	c.Assert(err, gc.ErrorMatches, "missing required arguments: model UUID and version")
+}
+
+func (s *upgradeToSuite) TestCommandsFailsWithOnlyOneArg(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "93608db4-f1cb-4da5-9926-8233981aef0a")
+	c.Assert(err, gc.ErrorMatches, "missing required arguments: model UUID and version")
+}
+
+func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
+	defer s.SetupMocks(c).Finish()
+
+	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testTargetVersion := "3.5.0"
+
+	upgradeToParams := &apiparams.UpgradeToRequest{
+		TargetVersion: testTargetVersion,
+		ModelUUID:     testModelUUID,
+	}
+
+	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
+		Logs: "success",
+	}, nil)
+	s.jimmClient.EXPECT().Close().Return(nil)
+
+	s.writer.EXPECT().Write(gomock.Any()).Return(0, nil)
+
+	upgradeToCmd := &upgradeToCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.jimmClient, nil
+		},
+		store: s.store,
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	upgradeToCmd.SetFlags(f)
+
+	err := upgradeToCmd.Init([]string{testModelUUID, testTargetVersion})
+	c.Assert(err, gc.IsNil)
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+	err = upgradeToCmd.Run(ctx)
+	c.Assert(err, gc.IsNil)
+}

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -44,23 +44,18 @@ func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
 	defer s.SetupMocks(c).Finish()
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetVersion := "3.5.0"
-	testLogs := "Upgrade initiated successfully\nController is being upgraded to version 3.5.0"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
-		TargetVersion: testTargetVersion,
-		ModelUUID:     testModelUUID,
+		TargetControllerVersion: testTargetVersion,
+		ModelTag:                testModelTag,
 	}
 
 	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Logs: testLogs,
+		Success: true,
 	}, nil)
 	s.jimmClient.EXPECT().Close().Return(nil)
-
-	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
-		c.Check(strings.Contains(string(b), "Upgrade initiated successfully"), gc.Equals, true)
-		return len(b), nil
-	})
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
@@ -84,15 +79,61 @@ func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 }
 
+func (s *upgradeToSuite) TestUpgradeToWithFailureResponse(c *gc.C) {
+	defer s.SetupMocks(c).Finish()
+
+	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
+	testTargetVersion := "3.5.0"
+	testErrorMessage := "upgrade failed: controller not ready"
+
+	upgradeToParams := &apiparams.UpgradeToRequest{
+		TargetControllerVersion: testTargetVersion,
+		ModelTag:                testModelTag,
+	}
+
+	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
+		Success: false,
+		Error:   testErrorMessage,
+	}, nil)
+	s.jimmClient.EXPECT().Close().Return(nil)
+
+	s.writer.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		c.Check(strings.Contains(string(b), testErrorMessage), gc.Equals, true)
+		return len(b), nil
+	})
+
+	upgradeToCmd := &upgradeToCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.jimmClient, nil
+		},
+		store: s.store,
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
+	f.SetOutput(s.writer)
+	upgradeToCmd.SetFlags(f)
+
+	upgradeToCmd.version = testTargetVersion
+	upgradeToCmd.modelUUID = testModelUUID
+
+	ctx := &cmd.Context{
+		Context: context.Background(),
+		Stdout:  s.writer,
+	}
+	err := upgradeToCmd.Run(ctx)
+	c.Assert(err, gc.IsNil)
+}
+
 func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
 	defer s.SetupMocks(c).Finish()
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetVersion := "3.5.0"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
-		TargetVersion: testTargetVersion,
-		ModelUUID:     testModelUUID,
+		TargetControllerVersion: testTargetVersion,
+		ModelTag:                testModelTag,
 	}
 	errorToReturn := errors.New("failed to initiate upgrade")
 	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errorToReturn)
@@ -122,31 +163,40 @@ func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
 
 func (s *upgradeToSuite) TestCommandsFailsWithMissingArgs(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil))
-	c.Assert(err, gc.ErrorMatches, "missing required arguments: model UUID and version")
+	c.Assert(err, gc.ErrorMatches, "missing required arguments: version and model UUID")
 }
 
 func (s *upgradeToSuite) TestCommandsFailsWithOnlyOneArg(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "93608db4-f1cb-4da5-9926-8233981aef0a")
-	c.Assert(err, gc.ErrorMatches, "missing required arguments: model UUID and version")
+	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "3.5.0")
+	c.Assert(err, gc.ErrorMatches, "missing required arguments: version and model UUID")
+}
+
+func (s *upgradeToSuite) TestCommandsFailsWithInvalidVersion(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "invalid-version", "93608db4-f1cb-4da5-9926-8233981aef0a")
+	c.Assert(err, gc.ErrorMatches, "invalid version format: invalid-version")
+}
+
+func (s *upgradeToSuite) TestCommandsFailsWithInvalidModelUUID(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "3.5.0", "invalid-uuid")
+	c.Assert(err, gc.ErrorMatches, "invalid model UUID: invalid-uuid")
 }
 
 func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
 	defer s.SetupMocks(c).Finish()
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetVersion := "3.5.0"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
-		TargetVersion: testTargetVersion,
-		ModelUUID:     testModelUUID,
+		TargetControllerVersion: testTargetVersion,
+		ModelTag:                testModelTag,
 	}
 
 	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Logs: "success",
+		Success: true,
 	}, nil)
 	s.jimmClient.EXPECT().Close().Return(nil)
-
-	s.writer.EXPECT().Write(gomock.Any()).Return(0, nil)
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
@@ -158,7 +208,7 @@ func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
 	f.SetOutput(s.writer)
 	upgradeToCmd.SetFlags(f)
 
-	err := upgradeToCmd.Init([]string{testModelUUID, testTargetVersion})
+	err := upgradeToCmd.Init([]string{testTargetVersion, testModelUUID})
 	c.Assert(err, gc.IsNil)
 
 	ctx := &cmd.Context{

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -55,6 +55,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewSetControllerDeprecatedCommand())
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
+	jaasCmd.Register(cmd.NewUpgradeToCommand())
 	jaasCmd.Register(cmd.NewJobStatusCommand())
 	jaasCmd.Register(cmd.NewJobStopCommand())
 	jaasCmd.Register(cmd.NewBootstrapStartCommand())

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -63,8 +63,6 @@ func (e *Error) ErrorInfo() map[string]any {
 // is constructed by processing the given arguments. The meaning of the
 // arguments is as follows:
 //
-//	errors.Op   - string representation of the operation being
-//	              performed.
 //	errors.Code - string code classifying the error.
 //	error       - underlying error that caused the new error.
 //	string      - A human readable message describing the error.

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -100,6 +100,13 @@ func (c *Client) SetControllerDeprecated(req *params.SetControllerDeprecatedRequ
 	return info, err
 }
 
+// UpgradeTo initiates a controller upgrade to the specified version.
+func (c *Client) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
+	var resp params.UpgradeToResponse
+	err := c.caller.APICall("JIMM", 4, "", "UpgradeTo", req, &resp)
+	return resp, err
+}
+
 // FullModelStatus returns the full status of the juju model.
 func (c *Client) FullModelStatus(req *params.FullModelStatusRequest) (jujuparams.FullStatus, error) {
 	var status jujuparams.FullStatus

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -236,18 +236,18 @@ type SetControllerDeprecatedRequest struct {
 	Deprecated bool `json:"deprecated"`
 }
 
-// UpgradeToRequest is the request that is sent in an UpgradeTo method.
+// UpgradeToRequest holds the parameters for phase 1 for automated upgrades.
 type UpgradeToRequest struct {
-	// TargetVersion is the target controller version to upgrade to.
-	TargetVersion string `json:"target-version"`
-
-	// ModelUUID is the UUID of the model to upgrade.
-	ModelUUID string `json:"model-uuid"`
+	// ModelTag is the tag of the model to upgrade.
+	ModelTag string `json:"model-tag"`
+	// TargetControllerVersion is the target controller version to upgrade to.
+	TargetControllerVersion string `json:"target-controller-version"`
 }
 
-// UpgradeToResponse is the response that is sent in an UpgradeTo method.
+// UpgradeToResponse holds the response for phase 1 of an automated upgrade.
 type UpgradeToResponse struct {
-	Logs string `json:"logs"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
 }
 
 // FullModelStatusRequest is the request that is sent in a FullModelStatus method.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -236,6 +236,20 @@ type SetControllerDeprecatedRequest struct {
 	Deprecated bool `json:"deprecated"`
 }
 
+// UpgradeToRequest is the request that is sent in an UpgradeTo method.
+type UpgradeToRequest struct {
+	// TargetVersion is the target controller version to upgrade to.
+	TargetVersion string `json:"target-version"`
+
+	// ModelUUID is the UUID of the model to upgrade.
+	ModelUUID string `json:"model-uuid"`
+}
+
+// UpgradeToResponse is the response that is sent in an UpgradeTo method.
+type UpgradeToResponse struct {
+	Logs string `json:"logs"`
+}
+
 // FullModelStatusRequest is the request that is sent in a FullModelStatus method.
 type FullModelStatusRequest struct {
 	ModelTag string

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -76,3 +76,4 @@ parts:
       ln -sf jaas bin/juju-job-stop
       ln -sf jaas bin/juju-bootstrap
       ln -sf jaas bin/juju-destroy-controller
+      ln -sf jaas bin/juju-upgrade-to


### PR DESCRIPTION
## Description

For now it calls the jimm facade that returns some simple `Logs` to print to stdout or an error.

Some changes from the spec which i think make more sense:
- no <model-uuid | model name>, i don't like the idea of having commands with mixed input and do custom logic to resolve one into the other. Users can just put the model uuid, also because model-name is not enough, expecially in JAAS, you need `owner/model-name`
<s> - version is not another arg but it's an optional flag. This is to conform with other upgrade command 
Ex. juju upgrade-controller  
```
You can upgrade the controller to a new patch version by specifying
the `--agent-version` flag. If not specified, the upgrade candidate
will default to the most recent patch version matching the current
major and minor version. Upgrading to a new major or minor version is
not supported.

Examples:

    juju upgrade-controller --dry-run
    juju upgrade-controller --agent-version 2.0.1
```
</s>