### PR TITLE
fix(jimm-action): default for CONTROLLER_NAME

### DIFF
--- a/local/jimm/grant-controller-access.sh
+++ b/local/jimm/grant-controller-access.sh
@@ -6,6 +6,8 @@
 
 set -eux
 
+CONTROLLER_NAME="${CONTROLLER_NAME:-qa-lxd}"
+
 # Source the `JAAS` variable for executing jaas commands.
 source "$(dirname "${BASH_SOURCE[0]}")/detect-jaas.sh"
 


### PR DESCRIPTION
# Description

smoke jaas in juju 3.6 is broken because grant-controller-access.sh doesn't have CONTROLLER_NAME set. This simple fix will set a default when CONTROLLER_NAME is not provided.