### PR TITLE
chore: update dashboard test sha

### DIFF
--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -71,7 +71,7 @@ jobs:
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run integration tests
-        uses: canonical/juju-dashboard/.github/actions/run-playwright@5fdd04eb8129d2602d326c322ef2ad918393c858
+        uses: canonical/juju-dashboard/.github/actions/run-playwright@d0c450599a13854d72cbfc4609d906d27800f38b
         with:
           test-identifier: e2e-jimm-docker-keycloak
         env:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -138,7 +138,7 @@ services:
       retries: 30
 
   juju-dashboard:
-    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.15.0-beta.4}
+    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.15.1-beta.3}
     container_name: juju-dashboard
     profiles: ["dev"]
     environment:


### PR DESCRIPTION
## Description
This PR updates the dashboard tests to the latest commit SHA and updates the dashboard container image in our docker compose.

The latest set of dashboard tests are failing because we set the admin user's email address as `jimm-test@canonical.com` while the dashboard tests expect this to be `jimm-test@example.com`, the web team is looking at this. We may want to consider making it configurable on our end, or making it configurable on the dashboard's end.

Fixes [JUJU-9037](https://warthogs.atlassian.net/browse/JUJU-9037)

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests


[JUJU-9037]: https://warthogs.atlassian.net/browse/JUJU-9037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ