### PR TITLE
Juju 8806/migrateandupgrade method

### DIFF
--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -207,6 +207,18 @@ type API interface {
 	// CredentialContents returns contents of the credential values for the specified
 	// cloud and credential name. Secrets will be included if requested.
 	CredentialContents(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
+
+	// UpgradeModel upgrades the model to the provided agent version.
+	// The provided target version could be version.Zero, in which case the
+	// best version is selected by the controller and returned as ChosenVersion
+	// in the result.
+	UpgradeModel(
+		modelUUID string,
+		targetVersion version.Number,
+		stream string,
+		ignoreAgentVersions bool,
+		dryRun bool,
+	) (version.Number, error)
 }
 
 // PermissionManager provides a way to manage permissions within JIMM.

--- a/internal/jimm/upgrade/mocks/api.go
+++ b/internal/jimm/upgrade/mocks/api.go
@@ -2241,6 +2241,45 @@ func (c *MockAPIUpdateCredentialCall) DoAndReturn(f func(context.Context, params
 	return c
 }
 
+// UpgradeModel mocks base method.
+func (m *MockAPI) UpgradeModel(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions, dryRun bool) (version.Number, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeModel", modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
+	ret0, _ := ret[0].(version.Number)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeModel indicates an expected call of UpgradeModel.
+func (mr *MockAPIMockRecorder) UpgradeModel(modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun any) *MockAPIUpgradeModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeModel", reflect.TypeOf((*MockAPI)(nil).UpgradeModel), modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
+	return &MockAPIUpgradeModelCall{Call: call}
+}
+
+// MockAPIUpgradeModelCall wrap *gomock.Call
+type MockAPIUpgradeModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAPIUpgradeModelCall) Return(arg0 version.Number, arg1 error) *MockAPIUpgradeModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAPIUpgradeModelCall) Do(f func(string, version.Number, string, bool, bool) (version.Number, error)) *MockAPIUpgradeModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAPIUpgradeModelCall) DoAndReturn(f func(string, version.Number, string, bool, bool) (version.Number, error)) *MockAPIUpgradeModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ValidateModelUpgrade mocks base method.
 func (m *MockAPI) ValidateModelUpgrade(arg0 context.Context, arg1 names.ModelTag, arg2 bool) error {
 	m.ctrl.T.Helper()

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -27,6 +27,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
+var (
+	AlreadyUpgradedError = jujuerrors.New("model has already been upgraded")
+)
+
 // BootstrapManager defines the bootstrap manager methods required by the upgrade manager.
 type BootstrapManager interface {
 	WaitForJobCompletion(ctx context.Context, jobId uuid.UUID, config bootstrap.WaitConfig) error
@@ -213,11 +217,22 @@ func (u *upgradeManager) MigrateAndUpgradeModel(ctx context.Context, user *openf
 			Attempts: 10,
 			Delay:    5 * time.Second,
 			Func: func() error {
-				// TODO: We don't care about the user here. We just wanna know if internal migration completed.
-				// Our ModelInfo handles the redirect, it'll error until the migration is complete (traversing the redirect err to
-				// the new controller). Can we remove the user?
 				mi, err = u.jujuManager.ModelInfo(ctx, user, mt)
-				return err
+				if err != nil {
+					return err
+				}
+
+				m, err := u.jujuManager.GetModel(ctx, mi.UUID)
+				if err != nil {
+					return err
+				}
+
+				// It hasn't migrated yet, so error out.
+				if m.Controller.Name != targetControllerName {
+					return errors.E("model has not yet migrated to target controller")
+				}
+
+				return nil
 			},
 			Clock: clock.WallClock,
 		},
@@ -245,7 +260,7 @@ func (u *upgradeManager) MigrateAndUpgradeModel(ctx context.Context, user *openf
 		// that manual intervention is required.
 	}
 	if jujuerrors.Is(upgradeErr, jujuerrors.AlreadyExists) {
-		upgradeErr = jujuerrors.New("model has already been upgraded")
+		upgradeErr = AlreadyUpgradedError
 	}
 
 	if upgradeErr != nil {

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -7,11 +7,15 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/juju/clock"
+	jujuerrors "github.com/juju/errors"
 	jujucloud "github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/retry"
 	"github.com/juju/version/v2"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -59,6 +63,15 @@ func NewUpgradeManager(
 	if bootstrapManager == nil {
 		return nil, errors.E("bootstrap manager cannot be nil")
 	}
+	if jujumanager == nil {
+		return nil, errors.E("juju manager cannot be nil")
+	}
+	if store == nil {
+		return nil, errors.E("store cannot be nil")
+	}
+	if dialer == nil {
+		return nil, errors.E("dialer cannot be nil")
+	}
 	return &upgradeManager{
 		bootstrapManager: bootstrapManager,
 		jujuManager:      jujumanager,
@@ -73,11 +86,11 @@ func NewUpgradeManager(
 //
 // It returns the cloud and credential to be used for bootstrapping
 // the new controller.
-func (j *upgradeManager) PrepareUpgradeTo(ctx context.Context, modelUUID string, targetVersion version.Number) (jujucloud.Cloud, jujucloud.Credential, error) {
+func (u *upgradeManager) PrepareUpgradeTo(ctx context.Context, modelUUID string, targetVersion version.Number) (jujucloud.Cloud, jujucloud.Credential, error) {
 	var bootstrapCloud jujucloud.Cloud
 	var bootstrapCredential jujucloud.Credential
 
-	m, err := j.jujuManager.GetModel(ctx, modelUUID)
+	m, err := u.jujuManager.GetModel(ctx, modelUUID)
 	if err != nil {
 		return bootstrapCloud, bootstrapCredential, errors.E(err)
 	}
@@ -91,7 +104,7 @@ func (j *upgradeManager) PrepareUpgradeTo(ctx context.Context, modelUUID string,
 		return bootstrapCloud, bootstrapCredential, errors.E(errors.CodeBadRequest, "target version must be greater than current version")
 	}
 
-	api, err := j.dialer.Dial(ctx, &m.Controller, names.ModelTag{}, nil, nil)
+	api, err := u.dialer.Dial(ctx, &m.Controller, names.ModelTag{}, nil, nil)
 	if err != nil {
 		return bootstrapCloud, bootstrapCredential, errors.E(fmt.Errorf("failed to dial the controller: %w", err))
 	}
@@ -138,6 +151,10 @@ func (j *upgradeManager) PrepareUpgradeTo(ctx context.Context, modelUUID string,
 		return bootstrapCloud, bootstrapCredential, errors.E("controller cloud is not marked as a controller cloud")
 	}
 
+	if !bootstrapCloud.IsControllerCloud {
+		return bootstrapCloud, bootstrapCredential, errors.E("controller cloud is not marked as a controller cloud")
+	}
+
 	return bootstrapCloud, bootstrapCredential, nil
 }
 
@@ -172,4 +189,74 @@ func (u *upgradeManager) CloneController(ctx context.Context, user *openfga.User
 	}
 
 	return nil
+}
+
+// MigrateAndUpgradeModel migrates a model to a new controller and upgrades the model's agent to the controller's agent version.
+func (u *upgradeManager) MigrateAndUpgradeModel(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, targetVersion version.Number) (version.Number, error) {
+	var controllerChosenVersion version.Number
+
+	// TODO: Once precheck PR merged, run precheck.
+
+	iimResult, err := u.jujuManager.InitiateInternalMigration(ctx, user, modelUUID, targetControllerName)
+	if err != nil {
+		return controllerChosenVersion, errors.E(fmt.Errorf("failed to initiate internal migration for upgrade: %w", err))
+	}
+
+	mt, err := names.ParseModelTag(iimResult.ModelTag)
+	if err != nil {
+		return controllerChosenVersion, errors.E(fmt.Errorf("failed to parse model tag from initiate internal migration result: %w", err))
+	}
+
+	var mi *jujuparams.ModelInfo
+	if err := retry.Call(
+		retry.CallArgs{
+			Attempts: 10,
+			Delay:    5 * time.Second,
+			Func: func() error {
+				// TODO: We don't care about the user here. We just wanna know if internal migration completed.
+				// Our ModelInfo handles the redirect, it'll error until the migration is complete (traversing the redirect err to
+				// the new controller). Can we remove the user?
+				mi, err = u.jujuManager.ModelInfo(ctx, user, mt)
+				return err
+			},
+			Clock: clock.WallClock,
+		},
+	); err != nil {
+		return controllerChosenVersion, errors.E(fmt.Errorf("failed to confirm internal migration completed: %w", err))
+	}
+
+	dbCtrl := &dbmodel.Controller{Name: targetControllerName}
+	if err := u.store.GetController(ctx, dbCtrl); err != nil {
+		return controllerChosenVersion, errors.E(errors.CodeNotFound, err, "controller not found")
+	}
+
+	api, err := u.dialer.Dial(ctx, dbCtrl, names.ModelTag{}, nil, nil)
+	if err != nil {
+		return controllerChosenVersion, errors.E(fmt.Errorf("failed to dial target controller: %w", err))
+	}
+
+	var upgradeErr error
+	controllerChosenVersion, upgradeErr = api.UpgradeModel(mi.UUID, targetVersion, "", false, true)
+	//nolint:staticcheck // Has a description to highlight this possibility.
+	if jujuparams.IsCodeUpgradeInProgress(upgradeErr) {
+		// Apparently upgrades can have issues, that can be manually resolved, then you can run
+		// the upgrade-model command with the --reset-previous-upgrade option.
+		// We can't do that here, so we just return an error. We could possible indicate to the user here
+		// that manual intervention is required.
+	}
+	if jujuerrors.Is(upgradeErr, jujuerrors.AlreadyExists) {
+		upgradeErr = jujuerrors.New("model has already been upgraded")
+	}
+
+	if upgradeErr != nil {
+		return controllerChosenVersion, errors.E(fmt.Errorf("failed to upgrade model after migration: %w", upgradeErr))
+	}
+
+	zapctx.Info(ctx, "model migrate and upgrade complete",
+		zap.String("model-uuid", modelUUID),
+		zap.String("target-controller", targetControllerName),
+		zap.String("target-version", targetVersion.String()),
+		zap.String("controller-chosen-version", controllerChosenVersion.String()),
+	)
+	return controllerChosenVersion, nil
 }

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -246,6 +246,17 @@ func (s *upgradeManagerSuite) TestMigrateAndUpgradeModel_Success(c *qt.C) {
 			UUID: mt.Id(),
 		}, nil)
 
+	s.jujuManager.EXPECT().
+		GetModel(gomock.Any(), mt.Id()).
+		Return(
+			dbmodel.Model{
+				Controller: dbmodel.Controller{
+					Name: targetController,
+				},
+			},
+			nil,
+		)
+
 	s.store.EXPECT().
 		GetController(ctx, gomock.Any()).
 		DoAndReturn(func(ctx context.Context, ctrl *dbmodel.Controller) error {

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -103,7 +103,6 @@ func (s *upgradeManagerSuite) TestPrepareUpgradeTo_Success(c *qt.C) {
 		},
 			nil,
 		)
-
 	s.dialer.EXPECT().
 		Dial(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
@@ -211,6 +210,61 @@ func (s *upgradeManagerSuite) TestCloneController_WaitForJobCompletionError(c *q
 
 	err = upgradeMgr.CloneController(c.Context(), &openfga.User{}, upgrade.CloneControllerParams{})
 	c.Assert(err, qt.ErrorMatches, ".*bootstrap job failed.*job failed.*")
+}
+
+func (s *upgradeManagerSuite) TestMigrateAndUpgradeModel_Success(c *qt.C) {
+	ctrl := s.setupTest(c)
+	defer ctrl.Finish()
+
+	ctx := c.Context()
+
+	upgradeMgr, err := upgrade.NewUpgradeManager(s.bootstrapManager, s.jujuManager, s.store, s.dialer)
+	c.Assert(err, qt.IsNil)
+
+	mt := names.NewModelTag("93608db4-f1cb-4da5-9926-8233981aef0a")
+	targetController := "4.0controller"
+	targetModelVersion, err := version.Parse("4.1.0")
+	c.Assert(err, qt.IsNil)
+
+	s.jujuManager.EXPECT().
+		InitiateInternalMigration(ctx, gomock.Any(), mt.Id(), targetController).
+		Return(
+			jujuparams.InitiateMigrationResult{
+				ModelTag:    mt.String(),
+				MigrationId: "1",
+			},
+			nil,
+		)
+
+	s.jujuManager.EXPECT().
+		ModelInfo(
+			gomock.Any(),
+			gomock.Any(),
+			mt,
+		).
+		Return(&jujuparams.ModelInfo{
+			UUID: mt.Id(),
+		}, nil)
+
+	s.store.EXPECT().
+		GetController(ctx, gomock.Any()).
+		DoAndReturn(func(ctx context.Context, ctrl *dbmodel.Controller) error {
+			*ctrl = dbmodel.Controller{
+				Name:         targetController,
+				AgentVersion: "4.1.0",
+			}
+			return nil
+		})
+
+	s.dialer.EXPECT().Dial(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(s.api, nil)
+
+	s.api.EXPECT().
+		UpgradeModel(mt.Id(), targetModelVersion, "", false, true).
+		Return(targetModelVersion, nil)
+
+	controllerChosenVersion, err := upgradeMgr.MigrateAndUpgradeModel(ctx, &openfga.User{}, mt.Id(), targetController, targetModelVersion)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controllerChosenVersion, qt.Equals, targetModelVersion)
 }
 
 //go:generate mockgen -typed -destination=./mocks/bootstrapmanager.go -package=mocks . BootstrapManager

--- a/internal/jujuclient/modelupgrader.go
+++ b/internal/jujuclient/modelupgrader.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Canonical.
+
+package jujuclient
+
+import (
+	"github.com/juju/juju/api/client/modelupgrader"
+	"github.com/juju/version/v2"
+)
+
+// UpgradeModel upgrades the model to the provided agent version.
+// The provided target version could be version.Zero, in which case the
+// best version is selected by the controller and returned as ChosenVersion
+// in the result.
+func (c Connection) UpgradeModel(
+	modelUUID string,
+	targetVersion version.Number,
+	stream string,
+	ignoreAgentVersions bool,
+	dryRun bool,
+) (version.Number, error) {
+	return modelupgrader.NewClient(&c).UpgradeModel(modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
+}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -176,6 +176,7 @@ type API struct {
 	ListStorageDetails_                func(ctx context.Context) ([]jujuparams.StorageDetails, error)
 	ListModels_                        func(ctx context.Context) ([]base.UserModel, error)
 	CredentialContents_                func(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
+	UpgradeModel_                      func(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 }
 
 func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
@@ -525,6 +526,13 @@ func (a *API) CredentialContents(cloud string, credential string, withSecrets bo
 		return nil, errors.E(errors.CodeNotImplemented)
 	}
 	return a.CredentialContents(cloud, credential, withSecrets)
+}
+
+func (a *API) UpgradeModel(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+	if a.UpgradeModel_ == nil {
+		return version.Number{}, errors.E(errors.CodeNotImplemented)
+	}
+	return a.UpgradeModel_(modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
 }
 
 var _ juju.API = &API{}


### PR DESCRIPTION
## Description
This PR builds upon #1740 and introduces the migrate and upgrade method. So, given we can prepare, bootstrap, we can now migrate and upgrade. 

There is a few hiccups in this PR, namely:
- I've left a TODO for when the dry-run of migrate is merged and where to add it.
- A todo, which is more of a question about user removal in ModelInfo, happy to remove this TODO once answered in this PR
- A TODO of where to backup, but that also has issues in that only IAAS can be backed up. 
- A TODO questioning what IgnoreAgentVersions means, I'm guessing it is the option to filter out versions?
- A comment below the "upgrade in progress", this is a situation we cannot handle right now. But I believe once we have a workflow engine, we can surface a user manual intervention required error, and then they could retry this upgrade. My final intent is that these will be done in separate retry-able jobs to handle this scenario.
- The controller actually "chooses" the version based on if it is possible to upgrade to it. I haven't dove into how it chooses, but I guess that's something to be aware of and needs a little bit of investigation.


## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

