### PR TITLE
test(migrate): migrate local charm suite

### DIFF
--- a/testing/localcharm_test.go
+++ b/testing/localcharm_test.go
@@ -1,34 +1,34 @@
 // Copyright 2024 Canonical.
 
-package jujuapi_test
+package testing
 
 import (
 	"fmt"
 	"strings"
 
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/juju/charm/v12"
 	"github.com/juju/charm/v12/resource"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/charms"
 	"github.com/juju/juju/api/client/resources"
 	"github.com/juju/juju/testcharms"
-	"github.com/juju/juju/testing/factory"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 )
 
 // localCharmSuite tests end-to-end deployment of a local charm.
 type localCharmSuite struct {
-	websocketSuite
+	jimmtest.WebsocketE2ESuite
 }
 
 var _ = gc.Suite(&localCharmSuite{})
 
 func (s *localCharmSuite) TestLocalCharmDeploy(c *gc.C) {
-	conn := s.open(c, &api.Info{
+	conn := s.Open(c, &api.Info{
 		ModelTag:  s.Model.ResourceTag(),
 		SkipLogin: false,
-	}, s.AdminUser.Name)
+	}, s.AdminUser.Name, nil)
 
 	client, err := charms.NewLocalCharmClient(conn)
 	c.Assert(err, gc.IsNil)
@@ -43,35 +43,42 @@ func (s *localCharmSuite) TestLocalCharmDeploy(c *gc.C) {
 }
 
 func (s *localCharmSuite) TestResourceEndpoint(c *gc.C) {
-	// setup: to upload resource we first need to create the application and the pending resource
-	modelState, err := s.StatePool.Get(s.Model.UUID.String)
-	c.Assert(err, gc.Equals, nil)
-	defer modelState.Release()
-	f := factory.NewFactory(modelState.State, s.StatePool)
+	// setup: app and pending resource
+	conn := s.Open(c, &api.Info{
+		ModelTag:  s.Model.ResourceTag(),
+		SkipLogin: false,
+	}, s.AdminUser.Name, nil)
+
+	charmClient, err := charms.NewLocalCharmClient(conn)
+	c.Assert(err, gc.IsNil)
+
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
-	app := f.MakeApplication(c, &factory.ApplicationParams{
-		Name: "test-app",
-		Charm: f.MakeCharm(c, &factory.CharmParams{
-			Name: charmArchive.Meta().Name,
-			URL:  curl.String(),
-		}),
-	})
-	pendingId, err := modelState.Resources().AddPendingResource(app.Name(), s.Model.OwnerIdentityName, resource.Resource{
-		Meta:   resource.Meta{Name: "test", Type: 1, Path: "file"},
-		Origin: resource.OriginStore,
-	})
-	c.Assert(err, gc.Equals, nil)
-	conn := s.open(c, &api.Info{
-		ModelTag:  s.Model.ResourceTag(),
-		SkipLogin: false,
-	}, s.AdminUser.Name)
+	url, err := charmClient.AddLocalCharm(curl, charmArchive, false, version.MustParse("2.6.6"))
+	c.Assert(err, gc.IsNil)
+
+	appName := "test-app"
+
 	uploadClient, err := resources.NewClient(conn)
 	c.Assert(err, gc.IsNil)
 
-	// test
-	err = uploadClient.Upload(app.Name(), "test", "file", pendingId, strings.NewReader("<data>"))
+	pendingIDs, err := uploadClient.AddPendingResources(resources.AddPendingResourcesArgs{
+		ApplicationID: appName,
+		CharmID:       resources.CharmID{URL: url.String()},
+		Resources: []resource.Resource{
+			{
+				Meta:   resource.Meta{Name: "test", Type: 1, Path: "file"},
+				Origin: resource.OriginStore,
+			},
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(pendingIDs, gc.HasLen, 1)
+	pendingId := pendingIDs[0]
+
+	// act
+	err = uploadClient.Upload(appName, "test", "file", pendingId, strings.NewReader("<data>"))
 	c.Assert(err, gc.IsNil)
 }


### PR DESCRIPTION
## Description
Migrate local charm tests to E2E suite.

I had to redesign the second test a little, since I couldn't find a way to reach into resource-related internals otherwise.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests
