### PR TITLE
chore: use the detect-jaas script to reliably execute JAAS commands

### DIFF
--- a/.github/actions/test-server/action.yaml
+++ b/.github/actions/test-server/action.yaml
@@ -176,8 +176,11 @@ runs:
         CONTROLLER_NAME: ${{ steps.lxd-controller.outputs.name }}
 
     - name: Grant all users with add-model access to backing controller
-      run: juju jaas add-permission user-everyone@external can_addmodel controller-${{ steps.lxd-controller.outputs.name }}
+      run: ./local/jimm/grant-controller-access.sh
+      working-directory: ${{ github.action_path }}/../../..
       shell: bash
+      env:
+        CONTROLLER_NAME: ${{ steps.lxd-controller.outputs.name }}
 
     - name: Provide service account with cloud-credentials
       run: ./local/jimm/setup-service-account.sh

--- a/local/jimm/grant-controller-access.sh
+++ b/local/jimm/grant-controller-access.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script is used to grant all users with access to a controller
+# in JAAS, this is useful for CI where we want to allow all users
+# to add models to a backing controller.
+
+set -eux
+
+# Source the `JAAS` variable for executing jaas commands.
+source "$(dirname "${BASH_SOURCE[0]}")/detect-jaas.sh"
+
+$JAAS add-permission user-everyone@external can_addmodel controller-"$CONTROLLER_NAME"


### PR DESCRIPTION
## Description
This PR tweaks the changes in https://github.com/canonical/jimm/pull/1770 which modified our `test-server` action to grant all users with access to a backing JAAS controller by running `juju jaas ...`. As it turns out, this is not the right way to do it because depending on the environment in which the action runs, the Juju CLI may be available as a Snap or built locally (in cases where this action is running in the Juju repo and the Juju CLI is built from source).

The right thing to do is to utilise the `detect-jaas.sh` script which handles these intricacies.
