### PR TITLE
test: refactor grantauditlog tests into unit tests

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -38,15 +38,6 @@ func NewModelStatusCommandForTesting(store jujuclient.ClientStore, lp jujuapi.Lo
 	return modelcmd.WrapBase(cmd)
 }
 
-func NewGrantAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &grantAuditLogAccessCommand{
-		store:    store,
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-
-	return modelcmd.WrapBase(cmd)
-}
-
 func NewRevokeAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &revokeAuditLogAccessCommand{
 		store:    store,

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -3,9 +3,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
-	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -32,6 +33,7 @@ func NewGrantAuditLogAccessCommand() cmd.Command {
 	cmd := &grantAuditLogAccessCommand{
 		store: jujuclient.NewFileClientStore(),
 	}
+	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -41,9 +43,10 @@ func NewGrantAuditLogAccessCommand() cmd.Command {
 type grantAuditLogAccessCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store    jujuclient.ClientStore
-	dialOpts *jujuapi.DialOpts
 	username string
+
+	store       jujuclient.ClientStore
+	jimmAPIFunc func() (JIMMAPI, error)
 }
 
 func (c *grantAuditLogAccessCommand) Info() *cmd.Info {
@@ -66,33 +69,49 @@ func (c *grantAuditLogAccessCommand) Init(args []string) error {
 	if len(args) == 0 {
 		return errors.E("missing username")
 	}
+
 	c.username, args = args[0], args[1:]
 	if len(args) > 0 {
 		return errors.E("unknown arguments")
+	}
+
+	if !names.IsValidUser(c.username) {
+		return errors.E("invalid username")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
-	if err != nil {
-		return errors.E(err, "could not determine controller")
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
 
-	userTag := names.NewUserTag(c.username)
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	api, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
 
-	client := api.NewClient(apiCaller)
-	err = client.GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{
-		UserTag: userTag.String(),
+	err = api.GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{
+		UserTag: names.NewUserTag(c.username).String(),
 	})
 	if err != nil {
 		return errors.E(err)
 	}
 
 	return nil
+}
+
+func (c *grantAuditLogAccessCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -91,6 +91,7 @@ func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return err
 	}
+	defer api.Close()
 
 	err = api.GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{
 		UserTag: names.NewUserTag(c.username).String(),

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/juju/cmd/v3"
@@ -12,7 +13,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -67,16 +67,16 @@ func (c *grantAuditLogAccessCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *grantAuditLogAccessCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return errors.E("missing username")
+		return errors.New("missing username")
 	}
 
 	c.username, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return errors.New("unknown arguments")
 	}
 
 	if !names.IsValidUser(c.username) {
-		return errors.E("invalid username")
+		return errors.New("invalid username")
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
 		UserTag: names.NewUserTag(c.username).String(),
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -106,7 +106,7 @@ func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
 func (c *grantAuditLogAccessCommand) newClient() (JIMMAPI, error) {
 	currentController, err := c.store.CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
 	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -76,7 +76,7 @@ func (c *grantAuditLogAccessCommand) Init(args []string) error {
 	}
 
 	if !names.IsValidUser(c.username) {
-		return errors.New("invalid username")
+		return fmt.Errorf("invalid username %q", c.username)
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -64,7 +64,7 @@ func TestGrantAuditLogAccessInit(t *testing.T) {
 	var command grantAuditLogAccessCommand
 
 	c.Assert(command.Init(nil), qt.ErrorMatches, "missing username")
-	c.Assert(command.Init([]string{"@@"}), qt.ErrorMatches, "invalid username")
+	c.Assert(command.Init([]string{"@@"}), qt.ErrorMatches, `invalid username "@@"`)
 	c.Assert(command.Init([]string{"bob@canonical.com", "extra"}), qt.ErrorMatches, "unknown arguments")
 
 	c.Assert(command.Init([]string{"bob@canonical.com"}), qt.IsNil)

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -1,31 +1,68 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"github.com/juju/cmd/v3/cmdtesting"
-	gc "gopkg.in/check.v1"
+	"testing"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	qt "github.com/frankban/quicktest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type grantAuditLogAccessSuite struct {
-	cmdtest.JimmCmdSuite
+func TestGrantAuditLogAccessRun_Success(t *testing.T) {
+	c := qt.New(t)
+
+	cmdMocks := setupCmdMocks(t)
+
+	cmdMocks.client.EXPECT().
+		GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{UserTag: "user-bob@canonical.com"}).
+		Return(nil).
+		Times(1)
+
+	command := &grantAuditLogAccessCommand{
+		username: "bob@canonical.com",
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+
+	err := command.Run(newTestContext(t))
+	c.Assert(err, qt.IsNil)
 }
 
-var _ = gc.Suite(&grantAuditLogAccessSuite{})
+func TestGrantAuditLogAccessRun_APIError(t *testing.T) {
+	c := qt.New(t)
 
-func (s *grantAuditLogAccessSuite) TestGrantAuditLogAccessSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	_, err := cmdtesting.RunCommand(c, cmd.NewGrantAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
-	c.Assert(err, gc.IsNil)
+	cmdMocks := setupCmdMocks(t)
+
+	cmdMocks.client.EXPECT().
+		GrantAuditLogAccess(gomock.Any()).
+		Return(errors.E("unauthorised access")).
+		Times(1)
+
+	command := &grantAuditLogAccessCommand{
+		username: "bob@canonical.com",
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+
+	err := command.Run(newTestContext(t))
+	c.Assert(err, qt.Not(qt.IsNil))
 }
 
-func (s *grantAuditLogAccessSuite) TestGrantAuditLogAccess(c *gc.C) {
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewGrantAuditLogAccessCommandForTesting(s.ClientStore(), bClient), "bob@canonical.com")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+func TestGrantAuditLogAccessInit(t *testing.T) {
+	c := qt.New(t)
+
+	var command grantAuditLogAccessCommand
+
+	c.Assert(command.Init(nil), qt.ErrorMatches, "missing username")
+	c.Assert(command.Init([]string{"@@"}), qt.ErrorMatches, "invalid username")
+	c.Assert(command.Init([]string{"bob@canonical.com", "extra"}), qt.ErrorMatches, "unknown arguments")
+
+	c.Assert(command.Init([]string{"bob@canonical.com"}), qt.IsNil)
+	c.Assert(command.username, qt.Equals, "bob@canonical.com")
 }

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -22,6 +22,8 @@ func TestGrantAuditLogAccessRun_Success(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	cmdMocks.client.EXPECT().Close()
+
 	command := &grantAuditLogAccessCommand{
 		username: "bob@canonical.com",
 		jimmAPIFunc: func() (JIMMAPI, error) {
@@ -42,6 +44,8 @@ func TestGrantAuditLogAccessRun_APIError(t *testing.T) {
 		GrantAuditLogAccess(gomock.Any()).
 		Return(errors.E("unauthorised access")).
 		Times(1)
+
+	cmdMocks.client.EXPECT().Close()
 
 	command := &grantAuditLogAccessCommand{
 		username: "bob@canonical.com",


### PR DESCRIPTION
## Description
Refactors grant audit log access tests into unit tests.

I added an additional bit of validation to the user tag as we were creating new name tag and it could have panicked. So we now validate in the Init() func. I've added a test to validate this.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
