### PR TITLE
ci: use hostname -I first entry for login-token-refresh-url qa-microk8s script

### DIFF
--- a/local/jimm/setup-microk8s-controller.sh
+++ b/local/jimm/setup-microk8s-controller.sh
@@ -7,5 +7,9 @@
 #   --node-ip=172.16.12.223
 #   to /var/snap/microk8s/current/args/kubelet
 # 4. sudo snap restart microk8s
-juju bootstrap microk8s "qa-microk8s" --config login-token-refresh-url=http://10.0.1.1:17070/.well-known/jwks.json 
+
+# Get the private IP address
+PRIVATE_IP=$(hostname -I | awk '{print $1}')
+
+juju bootstrap microk8s "qa-microk8s" --config login-token-refresh-url=http://${PRIVATE_IP}:17070/.well-known/jwks.json --debug
 


### PR DESCRIPTION
## Description
Use hostname -I for the login-token-refresh URL in qa-microk8s. This should work for mosto f our developers, enabling them to run qa-microk8s consistently - given the developer is connected to a home network / has some kind of DHCP as their primary network interface (eth0 / whatever).
