### PR TITLE
fix(debug-log args): fix debug logs args ignored

### DIFF
--- a/internal/jimmhttp/utils.go
+++ b/internal/jimmhttp/utils.go
@@ -14,6 +14,7 @@ import (
 )
 
 type contextPathKey struct{}
+type urlQueryParamsKey struct{}
 type migratingModelUUIDKey struct{}
 type clientVersionKey struct{}
 
@@ -22,6 +23,12 @@ type clientVersionKey struct{}
 func PathElementFromContext(ctx context.Context) string {
 	s, _ := ctx.Value(contextPathKey{}).(string)
 	return s
+}
+
+// QueryParamsFromContext returns the URL query parameters stored in the context.
+func QueryParamsFromContext(ctx context.Context) url.Values {
+	v, _ := ctx.Value(urlQueryParamsKey{}).(url.Values)
+	return v
 }
 
 // MigratingModelUUIDFromContext returns the value of the migrating model UUID

--- a/internal/jimmhttp/websocket.go
+++ b/internal/jimmhttp/websocket.go
@@ -54,6 +54,8 @@ func (h *WSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// Set the path of the request to the context for handling different endpoints.
 	ctx = context.WithValue(ctx, contextPathKey{}, req.URL.EscapedPath())
+	// Set the URL query parameters to the context for use by the websocket server.
+	ctx = context.WithValue(ctx, urlQueryParamsKey{}, req.URL.Query())
 	// Set the migrating model UUID if it exists in the request header.
 	ctx = context.WithValue(ctx, migratingModelUUIDKey{}, req.Header.Get(jujuparams.MigrationModelHTTPHeader))
 	// Set the client version from the request header, expected by Juju controllers.

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -116,7 +116,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		jujuparams.JujuClientVersion:        []string{jimmhttp.ClientVersionFromContext(ctx)},
 	}
 
-	controllerStream, err := api.ConnectControllerStream(logTransferPath, nil, headers)
+	controllerStream, err := api.ConnectControllerStream(logTransferPath, jimmhttp.QueryParamsFromContext(ctx), headers)
 	if err != nil {
 		zapctx.Error(ctx, "failed to connect stream", zap.Error(err))
 		writeError(fmt.Sprintf("failed to connect stream: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -106,7 +106,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 	}
 	defer api.Close()
 
-	controllerStream, err := api.ConnectStream(finalPath, nil)
+	controllerStream, err := api.ConnectStream(finalPath, jimmhttp.QueryParamsFromContext(ctx))
 	if err != nil {
 		zapctx.Error(ctx, "failed to connect stream", zap.Error(err))
 		writeError(fmt.Sprintf("failed to connect stream: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -228,7 +228,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 		jwtGenerator.SetTags(m.ResourceTag(), m.Controller.ResourceTag())
 		mt := m.ResourceTag()
 		zapctx.Debug(ctx, "Dialing Controller", zap.String("path", path))
-		controllerConn, err := jimmRPC.Dial(ctx, &m.Controller, mt, finalPath, nil)
+		controllerConn, err := jimmRPC.Dial(ctx, &m.Controller, mt, finalPath, nil, nil)
 		if err != nil {
 			zapctx.Error(ctx, "cannot dial controller", zap.String("controller", m.Controller.Name), zap.Error(err))
 			return rpcproxy.WebsocketConnectionWithMetadata{}, err

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -112,7 +112,7 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 // Dial implements jimm.Dialer.
 func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (juju.API, error) {
 
-	conn, err := rpc.Dial(ctx, ctl, modelTag, "", nil)
+	conn, err := rpc.Dial(ctx, ctl, modelTag, "", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -360,8 +360,7 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 		return nil, errors.E("invalid/missing controller credentials")
 	}
 	requestHeader := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
-
-	conn, err := rpc.Dial(c.ctx, c.ctl, modelTag, path, requestHeader)
+	conn, err := rpc.Dial(c.ctx, c.ctl, modelTag, path, requestHeader, attrs)
 	if err != nil {
 		return nil, errors.E(err)
 	}
@@ -387,7 +386,7 @@ func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extr
 		}
 	}
 
-	conn, err := rpc.Dial(c.ctx, c.ctl, names.ModelTag{}, path, header)
+	conn, err := rpc.Dial(c.ctx, c.ctl, names.ModelTag{}, path, header, attrs)
 	if err != nil {
 		return nil, errors.E(err)
 	}

--- a/internal/rpc/dial _test.go
+++ b/internal/rpc/dial _test.go
@@ -40,7 +40,7 @@ func TestDialIPv4(t *testing.T) {
 		},
 		Port: hp.Port(),
 	}})
-	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{})
+	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{}, nil)
 	c.Assert(err, qt.Equals, nil)
 }
 
@@ -64,7 +64,7 @@ func TestDialIPv6(t *testing.T) {
 		},
 		Port: hp.Port(),
 	}})
-	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{})
+	_, err = rpc.Dial(ctx, &controller, names.ModelTag{}, "", http.Header{}, nil)
 	c.Assert(err, qt.Equals, nil)
 }
 

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -90,14 +90,14 @@ func GetAddressesAndTLSConfig(ctx context.Context, ctl *dbmodel.Controller) ([]s
 // Dial connects to the controller/model and returns a raw websocket
 // that can be used as is.
 // It accepts the endpoints to dial, normally /api or /commands.
-func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, finalPath string, headers http.Header) (*websocket.Conn, error) {
+func Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, finalPath string, headers http.Header, attrs url.Values) (*websocket.Conn, error) {
 	addrs, tlsConfig := GetAddressesAndTLSConfig(ctx, ctl)
 	dialer := Dialer{
 		TLSConfig: tlsConfig,
 	}
 	var websocketUrls []string
 	for _, addr := range addrs {
-		websocketUrls = append(websocketUrls, websocketURL(addr, modelTag, finalPath))
+		websocketUrls = append(websocketUrls, websocketURL(addr, modelTag, finalPath, attrs))
 	}
 	zapctx.Debug(ctx, "Dialling all URLs", zap.Any("urls", websocketUrls))
 	conn, err := dialAll(ctx, &dialer, websocketUrls, headers)
@@ -122,7 +122,7 @@ func maybeReachable(scope network.Scope) bool {
 	}
 }
 
-func websocketURL(s string, mt names.ModelTag, finalPath string) string {
+func websocketURL(s string, mt names.ModelTag, finalPath string, attrs url.Values) string {
 	u := url.URL{
 		Scheme: "wss",
 		Host:   s,
@@ -135,6 +135,7 @@ func websocketURL(s string, mt names.ModelTag, finalPath string) string {
 	} else {
 		u.Path = path.Join(u.Path, finalPath)
 	}
+	u.RawQuery = attrs.Encode()
 	return u.String()
 }
 

--- a/testing/streammodelproxy_test.go
+++ b/testing/streammodelproxy_test.go
@@ -4,6 +4,7 @@ package testing
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/common"
@@ -28,6 +29,30 @@ func (s *streamProxySuite) TestDebugLogs(c *gc.C) {
 	// No actual logs come through either because of the JujuConnSuite or the fact that there is no application deployed.
 	_, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{})
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *streamProxySuite) TestDebugLogsWithParams(c *gc.C) {
+	conn := s.Open(c, &api.Info{ModelTag: s.Model.ResourceTag()}, "bob", nil)
+	defer conn.Close()
+
+	logChan, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{
+		NoTail: true,
+		Limit:  1,
+	})
+	c.Assert(err, gc.IsNil)
+	messages := 0
+	for {
+		select {
+		case _, ok := <-logChan:
+			if !ok {
+				c.Assert(messages, gc.Equals, 1)
+				return
+			}
+			messages++
+		case <-time.After(5 * time.Second):
+			c.Fatal("expected log channel to be closed, but it is still open after timeout")
+		}
+	}
 }
 
 // TestDebugLogsError tests that an error is returned from JIMM


### PR DESCRIPTION
# Description

our https proxy was dropping url query values, now it doesn't.

juju debug-logs args are passed as url args, and our proxy was dropping those, which is wrong.

I've taken the chance to pass url query params also for the controlller http proxy.

fix #1799

# QA

`juju debug-log --limit 1 --no-tail` now works and returns a single log.