### PR TITLE
refactor: adjust behaviour for bootstrap on public clouds

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -135,8 +135,6 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.config, "config",
 		"Specify a configuration file, or one or more configuration options.\n    (`--config config.yaml [--config key=value ...])`")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
-	// TODO(ale8k): Support passing cloud & cloudcredential files, for now we're looking up clouds and credentials added to the store.
-	// See cmd/juju/cloud/add.go L311 on a nice way to do this and credential will be somewhere in there too.
 }
 
 // Info implements modelcmd.Command.
@@ -157,6 +155,20 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 	bootstrapCloud, err := jujucloud.CloudByName(c.cloud)
 	if err != nil {
 		return fmt.Errorf("failed to get cloud %q: %w", c.cloud, err)
+	}
+
+	// If the cloud is a public cloud (AWS, Azure, etc), we clear bootstrapCloud to avoid sending
+	// unnecessary info, letting the server decide the cloud endpoints, etc.
+	// Regardless, the server uses its own cloud definition if it identifies the cloud is a public cloud.
+	publicClouds, _, err := jujucloud.PublicCloudMetadata(jujucloud.JujuPublicCloudsPath())
+	if err != nil {
+		return fmt.Errorf("failed to get public cloud metadata: %w", err)
+	}
+	for name := range publicClouds {
+		if name == c.cloud {
+			bootstrapCloud = nil
+			break
+		}
 	}
 
 	cloudCreds, err := c.ClientStore().CredentialForCloud(c.cloud)
@@ -210,7 +222,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		RegionName:        c.region,
 		ControllerName:    c.controllerName,
 		ControllerVersion: c.controllerVersion,
-		Cloud:             cloudToParams(*bootstrapCloud),
+		Cloud:             cloudToParams(bootstrapCloud),
 		Credential: jujuparams.CloudCredential{
 			Attributes: bootstrapCred.Attributes(),
 			AuthType:   string(bootstrapCred.AuthType()),
@@ -284,7 +296,10 @@ func (c *bootstrapCommand) newClient() (JIMMAPI, error) {
 
 // CloudToParams converts a jujucloud.Cloud to a jujuparams.Cloud.
 // Copied from api/client/cloud/cloud.go.
-func cloudToParams(cloud jujucloud.Cloud) jujuparams.Cloud {
+func cloudToParams(cloud *jujucloud.Cloud) jujuparams.Cloud {
+	if cloud == nil {
+		return jujuparams.Cloud{}
+	}
 	authTypes := make([]string, len(cloud.AuthTypes))
 	for i, authType := range cloud.AuthTypes {
 		authTypes[i] = string(authType)

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -5,14 +5,14 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/gnuflag"
 	jujucloud "github.com/juju/juju/cloud"
-	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"go.uber.org/mock/gomock"
@@ -79,11 +79,70 @@ func TestBootstrapArgParsing(t *testing.T) {
 	}
 }
 
-func TestBootstrapRunDetached(t *testing.T) {
+func TestBootstrapWithPublicCloud(t *testing.T) {
 	c := qt.New(t)
 	s := setupCmdMocks(c)
 
 	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
+	}, nil)
+
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartJobResponse, error) {
+		// If the cloud is public, the Cloud field should be empty.
+		c.Check(bsp.Cloud, qt.DeepEquals, jujuparams.Cloud{})
+		return &params.StartJobResponse{JobID: "test-job-id"}, nil
+	})
+	s.client.EXPECT().Close().Return(nil)
+
+	command := &bootstrapCommand{
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	command.SetClientStore(s.store)
+
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+	)
+
+	ctx := newTestContext(c)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+}
+
+// TestBootstrapApiParams verifies that the parameters passed to the
+// Bootstrap API are correctly constructed from the command line arguments.
+// It also uses a personal cloud to verify that the cloud params are set correctly.
+func TestBootstrapApiParams(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	// Override the Juju data dir to a temp dir. The cloud-related operations
+	// are not available on the store interface.
+	tmpJujuDir := t.TempDir()
+	defer os.RemoveAll(tmpJujuDir)
+	oldJujuDir := osenv.SetJujuXDGDataHome(tmpJujuDir)
+	defer osenv.SetJujuXDGDataHome(oldJujuDir)
+
+	cloudName := "my-cloud"
+	personalCloud := jujucloud.Cloud{
+		Name:      cloudName,
+		Type:      "openstack",
+		AuthTypes: jujucloud.AuthTypes{jujucloud.UserPassAuthType},
+		Endpoint:  "some-endpoint",
+	}
+	err := jujucloud.WritePersonalCloudMetadata(map[string]jujucloud.Cloud{
+		cloudName: personalCloud,
+	})
+	c.Assert(err, qt.IsNil)
 
 	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
@@ -95,7 +154,12 @@ func TestBootstrapRunDetached(t *testing.T) {
 			ControllerName: "controller-name",
 			CloudName:      cloudName,
 			RegionName:     "region",
-			Cloud:          jujuparams.Cloud{},
+			Cloud: jujuparams.Cloud{
+				Type:      "openstack",
+				AuthTypes: []string{string(jujucloud.UserPassAuthType)},
+				Endpoint:  "some-endpoint",
+				Regions:   []jujuparams.CloudRegion{},
+			},
 			Credential: jujuparams.CloudCredential{
 				AuthType:   string(jujucloud.UserPassAuthType),
 				Attributes: map[string]string{},
@@ -106,15 +170,13 @@ func TestBootstrapRunDetached(t *testing.T) {
 			},
 			ControllerVersion: "controller-version",
 		}
-		c.Assert(bsp.ControllerName, qt.Equals, expected.ControllerName)
-		c.Assert(bsp.CloudName, qt.Equals, expected.CloudName)
-		c.Assert(bsp.RegionName, qt.Equals, expected.RegionName)
-		// AWS is dynamically populated, i.e., 32 regions.
-		// So we expect just ec2 and it should be ok.
-		c.Assert(bsp.Cloud.Type, qt.Equals, "ec2")
-		c.Assert(bsp.Credential, qt.DeepEquals, expected.Credential)
-		c.Assert(bsp.Config, qt.DeepEquals, expected.Config)
-		c.Assert(bsp.ControllerVersion, qt.Equals, expected.ControllerVersion)
+		c.Check(bsp.ControllerName, qt.Equals, expected.ControllerName)
+		c.Check(bsp.CloudName, qt.Equals, expected.CloudName)
+		c.Check(bsp.RegionName, qt.Equals, expected.RegionName)
+		c.Check(bsp.Cloud, qt.DeepEquals, expected.Cloud)
+		c.Check(bsp.Credential, qt.DeepEquals, expected.Credential)
+		c.Check(bsp.Config, qt.DeepEquals, expected.Config)
+		c.Check(bsp.ControllerVersion, qt.Equals, expected.ControllerVersion)
 
 		return &params.StartJobResponse{
 			JobID: "test-job-id",
@@ -129,24 +191,56 @@ func TestBootstrapRunDetached(t *testing.T) {
 	}
 	command.SetClientStore(s.store)
 
-	configOpts := common.ConfigFlag{}
-	err := configOpts.Set("bootstrap-timeout=60")
-	c.Assert(err, qt.IsNil)
-	err = configOpts.Set("string-option=value")
-	c.Assert(err, qt.IsNil)
-
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = cloudName
-	command.region = "region"
-	command.controllerVersion = "controller-version"
-	command.config = configOpts
-	command.detach = true
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+		"--config", "bootstrap-timeout=60",
+		"--config", "string-option=value",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
 	err = mcmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestBootstrapRunDetached(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
+	}, nil)
+	s.client.EXPECT().StartBootstrapJob(gomock.Any()).Return(&params.StartJobResponse{
+		JobID: "test-job-id",
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	command := &bootstrapCommand{
+		bootstrapAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	command.SetClientStore(s.store)
+
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+		"--config", "bootstrap-timeout=60",
+		"--config", "string-option=value",
+	)
+
+	ctx := newTestContext(c)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -176,9 +270,12 @@ func TestBootstrapWatchLogs(t *testing.T) {
 		},
 	}
 	command.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.cloud = "aws"
+
+	initCommand(c, command,
+		"aws",
+		"controller-name",
+		"controller-version",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
@@ -198,12 +295,12 @@ func TestBootstrapFailsToGetCredential(t *testing.T) {
 		},
 	}
 	command.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = "aws" // Need a valid cloud to reach credential error.
-	command.region = "region"
-	command.controllerVersion = "controller-version"
+
+	initCommand(c, command,
+		"aws/region",
+		"controller-name",
+		"controller-version",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
@@ -228,12 +325,12 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 		},
 	}
 	command.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = "aws" // Need a valid cloud to reach credential error.
-	command.region = "region"
-	command.controllerVersion = "controller-version"
+
+	initCommand(c, command,
+		"aws/region",
+		"controller-name",
+		"controller-version",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
@@ -241,7 +338,12 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `multiple credentials found for cloud "aws", please set a default or specify one using --credential`)
 
 	// Now specify a credential and verify the command works.
-	command.credentialName = "cred-2"
+	initCommand(c, command,
+		"aws/region",
+		"controller-name",
+		"controller-version",
+		"--credential", "cred-2",
+	)
 
 	s.client.EXPECT().StartBootstrapJob(gomock.Any()).Return(&params.StartJobResponse{
 		JobID: "test-job-id",
@@ -281,13 +383,13 @@ func TestBootstrapWithDefaultCredential(t *testing.T) {
 		},
 	}
 	command.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = cloudName
-	command.region = "region"
-	command.controllerVersion = "controller-version"
-	command.detach = true
+
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
@@ -315,14 +417,14 @@ func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 		},
 	}
 	command.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	command.SetFlags(f)
-	command.controllerName = "controller-name"
-	command.cloud = cloudName
-	command.region = "region"
-	command.controllerVersion = "controller-version"
-	command.detach = true
-	command.credentialName = "cred-3" // Use a different credential than the default.
+
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+		"--credential", "cred-3",
+	)
 
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -261,7 +261,7 @@ func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 				CloudNameAndRegion: params.CloudNameAndRegion,
 				ControllerName:     params.ControllerName,
 				CloudCred:          params.CloudCred,
-				PersonalCloud:      params.PersonalCloud,
+				Cloud:              params.Cloud,
 				// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 				LoginTokenRefreshURL: b.jimmWellknownJWKSEndpoint,
 				// User defined config
@@ -340,9 +340,9 @@ type JobParams struct {
 	ControllerName     string
 	AgentVersion       string
 	CloudCred          jujucloud.Credential
-	// PersonalCloud is the personally defined cloud. Only necessary if the cloud is not a public
-	// cloud.
-	PersonalCloud jujucloud.Cloud
+	// Cloud contains the definition of the cloud e.g. endpoints, regions, TLS config.
+	// It only needs to be set if the cloud is not a public cloud (e.g. not AWS, Azure, etc).
+	Cloud jujucloud.Cloud
 
 	// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 
@@ -457,7 +457,7 @@ func (b *bootstrapManager) runBootstrap(
 			ControllerName:       p.ControllerName,
 			AgentVersion:         p.AgentVersion,
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
-			PersonalCloud:        p.PersonalCloud,
+			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
 			UserConfig:           p.UserConfig,
 		},

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -48,8 +48,8 @@ var (
 		ControllerName:     "a",
 		AgentVersion:       "3.6.3",
 
-		CloudCred:     jujucloud.Credential{},
-		PersonalCloud: jujucloud.Cloud{},
+		CloudCred: jujucloud.Credential{},
+		Cloud:     jujucloud.Cloud{},
 
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,
 	}
@@ -403,7 +403,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -671,7 +671,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -744,7 +744,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -824,7 +824,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -942,7 +942,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -1060,7 +1060,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -1198,7 +1198,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).Return(
@@ -1332,7 +1332,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 			ControllerName:       jobParams.ControllerName,
 			AgentVersion:         jobParams.AgentVersion,
 			DefaultLoginTokenURL: jobParams.LoginTokenRefreshURL,
-			PersonalCloud:        jobParams.PersonalCloud,
+			Cloud:                jobParams.Cloud,
 			CloudCred:            jobParams.CloudCred,
 		},
 	).DoAndReturn(func(ctx context.Context, bcp jujucommands.BootstrapCmdParams) (<-chan jujucommands.OutputLine, jujuclient.ClientStore, func(), error) {

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -20,8 +20,7 @@ type BootstrapParams struct {
 	ControllerName     string
 
 	CloudCred jujucloud.Credential
-	// PersonalCloud is the cloud-definition for a non-public cloud.
-	PersonalCloud jujucloud.Cloud
+	Cloud     jujucloud.Cloud
 
 	UserConfig map[string]string
 }

--- a/internal/jimm/upgrade/types.go
+++ b/internal/jimm/upgrade/types.go
@@ -14,8 +14,7 @@ type CloneControllerParams struct {
 	ControllerName     string
 
 	CloudCred jujucloud.Credential
-	// PersonalCloud is the cloud-definition for a non-public cloud.
-	PersonalCloud jujucloud.Cloud
+	Cloud     jujucloud.Cloud
 
 	UserConfig map[string]string
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -186,7 +186,7 @@ func (u *upgradeManager) CloneController(ctx context.Context, user *openfga.User
 		CloudNameAndRegion: params.CloudNameAndRegion,
 		ControllerName:     params.ControllerName,
 		CloudCred:          params.CloudCred,
-		PersonalCloud:      params.PersonalCloud,
+		Cloud:              params.Cloud,
 		UserConfig:         params.UserConfig,
 	})
 	if err != nil {
@@ -383,9 +383,7 @@ func (u *upgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		CloudCred:          bsCredential,
 	}
 
-	// TODO: Check if it is public cloud here and set PersonalCloud accordingly.
-	// For now, we're always setting it.
-	cloneParams.PersonalCloud = bsCloud
+	cloneParams.Cloud = bsCloud
 
 	// TODO: If K8S, override CloudNameAndRegion with HostCloudRegion from controller model summary.
 

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -363,7 +363,7 @@ func TestUpgradeTo_Success(t *testing.T) {
 			c.Assert(params.CLIVersion, qt.Equals, targetVersion.String())
 			c.Assert(params.CloudNameAndRegion, qt.Equals, "aws/us-east-1")
 			c.Assert(regexp.MustCompile(`^controller-\d+$`).MatchString(newControllerName), qt.IsTrue)
-			c.Assert(params.PersonalCloud.Name, qt.Equals, "aws")
+			c.Assert(params.Cloud.Name, qt.Equals, "aws")
 			return "550e8400-e29b-41d4-a716-446655440000", nil
 		})
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -662,7 +662,7 @@ func (r *controllerRoot) StartBootstrapJob(ctx context.Context, req apiparams.Bo
 		CloudNameAndRegion: cloudNameAndRegion,
 		ControllerName:     req.ControllerName,
 
-		PersonalCloud: cloudFromParams(req.CloudName, req.Cloud),
+		Cloud: cloudFromParams(req.CloudName, req.Cloud),
 		CloudCred: cloud.NewNamedCredential(
 			"bootstrap-credential",
 			cloud.AuthType(req.Credential.AuthType),

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -32,8 +32,9 @@ type BootstrapCmdParams struct {
 
 	// Additional args required (like adding credential, cloud, etc.) but JIMM will handle.
 
-	// May be left unset, if set, a personal cloud will be created and used for bootstrap.
-	PersonalCloud jujucloud.Cloud
+	// Cloud contains the details for the cloud.
+	// Only expected to be set if the cloud is not a public cloud (i.e. not AWS, Azure, etc).
+	Cloud jujucloud.Cloud
 	// The credential to use for the cloud.
 	CloudCred jujucloud.Credential
 
@@ -133,7 +134,6 @@ func (c *bootstrapCmd) Run(ctx context.Context, p BootstrapCmdParams) (<-chan Ou
 	osenv.SetJujuXDGDataHome(dataDir)
 
 	// Update public clouds
-	// TODO: Move this command to it's own file.
 	outputCh, err := c.runner.RunJujuCmd(ctx, []string{"update-public-clouds", "--client"})
 	if err != nil {
 		return nil, nil, nil, err
@@ -147,16 +147,17 @@ func (c *bootstrapCmd) Run(ctx context.Context, p BootstrapCmdParams) (<-chan Ou
 
 	store := jujuclient.NewFileClientStore()
 
-	// Check if we can get the cloud as a public cloud.
+	// If a cloud is not known to Juju i.e. clouds besides AWS, Azure, GCP, etc.,
+	// then we need to create a cloud entry on disk with information on how
+	// to reach the cloud, its regions, etc.
 	cloudName, regionName := splitCloudNameAndRegion(p.CloudNameAndRegion)
 	isAPublicCloud, err := isAValidPublicCloud(cloudName, regionName)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	if !isAPublicCloud {
-		// We presume it is a personal cloud
 		if err := jujucloud.WritePersonalCloudMetadata(map[string]jujucloud.Cloud{
-			cloudName: p.PersonalCloud,
+			cloudName: p.Cloud,
 		}); err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to write personal cloud: %w", err)
 		}
@@ -167,9 +168,6 @@ func (c *bootstrapCmd) Run(ctx context.Context, p BootstrapCmdParams) (<-chan Ou
 	// We only accept a single credential for bootstrapping.
 	cloudCred := jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
-			// TODO: Keying the credential by name is one means to ensure the
-			// credential is correctly passed and as we're using a single credential,
-			// this is OK. Ideally we should key it on name.
 			cloudName: p.CloudCred,
 		},
 	}

--- a/internal/jujucommands/bootstrap_test.go
+++ b/internal/jujucommands/bootstrap_test.go
@@ -168,7 +168,7 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_RunBootstrapCmd_PersonalCloud
 		AgentVersion:         "1.1.1",
 		DefaultLoginTokenURL: "myurl.com",
 
-		PersonalCloud: jujucloud.Cloud{
+		Cloud: jujucloud.Cloud{
 			Type: "lxd",
 			AuthTypes: jujucloud.AuthTypes{
 				jujucloud.CertificateAuthType,

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -116,7 +116,7 @@ func (s *controllerSuite) TestControllerVersion(c *gc.C) {
 	err := conn.APICall("Controller", 12, "", "ControllerVersion", nil, &result)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, jujuparams.ControllerVersionResults{
-		Version:   "3.6.13",
+		Version:   "3.6.14",
 		GitCommit: jimmversion.VersionInfo.GitCommit,
 	})
 }


### PR DESCRIPTION
## Description
This PR resolves some TODOs in the bootstrap and upgrade logic. Specifically the one that was targetted mentioned,
> // TODO: Check if it is public cloud here and set PersonalCloud accordingly.
> // For now, we're always setting it.

I checked whether our bootstrap logic supports bootstrapping onto public clouds. I was mostly able to successfully bootstrap to AWS with `./jaas bootstrap aws/us-east-1 my-test-controller 3.6.12`. I say _mostly_ because the machine was provisioned but the bootstrap failed near the end when the controller couldn't reach `https://jimm.localhost/.well-known/jwks.json` which was obviously only running locally. I'm not keen on deploying everything to AWS just to test this further as I was able to prove to myself this works and the code indicates the same.

Essentially the problem described in the TODO is that we shoudn't pass the cloud information to the StartBootstrap method if the cloud is a public cloud (i.e. AWS, Azure, etc). While it's not necessary to send the cloud info in these cases, it also doesn't do any harm, the bootstrap logic only writes these details to the filesystem if the cloud is not a public one. I did some renaming of the `PersonalCloud` field to just `Cloud` with some docstrings to hopefully make it clear (we pass these params around a lot so only some of the fields have docstrings).

In the end, the only substantial change I made was to the CLI, where we now skip sending the cloud information if it's a public cloud. This change is not required, since again, the server will decide whether it needs to use the cloud information. But I decided it was better to omit it if we know it's not needed.

I've also done some minor refactoring of the bootstrap command tests to accompany the above change.
 
Fixes [JUJU-8932](https://warthogs.atlassian.net/browse/JUJU-8932)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-8932]: https://warthogs.atlassian.net/browse/JUJU-8932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ