### PR TITLE
chore: update rockcraft.yaml to use go 1.25

### DIFF
--- a/rocks/jimm.yaml
+++ b/rocks/jimm.yaml
@@ -21,7 +21,7 @@ parts:
         source: .
         source-type: local
         build-snaps:
-          - go/1.24/stable
+          - go/1.25/stable
         build-packages:
           - git
           - make 


### PR DESCRIPTION
## Description
This PR updates `rockcraft.yaml` to specify Go 1.25. Our previous release failed because our `go.mod` was updated but the rockcraft build only had Go 1.24 installed.

I did attempt removing the `build-snaps` directive completely and building and it worked but it looks like (see [here](https://github.com/canonical/snapcraft/blob/main/snapcraft_legacy/plugins/v2/go.py)) that it's because it downloads Go from the latest/stable channel which is currently 1.25. It seems preferable to have the version pinned though it does cause pain when we update go.mod but forget to update rockcraft.yaml. 