### PR TITLE
feat: implement bare-minimum model get

### DIFF
--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical.
+
+package jujuapi
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
+	jimmversion "github.com/canonical/jimm/v3/version"
+	"github.com/juju/juju/rpc/params"
+)
+
+func init() {
+	facadeInit["ModelConfig"] = func(r *controllerRoot) []int {
+		modelGetMethod := rpc.Method(r.ModelGet)
+
+		r.AddMethod("ModelConfig", 3, "ModelGet", modelGetMethod)
+		return []int{3}
+	}
+}
+
+func (r *controllerRoot) ModelGet(ctx context.Context) (params.ModelConfigResults, error) {
+	return params.ModelConfigResults{
+		Config: map[string]params.ConfigValue{
+			"agent-version": {
+				Value:  jimmversion.VersionInfo.Version,
+				Source: "jimm",
+			},
+		},
+	}, nil
+}

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -24,7 +24,7 @@ func (r *controllerRoot) ModelGet(ctx context.Context) (params.ModelConfigResult
 	return params.ModelConfigResults{
 		Config: map[string]params.ConfigValue{
 			"agent-version": {
-				Value:  jimmversion.JIMM_CONTROLLER_VERSION,
+				Value:  jimmversion.ControllerVersion,
 				Source: "jimm",
 			},
 		},

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -20,7 +20,10 @@ func init() {
 	}
 }
 
-// ModelGet returns the model configuration.
+// ModelGet returns the model configuration in JIMM's case, this is used to return the "controller" model config.
+// As JIMM doesn't have a controller model, or even an agent for that matter, we simulate this.
+//
+// It is required because the CLI reports on the agent-version during a show-controller call.
 func (r *controllerRoot) ModelGet(ctx context.Context) (params.ModelConfigResults, error) {
 	return params.ModelConfigResults{
 		Config: map[string]params.ConfigValue{

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -20,6 +20,7 @@ func init() {
 	}
 }
 
+// ModelGet returns the model configuration.
 func (r *controllerRoot) ModelGet(ctx context.Context) (params.ModelConfigResults, error) {
 	return params.ModelConfigResults{
 		Config: map[string]params.ConfigValue{

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -5,9 +5,10 @@ package jujuapi
 import (
 	"context"
 
+	"github.com/juju/juju/rpc/params"
+
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	jimmversion "github.com/canonical/jimm/v3/version"
-	"github.com/juju/juju/rpc/params"
 )
 
 func init() {
@@ -23,7 +24,7 @@ func (r *controllerRoot) ModelGet(ctx context.Context) (params.ModelConfigResult
 	return params.ModelConfigResults{
 		Config: map[string]params.ConfigValue{
 			"agent-version": {
-				Value:  jimmversion.VersionInfo.Version,
+				Value:  jimmversion.JIMM_CONTROLLER_VERSION,
 				Source: "jimm",
 			},
 		},

--- a/internal/jujuapi/modelconfig_test.go
+++ b/internal/jujuapi/modelconfig_test.go
@@ -27,5 +27,5 @@ func (s *jimmSuite) TestModelGet(c *gc.C) {
 	c.Assert(ok, gc.Equals, true)
 	vers, ok := v.(string)
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(vers, gc.Equals, jimmversion.JIMM_CONTROLLER_VERSION)
+	c.Assert(vers, gc.Equals, jimmversion.ControllerVersion)
 }

--- a/internal/jujuapi/modelconfig_test.go
+++ b/internal/jujuapi/modelconfig_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical.
+
+package jujuapi_test
+
+import (
+	jimmversion "github.com/canonical/jimm/v3/version"
+	"github.com/juju/juju/api/client/modelconfig"
+	gc "gopkg.in/check.v1"
+)
+
+type modelConfigSuite struct {
+	websocketSuite
+}
+
+var _ = gc.Suite(&modelConfigSuite{})
+
+func (s *jimmSuite) TestModelGet(c *gc.C) {
+	conn := s.open(c, nil, "alice")
+	defer conn.Close()
+
+	client := modelconfig.NewClient(conn)
+	jimmversion.VersionInfo.Version = "test-version"
+	jimmCfg, err := client.ModelGet()
+	c.Assert(err, gc.IsNil)
+
+	v, ok := jimmCfg["agent-version"]
+	c.Assert(ok, gc.Equals, true)
+	vers, ok := v.(string)
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(vers, gc.Equals, "test-version")
+}

--- a/internal/jujuapi/modelconfig_test.go
+++ b/internal/jujuapi/modelconfig_test.go
@@ -19,7 +19,7 @@ func (s *jimmSuite) TestModelGet(c *gc.C) {
 	defer conn.Close()
 
 	client := modelconfig.NewClient(conn)
-	jimmversion.VersionInfo.Version = "test-version"
+
 	jimmCfg, err := client.ModelGet()
 	c.Assert(err, gc.IsNil)
 
@@ -27,5 +27,5 @@ func (s *jimmSuite) TestModelGet(c *gc.C) {
 	c.Assert(ok, gc.Equals, true)
 	vers, ok := v.(string)
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(vers, gc.Equals, "test-version")
+	c.Assert(vers, gc.Equals, jimmversion.JIMM_CONTROLLER_VERSION)
 }

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -73,7 +73,7 @@ func (d *Dialer) createLoginRequest1(ctx context.Context, controllerTag names.Co
 
 	return &jujuparams.LoginRequest{
 		AuthTag:       userTag.String(),
-		ClientVersion: jimmversion.JIMM_CONTROLLER_VERSION,
+		ClientVersion: jimmversion.ControllerVersion,
 		Token:         jwtString,
 	}, nil
 }

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -36,12 +36,10 @@ import (
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/rpc"
 	"github.com/canonical/jimm/v3/internal/servermon"
+	jimmversion "github.com/canonical/jimm/v3/version"
 )
 
 const (
-	// JIMM claims to be a 3.6.13 client.
-	jujuClientVersion = "3.6.13"
-
 	adminUser = "admin"
 )
 
@@ -75,7 +73,7 @@ func (d *Dialer) createLoginRequest1(ctx context.Context, controllerTag names.Co
 
 	return &jujuparams.LoginRequest{
 		AuthTag:       userTag.String(),
-		ClientVersion: jujuClientVersion,
+		ClientVersion: jimmversion.JIMM_CONTROLLER_VERSION,
 		Token:         jwtString,
 	}, nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -4,6 +4,11 @@ package version
 
 import "strings"
 
+const (
+	// JIMM claims to be a 3.6.12 controller and client.
+	JIMM_CONTROLLER_VERSION = "3.6.12"
+)
+
 // Version describes the current version of the code being run.
 type Version struct {
 	GitCommit string

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,8 @@ package version
 import "strings"
 
 const (
-	// JIMM claims to be a 3.6.12 controller and client.
-	JIMM_CONTROLLER_VERSION = "3.6.12"
+	// ControllerVersion is the controller version and client JIMM claims to be.
+	ControllerVersion = "3.6.12"
 )
 
 // Version describes the current version of the code being run.


### PR DESCRIPTION
## Description
Juju's show-model sources the agent-version for the controller from ModelGet. When not implemented, it causes the Juju CLI to error out detailing ModelGet wasn't implemented like so:
```
juju client not compatible with server: no such request - method ModelConfig.ModelGet is not implemented (not implemented)
re-install your juju client to match the version running on the controller
```

This now populates the version set in show-controller with JIMM's VersionInfo.Version.
And displays it like so:
```
jimm-dev:
  details:
    controller-uuid: 3217dbc9-8ea9-4381-9e97-01eab0b3f6bb
    api-endpoints: ['jimm.localhost:443']
    cloud: ""
    agent-version: 3.6.12
    agent-git-commit: unknown git commit
    controller-model-version: unknown version <- this was the offending line.
```

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
Simply run show-controller.
