### PR TITLE
ci: grant all users with access to backing controller

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -175,6 +175,10 @@ runs:
         JIMM_CONTROLLER_NAME: "jimm"
         CONTROLLER_NAME: ${{ steps.lxd-controller.outputs.name }}
 
+    - name: Grant all users with add-model access to backing controller
+      run: juju jaas add-permission user-everyone@external can_addmodel controller-${{ steps.lxd-controller.outputs.name }}
+      shell: bash
+
     - name: Provide service account with cloud-credentials
       run: ./local/jimm/setup-service-account.sh
       working-directory: ${{ github.action_path }}/../../..

--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -9,6 +9,10 @@ on:
     # Run twice a week: Mondays and Wednesdays at 03:00 UTC
     - cron: '0 3 * * 1,3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-dashboard:
     name: Test JIMM with the Juju dashboard


### PR DESCRIPTION
## Description
This PR fixes our failing dashboard integration tests by granting all users with add-model access to the backing controller. This preserves existing behavior for users of our setup-jimm action.

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests