### PR TITLE
test(migrate-e2e): migrate jimmSuite to websocketE2Esuite

### DIFF
--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -4,16 +4,21 @@ package jujuapi_test
 
 import (
 	"context"
+	"testing"
+	"time"
 
+	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/jimm/bootstrap"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
@@ -322,4 +327,66 @@ func (s *jimmUnitTestSuite) TestStartDestroyControllerJob(c *gc.C) {
 	ctrlInfo.Models = append(ctrlInfo.Models, dbmodel.Model{})
 	_, err = root.StartDestroyControllerJob(ctx, req)
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller with models")
+}
+
+// TestAuditLogAPIParamsConversion tests the conversion of API params to a AuditLogFilter struct.
+// Note that this test doesn't require a running Juju/JIMM controller so it doesn't use gc + the jimmSuite.
+func TestAuditLogAPIParamsConversion(t *testing.T) {
+	c := qt.New(t)
+	testCases := []struct {
+		about   string
+		request apiparams.FindAuditEventsRequest
+		result  db.AuditLogFilter
+		err     error
+	}{
+		{
+			about: "Test basic conversion",
+			request: apiparams.FindAuditEventsRequest{
+				After:    "2023-08-14T00:00:00Z",
+				Before:   "2023-08-14T00:00:00Z",
+				UserTag:  "user-alice",
+				Model:    "123",
+				Method:   "Deploy",
+				Offset:   10,
+				Limit:    10,
+				SortTime: false,
+			},
+			result: db.AuditLogFilter{
+				Start:       time.Date(2023, 8, 14, 0, 0, 0, 0, time.UTC),
+				End:         time.Date(2023, 8, 14, 0, 0, 0, 0, time.UTC),
+				IdentityTag: "user-alice",
+				Model:       "123",
+				Method:      "Deploy",
+				Offset:      10,
+				Limit:       10,
+				SortTime:    false,
+			},
+		}, {
+			about: "Test limit lower bound",
+			request: apiparams.FindAuditEventsRequest{
+				Limit: 0,
+			},
+			result: db.AuditLogFilter{
+				Limit: jujuapi.AuditLogDefaultLimit,
+			},
+		}, {
+			about: "Test limit upper bound",
+			request: apiparams.FindAuditEventsRequest{
+				Limit: jujuapi.AuditLogUpperLimit + 1,
+			},
+			result: db.AuditLogFilter{
+				Limit: jujuapi.AuditLogUpperLimit,
+			},
+		},
+	}
+	for _, test := range testCases {
+		c.Log(test.about)
+		res, err := jujuapi.AuditParamsToFilter(test.request)
+		if test.err == nil {
+			c.Assert(err, qt.IsNil)
+			c.Assert(res, qt.DeepEquals, test.result)
+		} else {
+			c.Assert(err, qt.ErrorMatches, test.err)
+		}
+	}
 }

--- a/internal/testutils/jimmtest/e2e_suite.go
+++ b/internal/testutils/jimmtest/e2e_suite.go
@@ -45,11 +45,11 @@ const (
 // ControllerInfo holds the controller connection information
 // retrieved from the configuration file.
 type ControllerInfo struct {
-	UUID     string `yaml:"uuid"`
-	Addrs    string `yaml:"addrs"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	CACert   string `yaml:"ca-cert"`
+	UUID     string   `yaml:"uuid"`
+	Addrs    []string `yaml:"addrs"`
+	Username string   `yaml:"username"`
+	Password string   `yaml:"password"`
+	CACert   string   `yaml:"ca-cert"`
 }
 
 // ControllersConfig holds the top-level structure of the controller.yaml file.
@@ -59,7 +59,7 @@ type ControllersConfig struct {
 
 // GetControllersConfig reads and parses the controller.yaml configuration file
 // from the path specified in the JIMM_BACKING_CONTROLLER_CONFIG environment variable.
-func GetControllersConfig(c *gc.C) *ControllersConfig {
+func (s *E2ESuite) GetControllersConfig(c *gc.C) *ControllersConfig {
 	configPath := os.Getenv(ControllersConfigEnvVar)
 	c.Assert(configPath, gc.Not(gc.Equals), "", gc.Commentf(
 		"%s environment variable is not set. "+
@@ -80,10 +80,22 @@ func GetControllersConfig(c *gc.C) *ControllersConfig {
 	return &config
 }
 
+// GetOneControllerConfig retrieves one controller configuration
+// from the controllers config file. It can be used in tests when
+// a valid controller config is needed.
+func (s *E2ESuite) GetOneControllerConfig(c *gc.C) (string, ControllerInfo) {
+	config := s.GetControllersConfig(c)
+	for name, info := range config.Controllers {
+		return name, info
+	}
+	c.Fatal("no controllers found in config")
+	return "", ControllerInfo{}
+}
+
 // Validate asserts that all required fields are set for this controller.
 func (info *ControllerInfo) Validate(c *gc.C, name string) {
 	c.Assert(info.UUID, gc.Not(gc.Equals), "", gc.Commentf("uuid is not set for controller %q", name))
-	c.Assert(info.Addrs, gc.Not(gc.Equals), "", gc.Commentf("addrs is not set for controller %q", name))
+	c.Assert(len(info.Addrs), gc.Not(gc.Equals), 0, gc.Commentf("addrs is not set for controller %q", name))
 	c.Assert(info.Username, gc.Not(gc.Equals), "", gc.Commentf("username is not set for controller %q", name))
 	c.Assert(info.Password, gc.Not(gc.Equals), "", gc.Commentf("password is not set for controller %q", name))
 	c.Assert(info.CACert, gc.Not(gc.Equals), "", gc.Commentf("ca-cert is not set for controller %q", name))
@@ -93,7 +105,7 @@ func (info *ControllerInfo) Validate(c *gc.C, name string) {
 func (info *ControllerInfo) ToAPIInfo() *api.Info {
 	return &api.Info{
 		ControllerUUID: info.UUID,
-		Addrs:          []string{info.Addrs},
+		Addrs:          info.Addrs,
 		Tag:            names.NewUserTag(info.Username),
 		Password:       info.Password,
 		CACert:         info.CACert,
@@ -291,7 +303,7 @@ func (s *E2ESuite) SetUpTest(c *gc.C) {
 	s.LoggingSuite.SetUpTest(c)
 
 	// Add all controllers from the config file
-	config := GetControllersConfig(c)
+	config := s.GetControllersConfig(c)
 	for name, info := range config.Controllers {
 		info.Validate(c, name)
 		controller := s.AddController(c, name, info.ToAPIInfo())

--- a/local/backing_test_controller/generate.sh
+++ b/local/backing_test_controller/generate.sh
@@ -39,8 +39,8 @@ echo "Extracting controller configuration for: ${CONTROLLER}"
 # Get controller UUID
 CONTROLLER_UUID=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}.details.controller-uuid")
 
-# Get controller API addresses (first one with port)
-CONTROLLER_ADDRS=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}.details.\"api-endpoints\"[0]")
+# Get all controller API addresses as a JSON array
+CONTROLLER_ADDRS=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}.details.\"api-endpoints\" | @json")
 
 # Get username and password from accounts.yaml
 CONTROLLER_USERNAME=$(cat ~/.local/share/juju/accounts.yaml | yq -r ".controllers.${CONTROLLER}.user")
@@ -53,7 +53,7 @@ CONTROLLER_CACERT=$(juju show-controller "${CONTROLLER}" | yq -r ".${CONTROLLER}
 export CONTROLLER CONTROLLER_UUID CONTROLLER_ADDRS CONTROLLER_USERNAME CONTROLLER_PASSWORD CONTROLLER_CACERT
 yq -n '
   .controllers.[strenv(CONTROLLER)].uuid = strenv(CONTROLLER_UUID) |
-  .controllers.[strenv(CONTROLLER)].addrs = strenv(CONTROLLER_ADDRS) |
+  .controllers.[strenv(CONTROLLER)].addrs = (strenv(CONTROLLER_ADDRS) | fromjson) |
   .controllers.[strenv(CONTROLLER)].username = strenv(CONTROLLER_USERNAME) |
   .controllers.[strenv(CONTROLLER)].password = strenv(CONTROLLER_PASSWORD) |
   .controllers.[strenv(CONTROLLER)]."ca-cert" = strenv(CONTROLLER_CACERT)

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -1,24 +1,22 @@
 // Copyright 2025 Canonical.
 
-package jujuapi_test
+package testing
 
 import (
 	"context"
-	"testing"
+	"slices"
 	"time"
 
-	qt "github.com/frankban/quicktest"
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/network"
 	jujuparams "github.com/juju/juju/rpc/params"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
@@ -27,59 +25,65 @@ import (
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/pkg/api"
+
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 type jimmSuite struct {
-	websocketSuite
+	jimmtest.WebsocketE2ESuite
 }
 
 var _ = gc.Suite(&jimmSuite{})
 
 func (s *jimmSuite) TestListControllersAdmin(c *gc.C) {
-	s.AddController(c, "controller-0", s.APIInfo(c))
-	s.AddController(c, "controller-2", s.APIInfo(c))
-
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
 	cis, err := client.ListControllers()
 	c.Assert(err, gc.Equals, nil)
-	c.Check(cis, jc.DeepEquals, []apiparams.ControllerInfo{{
-		Name:          "controller-0",
-		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
-		Status: jujuparams.EntityStatus{
-			Status: "available",
-		},
-	}, {
-		Name:          "controller-1",
-		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
-		Status: jujuparams.EntityStatus{
-			Status: "available",
-		},
-	}, {
-		Name:          "controller-2",
-		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
-		Status: jujuparams.EntityStatus{
-			Status: "available",
-		},
-	}})
+	confs := s.GetControllersConfig(c)
+	controllerInfos := make([]apiparams.ControllerInfo, 0, len(confs.Controllers))
+	for name, conf := range confs.Controllers {
+		controllerInfos = append(controllerInfos, apiparams.ControllerInfo{
+			Name:          name,
+			UUID:          conf.UUID,
+			APIAddresses:  conf.ToAPIInfo().Addrs,
+			CACertificate: conf.ToAPIInfo().CACert,
+			CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+			CloudRegion:   jimmtest.TestE2ECloudRegionName,
+			Status: jujuparams.EntityStatus{
+				Status: "available",
+			},
+		})
+	}
+
+	assertControllerInfos(c, cis, controllerInfos, confs)
+}
+
+// assertControllerInfos verifies that the controller infos match expectations, including API addresses.
+func assertControllerInfos(c *gc.C, actual []apiparams.ControllerInfo, expected []apiparams.ControllerInfo, confs *jimmtest.ControllersConfig) {
+	c.Check(actual, jimmtest.CmpEquals(
+		cmpopts.IgnoreFields(apiparams.ControllerInfo{}, "AgentVersion", "APIAddresses"),
+		cmpopts.SortSlices(func(a, b apiparams.ControllerInfo) bool {
+			return a.UUID < b.UUID
+		}),
+	), expected)
+
+	// Verify all configured addresses are present in the response
+	for _, ci := range actual {
+		for name, conf := range confs.Controllers {
+			if conf.UUID == ci.UUID {
+				expectedAddrs := conf.ToAPIInfo().Addrs
+				for _, expectedAddr := range expectedAddrs {
+					found := slices.Contains(ci.APIAddresses, expectedAddr)
+					c.Assert(found, gc.Equals, true, gc.Commentf(
+						"controller %q: expected address %q not found in APIAddresses %v",
+						name, expectedAddr, ci.APIAddresses))
+				}
+			}
+		}
+	}
 }
 
 func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
@@ -88,19 +92,19 @@ func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
 	ctrl0 := &dbmodel.Controller{
 		Name:      "dummy-0",
 		UUID:      "00000001-0000-0000-0000-000000000000",
-		CloudName: "dummy",
+		CloudName: jimmtest.TestE2ECloudName,
 	}
 
 	ctrl1 := &dbmodel.Controller{
 		Name:      "dummy-1",
 		UUID:      "00000001-0000-0000-0000-000000000001",
-		CloudName: "dummy",
+		CloudName: jimmtest.TestE2ECloudName,
 	}
 
 	ctrl2 := &dbmodel.Controller{
 		Name:      "dummy-2",
 		UUID:      "00000001-0000-0000-0000-000000000002",
-		CloudName: "dummy",
+		CloudName: jimmtest.TestE2ECloudName,
 	}
 
 	err := s.JIMM.Database.AddController(ctx, ctrl0)
@@ -127,7 +131,7 @@ func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
 	err = openfgaUser.SetControllerAccess(ctx, names.NewControllerTag(ctrl2.UUID), ofganames.CanAddModelRelation)
 	c.Assert(err, gc.IsNil)
 
-	conn := s.open(c, nil, "alex@canonical.com")
+	conn := s.Open(c, nil, "alex@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -137,7 +141,7 @@ func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
 		{
 			Name:     "dummy-0",
 			UUID:     "00000001-0000-0000-0000-000000000000",
-			CloudTag: "cloud-dummy",
+			CloudTag: names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
 			Status: jujuparams.EntityStatus{
 				Status: "available",
 			},
@@ -145,7 +149,7 @@ func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
 		{
 			Name:     "dummy-2",
 			UUID:     "00000001-0000-0000-0000-000000000002",
-			CloudTag: "cloud-dummy",
+			CloudTag: names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
 			Status: jujuparams.EntityStatus{
 				Status: "available",
 			},
@@ -154,10 +158,7 @@ func (s *jimmSuite) TestListControllersOrdinaryUser(c *gc.C) {
 }
 
 func (s *jimmSuite) TestListControllersUnauthorized(c *gc.C) {
-	s.AddController(c, "controller-0", s.APIInfo(c))
-	s.AddController(c, "controller-2", s.APIInfo(c))
-
-	conn := s.open(c, nil, "abrandnewuserwithnopermissions")
+	conn := s.Open(c, nil, "abrandnewuserwithnopermissions", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -167,9 +168,11 @@ func (s *jimmSuite) TestListControllersUnauthorized(c *gc.C) {
 }
 
 func (s *jimmSuite) TestAddControllerPublicAddressWithoutPort(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
+
+	_, conf := s.GetOneControllerConfig(c)
 
 	tests := []struct {
 		req           apiparams.AddControllerRequest
@@ -178,21 +181,21 @@ func (s *jimmSuite) TestAddControllerPublicAddressWithoutPort(c *gc.C) {
 		req: apiparams.AddControllerRequest{
 			Name:          "controller-2",
 			PublicAddress: "controller.test.com",
-			CACertificate: s.APIInfo(c).CACert,
+			CACertificate: conf.ToAPIInfo().CACert,
 		},
 		expectedError: `address controller.test.com: missing port in address \(bad request\)`,
 	}, {
 		req: apiparams.AddControllerRequest{
 			Name:          "controller-2",
 			PublicAddress: ":8080",
-			CACertificate: s.APIInfo(c).CACert,
+			CACertificate: conf.ToAPIInfo().CACert,
 		},
 		expectedError: `address :8080: host not specified in public address \(bad request\)`,
 	}, {
 		req: apiparams.AddControllerRequest{
 			Name:          "controller-2",
 			PublicAddress: "localhost:",
-			CACertificate: s.APIInfo(c).CACert,
+			CACertificate: conf.ToAPIInfo().CACert,
 		},
 		expectedError: `address localhost:: port not specified in public address \(bad request\)`,
 	}}
@@ -205,41 +208,43 @@ func (s *jimmSuite) TestAddControllerPublicAddressWithoutPort(c *gc.C) {
 }
 
 func (s *jimmSuite) TestAddController(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
-
-	info := s.APIInfo(c)
+	_, conf := s.GetOneControllerConfig(c)
+	info := conf.ToAPIInfo()
 
 	acr := apiparams.AddControllerRequest{
 		UUID:          info.ControllerUUID,
 		Name:          "controller-2",
 		APIAddresses:  info.Addrs,
 		CACertificate: info.CACert,
+		TLSHostname:   "juju-apiserver",
 		Username:      info.Tag.Id(),
 		Password:      info.Password,
 	}
 
 	ci, err := client.AddController(&acr)
 	c.Assert(err, gc.Equals, nil)
-	c.Assert(ci, jc.DeepEquals, apiparams.ControllerInfo{
-		Name:          "controller-2",
-		UUID:          info.ControllerUUID,
-		APIAddresses:  info.Addrs,
-		CACertificate: info.CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
+	ciExpected := apiparams.ControllerInfo{
+		Name:          acr.Name,
+		UUID:          acr.UUID,
+		CACertificate: acr.CACertificate,
+		APIAddresses:  acr.APIAddresses,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		Status: jujuparams.EntityStatus{
 			Status: "available",
 		},
-	})
+	}
+
+	assertControllerInfos(c, []apiparams.ControllerInfo{ci}, []apiparams.ControllerInfo{ciExpected}, s.GetControllersConfig(c))
 
 	_, err = client.AddController(&acr)
 	c.Assert(err, gc.ErrorMatches, `failed to add controller: controller "controller-2" already exists \(already exists\)`)
 	c.Assert(jujuparams.IsCodeAlreadyExists(err), gc.Equals, true)
 
-	conn = s.open(c, nil, "bob")
+	conn = s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client = api.NewClient(conn)
 	acr.Name = "controller-2"
@@ -254,17 +259,19 @@ func (s *jimmSuite) TestAddController(c *gc.C) {
 }
 
 func (s *jimmSuite) TestRemoveAndAddController(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
-	info := s.APIInfo(c)
+	_, conf := s.GetOneControllerConfig(c)
+	info := conf.ToAPIInfo()
 
 	acr := apiparams.AddControllerRequest{
 		UUID:          info.ControllerUUID,
 		Name:          "controller-2",
 		APIAddresses:  info.Addrs,
 		CACertificate: info.CACert,
+		TLSHostname:   "juju-apiserver",
 		Username:      info.Tag.Id(),
 		Password:      info.Password,
 	}
@@ -276,15 +283,15 @@ func (s *jimmSuite) TestRemoveAndAddController(c *gc.C) {
 	ciNew, err := client.AddController(&acr)
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(ci, gc.DeepEquals, ciNew)
-
 }
 
 func (s *jimmSuite) TestAddControllerCustomTLSHostname(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
-	info := s.APIInfo(c)
+	_, conf := s.GetOneControllerConfig(c)
+	info := conf.ToAPIInfo()
 
 	acr := apiparams.AddControllerRequest{
 		UUID:          info.ControllerUUID,
@@ -301,101 +308,105 @@ func (s *jimmSuite) TestAddControllerCustomTLSHostname(c *gc.C) {
 	acr.TLSHostname = "juju-apiserver"
 	ci, err := client.AddController(&acr)
 	c.Assert(err, gc.IsNil)
-	c.Assert(ci, jc.DeepEquals, apiparams.ControllerInfo{
-		Name:          "controller-2",
-		UUID:          info.ControllerUUID,
-		APIAddresses:  info.Addrs,
-		CACertificate: info.CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
+	ciExpected := apiparams.ControllerInfo{
+		Name:          acr.Name,
+		UUID:          acr.UUID,
+		CACertificate: acr.CACertificate,
+		APIAddresses:  acr.APIAddresses,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		Status: jujuparams.EntityStatus{
 			Status: "available",
 		},
-	})
-
+	}
+	assertControllerInfos(c, []apiparams.ControllerInfo{ci}, []apiparams.ControllerInfo{ciExpected}, s.GetControllersConfig(c))
 }
 
 func (s *jimmSuite) TestRemoveController(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
+	name, conf := s.GetOneControllerConfig(c)
+
 	_, err := client.RemoveController(&apiparams.RemoveControllerRequest{
-		Name: "controller-1",
+		Name: name,
 	})
 	c.Check(err, gc.ErrorMatches, `controller is still alive \(still alive\)`)
 	c.Check(jujuparams.ErrCode(err), gc.Equals, apiparams.CodeStillAlive)
 
-	conn2 := s.open(c, nil, "bob")
+	conn2 := s.Open(c, nil, "bob", nil)
 	defer conn2.Close()
 	client2 := api.NewClient(conn2)
 
 	_, err = client2.RemoveController(&apiparams.RemoveControllerRequest{
-		Name: "controller-1",
+		Name: name,
 	})
 	c.Check(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
 	c.Check(jujuparams.ErrCode(err), gc.Equals, jujuparams.CodeUnauthorized)
 
 	ci, err := client.RemoveController(&apiparams.RemoveControllerRequest{
-		Name:  "controller-1",
+		Name:  name,
 		Force: true,
 	})
 	c.Assert(err, gc.Equals, nil)
-	c.Check(ci, jc.DeepEquals, apiparams.ControllerInfo{
-		Name:          "controller-1",
+	ciExpected := apiparams.ControllerInfo{
+		Name:          name,
 		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
+		APIAddresses:  conf.ToAPIInfo().Addrs,
+		CACertificate: conf.ToAPIInfo().CACert,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		Status: jujuparams.EntityStatus{
 			Status: "available",
 		},
-	})
+	}
+	assertControllerInfos(c, []apiparams.ControllerInfo{ci}, []apiparams.ControllerInfo{ciExpected}, s.GetControllersConfig(c))
 }
 
 func (s *jimmSuite) TestSetControllerDeprecated(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
+	name, conf := s.GetOneControllerConfig(c)
+
 	ci, err := client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
-		Name:       "controller-1",
+		Name:       name,
 		Deprecated: true,
 	})
 	c.Assert(err, gc.Equals, nil)
-	c.Check(ci, jc.DeepEquals, apiparams.ControllerInfo{
-		Name:          "controller-1",
+	ciExpected := apiparams.ControllerInfo{
+		Name:          name,
 		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
-		AgentVersion:  s.Model.Controller.AgentVersion,
+		APIAddresses:  conf.ToAPIInfo().Addrs,
+		CACertificate: conf.ToAPIInfo().CACert,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		Status: jujuparams.EntityStatus{
 			Status: "deprecated",
 		},
-	})
+	}
+	assertControllerInfos(c, []apiparams.ControllerInfo{ci}, []apiparams.ControllerInfo{ciExpected}, s.GetControllersConfig(c))
 
 	ci, err = client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
-		Name:       "controller-1",
+		Name:       name,
 		Deprecated: false,
 	})
 	c.Assert(err, gc.Equals, nil)
-	c.Check(ci, jc.DeepEquals, apiparams.ControllerInfo{
-		Name:          "controller-1",
+	ciExpected = apiparams.ControllerInfo{
+		Name:          name,
 		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
+		APIAddresses:  conf.ToAPIInfo().Addrs,
+		CACertificate: conf.ToAPIInfo().CACert,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		AgentVersion:  s.Model.Controller.AgentVersion,
 		Status: jujuparams.EntityStatus{
 			Status: "available",
 		},
-	})
+	}
+	assertControllerInfos(c, []apiparams.ControllerInfo{ci}, []apiparams.ControllerInfo{ciExpected}, s.GetControllersConfig(c))
 
 	_, err = client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
 		Name:       "controller-2",
@@ -404,7 +415,7 @@ func (s *jimmSuite) TestSetControllerDeprecated(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `controller not found \(not found\)`)
 	c.Check(jujuparams.IsCodeNotFound(err), gc.Equals, true)
 
-	conn = s.open(c, nil, "bob")
+	conn = s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client = api.NewClient(conn)
 	_, err = client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
@@ -416,7 +427,7 @@ func (s *jimmSuite) TestSetControllerDeprecated(c *gc.C) {
 }
 
 func (s *jimmSuite) TestAuditLog(c *gc.C) {
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -429,7 +440,7 @@ func (s *jimmSuite) TestAuditLog(c *gc.C) {
 	err = mmclient.DestroyModel(s.Model.ResourceTag(), nil, nil, nil, &zeroDuration)
 	c.Assert(err, gc.Equals, nil)
 
-	conn2 := s.open(c, nil, "alice")
+	conn2 := s.Open(c, nil, "alice", nil)
 	defer conn2.Close()
 	client2 := api.NewClient(conn2)
 
@@ -503,7 +514,7 @@ func (s *jimmSuite) TestAuditLog(c *gc.C) {
 	c.Assert(err, gc.Equals, nil)
 
 	// now bob can access audit events as well
-	conn3 := s.open(c, nil, "bob")
+	conn3 := s.Open(c, nil, "bob", nil)
 	defer conn3.Close()
 	client3 := api.NewClient(conn3)
 
@@ -514,7 +525,7 @@ func (s *jimmSuite) TestAuditLog(c *gc.C) {
 }
 
 func (s *jimmSuite) TestAuditLogFilterByMethod(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	evs, err := client.FindAuditEvents(&apiparams.FindAuditEventsRequest{Method: "Deploy"})
@@ -522,73 +533,18 @@ func (s *jimmSuite) TestAuditLogFilterByMethod(c *gc.C) {
 	c.Assert(len(evs.Events), gc.Equals, 0)
 }
 
-// TestAuditLogAPIParamsConversion tests the conversion of API params to a AuditLogFilter struct.
-// Note that this test doesn't require a running Juju/JIMM controller so it doesn't use gc + the jimmSuite.
-func TestAuditLogAPIParamsConversion(t *testing.T) {
-	c := qt.New(t)
-	testCases := []struct {
-		about   string
-		request apiparams.FindAuditEventsRequest
-		result  db.AuditLogFilter
-		err     error
-	}{
-		{
-			about: "Test basic conversion",
-			request: apiparams.FindAuditEventsRequest{
-				After:    "2023-08-14T00:00:00Z",
-				Before:   "2023-08-14T00:00:00Z",
-				UserTag:  "user-alice",
-				Model:    "123",
-				Method:   "Deploy",
-				Offset:   10,
-				Limit:    10,
-				SortTime: false,
-			},
-			result: db.AuditLogFilter{
-				Start:       time.Date(2023, 8, 14, 0, 0, 0, 0, time.UTC),
-				End:         time.Date(2023, 8, 14, 0, 0, 0, 0, time.UTC),
-				IdentityTag: "user-alice",
-				Model:       "123",
-				Method:      "Deploy",
-				Offset:      10,
-				Limit:       10,
-				SortTime:    false,
-			},
-		}, {
-			about: "Test limit lower bound",
-			request: apiparams.FindAuditEventsRequest{
-				Limit: 0,
-			},
-			result: db.AuditLogFilter{
-				Limit: jujuapi.AuditLogDefaultLimit,
-			},
-		}, {
-			about: "Test limit upper bound",
-			request: apiparams.FindAuditEventsRequest{
-				Limit: jujuapi.AuditLogUpperLimit + 1,
-			},
-			result: db.AuditLogFilter{
-				Limit: jujuapi.AuditLogUpperLimit,
-			},
-		},
-	}
-	for _, test := range testCases {
-		c.Log(test.about)
-		res, err := jujuapi.AuditParamsToFilter(test.request)
-		if test.err == nil {
-			c.Assert(err, qt.IsNil)
-			c.Assert(res, qt.DeepEquals, test.result)
-		} else {
-			c.Assert(err, qt.ErrorMatches, test.err)
-		}
-	}
-}
-
 func (s *jimmSuite) TestFullModelStatus(c *gc.C) {
-	s.AddController(c, "controller-2", s.APIInfo(c))
-	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-1", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, s.Model2.CloudCredential.ResourceTag())
+	_, conf := s.GetOneControllerConfig(c)
 
-	conn := s.open(c, nil, "bob")
+	s.AddController(c, "controller-2", conf.ToAPIInfo())
+	modelName := petname.Generate(2, "-")
+	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"),
+		modelName,
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
+		s.Model2.CloudCredential.ResourceTag())
+
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -602,7 +558,7 @@ func (s *jimmSuite) TestFullModelStatus(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, "unauthorized.*")
 
-	conn = s.open(c, nil, "alice@canonical.com")
+	conn = s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client = api.NewClient(conn)
 
@@ -610,49 +566,56 @@ func (s *jimmSuite) TestFullModelStatus(c *gc.C) {
 		ModelTag: mt.String(),
 	})
 	c.Assert(err, gc.Equals, nil)
-	c.Assert(status, jimmtest.CmpEquals(cmpopts.EquateEmpty(), cmpopts.IgnoreTypes(&time.Time{})), jujuparams.FullStatus{
-		Model: jujuparams.ModelStatusInfo{
-			Name:        "model-1",
-			Type:        "iaas",
-			CloudTag:    names.NewCloudTag(jimmtest.TestCloudName).String(),
-			CloudRegion: jimmtest.TestCloudRegionName,
-			Version:     jujuversion.Current.String(),
-			ModelStatus: jujuparams.DetailedStatus{
-				Status: "available",
+	c.Assert(status,
+		jimmtest.CmpEquals(
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreTypes(&time.Time{}),
+			cmpopts.IgnoreFields(jujuparams.ModelStatusInfo{}, "Version"),
+		),
+		jujuparams.FullStatus{
+			Model: jujuparams.ModelStatusInfo{
+				Name:        modelName,
+				Type:        "iaas",
+				CloudTag:    names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+				CloudRegion: jimmtest.TestE2ECloudRegionName,
+				ModelStatus: jujuparams.DetailedStatus{
+					Status: "available",
+				},
+				SLA: "unsupported",
 			},
-			SLA: "unsupported",
-		},
-	})
+		})
 }
 
 func (s *jimmSuite) TestUpdateMigratedModel(c *gc.C) {
-	s.AddController(c, "controller-2", s.APIInfo(c))
+	name, conf := s.GetOneControllerConfig(c)
+
+	s.AddController(c, "controller-2", conf.ToAPIInfo())
 
 	// Open the API connection as user "bob".
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 
 	req := apiparams.UpdateMigratedModelRequest{
 		ModelTag:         names.NewModelTag(s.Model2.UUID.String).String(),
-		TargetController: "controller-1",
+		TargetController: name,
 	}
 	err := conn.APICall("JIMM", 4, "", "UpdateMigratedModel", &req, nil)
 	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
 
 	// Open the API connection as user "alice".
-	conn = s.open(c, nil, "alice")
+	conn = s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	req = apiparams.UpdateMigratedModelRequest{
 		ModelTag:         names.NewModelTag(s.Model2.UUID.String).String(),
-		TargetController: "controller-1",
+		TargetController: name,
 	}
 	err = conn.APICall("JIMM", 4, "", "UpdateMigratedModel", &req, nil)
 	c.Assert(err, gc.Equals, nil)
 
 	req = apiparams.UpdateMigratedModelRequest{
 		ModelTag:         "invalid-model-tag",
-		TargetController: "controller-1",
+		TargetController: name,
 	}
 	err = conn.APICall("JIMM", 4, "", "UpdateMigratedModel", &req, nil)
 	c.Assert(err, gc.ErrorMatches, `"invalid-model-tag" is not a valid tag \(bad request\)`)
@@ -660,8 +623,10 @@ func (s *jimmSuite) TestUpdateMigratedModel(c *gc.C) {
 
 func (s *jimmSuite) TestImportModel(c *gc.C) {
 	// Open the API connection as user "bob".
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
+
+	name, _ := s.GetOneControllerConfig(c)
 
 	err := s.JIMM.OpenFGAClient.RemoveControllerModel(context.Background(), s.Model2.Controller.ResourceTag(), s.Model2.ResourceTag())
 	c.Assert(err, gc.Equals, nil)
@@ -669,7 +634,7 @@ func (s *jimmSuite) TestImportModel(c *gc.C) {
 	c.Assert(err, gc.Equals, nil)
 
 	req := apiparams.ImportModelRequest{
-		Controller: "controller-1",
+		Controller: name,
 		ModelTag:   s.Model2.Tag().String(),
 		Owner:      "",
 	}
@@ -677,7 +642,7 @@ func (s *jimmSuite) TestImportModel(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
 
 	// Open the API connection as user "alice".
-	conn = s.open(c, nil, "alice")
+	conn = s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	err = conn.APICall("JIMM", 4, "", "ImportModel", &req, nil)
@@ -690,7 +655,7 @@ func (s *jimmSuite) TestImportModel(c *gc.C) {
 	c.Check(model2.CreatedAt.After(s.Model2.CreatedAt), gc.Equals, true)
 
 	req = apiparams.ImportModelRequest{
-		Controller: "controller-1",
+		Controller: name,
 		ModelTag:   "invalid-model-tag",
 	}
 	err = conn.APICall("JIMM", 4, "", "ImportModel", &req, nil)
@@ -706,21 +671,24 @@ func (s *jimmSuite) TestAddCloudToController(c *gc.C) {
 	err = s.JIMM.Database.GetIdentity(ctx, u)
 	c.Assert(err, gc.IsNil)
 
-	conn := s.open(c, nil, "alice@canonical.com")
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
+	name, _ := s.GetOneControllerConfig(c)
+	cloudName := petname.Generate(2, "-")
+
 	req := apiparams.AddCloudToControllerRequest{
-		ControllerName: "controller-1",
+		ControllerName: name,
 		AddCloudArgs: jujuparams.AddCloudArgs{
-			Name: "test-cloud",
+			Name: cloudName,
 			Cloud: jujuapi.CloudToParams(cloud.Cloud{
-				Name:             "test-cloud",
+				Name:             cloudName,
 				Type:             "kubernetes",
 				AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
 				Endpoint:         "https://0.1.2.3:5678",
 				IdentityEndpoint: "https://0.1.2.3:5679",
 				StorageEndpoint:  "https://0.1.2.3:5680",
-				HostCloudRegion:  jimmtest.TestCloudName + "/" + jimmtest.TestCloudRegionName,
+				HostCloudRegion:  jimmtest.TestE2EProviderType + "/" + jimmtest.TestE2ECloudRegionName,
 			}),
 		},
 	}
@@ -729,10 +697,17 @@ func (s *jimmSuite) TestAddCloudToController(c *gc.C) {
 
 	user := openfga.NewUser(u, s.OFGAClient)
 
-	cloud, err := s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
+	cloud, err := s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, gc.IsNil)
-	c.Assert(cloud.Name, gc.DeepEquals, "test-cloud")
+	c.Assert(cloud.Name, gc.DeepEquals, cloudName)
 	c.Assert(cloud.Type, gc.DeepEquals, "kubernetes")
+
+	req1 := apiparams.RemoveCloudFromControllerRequest{
+		CloudTag:       names.NewCloudTag(cloudName).String(),
+		ControllerName: name,
+	}
+	err = conn.APICall("JIMM", 4, "", "RemoveCloudFromController", &req1, nil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *jimmSuite) TestAddExistingCloudToController(c *gc.C) {
@@ -744,16 +719,19 @@ func (s *jimmSuite) TestAddExistingCloudToController(c *gc.C) {
 	err = s.JIMM.Database.GetIdentity(ctx, u)
 	c.Assert(err, gc.IsNil)
 
-	conn := s.open(c, nil, "alice@canonical.com")
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
+	name, _ := s.GetOneControllerConfig(c)
+
+	cloudName := petname.Generate(2, "-")
 	force := true
 	req := apiparams.AddCloudToControllerRequest{
-		ControllerName: "controller-1",
+		ControllerName: name,
 		AddCloudArgs: jujuparams.AddCloudArgs{
-			Name: "test-cloud",
+			Name: cloudName,
 			Cloud: jujuapi.CloudToParams(cloud.Cloud{
-				Name:             "test-cloud",
+				Name:             cloudName,
 				Type:             "MAAS",
 				AuthTypes:        cloud.AuthTypes{cloud.OAuth1AuthType},
 				Endpoint:         "https://0.1.2.3:5678",
@@ -766,22 +744,30 @@ func (s *jimmSuite) TestAddExistingCloudToController(c *gc.C) {
 	err = conn.APICall("JIMM", 4, "", "AddCloudToController", &req, nil)
 	c.Assert(err, gc.Equals, nil)
 	user := openfga.NewUser(u, s.OFGAClient)
-	cloud, err := s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
+	cloud, err := s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, gc.IsNil)
-	c.Assert(cloud.Name, gc.DeepEquals, "test-cloud")
+	c.Assert(cloud.Name, gc.DeepEquals, cloudName)
 	c.Assert(cloud.Type, gc.DeepEquals, "MAAS")
 	// Simulate the cloud being present on the Juju controller but not in JIMM.
 	err = s.JIMM.Database.DeleteCloud(ctx, &cloud)
 	c.Assert(err, gc.IsNil)
-	cloud, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
+	cloud, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, gc.NotNil)
 	c.Assert(errors.ErrorCode(err), gc.Equals, errors.CodeNotFound)
 	err = conn.APICall("JIMM", 4, "", "AddCloudToController", &req, nil)
 	c.Assert(err, gc.Equals, nil)
-	cloud, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
+	cloud, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, gc.IsNil)
-	c.Assert(cloud.Name, gc.DeepEquals, "test-cloud")
+	c.Assert(cloud.Name, gc.DeepEquals, cloudName)
 	c.Assert(cloud.Type, gc.DeepEquals, "MAAS")
+
+	req1 := apiparams.RemoveCloudFromControllerRequest{
+		CloudTag:       names.NewCloudTag(cloudName).String(),
+		ControllerName: name,
+	}
+	err = conn.APICall("JIMM", 4, "", "RemoveCloudFromController", &req1, nil)
+	c.Assert(err, gc.Equals, nil)
+
 }
 
 func (s *jimmSuite) TestRemoveCloudFromController(c *gc.C) {
@@ -793,21 +779,23 @@ func (s *jimmSuite) TestRemoveCloudFromController(c *gc.C) {
 	err = s.JIMM.Database.GetIdentity(ctx, u)
 	c.Assert(err, gc.IsNil)
 
-	conn := s.open(c, nil, "alice@canonical.com")
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
+	name, _ := s.GetOneControllerConfig(c)
+	cloudName := petname.Generate(2, "-")
 	req := apiparams.AddCloudToControllerRequest{
-		ControllerName: "controller-1",
+		ControllerName: name,
 		AddCloudArgs: jujuparams.AddCloudArgs{
-			Name: "test-cloud",
+			Name: cloudName,
 			Cloud: jujuapi.CloudToParams(cloud.Cloud{
-				Name:             "test-cloud",
+				Name:             cloudName,
 				Type:             "kubernetes",
 				AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
 				Endpoint:         "https://0.1.2.3:5678",
 				IdentityEndpoint: "https://0.1.2.3:5679",
 				StorageEndpoint:  "https://0.1.2.3:5680",
-				HostCloudRegion:  jimmtest.TestCloudName + "/" + jimmtest.TestCloudRegionName,
+				HostCloudRegion:  jimmtest.TestE2EProviderType + "/" + jimmtest.TestE2ECloudRegionName,
 			}),
 		},
 	}
@@ -816,48 +804,49 @@ func (s *jimmSuite) TestRemoveCloudFromController(c *gc.C) {
 
 	user := openfga.NewUser(u, s.OFGAClient)
 
-	_, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
+	_, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, gc.Equals, nil)
 
 	req1 := apiparams.RemoveCloudFromControllerRequest{
-		CloudTag:       names.NewCloudTag("test-cloud").String(),
-		ControllerName: "controller-1",
+		CloudTag:       names.NewCloudTag(cloudName).String(),
+		ControllerName: name,
 	}
 	err = conn.APICall("JIMM", 4, "", "RemoveCloudFromController", &req1, nil)
 	c.Assert(err, gc.Equals, nil)
 
-	_, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag("test-cloud"))
-	c.Assert(err, gc.ErrorMatches, `cloud "test-cloud" not found`)
+	_, err = s.JIMM.JujuManager().GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
+	c.Assert(err, gc.ErrorMatches, `cloud "`+cloudName+`" not found`)
 }
 
 func (s *jimmSuite) TestCrossModelQuery(c *gc.C) {
-	s.AddController(c, "controller-2", s.APIInfo(c))
 	s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-20",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		petname.Generate(2, "-"),
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
+	model21Name := petname.Generate(2, "-")
 	s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-21",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		model21Name,
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
+	model22Name := petname.Generate(2, "-")
 	s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-22",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		model22Name,
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
 
-	conn := s.open(c, nil, "charlie")
+	conn := s.Open(c, nil, "charlie", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -896,7 +885,7 @@ func (s *jimmSuite) TestCrossModelQuery(c *gc.C) {
 	// Query for two very specific models
 	res, err = client.CrossModelQuery(&apiparams.CrossModelQueryRequest{
 		Type:  "jq",
-		Query: "select((.model.name==\"model-21\") or .model.name==\"model-22\")",
+		Query: "select((.model.name==\"" + model21Name + "\") or .model.name==\"" + model22Name + "\")",
 	})
 	c.Assert(err, gc.IsNil)
 	c.Assert(res.Results, gc.HasLen, 2)
@@ -907,23 +896,25 @@ func (s *jimmSuite) TestCrossModelQuery(c *gc.C) {
 // Because our test suite only spins up 1 controller the further we can go is reaching Juju pre-checks which
 // detect that a model with the same UUID already exists on the target controller.
 func (s *jimmSuite) TestJimmModelMigrationSuperuser(c *gc.C) {
+	modelName := petname.Generate(2, "-")
 	mt := s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-20",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		modelName,
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
 
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
+	name, _ := s.GetOneControllerConfig(c)
 	res, err := client.MigrateModel(&apiparams.MigrateModelRequest{
 		Specs: []apiparams.MigrateModelInfo{
-			{TargetModelNameOrUUID: mt.Id(), TargetController: "controller-1"},
-			{TargetModelNameOrUUID: "charlie@canonical.com/model-20", TargetController: "controller-1"},
+			{TargetModelNameOrUUID: mt.Id(), TargetController: name},
+			{TargetModelNameOrUUID: "charlie@canonical.com/" + modelName, TargetController: name},
 		},
 	})
 	c.Assert(err, gc.IsNil)
@@ -941,22 +932,23 @@ func (s *jimmSuite) TestJimmModelMigrationSuperuser(c *gc.C) {
 }
 
 func (s *jimmSuite) TestJimmModelMigrationNonSuperuser(c *gc.C) {
+	modelName := petname.Generate(2, "-")
 	mt := s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-20",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		modelName,
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
 
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
-
+	name, _ := s.GetOneControllerConfig(c)
 	res, err := client.MigrateModel(&apiparams.MigrateModelRequest{
 		Specs: []apiparams.MigrateModelInfo{
-			{TargetModelNameOrUUID: mt.Id(), TargetController: "controller-1"},
+			{TargetModelNameOrUUID: mt.Id(), TargetController: name},
 		},
 	})
 	c.Assert(err, gc.IsNil)
@@ -966,7 +958,7 @@ func (s *jimmSuite) TestJimmModelMigrationNonSuperuser(c *gc.C) {
 }
 
 func (s *jimmSuite) TestVersion(c *gc.C) {
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	versionInfo, err := client.Version()
@@ -976,12 +968,13 @@ func (s *jimmSuite) TestVersion(c *gc.C) {
 }
 
 func (s *jimmSuite) TestPrepareModelMigration(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
+	_, conf := s.GetOneControllerConfig(c)
 
 	ctlName := "prepare-model-migration-controller"
-	s.AddController(c, ctlName, s.APIInfo(c))
+	s.AddController(c, ctlName, conf.ToAPIInfo())
 
 	migrationToken, err := client.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
 		ModelTag:              names.NewModelTag("5650ac3f-8332-437f-874f-089e0e447e7f").String(),
@@ -997,21 +990,23 @@ func (s *jimmSuite) TestListMigrationTargets(c *gc.C) {
 	mt := s.AddModel(
 		c,
 		names.NewUserTag("charlie@canonical.com"),
-		"model-0",
-		names.NewCloudTag(jimmtest.TestCloudName),
-		jimmtest.TestCloudRegionName,
+		petname.Generate(2, "-"),
+		names.NewCloudTag(jimmtest.TestE2ECloudName),
+		jimmtest.TestE2ECloudRegionName,
 		s.Model2.CloudCredential.ResourceTag(),
 	)
 
 	// Add migration target controller
-	info := s.APIInfo(c)
+	_, conf := s.GetOneControllerConfig(c)
+	info := conf.ToAPIInfo()
 	ctl := &dbmodel.Controller{
 		UUID:          info.ControllerUUID,
 		Name:          "controller-2",
 		CACertificate: info.CACert,
 		Addresses:     nil,
-		CloudName:     jimmtest.TestCloudName,
-		CloudRegion:   jimmtest.TestCloudRegionName,
+		CloudName:     jimmtest.TestE2ECloudName,
+		TLSHostname:   "juju-apiserver",
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 	}
 	ctlCreds := juju.ControllerCreds{
 		AdminIdentityName: info.Tag.Id(),
@@ -1029,7 +1024,7 @@ func (s *jimmSuite) TestListMigrationTargets(c *gc.C) {
 	err := s.JIMM.JujuManager().AddController(context.Background(), s.AdminUser, ctl, ctlCreds)
 	c.Assert(err, gc.Equals, nil)
 
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1037,23 +1032,26 @@ func (s *jimmSuite) TestListMigrationTargets(c *gc.C) {
 		ModelTag: mt.String(),
 	})
 	c.Assert(err, gc.Equals, nil)
-	c.Check(cis, jc.DeepEquals, []apiparams.ControllerInfo{{
+
+	expectedControllerInfo := []apiparams.ControllerInfo{{
 		Name:          "controller-2",
 		UUID:          s.Model.Controller.UUID,
-		APIAddresses:  s.APIInfo(c).Addrs,
-		CACertificate: s.APIInfo(c).CACert,
-		CloudTag:      names.NewCloudTag(jimmtest.TestCloudName).String(),
-		CloudRegion:   jimmtest.TestCloudRegionName,
+		APIAddresses:  info.Addrs,
+		CACertificate: info.CACert,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
 		AgentVersion:  s.Model.Controller.AgentVersion,
 		Status: jujuparams.EntityStatus{
 			Status: "available",
 		},
-	}})
+	}}
+
+	assertControllerInfos(c, cis, expectedControllerInfo, s.GetControllersConfig(c))
 }
 
 // TestUpgradeTo_Unauthorized verifies non-admins cannot call the facade.
 func (s *jimmSuite) TestUpgradeTo_Unauthorized(c *gc.C) {
-	conn := s.open(c, nil, "bob")
+	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1068,7 +1066,7 @@ func (s *jimmSuite) TestUpgradeTo_Unauthorized(c *gc.C) {
 
 // TestUpgradeTo_InvalidModelTag verifies invalid model tags are rejected.
 func (s *jimmSuite) TestUpgradeTo_InvalidModelTag(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1082,7 +1080,7 @@ func (s *jimmSuite) TestUpgradeTo_InvalidModelTag(c *gc.C) {
 
 // TestUpgradeTo_InvalidVersion verifies invalid version strings are rejected.
 func (s *jimmSuite) TestUpgradeTo_InvalidVersion(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1096,7 +1094,7 @@ func (s *jimmSuite) TestUpgradeTo_InvalidVersion(c *gc.C) {
 
 // TestUpgradeTo_TargetVersionLowerOrEqual ensures we return a success=false response when the target is <= current.
 func (s *jimmSuite) TestUpgradeTo_TargetVersionLower(c *gc.C) {
-	conn := s.open(c, nil, "alice")
+	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)


### PR DESCRIPTION
# Description

In this pr i migrate the jimmSuite to the new websocketE2ESuite.

To do so we need to do some adjustments:
- modelName and cloudName are not hardcoded but generated with `petname`, to make sure we can then parallelize these tests in the future
- change the `controllers.yaml` file to contain all ip addresses for a controller
- change the assert func to check for controller info to check all the expected addrs are present in the response. We need a custom assert function because JIMM is setting controller addresses from the response from the Juju controller, which contains 127.0.0.1 and :: we want to exclude from the comparison. 