### PR TITLE
test: tweak upgrade-to test

### DIFF
--- a/local/jimm/setup-controller.sh
+++ b/local/jimm/setup-controller.sh
@@ -33,6 +33,10 @@ else
   echo "Skipping connecting the controller to JIMM"
 fi
 
+if [[ -n "${AGENT_VERSION:-}" ]]; then
+  BOOTSTRAP_ARGS+=(--agent-version "${AGENT_VERSION}")
+fi
+
 echo "Bootstrapping controller"
 JUJU_DEV_FEATURE_FLAGS=ssh-jump juju bootstrap "${BOOTSTRAP_ARGS[@]}"
 rm "$CLOUDINIT_FILE"

--- a/tests/upgrades/upgrade.sh
+++ b/tests/upgrades/upgrade.sh
@@ -1,54 +1,76 @@
 #!/bin/bash
 
-# This test upgrades a single model juju controller from one version to another
+# This test upgrades a single model from one version to another
 # utilising JAAS' upgrade-to command.
+
+# This test is currently skipped due to:
+# 1. jaas add-model command not yet available.
 
 set -euo pipefail
 
-# TODO: This test is very slow, and appears to be slowing the runner down to a 
-# complete hault.
+source "local/jimm/detect-jaas.sh"
+
 # See: https://warthogs.atlassian.net/browse/JUJU-8938
-# source "local/jimm/detect-jaas.sh"
+JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
+UPGRADE_CONTROLLER="upgrade-source-controller"
+SOURCE_CONTROLLER_VERSION="3.6.11"
+# Generate a random 4-character suffix for the model name.
+RAND_SUFFIX=$(tr -dc 'a-z0-9' </dev/urandom | head -c 4 || true)
+UPGRADING_MODEL_NAME="upgrading-model-$RAND_SUFFIX"
 
-# # Reset Juju on EXIT.
-# trap 'sudo snap refresh juju --channel=3/stable' EXIT
+# Setup controller with desired agent version then add the controller to JIMM.
+echo
+controller_exists=$(juju controllers | grep -c "$UPGRADE_CONTROLLER" || true)
+if [[ "$controller_exists" -gt 0 ]]; then
+    echo "Controller $UPGRADE_CONTROLLER already exists, skipping setup."
+else
+    echo "Setting up $UPGRADE_CONTROLLER"
+    AGENT_VERSION="$SOURCE_CONTROLLER_VERSION" CONTROLLER_NAME="$UPGRADE_CONTROLLER" local/jimm/setup-controller.sh
+    CONTROLLER_NAME="$UPGRADE_CONTROLLER" local/jimm/add-controller.sh
+fi
 
-# export CONTROLLER_NAME="man-of-iron"
-# JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
+# Switch to JIMM controller
+juju switch "$JIMM_CONTROLLER_NAME"
 
-# # Switch to an older Juju temporarily, so that we can upgrade the model when migrated.
-# sudo snap refresh juju --channel=3/stable --revision=32912
+# Create the model that will be upgraded.
+echo
+echo "Creating $UPGRADING_MODEL_NAME"
+$JAAS add-model "$UPGRADING_MODEL_NAME" localhost --target-controller "$UPGRADE_CONTROLLER"
 
-# echo
-# echo "Bootstrapping lxd controller configured with login-token-refresh-url"
-# local/jimm/setup-controller.sh
+echo
+echo "Fetching current model version"
+current_model_version="$(juju show-model "$UPGRADING_MODEL_NAME" | yq -r ".${UPGRADING_MODEL_NAME}.agent-version")"
+echo "Current model version is $current_model_version"
 
-# echo
-# echo "Adding controller to jimm"
-# local/jimm/add-controller.sh
+if [ "$current_model_version" != "$SOURCE_CONTROLLER_VERSION" ]; then
+    echo "Model should be at version $SOURCE_CONTROLLER_VERSION to perform upgrade test, but is at $current_model_version"
+    exit 1
+fi
 
-# echo
-# echo "Upgrading Juju 3.6.11 model to 3.6.12"
-# $JAAS upgrade-to 3.6.12 $(juju show-model test-lxd | yq '.test-lxd.model-uuid')
+echo
+echo "Upgrading Juju $current_model_version model to 3.6.12"
+$JAAS upgrade-to 3.6.12 "$(juju show-model "$UPGRADING_MODEL_NAME" | yq -r ".${UPGRADING_MODEL_NAME}.model-uuid")"
 
-# echo 
-# echo "Verifying model has been migrated from the original controller"
-# juju switch man-of-iron
-# if jujy models --format json | jq -e '.models | (length == 1) and (.[0].name == "admin/controller")'; then
-#   echo "Success: Only the controller model remains."
-# else
-#   echo "Failure: Expected only the controller model, but found something else."
-#   juju models
-#   exit 1
-# fi
+echo
+echo "Verifying model has been upgraded from $current_model_version"
+echo "Waiting for upgrade to complete (timeout: 5 minutes)..."
+max_attempts=60  # 60 attempts = 5 minutes / 5 seconds
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+    sleep 5
+    new_version="$(juju show-model "$UPGRADING_MODEL_NAME" | yq -r ".${UPGRADING_MODEL_NAME}.agent-version")"
+    if [ "$new_version" != "$current_model_version" ]; then
+        echo "Model upgrade completed to version $new_version."
+        break
+    fi
+    echo 
+    echo "Upgrade still in progress (attempt $attempt/$max_attempts)"
+    attempt=$((attempt + 1))
+done
+if [ $attempt -gt $max_attempts ]; then
+    echo "Upgrade did not complete within 5 minutes."
+    exit 1
+fi
 
-# echo
-# echo "Verifying model has been upgraded from 3.6.11"
-# juju switch $JIMM_CONTROLLER_NAME:test-lxd
-# if juju status --format json | jq -e '.model.version != "3.6.11"'; then
-#   echo "Validation successful: The model version is not 3.6.11."
-#   # Script continues...
-# else
-#   echo "Validation failed: The model version is still 3.6.11."
-#   exit 1
-# fi
+echo
+echo "Upgrade test completed successfully."


### PR DESCRIPTION
## Description
This PR modifies the upgrade test. It avoids installing a fixed version of the Juju snap to bootstrap an old agent version and instead relies on the bootstrap command's `--agent-version` flag.

The test bootstraps a controller with a fixed agent version of 3.6.11, creates a model on that controller, and then attempts to upgrade it. It verifies the upgrade is complete by polling so that when the API becomes async minimal changes to the test will be required.

In order to create the model on the correct controller we use a JAAS command that is currently WIP i.e. `juju jaas add-model --target-controller`. Once this functionality lands this test should be ready.

One hurdle faced here was how the bootstrapped controller (done during `upgrade-to` execution) would connect to `jimm.localhost`. In the integration test workflow we the login-token-refresh-url to `"http://${{ env.MACHINE_IP }}:17070/.well-known/jwks.json"` where `MACHINE_IP` is the address of the default network interface on the device. This routes traffic from containers to the host to the JIMM container exposed alongside Traefik without TLS and makes the testing much easier. We may want to, in the future, consider cloning the controller with all its config (controller and model config).

On a final note, this test is quite slow because it is bootstrapping 2 controllers. It is worth a dicussion on how to improve this. Some ideas include,
- Speed up bootstrap
- Run the integration test workflow periodically (maybe daily) and allow a label on PRs to trigger it.

Fixes [JUJU-8938](https://warthogs.atlassian.net/browse/JUJU-8938)
 
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests


[JUJU-8938]: https://warthogs.atlassian.net/browse/JUJU-8938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ