### PR TITLE
chore(ofga): use 0.17.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 require (
 	github.com/antonlindstrom/pgstore v0.0.0-20220421113606-e3a6e3fed12a
 	github.com/canonical/go-service v1.0.0
-	github.com/canonical/ofga v0.16.1
+	github.com/canonical/ofga v0.17.1
 	github.com/canonical/rebac-admin-ui-handlers v0.2.0
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/canonical/go-service v1.0.0 h1:TF6TsEp04xAoI5pPoWjTYmEwLjbPATSnHEyeJC
 github.com/canonical/go-service v1.0.0/go.mod h1:GzNLXpkGdglL0kjREXoLXj2rB2Qx+EvAGncRDqCENYQ=
 github.com/canonical/lxd v0.0.0-20251112203541-660577aa1183 h1:RIcZMvVRrpT4RHiKr8byTa1rHYCQZF0q5rgVlbiovMM=
 github.com/canonical/lxd v0.0.0-20251112203541-660577aa1183/go.mod h1:MYdE1ID6Km0wWecLfqErbD0v6rqOgLQk91H/zSCWj0I=
-github.com/canonical/ofga v0.16.1 h1:gGmFLvYl6vxT0vUiw1y3uhKNPrWXhpzY0VdFErAn7Qk=
-github.com/canonical/ofga v0.16.1/go.mod h1:s9Tnedo/G2OSboSzW1kieCeXzAudOSA5FuakKi+Nn4o=
+github.com/canonical/ofga v0.17.1 h1:NLRXu62KZ2mh7b5gyeBcHJfvLPdCNX9uJCB7US+j/0A=
+github.com/canonical/ofga v0.17.1/go.mod h1:s9Tnedo/G2OSboSzW1kieCeXzAudOSA5FuakKi+Nn4o=
 github.com/canonical/rebac-admin-ui-handlers v0.2.0 h1:zzmixU1LNlbSktwkti6y8PuVqkbNPatj1tM4mC/G8Tk=
 github.com/canonical/rebac-admin-ui-handlers v0.2.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -463,7 +463,7 @@ func ListUsersWithAccess[T ofganames.ResourceTagger](ctx context.Context, client
 	entities, err := client.cofgaClient.FindUsersByRelation(ctx, Tuple{
 		Relation: relation,
 		Target:   ofganames.ConvertTag(resource),
-	}, 999)
+	})
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Update to latest `canonical/ofga`: https://github.com/canonical/ofga/releases/tag/v0.17.1

It should improve performance of the findUsers method.
