### PR TITLE
fix: fixes add-model response when no controllers are registered

### DIFF
--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -180,7 +180,7 @@ func (d *Database) CountControllers(ctx context.Context) (count int, err error) 
 	const op = "db.CountControllers"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return -1, errors.E(err)
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -176,7 +176,7 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 }
 
 // CountControllers returns the number of controllers stored in the database.
-func (d *Database) CountControllers(ctx context.Context) (count int64, err error) {
+func (d *Database) CountControllers(ctx context.Context) (count int, err error) {
 	const op = "db.CountControllers"
 
 	if err := d.ready(); err != nil {
@@ -188,8 +188,9 @@ func (d *Database) CountControllers(ctx context.Context) (count int64, err error
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	db := d.DB.WithContext(ctx)
-	if err := db.Model(&dbmodel.Controller{}).Count(&count).Error; err != nil {
-		return 0, errors.E(dbError(err))
+	var count64 int64
+	if err := db.Model(&dbmodel.Controller{}).Count(&count64).Error; err != nil {
+		return -1, errors.E(dbError(err))
 	}
-	return count, nil
+	return int(count64), nil
 }

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -174,3 +174,22 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 	}
 	return nil
 }
+
+// CountControllers returns the number of controllers stored in the database.
+func (d *Database) CountControllers(ctx context.Context) (count int64, err error) {
+	const op = "db.CountControllers"
+
+	if err := d.ready(); err != nil {
+		return 0, errors.E(err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
+	db := d.DB.WithContext(ctx)
+	if err := db.Model(&dbmodel.Controller{}).Count(&count).Error; err != nil {
+		return 0, errors.E(dbError(err))
+	}
+	return count, nil
+}

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -363,7 +363,7 @@ func (s *dbSuite) TestCountControllers(c *qt.C) {
 
 	count, err := s.Database.CountControllers(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(count, qt.Equals, int64(0))
+	c.Assert(count, qt.Equals, 0)
 
 	cloud := dbmodel.Cloud{
 		Name: "test-cloud",
@@ -381,5 +381,5 @@ func (s *dbSuite) TestCountControllers(c *qt.C) {
 
 	count, err = s.Database.CountControllers(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(count, qt.Equals, int64(1))
+	c.Assert(count, qt.Equals, 1)
 }

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -356,3 +356,30 @@ func (s *dbSuite) TestForEachControllerModel(c *qt.C) {
 		"00000002-0000-0000-0000-000000000004",
 	})
 }
+
+func (s *dbSuite) TestCountControllers(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+
+	count, err := s.Database.CountControllers(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, int64(0))
+
+	cloud := dbmodel.Cloud{
+		Name: "test-cloud",
+	}
+	err = s.Database.AddCloud(context.Background(), &cloud)
+	c.Assert(err, qt.IsNil)
+
+	controller := dbmodel.Controller{
+		Name:      "test-controller",
+		UUID:      "00000000-0000-0000-0000-0000-0000000000001",
+		CloudName: "test-cloud",
+	}
+	err = s.Database.AddController(context.Background(), &controller)
+	c.Assert(err, qt.Equals, nil)
+
+	count, err = s.Database.CountControllers(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, int64(1))
+}

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -61,7 +61,7 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 // returned unchanged. The given function should not update the database.
 //
 // Additionally, if there are no controllers registered with JIMM then an
-// error with a code of CodeNoControllers will be returned.
+// error of "no controllers registered" will be returned.
 func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
 
 	ctrlCount, err := j.Database.CountControllers(ctx)

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -66,7 +66,7 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 
 	ctrlCount, err := j.Database.CountControllers(ctx)
 	if err != nil {
-		return errors.E(fmt.Errorf("cannot count controllers: %w", err))
+		return errors.E(fmt.Errorf("cannot get count controllers: %w", err))
 	}
 
 	if ctrlCount == 0 {

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -59,7 +59,19 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 // true then f will be called with all clouds known to JIMM. If f returns
 // an error then iteration will stop immediately and the error will be
 // returned unchanged. The given function should not update the database.
+//
+// Additionally, if there are no controllers registered with JIMM then an
+// error with a code of CodeNoControllers will be returned.
 func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
+
+	ctrlCount, err := j.Database.CountControllers(ctx)
+	if err != nil {
+		return errors.E(fmt.Errorf("cannot count controllers: %w", err))
+	}
+
+	if ctrlCount == 0 {
+		return errors.E("no controllers registered")
+	}
 
 	clouds, err := j.Database.GetClouds(ctx)
 	if err != nil {

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -175,6 +175,17 @@ func TestForEachCloud(t *testing.T) {
 	err = j.Database.AddCloud(ctx, cloud)
 	c.Assert(err, qt.IsNil)
 
+	// ForEachCloud requires controllers be registered. Simulate this by adding the database entry.
+	err = j.Database.AddController(
+		ctx,
+		&dbmodel.Controller{
+			Name:      "test-controller",
+			UUID:      "00000000-0000-0000-0000-000000000001",
+			CloudName: cloud.Name,
+		},
+	)
+	c.Assert(err, qt.IsNil)
+
 	err = alice.SetCloudAccess(ctx, cloud.ResourceTag(), ofganames.AdministratorRelation)
 	c.Assert(err, qt.IsNil)
 	err = bob.SetCloudAccess(ctx, cloud.ResourceTag(), ofganames.CanAddModelRelation)
@@ -297,6 +308,35 @@ func TestForEachCloud(t *testing.T) {
 		Name:      "test-cloud-3",
 		Regions:   []dbmodel.CloudRegion{},
 	}})
+}
+
+func TestForEachCloud_NoControllers(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	aliceIdentity, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+	alice := openfga.NewUser(
+		aliceIdentity,
+		j.OpenFGAClient,
+	)
+
+	cloud := &dbmodel.Cloud{
+		Name: "test-cloud-1",
+	}
+	err = j.Database.AddCloud(ctx, cloud)
+	c.Assert(err, qt.IsNil)
+
+	err = alice.SetCloudAccess(ctx, cloud.ResourceTag(), ofganames.AdministratorRelation)
+	c.Assert(err, qt.IsNil)
+
+	err = j.ForEachUserCloud(ctx, alice, func(cld *dbmodel.Cloud) error {
+		return nil
+	})
+
+	c.Assert(err, qt.ErrorMatches, "no controllers registered")
 }
 
 const addHostedCloudTestEnv = `clouds:


### PR DESCRIPTION
## Description
Fixes https://warthogs.atlassian.net/browse/JUJU-9051, a bug that @alesstimec found.

When running add-model against JIMM, and no controllers were registered, the code path for [this](https://github.com/ale8k/juju/blob/2c70d10b5744dcd076d237a7a64147cac6116347/cmd/juju/controller/addmodel.go#L430-L434) was running. This is because Juju was attempting to get the cloud [here](https://github.com/ale8k/juju/blob/2c70d10b5744dcd076d237a7a64147cac6116347/cmd/juju/controller/addmodel.go#L454-L457) in order to retrieve the credential to add the model.

I've solved this by adding a count controllers DB call, and checking in ForEachUserCloud that controllers are registered. This error is propogated through the facade and now returned from the Clouds() call. Surfaced like so:
```
➜  jimm git:(juju-9051/fix-add-model-no-controllers) ✗ juju add-model a
ERROR no controllers registered
``` 
I did think of putting it in the facade call but any call to ForEachUserCloud is moot without having controllers, hence why I added the check here. We should probably add this to all Cloud retrieval calls, but I didn't want to scope creep this PR.


## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
Spin up jimm without controllers, login, and run add-model.
