### PR TITLE
ci(traefik): track v2, so it contains fixes for the v2 version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: "traefik:2.9"
+    image: "traefik:v2"
     container_name: traefik
     profiles: ["dev", "test"]
     ports:


### PR DESCRIPTION
# Description

Having 2.11.31 is necessary for traefik to work with docker 29. See https://github.com/traefik/traefik/issues/12253#issuecomment-3583460264