### PR TITLE
fix: e2e suite DeployApplication on non-amd64 architectures

### DIFF
--- a/internal/testutils/jimmtest/e2e_suite.go
+++ b/internal/testutils/jimmtest/e2e_suite.go
@@ -11,12 +11,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"runtime"
 	"sync"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/go-chi/chi/v5"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/application"
+	"github.com/juju/juju/core/constraints"
 	jclient "github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/jsoncodec"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -206,8 +208,9 @@ func (s *WebsocketE2ESuite) DeployApplication(c *gc.C, user *openfga.User, model
 		ApplicationName: appName,
 		Channel:         utils.Ptr("latest/stable"),
 		NumUnits:        utils.Ptr(1),
+		Cons:            constraints.Value{Arch: utils.Ptr(runtime.GOARCH)},
 	})
-	for err := range errs {
+	for _, err := range errs {
 		c.Assert(err, gc.Equals, nil)
 	}
 


### PR DESCRIPTION
## Description
Pass the architecture constraint into the E2E suite's `DeployApplication`. By default, if there is no arch constraint Juju fills in `amd64`. 

This was noticed by trying to run the tests on an Ubuntu `arm64` VM. To me this seems like a wider problem that will need addressing in many Juju-related tools.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
Run the E2E tests, or specifically `TestListModelSummaries`.

I'd appreciate someone trying this on `amd64` as well to make sure I haven't broken it.