### PR TITLE
feat: modify jimm ListControllers to list controllers users have can_addmodel permission on

### DIFF
--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -47,21 +47,6 @@ var (
     data: {}
     since: null
 `
-
-	expectedOutput = `- name: jaas
-  uuid: 6acf4fd8-32d6-49ea-b4eb-dcb9d1590c11
-  publicaddress: ""
-  apiaddresses: \[\]
-  cacertificate: ""
-  cloudtag: ""
-  cloudregion: ""
-  agentversion: .*
-  status:
-    status: available
-    info: ""
-    data: {}
-    since: null
-`
 )
 
 type listControllersSuite struct {
@@ -87,5 +72,5 @@ func (s *listControllersSuite) TestListControllers(c *gc.C) {
 	bClient := s.SetupCLIAccess(c, "bob")
 	context, err := cmdtesting.RunCommand(c, cmd.NewListControllersCommandForTesting(s.ClientStore(), bClient))
 	c.Assert(err, gc.IsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, expectedOutput)
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, `\[\]\n?`)
 }

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -76,7 +76,7 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 			zapctx.Error(ctx, "error checking user permissions for controller", zap.String("controller", c.Name), zap.Error(err))
 			return nil
 		}
-		if user.JimmAdmin || canAddModel {
+		if canAddModel {
 			controllers = append(controllers, *c)
 		}
 		return nil

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -12,6 +12,8 @@ import (
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/canonical/jimm/v3/internal/db"
@@ -64,15 +66,19 @@ func (j *JujuManager) ControllerInfo(ctx context.Context, name string) (*dbmodel
 	return &ctl, nil
 }
 
-// ListControllers returns a list of controllers the user has access to.
+// ListControllers returns a list of controllers the user has can_addmodel to.
+// JIMM admins get all controllers.
 func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error) {
-	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
-	}
-
 	var controllers []dbmodel.Controller
 	err := j.Database.ForEachController(ctx, func(c *dbmodel.Controller) error {
-		controllers = append(controllers, *c)
+		canAddModel, err := user.IsAllowedAddModelToController(ctx, c.ResourceTag())
+		if err != nil {
+			zapctx.Error(ctx, "error checking user permissions for controller", zap.String("controller", c.Name), zap.Error(err))
+			return nil
+		}
+		if user.JimmAdmin || canAddModel {
+			controllers = append(controllers, *c)
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -39,24 +39,27 @@ controllers:
   cloud: test
   region: test-region-1
   agent-version: 3.2.1
+  users:
+    - username: bob@canonical.com
+      access: add-model
+    - username: eve@canonical.com
+      access: add-model
 - name: test2
   uuid: 00000001-0000-0000-0000-000000000002
   cloud: test
   region: test-region-2
   agent-version: 3.2.0
+  users:
+    - username: bob@canonical.com
+      access: add-model
 - name: test3
   uuid: 00000001-0000-0000-0000-000000000003
   cloud: test
   region: test-region-3
   agent-version: 2.1.0
-users:
-- username: alice@canonical.com
-  controller-access: superuser
-- username: bob@canonical.com
-  can-add-model: [00000001-0000-0000-0000-000000000001, 00000001-0000-0000-0000-000000000002]
-- username: eve@canonical.com
-  can-add-model: [00000001-0000-0000-0000-000000000001, 00000001-0000-0000-0000-000000000003]
-- username: notallowedanycontrollers@canonical.com
+  users:
+    - username: eve@canonical.com
+      access: add-model
 `
 
 func TestControllerInfo(t *testing.T) {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -40,9 +40,9 @@ controllers:
   region: test-region-1
   agent-version: 3.2.1
   users:
-    - username: bob@canonical.com
+    - user: bob@canonical.com
       access: add-model
-    - username: eve@canonical.com
+    - user: eve@canonical.com
       access: add-model
 - name: test2
   uuid: 00000001-0000-0000-0000-000000000002
@@ -50,7 +50,7 @@ controllers:
   region: test-region-2
   agent-version: 3.2.0
   users:
-    - username: bob@canonical.com
+    - user: bob@canonical.com
       access: add-model
 - name: test3
   uuid: 00000001-0000-0000-0000-000000000003
@@ -58,8 +58,11 @@ controllers:
   region: test-region-3
   agent-version: 2.1.0
   users:
-    - username: eve@canonical.com
+    - user: eve@canonical.com
       access: add-model
+users:
+  - username: alice@canonical.com
+    controller-access: superuser
 `
 
 func TestControllerInfo(t *testing.T) {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -53,9 +53,10 @@ users:
 - username: alice@canonical.com
   controller-access: superuser
 - username: bob@canonical.com
-  controller-access: login
+  can-add-model: [00000001-0000-0000-0000-000000000001, 00000001-0000-0000-0000-000000000002]
 - username: eve@canonical.com
-  controller-access: "no-access"
+  can-add-model: [00000001-0000-0000-0000-000000000001, 00000001-0000-0000-0000-000000000003]
+- username: notallowedanycontrollers@canonical.com
 `
 
 func TestControllerInfo(t *testing.T) {
@@ -92,30 +93,49 @@ func TestListControllers(t *testing.T) {
 		jimmAdmin           bool
 		expectedControllers []dbmodel.Controller
 		expectedError       string
-	}{{
-		about:     "superuser can list controllers",
-		user:      env.User("alice@canonical.com").DBObject(c, j.Database),
-		jimmAdmin: true,
-		expectedControllers: []dbmodel.Controller{
-			env.Controller("test1").DBObject(c, j.Database),
-			env.Controller("test2").DBObject(c, j.Database),
-			env.Controller("test3").DBObject(c, j.Database),
+	}{
+		{
+			about:     "superuser can list controllers",
+			user:      env.User("alice@canonical.com").DBObject(c, j.Database),
+			jimmAdmin: true,
+			expectedControllers: []dbmodel.Controller{
+				env.Controller("test1").DBObject(c, j.Database),
+				env.Controller("test2").DBObject(c, j.Database),
+				env.Controller("test3").DBObject(c, j.Database),
+			},
 		},
-	}, {
-		about:         "add-model user can not list controllers",
-		user:          env.User("bob@canonical.com").DBObject(c, j.Database),
-		expectedError: "unauthorized",
-	}, {
-		about:         "user withouth access rights cannot list controllers",
-		user:          env.User("eve@canonical.com").DBObject(c, j.Database),
-		expectedError: "unauthorized",
-	}}
+		{
+			about:     "bob has can_addmodel to test1 and test2 controllers",
+			user:      env.User("bob@canonical.com").DBObject(c, j.Database),
+			jimmAdmin: false,
+			expectedControllers: []dbmodel.Controller{
+				env.Controller("test1").DBObject(c, j.Database),
+				env.Controller("test2").DBObject(c, j.Database),
+			},
+		},
+		{
+			about:     "eve has can_addmodel to test1 and test3 controllers",
+			user:      env.User("eve@canonical.com").DBObject(c, j.Database),
+			jimmAdmin: false,
+			expectedControllers: []dbmodel.Controller{
+				env.Controller("test1").DBObject(c, j.Database),
+				env.Controller("test3").DBObject(c, j.Database),
+			},
+		},
+		{
+			about:               "user without access cannot list any controllers",
+			user:                env.User("notallowedanycontrollers@canonical.com").DBObject(c, j.Database),
+			jimmAdmin:           false,
+			expectedControllers: nil,
+		},
+	}
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
 			user := openfga.NewUser(&test.user, j.OpenFGAClient)
 			user.JimmAdmin = test.jimmAdmin
 			controllers, err := j.ListControllers(ctx, user)
+
 			if test.expectedError != "" {
 				c.Assert(err, qt.ErrorMatches, test.expectedError)
 			} else {
@@ -369,11 +389,11 @@ func TestRemoveAndAddController(t *testing.T) {
 	j := newTestJujuManager(c, nil)
 
 	env := jimmtest.ParseEnvironment(c, removeAndAddControllerTestEnv)
-	env.PopulateDB(c, j.Database)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 	controller := env.Controllers[0]
 
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
-	user := openfga.NewUser(&dbUser, nil)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 	user.JimmAdmin = true
 
 	err := j.RemoveController(ctx, user, "controller-1", true)

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -229,39 +229,18 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 	return ctl.ToAPIControllerInfo(), nil
 }
 
-// ListControllers returns the list of juju controllers hosting models
-// as part of this JAAS system.
-// If the user is not an admin, they will only receive information about
-// JIMM itself - note that the controller name returned is "jaas".
+// ListControllers returns the list of juju controllers the user has can_addmodel access to on the controller.
 func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListControllersResponse, error) {
-
-	if !r.user.JimmAdmin {
-		// if the user isn't a controller admin return JAAS
-		// itself as the only controller.
-		srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
-		if err != nil {
-			return apiparams.ListControllersResponse{}, errors.E(err)
-		}
-		jimmCtl := apiparams.ControllerInfo{
-			Name: "jaas",
-			UUID: r.params.ControllerUUID,
-			// TODO(mhilton)enable setting the public address.
-			AgentVersion: srvVersion.String(),
-			Status: jujuparams.EntityStatus{
-				Status: "available",
-			},
-		}
-		controllers := []apiparams.ControllerInfo{jimmCtl}
-		return apiparams.ListControllersResponse{Controllers: controllers}, nil
-	}
 	dbControllers, err := r.jimm.JujuManager().ListControllers(ctx, r.user)
 	if err != nil {
 		return apiparams.ListControllersResponse{}, errors.E(err)
 	}
+
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
 		controllersInfo = append(controllersInfo, ctl.ToAPIControllerInfo())
 	}
+
 	return apiparams.ListControllersResponse{
 		Controllers: controllersInfo,
 	}, nil

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
@@ -35,7 +36,7 @@ type jimmSuite struct {
 
 var _ = gc.Suite(&jimmSuite{})
 
-func (s *jimmSuite) TestListControllers(c *gc.C) {
+func (s *jimmSuite) TestListControllersAdmin(c *gc.C) {
 	s.AddController(c, "controller-0", s.APIInfo(c))
 	s.AddController(c, "controller-2", s.APIInfo(c))
 
@@ -81,6 +82,77 @@ func (s *jimmSuite) TestListControllers(c *gc.C) {
 	}})
 }
 
+func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
+	ctx := context.Background()
+
+	ctrl0 := &dbmodel.Controller{
+		Name:      "dummy-0",
+		UUID:      "00000001-0000-0000-0000-000000000000",
+		CloudName: "dummy",
+	}
+
+	ctrl1 := &dbmodel.Controller{
+		Name:      "dummy-1",
+		UUID:      "00000001-0000-0000-0000-000000000001",
+		CloudName: "dummy",
+	}
+
+	ctrl2 := &dbmodel.Controller{
+		Name:      "dummy-2",
+		UUID:      "00000001-0000-0000-0000-000000000002",
+		CloudName: "dummy",
+	}
+
+	err := s.JIMM.Database.AddController(ctx, ctrl0)
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.Database.AddController(ctx, ctrl1)
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.Database.AddController(ctx, ctrl2)
+	c.Assert(err, gc.IsNil)
+
+	// Explicitly set access to controllers 0 and 2, but not 1.
+	u, err := dbmodel.NewIdentity("alex@canonical.com")
+	c.Assert(err, gc.IsNil)
+
+	err = s.JIMM.Database.GetIdentity(ctx, u)
+	c.Assert(err, gc.IsNil)
+
+	openfgaUser := openfga.NewUser(u, s.JIMM.OpenFGAClient)
+
+	err = openfgaUser.SetControllerAccess(ctx, names.NewControllerTag(ctrl0.UUID), ofganames.CanAddModelRelation)
+	c.Assert(err, gc.IsNil)
+
+	err = openfgaUser.SetControllerAccess(ctx, names.NewControllerTag(ctrl2.UUID), ofganames.CanAddModelRelation)
+	c.Assert(err, gc.IsNil)
+
+	conn := s.open(c, nil, "alex@canonical.com")
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+	cis, err := client.ListControllers()
+	c.Assert(err, gc.Equals, nil)
+	c.Check(cis, jc.DeepEquals, []apiparams.ControllerInfo{
+		{
+			Name:     "dummy-0",
+			UUID:     "00000001-0000-0000-0000-000000000000",
+			CloudTag: "cloud-dummy",
+			Status: jujuparams.EntityStatus{
+				Status: "available",
+			},
+		},
+		{
+			Name:     "dummy-2",
+			UUID:     "00000001-0000-0000-0000-000000000002",
+			CloudTag: "cloud-dummy",
+			Status: jujuparams.EntityStatus{
+				Status: "available",
+			},
+		},
+	})
+}
+
 func (s *jimmSuite) TestListControllersUnauthorized(c *gc.C) {
 	s.AddController(c, "controller-0", s.APIInfo(c))
 	s.AddController(c, "controller-2", s.APIInfo(c))
@@ -91,14 +163,7 @@ func (s *jimmSuite) TestListControllersUnauthorized(c *gc.C) {
 	client := api.NewClient(conn)
 	cis, err := client.ListControllers()
 	c.Assert(err, gc.Equals, nil)
-	c.Check(cis, jc.DeepEquals, []apiparams.ControllerInfo{{
-		Name:         "jaas",
-		UUID:         jimmtest.ControllerUUID,
-		AgentVersion: s.Model.Controller.AgentVersion,
-		Status: jujuparams.EntityStatus{
-			Status: "available",
-		},
-	}})
+	c.Check(cis, jc.DeepEquals, []apiparams.ControllerInfo{})
 }
 
 func (s *jimmSuite) TestAddControllerPublicAddressWithoutPort(c *gc.C) {

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -157,7 +157,7 @@ func (s *jimmSuite) TestListControllersUnauthorized(c *gc.C) {
 	s.AddController(c, "controller-0", s.APIInfo(c))
 	s.AddController(c, "controller-2", s.APIInfo(c))
 
-	conn := s.open(c, nil, "bob")
+	conn := s.open(c, nil, "abrandnewuserwithnopermissions")
 	defer conn.Close()
 
 	client := api.NewClient(conn)

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -131,23 +131,6 @@ func (u User) addUserRelations(c *qt.C, jimmTag names.ControllerTag, db *db.Data
 		err := openfgaUser.SetControllerAccess(context.Background(), jimmTag, ofganames.AdministratorRelation)
 		c.Assert(err, qt.IsNil)
 	}
-	if len(u.CanAddModel) > 0 {
-		dbUser := u.DBObject(c, db)
-		openfgaUser := openfga.NewUser(&dbUser, client)
-
-		for _, controllerUUID := range u.CanAddModel {
-			if names.IsValidController(controllerUUID) == false {
-				c.Fatalf("invalid controller UUID for can-add-model: %s", u.CanAddModel)
-			}
-
-			err := openfgaUser.SetControllerAccess(
-				context.Background(),
-				names.NewControllerTag(controllerUUID),
-				ofganames.CanAddModelRelation,
-			)
-			c.Assert(err, qt.IsNil)
-		}
-	}
 }
 
 // addCloudRelations adds permissions the cloud should have and adds permissions for users to the cloud.
@@ -558,8 +541,6 @@ type User struct {
 	Username         string `json:"username"`
 	DisplayName      string `json:"display-name"`
 	ControllerAccess string `json:"controller-access"`
-	// CanAddModel takes a list of controller UUIDs the user can add models to.
-	CanAddModel []string `json:"can-add-model"`
 
 	env *Environment
 	dbo dbmodel.Identity

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -127,9 +127,26 @@ func (e *Environment) User(name string) *User {
 func (u User) addUserRelations(c *qt.C, jimmTag names.ControllerTag, db *db.Database, client *openfga.OFGAClient) {
 	if u.ControllerAccess == "superuser" {
 		dbUser := u.DBObject(c, db)
-		u := openfga.NewUser(&dbUser, client)
-		err := u.SetControllerAccess(context.Background(), jimmTag, ofganames.AdministratorRelation)
+		openfgaUser := openfga.NewUser(&dbUser, client)
+		err := openfgaUser.SetControllerAccess(context.Background(), jimmTag, ofganames.AdministratorRelation)
 		c.Assert(err, qt.IsNil)
+	}
+	if len(u.CanAddModel) > 0 {
+		dbUser := u.DBObject(c, db)
+		openfgaUser := openfga.NewUser(&dbUser, client)
+
+		for _, controllerUUID := range u.CanAddModel {
+			if names.IsValidController(controllerUUID) == false {
+				c.Fatalf("invalid controller UUID for can-add-model: %s", u.CanAddModel)
+			}
+
+			err := openfgaUser.SetControllerAccess(
+				context.Background(),
+				names.NewControllerTag(controllerUUID),
+				ofganames.CanAddModelRelation,
+			)
+			c.Assert(err, qt.IsNil)
+		}
 	}
 }
 
@@ -541,6 +558,8 @@ type User struct {
 	Username         string `json:"username"`
 	DisplayName      string `json:"display-name"`
 	ControllerAccess string `json:"controller-access"`
+	// CanAddModel takes a list of controller UUIDs the user can add models to.
+	CanAddModel []string `json:"can-add-model"`
 
 	env *Environment
 	dbo dbmodel.Identity


### PR DESCRIPTION
## Description
This PR modifies the ListControllers method of JIMM to list only controllers the user has can_addmodel on.

For admin users, it returns all controllers.

I modified it further in that we no longer return the JIMM controller, wasn't really sure there's a point of returning JIMM in the set and it was only returned when the user wasn't an admin anyway.

I added an additional test to Juju API, which might appear kind of pointless, but it at least tests that when calling JIMM's API it does behave as expected - even if we are returning dummy database entries.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

