### PR TITLE
feat: builds jaas snap for arm64

### DIFF
--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -6,6 +6,10 @@ grade: stable
 base: bare
 build-base: core20
 confinement: strict
+architectures:
+  - build-on: [amd64]
+    run-on: [amd64, arm64]
+
 
 slots:
   jaas-plugin:


### PR DESCRIPTION
## Description
Builds the JAAS snap for ARM64 too. I'm not sure if our workflow needs updating and it isn't clear on the action page here:
https://github.com/canonical/action-build

Our build process will (I think? Can't build locally due to a separate issue) produce two snaps now for each architecture.

I think our currently workflow is a "single" snap to be uploaded, but our build will produce two now.  I think this PR needs to update the workflow but I'm not sure exactly how to do this other than hardcode the names in the artifact upload. Open to suggestions.

EDIT:
In the snap builder code I can see
```ts
async outputSnap(): Promise<string> {
  const files = await this._readdir(this.projectRoot)
  const snaps = files.filter(name => name.endsWith('.snap'))

  if (snaps.length === 0) {
    throw new Error('No snap files produced by build')
  }
  if (snaps.length > 1) {
    core.warning(`Multiple snaps found in ${this.projectRoot}`)
  }
  return path.join(this.projectRoot, snaps[0])
}
```

So it seems they just take [0]... We probably shouldn't use this action for outputs and upload manually. It seems fine for building though.