### PR TITLE
fix: find offers not-found error

### DIFF
--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -8,12 +8,13 @@ package description
 import (
 	"fmt"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	descriptionv10 "github.com/juju/description/v10"
 	descriptionv9 "github.com/juju/description/v9"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 const latestDescriptionVersion = 10

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -516,6 +516,9 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 
 	for _, ctl := range controllers {
 		eg.Go(func() error {
+			// Return early if a single controller has an error
+			// to avoid misleading clients about what exists which
+			// could cause unneeded reconciliation.
 			api, err := j.dial(ctx, ctl, names.ModelTag{}, nil)
 			if err != nil {
 				return errors.E(err)
@@ -523,6 +526,9 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 			defer api.Close()
 			controllerOffers, err := query(api)
 			if err != nil {
+				if errors.ErrorCode(err) == errors.CodeNotFound {
+					return nil
+				}
 				return errors.E(err)
 			}
 			for _, offer := range controllerOffers {

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -2151,3 +2151,101 @@ func TestRevokeOfferAccessOnController(t *testing.T) {
 		}
 	}
 }
+
+const offerNotFoundTestEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+- owner: alice@canonical.com
+  name: cred-1
+  cloud: test-cloud
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+- name: controller-2
+  uuid: 00000001-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: controller-2
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: bob@canonical.com
+  life: alive
+  users:
+  - user: bob@canonical.com
+    access: admin
+application-offers:
+- name: offer-1
+  url: test-offer-url
+  uuid: 00000012-0000-0000-0000-000000000001
+  model-name: model-1
+  model-owner: bob@canonical.com
+  application-name: application-1
+  application-description: app description 1
+`
+
+func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Define expected offer from the "good" controller
+	// Details copy the offer defined in the test environment
+	expectedOffer := jujuparams.ApplicationOfferAdminDetailsV5{
+		ApplicationOfferDetailsV5: jujuparams.ApplicationOfferDetailsV5{
+			OfferUUID: "00000012-0000-0000-0000-000000000001",
+			OfferURL:  "test-offer-url",
+			OfferName: "offer-1",
+		},
+	}
+
+	controller1Dialed := false
+	// Setup dialers for two controllers
+	dialers := jimmtest.DialerMap{
+		"controller-1": &jimmtest.Dialer{
+			API: &jimmtest.API{
+				FindApplicationOffers_: func(ctx context.Context, of []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+					controller1Dialed = true
+					return nil, errors.E(errors.CodeNotFound, "offer not found")
+				},
+			},
+		},
+		"controller-2": &jimmtest.Dialer{
+			API: &jimmtest.API{
+				FindApplicationOffers_: func(ctx context.Context, of []jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error) {
+					return []jujuparams.ApplicationOfferAdminDetailsV5{expectedOffer}, nil
+				},
+			},
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: dialers,
+	})
+
+	// Initialize environment with one controller
+	env := jimmtest.ParseEnvironment(c, offerNotFoundTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	user, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	filters := []jujuparams.OfferFilter{{
+		OfferName: "test-offer",
+		ModelName: "model-1",
+		OwnerName: "bob@canonical.com",
+	}}
+
+	offers, err := j.FindApplicationOffers(ctx, openfga.NewUser(user, j.OpenFGAClient), filters...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(offers, qt.HasLen, 1)
+	c.Check(offers[0].OfferUUID, qt.Equals, expectedOffer.OfferUUID)
+	c.Check(controller1Dialed, qt.IsTrue)
+}


### PR DESCRIPTION
## Description
This PR fixes https://github.com/juju/terraform-provider-juju/issues/990.

The issue raised is that the Terraform client is calling `FindApplicationOffer` and passing the model name + model owner + offer name. In JIMM's implementation of `FindApplicationOffer` we dial each controller and call `FindApplicationOffer` on each, passing those original query parameters, acting as an aggregator. 

The problem comes in because when Juju receives the filter parameters and the model owner and model name fields are set, a `NotFound` error is returned if the model doesn't exist. This causes the issue because aggregating across multiple controllers, the model can only exist on one of them.

The solution is either to avoid failing the aggregation process when 1 controller fails, for any reasons, or catch the `NotFound` error. The former solution seems attractive at first since it seems like a bad idea to return an error if we fail to dial only 1 controller but if the offer was hosted on that controller and we skip it because it is down, we might give the client the impression that the offer doesn't exist which can trigger reconciliation loops in tools like ArgoCD/Flux. So I've gone with the latter approach to capture the `NotFound` error. I've added a test and tested manually.

Fixes [JUJU-8913](https://warthogs.atlassian.net/browse/JUJU-8913)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-8913]: https://warthogs.atlassian.net/browse/JUJU-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ