### PR TITLE
doc: update add-permission command doc

### DIFF
--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -41,6 +41,10 @@ These are used to define access control between resources.
 The object and target object must be of the form <tag>-<objectname> or <tag>-<object-uuid>
 E.g. "user-Alice" or "controller-MyController"
 
+Certain reserved tags exist to denote specific resource types:
+- The user-everyone@external tag represents all users.
+- The controller-jimm tag represents the JIMM controller itself.
+
 -f    Read from a file where filename is the location of a JSON encoded file of the form:
     [
         {
@@ -56,21 +60,28 @@ E.g. "user-Alice" or "controller-MyController"
     ]
 
 Certain constraints apply when creating/removing permissions, namely:
-Object may be one of:
+Resources may be one of:
 
     user tag                = "user-<name>"
     group tag               = "group-<name>"
+	role tag 			    = "role-<name>"
     controller tag          = "controller-<name>"
     model tag               = "model-<name>"
-    application offer tag   = "offer-<name>"
+	cloud tag			    = "cloud-<name>"
+    application-offer tag   = "applicationoffer-<name>"
 
 If target_object is a group, the relation can only be:
 
     member
 
+If target_object is a role, the relation can only be:
+
+	assignee
+
 If target_object is a controller, the relation can be one of:
 
-    loginer
+    audit_log_viewer (only relevent for the JIMM controller)
+	can_addmodel
     administrator
 
 If target_object is a model, the relation can be one of:
@@ -79,17 +90,25 @@ If target_object is a model, the relation can be one of:
     writer
     administrator
 
+If target_object is a cloud, the relation can be one of:
+
+	administrator
+	can_addmodel
+
 If target_object is an application offer, the relation can be one of:
 
     reader
     consumer
     administrator
 
-
-Additionally, if the object is a group, a userset can be applied by adding #member as follows.
+If the object is a group, a userset must be applied by adding #member as follows.
 This will grant/revoke access to all users within TeamA:
 
     group-TeamA#member administrator controller-MyController
+
+Similarly if the object is a role, a userset must be applied by adding #member as follows.
+
+	role-Auditor#assignee audit_log_viewer controller-MyController
 `
 
 	addPermissionDoc = `

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -307,10 +307,11 @@ func (t *tagResolver) cloudTag(ctx context.Context, db *db.Database) (*ofga.Enti
 	return ofganames.ConvertTagWithRelation(cloud.ResourceTag(), t.relation), nil
 }
 
-// resolveTag resolves JIMM tag [of any kind available] (i.e., controller-mycontroller:alex@canonical.com/mymodel.myoffer)
-// into a juju string tag (i.e., controller-<controller uuid>).
+// resolveTag resolves tags with names (of any kind) i.e., controller-myController
+// into a tag with UUIDs for resources that require UUID i.e., controller-<controller uuid>.
+// Mostly just usernames are left as-is since they are already unique identifiers.
 //
-// If the JIMM tag is aleady of juju string tag form, the transformation is left alone.
+// If the tag already contains a UUID, the transformation is left alone.
 //
 // In both cases though, the resource the tag pertains to is validated to exist within the database.
 func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, error) {


### PR DESCRIPTION
## Description
This PR updates some outdated help text on the `add-permission` command on the jaas cli.

The easiest way to cross-reference these changes is to look at our tag resolver code at `internal/jimm/permissions/tagresolver.go` and at our OpenFGA auth model at `openfga/authorisation_model.fga`.