### PR TITLE
feat: add internal description package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -313,7 +313,10 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 )
 
-require github.com/ulikunitz/xz v0.5.12
+require (
+	github.com/juju/description/v10 v10.0.0
+	github.com/ulikunitz/xz v0.5.12
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,8 @@ github.com/juju/cmd/v3 v3.2.2/go.mod h1:lGtDvm2BG+FKnIS8yY/vrhxQNX9imnL6bPIYGSTc
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
+github.com/juju/description/v10 v10.0.0 h1:5BJql9jyiaC3oBjlWuTHYn96mOHiSf08SzykRGYQLHM=
+github.com/juju/description/v10 v10.0.0/go.mod h1:atb839RygQykDwCJxAi2iaEk1fqUdIoptpLWXjjj02A=
 github.com/juju/description/v9 v9.0.0 h1:NgACLkwB5u70ABSTm6TGRe5518ZuSErMmEIxC3WQmeA=
 github.com/juju/description/v9 v9.0.0/go.mod h1:w4GHAaswKodwxc5YMVjR8ZkSwHCjyI3JTtWSbIKHr2s=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Canonical.
+
+// Package description provides version-agnostic wrappers around major versions
+// of `github.com/juju/description` which hold Juju model descriptions, to
+// facilitate migrations between different Juju versions.
+package description
+
+import (
+	"fmt"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	descriptionv10 "github.com/juju/description/v10"
+	descriptionv9 "github.com/juju/description/v9"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+)
+
+const latestDescriptionVersion = 10
+
+// CloudCredentialArgs holds the arguments needed to set a cloud credential.
+type CloudCredentialArgs struct {
+	Owner      names.UserTag
+	Cloud      names.CloudTag
+	Name       string
+	AuthType   string
+	Attributes map[string]string
+}
+
+// Model provides a version-agnostic interface for accessing
+// model description data during migrations.
+type Model interface {
+	Owner() names.UserTag
+	Users() []User
+	CloudRegion() string
+	Applications() []Application
+	SetOwner(owner names.UserTag)
+	ClearUsers()
+	CloudCredential() CloudCredential
+	SetCloudCredential(args CloudCredentialArgs)
+	Config() map[string]interface{}
+	Serialize() ([]byte, error)
+}
+
+// User represents a user in the model description.
+type User interface {
+	Name() names.UserTag
+	Access() string
+}
+
+// Application represents an application in the model description.
+type Application interface {
+	Name() string
+	Offers() []ApplicationOffer
+}
+
+// ApplicationOffer represents an application offer in the model description.
+type ApplicationOffer interface {
+	OfferUUID() string
+	OfferName() string
+	ACL() map[string]string
+}
+
+// CloudCredential represents the current cloud credential for the model.
+type CloudCredential interface {
+	Owner() string
+	Cloud() string
+	Name() string
+	AuthType() string
+	Attributes() map[string]string
+}
+
+// Deserialize creates a new Model instance by deserializing
+// the provided raw description data according to the target controller version.
+func Deserialize(raw []byte, targetControllerVersion version.Number) (Model, error) {
+	version, err := migrationDescriptionVersion(targetControllerVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	switch version {
+	case 9:
+		desc, err := descriptionv9.Deserialize(raw)
+		if err != nil {
+			return nil, errors.E("failed to deserialize v9 model description: %w", err)
+		}
+		return &migrationDescriptionV9{desc: desc}, nil
+	case 10:
+		desc, err := descriptionv10.Deserialize(raw)
+		if err != nil {
+			return nil, errors.E("failed to deserialize v10 model description: %w", err)
+		}
+		return &migrationDescriptionV10{desc: desc}, nil
+	default:
+		return nil, errors.E("unsupported description version")
+	}
+}
+
+// migrationDescriptionVersion returns the migration description package
+// version to use for a given controller version.
+func migrationDescriptionVersion(controllerVersion version.Number) (int, error) {
+	v := controllerVersion
+
+	switch {
+	case v.Compare(version.MustParse("3.6.9")) < 0:
+		return 0, errors.E("unsupported controller version, must be at least 3.6.9")
+	case v.Compare(version.MustParse("3.6.9")) >= 0 && v.Compare(version.MustParse("3.6.12")) <= 0:
+		return 9, nil
+	case v.Compare(version.MustParse("3.6.13")) == 0:
+		return 10, nil
+	default:
+		return latestDescriptionVersion, nil
+	}
+}
+
+// TryDetermineModelUUID attempts to extract the model UUID from the
+// migration description data using the latest known description format.
+func TryDetermineModelUUID(raw []byte) (string, error) {
+	model, err := descriptionv10.Deserialize(raw)
+	if err != nil {
+		return "", errors.E("failed to deserialize model description: %w", err)
+	}
+	modelUUIDStr, ok := model.Config()[config.UUIDKey].(string)
+	if !ok {
+		return "", errors.E(fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+	}
+	return modelUUIDStr, nil
+}

--- a/internal/description/description_test.go
+++ b/internal/description/description_test.go
@@ -1,0 +1,199 @@
+// Copyright 2025 Canonical.
+
+package description
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	descriptionv10 "github.com/juju/description/v10"
+	descriptionv9 "github.com/juju/description/v9"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+)
+
+func TestDescriptionWrappers(t *testing.T) {
+	c := qt.New(t)
+
+	// Common data
+	ownerTag := names.NewUserTag("admin")
+	userTag := names.NewUserTag("user1")
+	cloudTag := names.NewCloudTag("aws")
+
+	// Setup v9 model
+	m9 := descriptionv9.NewModel(descriptionv9.ModelArgs{
+		Owner: ownerTag,
+		Config: map[string]any{
+			"uuid": "model-uuid",
+		},
+		AgentVersion: "3.6.12",
+		Type:         "iaas",
+	})
+	m9.SetStatus(descriptionv9.StatusArgs{Value: "available"})
+	m9.AddUser(descriptionv9.UserArgs{
+		Name:   userTag,
+		Access: "read",
+	})
+	m9.SetCloudCredential(descriptionv9.CloudCredentialArgs{
+		Owner:      ownerTag,
+		Cloud:      cloudTag,
+		Name:       "cred1",
+		AuthType:   "oauth2",
+		Attributes: map[string]string{"a": "b"},
+	})
+	app9 := m9.AddApplication(descriptionv9.ApplicationArgs{
+		Tag: names.NewApplicationTag("app1"),
+	})
+	app9.SetStatus(descriptionv9.StatusArgs{Value: "active"})
+	app9.AddOffer(descriptionv9.ApplicationOfferArgs{
+		OfferName:              "offer1",
+		OfferUUID:              "offer-uuid",
+		ACL:                    map[string]string{"user": "read"},
+		Endpoints:              map[string]string{"relation": "remote"},
+		ApplicationName:        "app1",
+		ApplicationDescription: "desc",
+	})
+
+	// Serialize v9
+	bytes9, err := descriptionv9.Serialize(m9)
+	c.Assert(err, qt.IsNil)
+
+	// Deserialize using wrapper
+	wrapper9, err := Deserialize(bytes9, version.MustParse("3.6.12"))
+	c.Assert(err, qt.IsNil)
+
+	// Setup v10 model
+	m10 := descriptionv10.NewModel(descriptionv10.ModelArgs{
+		Owner: ownerTag,
+		Config: map[string]any{
+			"uuid": "model-uuid",
+		},
+		AgentVersion: "3.6.13",
+		Type:         "iaas",
+	})
+	m10.SetStatus(descriptionv10.StatusArgs{Value: "available"})
+	m10.AddUser(descriptionv10.UserArgs{
+		Name:   userTag,
+		Access: "read",
+	})
+	m10.SetCloudCredential(descriptionv10.CloudCredentialArgs{
+		Owner:      ownerTag,
+		Cloud:      cloudTag,
+		Name:       "cred1",
+		AuthType:   "oauth2",
+		Attributes: map[string]string{"a": "b"},
+	})
+	app10 := m10.AddApplication(descriptionv10.ApplicationArgs{
+		Tag: names.NewApplicationTag("app1"),
+	})
+	app10.SetStatus(descriptionv10.StatusArgs{Value: "active"})
+	app10.AddOffer(descriptionv10.ApplicationOfferArgs{
+		OfferName:              "offer1",
+		OfferUUID:              "offer-uuid",
+		ACL:                    map[string]string{"user": "read"},
+		Endpoints:              map[string]string{"relation": "remote"},
+		ApplicationName:        "app1",
+		ApplicationDescription: "desc",
+	})
+
+	// Serialize v10
+	bytes10, err := descriptionv10.Serialize(m10)
+	c.Assert(err, qt.IsNil)
+
+	// Deserialize using wrapper
+	wrapper10, err := Deserialize(bytes10, version.MustParse("3.6.13"))
+	c.Assert(err, qt.IsNil)
+
+	// Verify both wrappers return same values
+	wrappers := []Model{wrapper9, wrapper10}
+	for _, w := range wrappers {
+		c.Check(w.Owner(), qt.Equals, ownerTag)
+
+		users := w.Users()
+		c.Assert(users, qt.HasLen, 1)
+		c.Check(users[0].Name(), qt.Equals, userTag)
+		c.Check(users[0].Access(), qt.Equals, "read")
+
+		cred := w.CloudCredential()
+		c.Check(cred.Owner(), qt.Equals, ownerTag.Id())
+		c.Check(cred.Cloud(), qt.Equals, cloudTag.Id())
+		c.Check(cred.Name(), qt.Equals, "cred1")
+		c.Check(cred.AuthType(), qt.Equals, "oauth2")
+		c.Check(cred.Attributes(), qt.DeepEquals, map[string]string{"a": "b"})
+
+		apps := w.Applications()
+		c.Assert(apps, qt.HasLen, 1)
+		c.Check(apps[0].Name(), qt.Equals, "app1")
+
+		offers := apps[0].Offers()
+		c.Assert(offers, qt.HasLen, 1)
+		c.Check(offers[0].OfferName(), qt.Equals, "offer1")
+		c.Check(offers[0].OfferUUID(), qt.Equals, "offer-uuid")
+		c.Check(offers[0].ACL(), qt.DeepEquals, map[string]string{"user": "read"})
+	}
+}
+
+func TestMigrationDescriptionVersion(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		version     string
+		expected    int
+		expectError bool
+	}{
+		{
+			name:        "version 3.5.0 returns error",
+			version:     "3.5.0",
+			expectError: true,
+		},
+		{
+			name:        "version 3.6.0 returns error",
+			version:     "3.6.0",
+			expectError: true,
+		},
+		{
+			name:     "version 3.6.9 returns 9",
+			version:  "3.6.9",
+			expected: 9,
+		},
+		{
+			name:     "version 3.6.12 returns 9",
+			version:  "3.6.12",
+			expected: 9,
+		},
+		{
+			name:     "version 3.6.13 returns 10",
+			version:  "3.6.13",
+			expected: 10,
+		},
+		{
+			name:     "version 3.6.14 returns latest (10)",
+			version:  "3.6.14",
+			expected: latestDescriptionVersion,
+		},
+		{
+			name:     "version 3.7.0 returns latest (10)",
+			version:  "3.7.0",
+			expected: latestDescriptionVersion,
+		},
+		{
+			name:     "version 4.0.0 returns latest (10)",
+			version:  "4.0.0",
+			expected: latestDescriptionVersion,
+		},
+	}
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			v, err := version.Parse(tt.version)
+			c.Assert(err, qt.IsNil)
+			result, err := migrationDescriptionVersion(v)
+			if tt.expectError {
+				c.Assert(err, qt.Not(qt.IsNil))
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.Equals, tt.expected)
+		})
+	}
+}

--- a/internal/description/v10.go
+++ b/internal/description/v10.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Canonical.
+
+package description
+
+import (
+	descriptionv10 "github.com/juju/description/v10"
+	"github.com/juju/names/v5"
+)
+
+// migrationDescriptionV10 implements the Description interface.
+type migrationDescriptionV10 struct {
+	desc descriptionv10.Model
+}
+
+// Serialize serializes the model description.
+func (md *migrationDescriptionV10) Serialize() ([]byte, error) {
+	return descriptionv10.Serialize(md.desc)
+}
+
+// Owner returns the owner of the model.
+func (md *migrationDescriptionV10) Owner() names.UserTag {
+	return md.desc.Owner()
+}
+
+// SetOwner sets the owner of the model.
+func (md *migrationDescriptionV10) SetOwner(owner names.UserTag) {
+	md.desc.SetOwner(owner)
+}
+
+// Users returns the users with access to the model.
+func (md *migrationDescriptionV10) Users() []User {
+	v10Users := md.desc.Users()
+	users := make([]User, len(v10Users))
+	for i, u := range v10Users {
+		users[i] = u
+	}
+	return users
+}
+
+// ClearUsers removes all users from the model description.
+func (md *migrationDescriptionV10) ClearUsers() {
+	md.desc.SetUsers(nil)
+}
+
+// CloudCredential returns the cloud credential used by the model.
+func (md *migrationDescriptionV10) CloudCredential() CloudCredential {
+	return md.desc.CloudCredential()
+}
+
+// CloudRegion returns the cloud region the model is deployed to.
+func (md *migrationDescriptionV10) CloudRegion() string {
+	return md.desc.CloudRegion()
+}
+
+// SetCloudCredential sets the cloud credential for the model.
+func (md *migrationDescriptionV10) SetCloudCredential(args CloudCredentialArgs) {
+	md.desc.SetCloudCredential(descriptionv10.CloudCredentialArgs{
+		Owner:      args.Owner,
+		Cloud:      args.Cloud,
+		Name:       args.Name,
+		AuthType:   args.AuthType,
+		Attributes: args.Attributes,
+	})
+}
+
+// Config returns the model configuration.
+func (md *migrationDescriptionV10) Config() map[string]any {
+	return md.desc.Config()
+}
+
+// Applications returns the applications in the model.
+func (md *migrationDescriptionV10) Applications() []Application {
+	v10Apps := md.desc.Applications()
+	apps := make([]Application, len(v10Apps))
+	for i, a := range v10Apps {
+		apps[i] = &applicationV10{app: a}
+	}
+	return apps
+}
+
+// applicationV10 wraps an application description.
+type applicationV10 struct {
+	app descriptionv10.Application
+}
+
+// Name returns the application name.
+func (a *applicationV10) Name() string {
+	return a.app.Name()
+}
+
+// Offers returns the application offers.
+func (a *applicationV10) Offers() []ApplicationOffer {
+	v10Offers := a.app.Offers()
+	offers := make([]ApplicationOffer, len(v10Offers))
+	for i, o := range v10Offers {
+		offers[i] = o
+	}
+	return offers
+}

--- a/internal/description/v9.go
+++ b/internal/description/v9.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Canonical.
+
+package description
+
+import (
+	descriptionv9 "github.com/juju/description/v9"
+	"github.com/juju/names/v5"
+)
+
+// migrationDescriptionV9 implements the Description interface.
+type migrationDescriptionV9 struct {
+	desc descriptionv9.Model
+}
+
+// Serialize serializes the model description.
+func (md *migrationDescriptionV9) Serialize() ([]byte, error) {
+	return descriptionv9.Serialize(md.desc)
+}
+
+// Owner returns the owner of the model.
+func (md *migrationDescriptionV9) Owner() names.UserTag {
+	return md.desc.Owner()
+}
+
+// SetOwner sets the owner of the model.
+func (md *migrationDescriptionV9) SetOwner(owner names.UserTag) {
+	md.desc.SetOwner(owner)
+}
+
+// Users returns the users with access to the model.
+func (md *migrationDescriptionV9) Users() []User {
+	v9Users := md.desc.Users()
+	users := make([]User, len(v9Users))
+	for i, u := range v9Users {
+		users[i] = u
+	}
+	return users
+}
+
+// ClearUsers removes all users from the model description.
+func (md *migrationDescriptionV9) ClearUsers() {
+	md.desc.SetUsers(nil)
+}
+
+// CloudCredential returns the cloud credential used by the model.
+func (md *migrationDescriptionV9) CloudCredential() CloudCredential {
+	return md.desc.CloudCredential()
+}
+
+// CloudRegion returns the cloud region the model is deployed to.
+func (md *migrationDescriptionV9) CloudRegion() string {
+	return md.desc.CloudRegion()
+}
+
+// SetCloudCredential sets the cloud credential for the model.
+func (md *migrationDescriptionV9) SetCloudCredential(args CloudCredentialArgs) {
+	md.desc.SetCloudCredential(descriptionv9.CloudCredentialArgs{
+		Owner:      args.Owner,
+		Cloud:      args.Cloud,
+		Name:       args.Name,
+		AuthType:   args.AuthType,
+		Attributes: args.Attributes,
+	})
+}
+
+// Config returns the model configuration.
+func (md *migrationDescriptionV9) Config() map[string]any {
+	return md.desc.Config()
+}
+
+// Applications returns the applications in the model.
+func (md *migrationDescriptionV9) Applications() []Application {
+	v9Apps := md.desc.Applications()
+	apps := make([]Application, len(v9Apps))
+	for i, a := range v9Apps {
+		apps[i] = &applicationV9{app: a}
+	}
+	return apps
+}
+
+// applicationV9 wraps an application description.
+type applicationV9 struct {
+	app descriptionv9.Application
+}
+
+// Name returns the application name.
+func (a *applicationV9) Name() string {
+	return a.app.Name()
+}
+
+// Offers returns the application offers.
+func (a *applicationV9) Offers() []ApplicationOffer {
+	v9Offers := a.app.Offers()
+	offers := make([]ApplicationOffer, len(v9Offers))
+	for i, o := range v9Offers {
+		offers[i] = o
+	}
+	return offers
+}


### PR DESCRIPTION
## Description
This PR adds a new package at `internal/description` that wraps Juju `github.com/juju/description` package across major versions. This will allow model imports to work across a wider range of controller versions. This PR splits off the work from https://github.com/canonical/jimm/pull/1757 into a smaller change-set.

Partially fixes [JUJU-8914](https://warthogs.atlassian.net/browse/JUJU-8914)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8914]: https://warthogs.atlassian.net/browse/JUJU-8914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ