### PR TITLE
ci: configure dockerhub mirror

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_test:
     name: Build and Test

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,6 +5,10 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   startjimm:
     name: Test JIMM with Juju controller

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -22,6 +22,21 @@ jobs:
           sudo usermod -a -G microk8s "$USER"
           newgrp microk8s
 
+          # Configure DockerHub mirror if provided
+          if [[ "${DOCKERHUB_MIRROR}" ]]; then
+            echo "Configuring DockerHub mirror: $DOCKERHUB_MIRROR"
+            sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml > /dev/null << EOF
+          server = "$DOCKERHUB_MIRROR"
+
+          [host."$DOCKERHUB_MIRROR"]
+              capabilities = ["pull", "resolve"]
+          EOF
+            cat /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
+
+            microk8s stop
+            microk8s start
+          fi
+
           sudo microk8s enable storage
           subnet="$(ip route get 1 | head -n 1 | awk '{print $7}' | awk -F. '{print $1 "." $2 "." $3 ".240/24"}')"
           echo "MetalLB subnet: $subnet"


### PR DESCRIPTION
## Description
Thanks to some [help](https://chat.canonical.com/canonical/pl/3czj48u17fdzietpci6ebtyjjy) from platform engineering, it was found that Microk8s was failing to complete its setup because it was hitting Dockerhub rate-limiting errors when our integration test job runs on PS7. This PR ensures Microk8s uses our Dockerhub registry mirror.

Used https://github.com/canonical/github-runner-operator/pull/662 and https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-avoid-dockerhub-rate-limits/ as references.
