### PR TITLE
test: addcloudtocontroller unit test

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -8,19 +8,16 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
-	jujuapi "github.com/juju/juju/api"
 	"github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	jujucmdcommon "github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	jimmjujuapi "github.com/canonical/jimm/v3/internal/jujuapi"
-	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
@@ -42,7 +39,6 @@ is already known and will error otherwise.
 // controller in JIMM.
 func NewAddCloudToControllerCommand() cmd.Command {
 	cmd := &addCloudToControllerCommand{
-		store:           jujuclient.NewFileClientStore(), // Can be removed alongside all "newClient" calls if we like the new newClient approach.
 		cloudByNameFunc: jujucmdcommon.CloudByName,
 		jimmAPIFunc:     NewClient,
 	}
@@ -71,8 +67,6 @@ type addCloudToControllerCommand struct {
 
 	jimmAPIFunc     APIClientFunc
 	cloudByNameFunc func(string) (*cloud.Cloud, error)
-	store           jujuclient.ClientStore // Both of these can be removed if we like new way. We don't touch store as JIMM and use it for dialing only I think?
-	dialOpts        *jujuapi.DialOpts
 }
 
 // Info implements Command.Info.
@@ -159,41 +153,6 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 	}
 	ctxt.Infof("Cloud %q added to controller %q.", c.cloudName, c.dstControllerName)
 
-	// Old:
-	// err = c.addCloudToController(ctxt, newCloud)
-	// if err != nil {
-	// 	return errors.E(err, fmt.Sprintf("error adding cloud to controller: %v", err))
-	// }
-
-	return nil
-}
-
-func (c *addCloudToControllerCommand) addCloudToController(ctxt *cmd.Context, cloud *cloud.Cloud) error {
-	currentController, err := c.store.CurrentController()
-	if err != nil {
-		return errors.E(err, "could not determine the current controller")
-	}
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
-	if err != nil {
-		return err
-	}
-	client := api.NewClient(apiCaller)
-
-	params := &apiparams.AddCloudToControllerRequest{
-		ControllerName: c.dstControllerName,
-		AddCloudArgs: params.AddCloudArgs{
-			Name:  c.cloudName,
-			Cloud: jimmjujuapi.CloudToParams(*cloud),
-			Force: &c.force,
-		},
-	}
-
-	err = client.AddCloudToController(params)
-	if err != nil {
-		return errors.E(err)
-	}
-
-	ctxt.Infof("Cloud %q added to controller %q.", c.cloudName, c.dstControllerName)
 	return nil
 }
 

--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -9,8 +9,8 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	"github.com/juju/juju/cloud"
+	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
-	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
 	jujucmdcommon "github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/rpc/params"
@@ -89,7 +89,7 @@ func (c *addCloudToControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 
 	f.BoolVar(&c.force, "force", false, "Forces the cloud to be added to the controller")
-	f.StringVar(&c.cloudDefinitionFile, "cloud", "", "The path to the cloud's definition file.")
+	f.StringVar(&c.cloudDefinitionFile, "cloud", "", "The path to the cloud's definition file. The cloud name must be present in the file.")
 }
 
 // Init implements the cmd.Command interface.
@@ -117,7 +117,7 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 	var newCloud *cloud.Cloud
 	var err error
 	if c.cloudDefinitionFile != "" {
-		newCloud, err = c.readCloudFromFile(ctxt)
+		newCloud, err = c.readCloudFromFile()
 		if err != nil {
 			return errors.E(err, fmt.Sprintf("error reading cloud from file: %v", err))
 		}
@@ -156,43 +156,23 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 	return nil
 }
 
-func (c *addCloudToControllerCommand) readCloudFromFile(ctxt *cmd.Context) (*cloud.Cloud, error) {
-	r := &jujucmdcloud.CloudFileReader{
-		CloudMetadataStore: &cloudToCommandAdapter{},
-		CloudName:          c.cloudName,
-	}
-	newCloud, err := r.ReadCloudFromFile(c.cloudDefinitionFile, ctxt)
+func (c *addCloudToControllerCommand) readCloudFromFile() (*cloud.Cloud, error) {
+	cloudDefinitionData, err := os.ReadFile(c.cloudDefinitionFile)
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	return newCloud, nil
-}
+	specifiedClouds, err := jujucloud.ParseCloudMetadata(cloudDefinitionData)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+	if len(specifiedClouds) == 0 {
+		return nil, errors.E("no clouds found in parsed yaml, please validate yaml keys")
+	}
+	var ok bool
+	foundCloud, ok := specifiedClouds[c.cloudName]
+	if !ok {
+		return nil, errors.E(fmt.Sprintf("cloud %q not found in file %q", c.cloudName, c.cloudDefinitionFile))
+	}
 
-type cloudToCommandAdapter struct {
-	jujucmdcloud.CloudMetadataStore
-}
-
-// ReadCloudData implements CloudMetadataStore.ReadCloudData.
-func (cloudToCommandAdapter) ReadCloudData(path string) ([]byte, error) {
-	return os.ReadFile(path)
-}
-
-// ParseOneCloud implements CloudMetadataStore.ParseOneCloud.
-func (cloudToCommandAdapter) ParseOneCloud(data []byte) (cloud.Cloud, error) {
-	return cloud.ParseOneCloud(data)
-}
-
-// PublicCloudMetadata implements CloudMetadataStore.PublicCloudMetadata.
-func (cloudToCommandAdapter) PublicCloudMetadata(searchPaths ...string) (map[string]cloud.Cloud, bool, error) {
-	return cloud.PublicCloudMetadata(searchPaths...)
-}
-
-// PersonalCloudMetadata implements CloudMetadataStore.PersonalCloudMetadata.
-func (cloudToCommandAdapter) PersonalCloudMetadata() (map[string]cloud.Cloud, error) {
-	return cloud.PersonalCloudMetadata()
-}
-
-// WritePersonalCloudMetadata implements CloudMetadataStore.WritePersonalCloudMetadata.
-func (cloudToCommandAdapter) WritePersonalCloudMetadata(cloudsMap map[string]cloud.Cloud) error {
-	return cloud.WritePersonalCloudMetadata(cloudsMap)
+	return &foundCloud, nil
 }

--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	"github.com/juju/juju/cloud"
-	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	jujucmdcommon "github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -161,7 +160,7 @@ func (c *addCloudToControllerCommand) readCloudFromFile() (*cloud.Cloud, error) 
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	specifiedClouds, err := jujucloud.ParseCloudMetadata(cloudDefinitionData)
+	specifiedClouds, err := cloud.ParseCloudMetadata(cloudDefinitionData)
 	if err != nil {
 		return nil, errors.E(err)
 	}

--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -42,8 +42,9 @@ is already known and will error otherwise.
 // controller in JIMM.
 func NewAddCloudToControllerCommand() cmd.Command {
 	cmd := &addCloudToControllerCommand{
-		store:           jujuclient.NewFileClientStore(),
+		store:           jujuclient.NewFileClientStore(), // Can be removed alongside all "newClient" calls if we like the new newClient approach.
 		cloudByNameFunc: jujucmdcommon.CloudByName,
+		jimmAPIFunc:     NewClient,
 	}
 
 	return modelcmd.WrapBase(cmd)
@@ -68,8 +69,9 @@ type addCloudToControllerCommand struct {
 	// compatible with the cloud on which the controller is running.
 	force bool
 
+	jimmAPIFunc     APIClientFunc
 	cloudByNameFunc func(string) (*cloud.Cloud, error)
-	store           jujuclient.ClientStore
+	store           jujuclient.ClientStore // Both of these can be removed if we like new way. We don't touch store as JIMM and use it for dialing only I think?
 	dialOpts        *jujuapi.DialOpts
 }
 
@@ -139,10 +141,29 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 		newCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 	}
 
-	err = c.addCloudToController(ctxt, newCloud)
+	jimmAPI, err := c.jimmAPIFunc(nil)
 	if err != nil {
-		return errors.E(err, fmt.Sprintf("error adding cloud to controller: %v", err))
+		return errors.E(err, "could not create JIMM API client")
 	}
+	defer jimmAPI.Close()
+
+	if err := jimmAPI.AddCloudToController(&apiparams.AddCloudToControllerRequest{
+		ControllerName: c.dstControllerName,
+		AddCloudArgs: params.AddCloudArgs{
+			Name:  c.cloudName,
+			Cloud: jimmjujuapi.CloudToParams(*newCloud),
+			Force: &c.force,
+		},
+	}); err != nil {
+		return errors.E(err)
+	}
+	ctxt.Infof("Cloud %q added to controller %q.", c.cloudName, c.dstControllerName)
+
+	// Old:
+	// err = c.addCloudToController(ctxt, newCloud)
+	// if err != nil {
+	// 	return errors.E(err, fmt.Sprintf("error adding cloud to controller: %v", err))
+	// }
 
 	return nil
 }

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -1,210 +1,76 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"context"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
+	"bytes"
+	"testing"
 
-	"github.com/juju/cmd/v3/cmdtesting"
+	qt "github.com/frankban/quicktest"
+	jujucmd "github.com/juju/cmd/v3"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloud"
-	"github.com/juju/names/v5"
-	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/rpc/params"
+	"go.uber.org/mock/gomock"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/errors"
-	"github.com/canonical/jimm/v3/internal/openfga"
-	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	"github.com/canonical/jimm/v3/cmd/jaas/cmd/mocks"
+	jimmjujuapi "github.com/canonical/jimm/v3/internal/jujuapi"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type addCloudToControllerSuite struct {
-	cmdtest.JimmCmdSuite
+// Replace with utils in crossmodelquery pr prior to merging.
+func setupMocks(t *testing.T) *mocks.MockJIMMAPI {
+	ctrl := gomock.NewController(t)
+	jimmAPI := mocks.NewMockJIMMAPI(ctrl)
+
+	t.Cleanup(ctrl.Finish)
+
+	return jimmAPI
 }
 
-var _ = gc.Suite(&addCloudToControllerSuite{})
-
-func (s *addCloudToControllerSuite) SetUpTest(c *gc.C) {
-	s.JimmCmdSuite.SetUpTest(c)
-
-	// We add user bob, who is a JIMM administrator.
-	i, err := dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, gc.IsNil)
-	err = s.JIMM.Database.UpdateIdentity(context.Background(), i)
-	c.Assert(err, gc.IsNil)
-
-	// We add a test-cloud cloud.
-	info := s.APIInfo(c)
-	err = s.JIMM.Database.AddCloud(context.Background(), &dbmodel.Cloud{
-		Name:    "test-cloud",
-		Type:    "kubernetes",
-		Regions: []dbmodel.CloudRegion{{Name: "default", CloudName: "test-cloud"}},
-	})
-	c.Assert(err, gc.IsNil)
-	region, err := s.JIMM.Database.FindRegionByCloudType(context.Background(), "kubernetes", "default")
-	c.Assert(err, gc.IsNil)
-
-	// We grant user bob administrator access to JIMM and the added
-	// test-cloud.
-	i, err = dbmodel.NewIdentity("bob@canonical.com")
-	c.Assert(err, gc.IsNil)
-	bob := openfga.NewUser(
-		i,
-		s.JIMM.OpenFGAClient,
-	)
-	err = bob.SetControllerAccess(context.Background(), s.JIMM.ResourceTag(), ofganames.AdministratorRelation)
-	c.Assert(err, gc.IsNil)
-	err = bob.SetCloudAccess(context.Background(), names.NewCloudTag("test-cloud"), ofganames.AdministratorRelation)
-	c.Assert(err, gc.IsNil)
-
-	err = s.JIMM.Database.AddController(context.Background(), &dbmodel.Controller{
-		Name:          "controller-1",
-		CACertificate: info.CACert,
-		UUID:          info.ControllerUUID,
-		PublicAddress: info.Addrs[0],
-		CloudName:     "test-cloud",
-		CloudRegion:   "default",
-		CloudRegions: []dbmodel.CloudRegionControllerPriority{{
-			CloudRegion: *region,
-			Priority:    1,
-		}},
-	})
-	c.Assert(err, gc.IsNil)
-
-	err = s.JIMM.OpenFGAClient.AddController(context.Background(), s.JIMM.ResourceTag(), names.NewControllerTag(info.ControllerUUID))
-	c.Assert(err, gc.IsNil)
+// Replace with utils in crossmodelquery pr prior to merging.
+func newTestContext(t *testing.T) *jujucmd.Context {
+	return &jujucmd.Context{
+		Context: t.Context(),
+		Dir:     t.TempDir(),
+		Stdin:   &bytes.Buffer{},
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
 }
+func TestAddCloudToControllerRun(t *testing.T) {
+	c := qt.New(t)
 
-func (s *addCloudToControllerSuite) TestAddCloudToController(c *gc.C) {
-	tests := []struct {
-		about             string
-		cloudInfo         string
-		force             bool
-		cloudByNameFunc   func(cloudName string) (*cloud.Cloud, error)
-		expectedCloudName string
-		expectedIndex     int
-		expectedError     string
-	}{
-		{
-			about: "Add Kubernetes Cloud",
-			cloudInfo: `
-clouds:
-  test-hosted-cloud:
-    type: kubernetes
-    auth-types: [certificate]
-    host-cloud-region: kubernetes/default`,
-			force:             false,
-			expectedCloudName: "test-hosted-cloud",
-			expectedIndex:     1,
-			expectedError:     "",
-		}, {
-			about: "Add MAAS Cloud",
-			cloudInfo: `
-clouds:
-  test-maas-cloud:
-    type: maas
-    auth-types: [oauth1]
-    regions:
-      default: {}`,
-			force:             true,
-			expectedCloudName: "test-maas-cloud",
-			expectedIndex:     2,
-			expectedError:     "",
-		}, {
-			about: "Add cloud with unknown provider",
-			cloudInfo: `
-clouds:
-  test-unknown-cloud:
-    type: unknown
-    auth-types: [oauth1]
-    regions:
-      default: {}`,
-			force:             false,
-			expectedCloudName: "test-unknown-cloud",
-			expectedError:     ".*no registered provider.*",
-		}, {
-			about: "Add cloud to controller with wrong name",
-			cloudInfo: `
-clouds:
-  test-hosted-cloud-2:
-    type: kubernetes
-    auth-types: [certificate]
-    host-cloud-region: kubernetes/default`,
-			force:             false,
-			expectedCloudName: "test-cloud",
-			expectedError:     ".* cloud .* not found in file .*",
-		}, {
-			about: "Add existing cloud to controller",
-			cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
-				return &cloud.Cloud{
-					Name:            "test-hosted-cloud-2",
-					Type:            "kubernetes",
-					AuthTypes:       []cloud.AuthType{"certificate"},
-					HostCloudRegion: "kubernetes/default",
-				}, nil
-			},
-			force:             false,
-			expectedCloudName: "test-hosted-cloud-2",
-			expectedIndex:     3,
-			expectedError:     "",
-		}, {
-			about: "Add existing cloud to controller where existing cloud is not found",
-			cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
-				return nil, errors.E("not found")
-			},
-			force:             false,
-			expectedCloudName: "test-cloud",
-			expectedError:     "could not find existing cloud, please provide a cloud file",
+	force := false
+	jimmAPIMock := setupMocks(t)
+
+	expectedCloud := &cloud.Cloud{
+		Name:            "test-hosted-cloud",
+		Type:            "kubernetes",
+		AuthTypes:       []cloud.AuthType{"certificate"},
+		HostCloudRegion: "kubernetes/default",
+		Regions:         []cloud.Region{{Name: cloud.DefaultCloudRegion}}, // Verify DefaultCloudRegion is set. It's all this test can do really.
+	}
+
+	jimmAPIMock.EXPECT().Close().Times(1)
+	jimmAPIMock.EXPECT().AddCloudToController(&apiparams.AddCloudToControllerRequest{
+		ControllerName: "",
+		AddCloudArgs: params.AddCloudArgs{
+			Name:  "",
+			Cloud: jimmjujuapi.CloudToParams(*expectedCloud),
+			Force: &force,
+		},
+	}).Return(nil).Times(1)
+
+	cmd := addCloudToControllerCommand{
+		cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
+			return expectedCloud, nil
+		},
+		jimmAPIFunc: func(dialOpts *api.DialOpts) (JIMMAPI, error) {
+			return jimmAPIMock, nil
 		},
 	}
 
-	for _, test := range tests {
-		c.Log(test.about)
-		tmpfile, cleanupFunc := writeTempFile(c, test.cloudInfo)
-
-		bClient := s.SetupCLIAccess(c, "bob@canonical.com")
-		// Running the command succeeds
-		newCmd := cmd.NewAddCloudToControllerCommandForTesting(s.ClientStore(), bClient, test.cloudByNameFunc)
-		var err error
-		if test.cloudInfo != "" {
-			_, err = cmdtesting.RunCommand(c, newCmd, "controller-1", test.expectedCloudName, "--cloud="+tmpfile, "--force="+strconv.FormatBool(test.force))
-		} else {
-			_, err = cmdtesting.RunCommand(c, newCmd, "controller-1", test.expectedCloudName, "--force="+strconv.FormatBool(test.force))
-		}
-
-		if test.expectedError != "" {
-			c.Assert(err, gc.NotNil)
-			errWithoutBreaks := strings.ReplaceAll(err.Error(), "\n", "")
-			c.Assert(errWithoutBreaks, gc.Matches, test.expectedError)
-		} else {
-			c.Assert(err, gc.IsNil)
-			cloud := dbmodel.Cloud{Name: test.expectedCloudName}
-			err = s.JIMM.Database.GetCloud(context.Background(), &cloud)
-			c.Assert(err, gc.IsNil)
-			controller := dbmodel.Controller{Name: "controller-1"}
-			err = s.JIMM.Database.GetController(context.Background(), &controller)
-			c.Assert(err, gc.IsNil)
-			c.Assert(controller.CloudRegions[test.expectedIndex].CloudRegion.CloudName, gc.Equals, test.expectedCloudName)
-		}
-		cleanupFunc()
-		// Needed for JIMM CLI table tests
-		s.RefreshControllerAddress(c)
-	}
-}
-
-func writeTempFile(c *gc.C, content string) (string, func()) {
-	dir, err := os.MkdirTemp("", "add-cloud-to-controller-test")
-	c.Assert(err, gc.Equals, nil)
-
-	tmpfn := filepath.Join(dir, "tmp.yaml")
-
-	err = os.WriteFile(tmpfn, []byte(content), 0600)
-	c.Assert(err, gc.Equals, nil)
-	return tmpfn, func() {
-		os.RemoveAll(dir)
-	}
+	err := cmd.Run(newTestContext(t))
+	c.Assert(err, qt.IsNil)
 }

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -54,9 +54,8 @@ func TestAddCloudToControllerRun(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
-func TestAddCloudToControllerRun_CloudFile(t *testing.T) {
+func TestAddCloudToControllerRun_Run_CloudFromFile(t *testing.T) {
 	c := qt.New(t)
-	c.Skip("This test is failing since 3.6.12 since the providers moved to internal.")
 
 	writeTempFile := func(c *qt.C, content string) (string, func()) {
 		dir, err := os.MkdirTemp("", "add-cloud-to-controller-test")
@@ -83,7 +82,29 @@ clouds:
 
 	cmdMocks := setupCmdMocks(t)
 
+	cmdMocks.client.EXPECT().Close().Times(1)
+
+	// Expect args to be the cloud read from file.
+	expectedCloud := &cloud.Cloud{
+		Name:      "test-maas-cloud",
+		Type:      "maas",
+		AuthTypes: []cloud.AuthType{"oauth1"},
+		Regions:   []cloud.Region{{Name: "default"}},
+	}
+
+	force := false
+
+	cmdMocks.client.EXPECT().AddCloudToController(&apiparams.AddCloudToControllerRequest{
+		ControllerName: "",
+		AddCloudArgs: params.AddCloudArgs{
+			Name:  "test-maas-cloud",
+			Cloud: jimmjujuapi.CloudToParams(*expectedCloud),
+			Force: &force,
+		},
+	}).Return(nil).Times(1)
+
 	cmd := addCloudToControllerCommand{
+		cloudName:           "test-maas-cloud",
 		cloudDefinitionFile: cloudFile,
 		jimmAPIFunc: func(dialOpts *api.DialOpts) (JIMMAPI, error) {
 			return cmdMocks.client, nil

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -3,46 +3,23 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	jujucmd "github.com/juju/cmd/v3"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/rpc/params"
-	"go.uber.org/mock/gomock"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd/mocks"
 	jimmjujuapi "github.com/canonical/jimm/v3/internal/jujuapi"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-// Replace with utils in crossmodelquery pr prior to merging.
-func setupMocks(t *testing.T) *mocks.MockJIMMAPI {
-	ctrl := gomock.NewController(t)
-	jimmAPI := mocks.NewMockJIMMAPI(ctrl)
-
-	t.Cleanup(ctrl.Finish)
-
-	return jimmAPI
-}
-
-// Replace with utils in crossmodelquery pr prior to merging.
-func newTestContext(t *testing.T) *jujucmd.Context {
-	return &jujucmd.Context{
-		Context: t.Context(),
-		Dir:     t.TempDir(),
-		Stdin:   &bytes.Buffer{},
-		Stdout:  &bytes.Buffer{},
-		Stderr:  &bytes.Buffer{},
-	}
-}
 func TestAddCloudToControllerRun(t *testing.T) {
 	c := qt.New(t)
 
 	force := false
-	jimmAPIMock := setupMocks(t)
+
+	cmdMocks := setupCmdMocks(t)
 
 	expectedCloud := &cloud.Cloud{
 		Name:            "test-hosted-cloud",
@@ -52,8 +29,8 @@ func TestAddCloudToControllerRun(t *testing.T) {
 		Regions:         []cloud.Region{{Name: cloud.DefaultCloudRegion}}, // Verify DefaultCloudRegion is set. It's all this test can do really.
 	}
 
-	jimmAPIMock.EXPECT().Close().Times(1)
-	jimmAPIMock.EXPECT().AddCloudToController(&apiparams.AddCloudToControllerRequest{
+	cmdMocks.client.EXPECT().Close().Times(1)
+	cmdMocks.client.EXPECT().AddCloudToController(&apiparams.AddCloudToControllerRequest{
 		ControllerName: "",
 		AddCloudArgs: params.AddCloudArgs{
 			Name:  "",
@@ -67,7 +44,7 @@ func TestAddCloudToControllerRun(t *testing.T) {
 			return expectedCloud, nil
 		},
 		jimmAPIFunc: func(dialOpts *api.DialOpts) (JIMMAPI, error) {
-			return jimmAPIMock, nil
+			return cmdMocks.client, nil
 		},
 	}
 

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -43,6 +45,46 @@ func TestAddCloudToControllerRun(t *testing.T) {
 		cloudByNameFunc: func(cloudName string) (*cloud.Cloud, error) {
 			return expectedCloud, nil
 		},
+		jimmAPIFunc: func(dialOpts *api.DialOpts) (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+
+	err := cmd.Run(newTestContext(t))
+	c.Assert(err, qt.IsNil)
+}
+
+func TestAddCloudToControllerRun_CloudFile(t *testing.T) {
+	c := qt.New(t)
+	c.Skip("This test is failing since 3.6.12 since the providers moved to internal.")
+
+	writeTempFile := func(c *qt.C, content string) (string, func()) {
+		dir, err := os.MkdirTemp("", "add-cloud-to-controller-test")
+		c.Assert(err, qt.IsNil)
+
+		tmpfn := filepath.Join(dir, "tmp.yaml")
+
+		err = os.WriteFile(tmpfn, []byte(content), 0600)
+		c.Assert(err, qt.IsNil)
+		return tmpfn, func() {
+			os.RemoveAll(dir)
+		}
+	}
+
+	cloudFile, cleanup := writeTempFile(c, `
+clouds:
+  test-maas-cloud:
+    type: maas
+    auth-types: [oauth1]
+    regions:
+      default: {}`)
+
+	c.Cleanup(cleanup)
+
+	cmdMocks := setupCmdMocks(t)
+
+	cmd := addCloudToControllerCommand{
+		cloudDefinitionFile: cloudFile,
 		jimmAPIFunc: func(dialOpts *api.DialOpts) (JIMMAPI, error) {
 			return cmdMocks.client, nil
 		},

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -80,7 +80,6 @@ func (s *addCloudToControllerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *addCloudToControllerSuite) TestAddCloudToController(c *gc.C) {
-	c.Skip("This test is failing since 3.6.12 since the providers moved to internal.")
 	tests := []struct {
 		about             string
 		cloudInfo         string

--- a/cmd/jaas/cmd/apiroot.go
+++ b/cmd/jaas/cmd/apiroot.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/pkg/api"
+	jujuapi "github.com/juju/juju/api"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+// APIClientFunc is a function that returns a JIMMAPI client.
+type APIClientFunc func(dialOpts *jujuapi.DialOpts) (JIMMAPI, error)
+
+// NewClient creates a new JIMMAPI client using the provided dial options.
+func NewClient(dialOpts *jujuapi.DialOpts) (JIMMAPI, error) {
+	store := jujuclient.NewFileClientStore()
+	currentController, err := store.CurrentController()
+	if err != nil {
+		return nil, errors.E(err, "could not determine the current controller")
+	}
+
+	modelCmd := modelcmd.ControllerCommandBase{}
+	apiCaller, err := modelCmd.NewAPIRootWithDialOpts(store, currentController, "", dialOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
+}

--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"github.com/juju/cmd/v3"
 	jujuapi "github.com/juju/juju/api"
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
@@ -62,16 +61,6 @@ func NewListAuditEventsCommandForTesting(store jujuclient.ClientStore, lp jujuap
 	cmd := &listAuditEventsCommand{
 		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-
-	return modelcmd.WrapBase(cmd)
-}
-
-func NewAddCloudToControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider, cloudByNameFunc func(string) (*cloud.Cloud, error)) cmd.Command {
-	cmd := &addCloudToControllerCommand{
-		store:           store,
-		cloudByNameFunc: cloudByNameFunc,
-		dialOpts:        cmdtest.TestDialOpts(lp),
 	}
 
 	return modelcmd.WrapBase(cmd)

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -25,6 +25,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 		Name: "jaas",
 		Doc:  jaasDoc,
 	})
+
 	// Register commands here:
 	jaasCmd.Register(cmd.NewAddCloudToControllerCommand())
 	jaasCmd.Register(cmd.NewAddGroupCommand())

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -11,7 +11,7 @@ Add cloud to specific controller in jimm
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
-| `--cloud` |  | The path to the cloud's definition file. |
+| `--cloud` |  | The path to the cloud's definition file. The cloud name must be present in the file. |
 | `--force` | false | Forces the cloud to be added to the controller |
 | `--format` | yaml | Specify output format (json&#x7c;yaml) |
 | `-o`, `--output` |  | Specify an output file |

--- a/internal/testutils/cmdtest/jimmsuite.go
+++ b/internal/testutils/cmdtest/jimmsuite.go
@@ -187,19 +187,6 @@ func (s *JimmCmdSuite) SetupCLIAccess(c *gc.C, username string) api.LoginProvide
 	return lp
 }
 
-// RefreshControllerAddress is a useful helper function when writing table tests for JIMM CLI
-// commands that use NewAPIRootWithDialOpts. Each invocation of the NewAPIRootWithDialOpts function
-// updates the ClientStore and removes local IPs thus removing JIMM's IP.
-// Call this function in your table tests after each test run.
-func (s *JimmCmdSuite) RefreshControllerAddress(c *gc.C) {
-	jimm, ok := s.ClientStore().Controllers["JIMM"]
-	c.Assert(ok, gc.Equals, true)
-	u, err := url.Parse(s.HTTP.URL)
-	c.Assert(err, gc.IsNil)
-	jimm.APIEndpoints = []string{u.Host}
-	s.ClientStore().Controllers["JIMM"] = jimm
-}
-
 func (s *JimmCmdSuite) AddController(c *gc.C, name string, info *api.Info) {
 	ctl := &dbmodel.Controller{
 		UUID:          info.ControllerUUID,


### PR DESCRIPTION
## Description
Refactors add cloud to controller into a unit test. I've also added a single place to create JIMM API clients as:

1. We're not dialing any real controller anymore, so we don't care about the store
2. It removes the need to do "newClient" in every command and use the store. The store seems to only be used to dial for our cmd.
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
