### PR TITLE
feat(show-model): adds show-model command

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -20,7 +20,7 @@ func TestAddCloudToControllerRun(t *testing.T) {
 
 	force := false
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	expectedCloud := &cloud.Cloud{
 		Name:            "test-hosted-cloud",
@@ -49,7 +49,7 @@ func TestAddCloudToControllerRun(t *testing.T) {
 		},
 	}
 
-	err := cmd.Run(newTestContext(t))
+	err := cmd.Run(newTestContext(c))
 	c.Assert(err, qt.IsNil)
 }
 
@@ -79,7 +79,7 @@ clouds:
 
 	c.Cleanup(cleanup)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().Close().Times(1)
 
@@ -110,6 +110,6 @@ clouds:
 		},
 	}
 
-	err := cmd.Run(newTestContext(t))
+	err := cmd.Run(newTestContext(c))
 	c.Assert(err, qt.IsNil)
 }

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -80,7 +80,7 @@ func TestBootstrapArgParsing(t *testing.T) {
 
 func TestBootstrapRunDetached(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	cloudName := "aws"
 
@@ -143,14 +143,14 @@ func TestBootstrapRunDetached(t *testing.T) {
 	command.config = configOpts
 	command.detach = true
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err = command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
 func TestBootstrapWatchLogs(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.store.EXPECT().CredentialForCloud("aws").Return(&jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
@@ -178,14 +178,14 @@ func TestBootstrapWatchLogs(t *testing.T) {
 	command.SetFlags(f)
 	command.cloud = "aws"
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
 func TestBootstrapFailsToGetCredential(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.store.EXPECT().CredentialForCloud("aws").Return(nil, errors.New("credential not found"))
 
@@ -202,14 +202,14 @@ func TestBootstrapFailsToGetCredential(t *testing.T) {
 	command.region = "region"
 	command.controllerVersion = "controller-version"
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `failed to get credential for cloud "aws": credential not found`)
 }
 
 func TestBootstrapMultipleCredentials(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.store.EXPECT().CredentialForCloud("aws").Return(&jujucloud.CloudCredential{
 		AuthCredentials: map[string]jujucloud.Credential{
@@ -231,7 +231,7 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 	command.region = "region"
 	command.controllerVersion = "controller-version"
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `multiple credentials found for cloud "aws", please set a default or specify one using --credential`)
 
@@ -255,7 +255,7 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 
 func TestBootstrapWithDefaultCredential(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	cloudName := "aws"
 
@@ -284,14 +284,14 @@ func TestBootstrapWithDefaultCredential(t *testing.T) {
 	command.controllerVersion = "controller-version"
 	command.detach = true
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
 func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	cloudName := "aws"
 
@@ -318,7 +318,7 @@ func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 	command.detach = true
 	command.credentialName = "cred-3" // Use a different credential than the default.
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `no credential found with name "cred-3"`)
 }

--- a/cmd/jaas/cmd/crossmodelquery_test.go
+++ b/cmd/jaas/cmd/crossmodelquery_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCrossModelQueryRun(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	expectedReq := &apiparams.CrossModelQueryRequest{
 		Type:  "jq",
@@ -41,7 +41,7 @@ func TestCrossModelQueryRun(t *testing.T) {
 
 	initCommand(c, command, ".applications")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
@@ -64,7 +64,7 @@ func TestCrossModelQueryRunClientError(t *testing.T) {
 
 	initCommand(c, command, ".applications")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, "could not create JIMM client: boom")
 }

--- a/cmd/jaas/cmd/destroycontroller_test.go
+++ b/cmd/jaas/cmd/destroycontroller_test.go
@@ -62,7 +62,7 @@ func TestArgParsing(t *testing.T) {
 func TestRunDetached(t *testing.T) {
 	c := qt.New(t)
 
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.client.EXPECT().StartDestroyControllerJob(gomock.Any()).DoAndReturn(func(bsp *params.DestroyControllerRequest) (*params.StartJobResponse, error) {
 		expected := &params.DestroyControllerRequest{
@@ -85,7 +85,7 @@ func TestRunDetached(t *testing.T) {
 
 	initCommand(c, command, "controller-name", "--detach", "--no-prompt")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
@@ -93,7 +93,7 @@ func TestRunDetached(t *testing.T) {
 func TestWatchLogs(t *testing.T) {
 	c := qt.New(t)
 
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.client.EXPECT().StartDestroyControllerJob(gomock.Any()).Return(&params.StartJobResponse{
 		JobID: "test-job-id",
@@ -115,7 +115,7 @@ func TestWatchLogs(t *testing.T) {
 
 	initCommand(c, command, "controller-name", "--no-prompt")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -15,7 +15,7 @@ import (
 func TestGrantAuditLogAccessRun_Success(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().
 		GrantAuditLogAccess(&apiparams.AuditLogAccessRequest{UserTag: "user-bob@canonical.com"}).
@@ -31,14 +31,14 @@ func TestGrantAuditLogAccessRun_Success(t *testing.T) {
 		},
 	}
 
-	err := command.Run(newTestContext(t))
+	err := command.Run(newTestContext(c))
 	c.Assert(err, qt.IsNil)
 }
 
 func TestGrantAuditLogAccessRun_APIError(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().
 		GrantAuditLogAccess(gomock.Any()).
@@ -54,7 +54,7 @@ func TestGrantAuditLogAccessRun_APIError(t *testing.T) {
 		},
 	}
 
-	err := command.Run(newTestContext(t))
+	err := command.Run(newTestContext(c))
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 

--- a/cmd/jaas/cmd/group_test.go
+++ b/cmd/jaas/cmd/group_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAddGroup(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	// Setup expectations
 	expectedGroup := params.Group{
@@ -39,7 +39,7 @@ func TestAddGroup(t *testing.T) {
 	command.SetClientStore(s.store)
 	initCommand(c, command, "test-group")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
@@ -52,7 +52,7 @@ func TestAddGroup(t *testing.T) {
 
 func TestAddGroupAPIError(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	expectedErr := errors.New("failed to connect")
 
@@ -65,14 +65,14 @@ func TestAddGroupAPIError(t *testing.T) {
 	command.SetClientStore(s.store)
 	initCommand(c, command, "test-group")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNotNil)
 }
 
 func TestRenameGroup(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	// Setup expectations
 	s.client.EXPECT().RenameGroup(gomock.Any()).DoAndReturn(func(rgr *params.RenameGroupRequest) error {
@@ -93,14 +93,14 @@ func TestRenameGroup(t *testing.T) {
 	command.SetClientStore(s.store)
 	initCommand(c, command, "old-group", "new-group")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
 func TestRemoveGroup(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	// Setup expectations
 	s.client.EXPECT().RemoveGroup(gomock.Any()).DoAndReturn(func(rgr *params.RemoveGroupRequest) error {
@@ -117,7 +117,7 @@ func TestRemoveGroup(t *testing.T) {
 	}
 
 	initCommand(c, command, "test-group")
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	ctx.Stdin = bytes.NewBufferString("y\n")
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
@@ -125,7 +125,7 @@ func TestRemoveGroup(t *testing.T) {
 
 func TestRemoveGroupForce(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	// Setup expectations
 	s.client.EXPECT().RemoveGroup(gomock.Any()).DoAndReturn(func(rgr *params.RemoveGroupRequest) error {
@@ -143,14 +143,14 @@ func TestRemoveGroupForce(t *testing.T) {
 
 	initCommand(c, command, "test-group", "--force")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
 func TestListGroups(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	// Setup expectations
 	s.client.EXPECT().ListGroups(gomock.Any()).Return([]params.Group{
@@ -167,7 +167,7 @@ func TestListGroups(t *testing.T) {
 	command.SetClientStore(s.store)
 	initCommand(c, command)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }

--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -34,6 +34,7 @@ type JIMMAPI interface {
 
 	// Model operations
 	FullModelStatus(req *params.FullModelStatusRequest) (jujuparams.FullStatus, error)
+	ModelControllerInfo(model string) (*params.ModelControllerInfo, error)
 
 	// Audit log operations
 	FindAuditEvents(req *params.FindAuditEventsRequest) (params.AuditEvents, error)

--- a/cmd/jaas/cmd/jobstop_test.go
+++ b/cmd/jaas/cmd/jobstop_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestJobStop(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	jobId := "test-job-id"
 	s.client.EXPECT().StopJob(gomock.Any()).Return(nil)
@@ -27,7 +27,7 @@ func TestJobStop(t *testing.T) {
 
 	initCommand(c, command, jobId)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
@@ -37,7 +37,7 @@ func TestJobStop(t *testing.T) {
 
 func TestJobStopError(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	jobId := "test-job-id"
 	s.client.EXPECT().StopJob(gomock.Any()).Return(errors.New("an error"))
@@ -51,7 +51,7 @@ func TestJobStopError(t *testing.T) {
 
 	initCommand(c, command, jobId)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, "failed to stop job: an error")
 }

--- a/cmd/jaas/cmd/listauditevents_test.go
+++ b/cmd/jaas/cmd/listauditevents_test.go
@@ -20,7 +20,7 @@ import (
 func TestListAuditEventsRun_Success(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	expected := apiparams.AuditEvents{Events: []apiparams.AuditEvent{{MessageId: 1}}}
 
@@ -43,7 +43,7 @@ func TestListAuditEventsRun_Success(t *testing.T) {
 	fs := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
 	command.SetFlags(fs)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
@@ -54,7 +54,7 @@ func TestListAuditEventsRun_Success(t *testing.T) {
 func TestListAuditEventsRun_APICallFails(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().
 		FindAuditEvents(gomock.Any()).
@@ -72,7 +72,7 @@ func TestListAuditEventsRun_APICallFails(t *testing.T) {
 	fs := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
 	command.SetFlags(fs)
 
-	err := command.Run(newTestContext(t))
+	err := command.Run(newTestContext(c))
 	c.Assert(err, qt.ErrorMatches, ".*nope.*")
 }
 
@@ -87,7 +87,7 @@ func TestListAuditEventsInit_RejectsArgs(t *testing.T) {
 func TestListAuditEventsRun_FlagsArePassedToAPICorrectly(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().
 		FindAuditEvents(gomock.Any()).
@@ -127,14 +127,14 @@ func TestListAuditEventsRun_FlagsArePassedToAPICorrectly(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	err = command.Run(newTestContext(t))
+	err = command.Run(newTestContext(c))
 	c.Assert(err, qt.IsNil)
 }
 
 func TestListAuditEventsRun_TabularFormat(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -170,7 +170,7 @@ func TestListAuditEventsRun_TabularFormat(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err = command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 

--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestListControllersSuperuser(t *testing.T) {
 	c := qt.New(t)
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	expectedControllers := []params.ControllerInfo{
 		{
@@ -62,7 +62,7 @@ func TestListControllersSuperuser(t *testing.T) {
 
 	initCommand(c, command)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
@@ -76,7 +76,7 @@ func TestListControllersSuperuser(t *testing.T) {
 
 func TestListControllersEmpty(t *testing.T) {
 	c := qt.New(t)
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().ListControllers().Return([]params.ControllerInfo{}, nil)
 	cmdMocks.client.EXPECT().Close().Return(nil)
@@ -90,7 +90,7 @@ func TestListControllersEmpty(t *testing.T) {
 
 	initCommand(c, command)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)

--- a/cmd/jaas/cmd/listmigrationtargets_test.go
+++ b/cmd/jaas/cmd/listmigrationtargets_test.go
@@ -56,7 +56,7 @@ func TestListMigrationTargetsValidation(t *testing.T) {
 
 func TestListMigrationTargets(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(t)
+	s := setupCmdMocks(c)
 
 	s.client.EXPECT().ListMigrationTargets(gomock.Any()).DoAndReturn(func(lmtr *params.ListMigrationTargetsRequest) ([]params.ControllerInfo, error) {
 		c.Check(lmtr.ModelTag, qt.Equals, "model-e14aff09-e951-413b-833d-60b1a27bd604")
@@ -79,7 +79,7 @@ func TestListMigrationTargets(t *testing.T) {
 
 	initCommand(c, command, "e14aff09-e951-413b-833d-60b1a27bd604")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 

--- a/cmd/jaas/cmd/migrateinternalmodel_test.go
+++ b/cmd/jaas/cmd/migrateinternalmodel_test.go
@@ -18,7 +18,7 @@ import (
 func TestMigrateInternalModelCommand_BuildsRequestAndWritesOutput(t *testing.T) {
 	c := qt.New(t)
 
-	cmdMocks := setupCmdMocks(t)
+	cmdMocks := setupCmdMocks(c)
 
 	cmdMocks.client.EXPECT().
 		MigrateModel(gomock.Any()).
@@ -48,7 +48,7 @@ func TestMigrateInternalModelCommand_BuildsRequestAndWritesOutput(t *testing.T) 
 	err := cmdtesting.InitCommand(command, []string{"controller-1", "model-uuid-1", "owner/model-2"})
 	c.Assert(err, qt.IsNil)
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err = command.Run(ctx)
 	c.Assert(err, qt.IsNil)
 

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -857,6 +857,45 @@ func (c *MockJIMMAPIMigrateModelCall) DoAndReturn(f func(*params.MigrateModelReq
 	return c
 }
 
+// ModelControllerInfo mocks base method.
+func (m *MockJIMMAPI) ModelControllerInfo(model string) (*params.ModelControllerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModelControllerInfo", model)
+	ret0, _ := ret[0].(*params.ModelControllerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModelControllerInfo indicates an expected call of ModelControllerInfo.
+func (mr *MockJIMMAPIMockRecorder) ModelControllerInfo(model any) *MockJIMMAPIModelControllerInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelControllerInfo", reflect.TypeOf((*MockJIMMAPI)(nil).ModelControllerInfo), model)
+	return &MockJIMMAPIModelControllerInfoCall{Call: call}
+}
+
+// MockJIMMAPIModelControllerInfoCall wrap *gomock.Call
+type MockJIMMAPIModelControllerInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIModelControllerInfoCall) Return(arg0 *params.ModelControllerInfo, arg1 error) *MockJIMMAPIModelControllerInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIModelControllerInfoCall) Do(f func(string) (*params.ModelControllerInfo, error)) *MockJIMMAPIModelControllerInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIModelControllerInfoCall) DoAndReturn(f func(string) (*params.ModelControllerInfo, error)) *MockJIMMAPIModelControllerInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // PrepareModelMigration mocks base method.
 func (m *MockJIMMAPI) PrepareModelMigration(req *params.PrepareModelMigrationRequest) (params.PrepareModelMigrationResponse, error) {
 	m.ctrl.T.Helper()

--- a/cmd/jaas/cmd/showmodel.go
+++ b/cmd/jaas/cmd/showmodel.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Canonical.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujuapi "github.com/juju/juju/api"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/jujuclient"
+
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	showModelCommandDoc = `
+Displays information about which controller the specified model is running on.
+
+The model can be specified using either:
+  - Model UUID (e.g., "2cb433a6-04eb-4ec4-9567-90426d20a004")
+  - Owner and model name (e.g., "alice@canonical.com/my-model")
+
+The output includes the model name, model UUID, controller name, and controller UUID.
+`
+	showModelCommandExample = `
+    jaas show-model 2cb433a6-04eb-4ec4-9567-90426d20a004
+    jaas show-model alice@canonical.com/my-model
+    jaas show-model alice@canonical.com/my-model --format json
+    jaas show-model alice@canonical.com/my-model --format yaml
+`
+)
+
+// NewShowModelCommand returns a command to display model controller information.
+func NewShowModelCommand() cmd.Command {
+	cmd := &showModelCommand{
+		store: jujuclient.NewFileClientStore(),
+	}
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// showModelCommand displays information about
+// which controller the specified model is running on.
+type showModelCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	store          jujuclient.ClientStore
+	dialOpts       *jujuapi.DialOpts
+	modelQualifier string
+	client         JIMMAPI
+}
+
+func (c *showModelCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "show-model",
+		Args:     "<model>",
+		Purpose:  "Displays information about a model and its controller",
+		Doc:      showModelCommandDoc,
+		Examples: showModelCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
+		"yaml":    cmd.FormatYaml,
+		"json":    cmd.FormatJson,
+		"tabular": c.formatTabular,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *showModelCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("missing model qualifier")
+	}
+	c.modelQualifier, args = args[0], args[1:]
+	if len(args) > 0 {
+		return fmt.Errorf("unknown arguments: %v", args)
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *showModelCommand) Run(ctxt *cmd.Context) error {
+	var client JIMMAPI
+	if c.client != nil {
+		client = c.client
+	} else {
+		currentController, err := c.store.CurrentController()
+		if err != nil {
+			return fmt.Errorf("could not determine controller: %w", err)
+		}
+
+		apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+		if err != nil {
+			return err
+		}
+
+		client = api.NewClient(apiCaller)
+	}
+
+	info, err := client.ModelControllerInfo(c.modelQualifier)
+	if err != nil {
+		return err
+	}
+
+	err = c.out.Write(ctxt, info)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// formatTabular formats the model controller info in a tabular format.
+func (c *showModelCommand) formatTabular(writer io.Writer, value interface{}) error {
+	info, ok := value.(*apiparams.ModelControllerInfo)
+	if !ok {
+		return fmt.Errorf("expected *apiparams.ModelControllerInfo, got %T", value)
+	}
+
+	tw := output.TabWriter(writer)
+	w := output.Wrapper{TabWriter: tw}
+
+	w.PrintHeaders(output.EmphasisHighlight.DefaultBold, "Model name", "Model UUID", "Controller name", "Controller UUID")
+	w.Println(info.ModelName, info.ModelUUID, info.ControllerName, info.ControllerUUID)
+	w.Flush()
+
+	return nil
+}

--- a/cmd/jaas/cmd/showmodel_test.go
+++ b/cmd/jaas/cmd/showmodel_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Canonical.
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/gnuflag"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+func runShowModelCommand(c *qt.C, mocks *cmdMocks, args ...string) (string, error) {
+	showCmd := showModelCommand{
+		store:  mocks.store,
+		client: mocks.client,
+	}
+
+	ctx := newTestContext(c)
+	f := gnuflag.NewFlagSetWithFlagKnownAs(showCmd.Info().Name, gnuflag.ContinueOnError, cmd.FlagAlias(&showCmd, "flag"))
+	f.SetOutput(io.Discard)
+	showCmd.SetFlags(f)
+	err := f.Parse(showCmd.AllowInterspersedFlags(), args)
+	c.Assert(err, qt.IsNil)
+
+	err = showCmd.Init(f.Args())
+	if err != nil {
+		return "", err
+	}
+
+	err = showCmd.Run(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return cmdtesting.Stdout(ctx), nil
+}
+
+func TestShowModelOutput(t *testing.T) {
+	c := qt.New(t)
+
+	modelControllerInfo := &apiparams.ModelControllerInfo{
+		ModelName:      "test-model",
+		ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+		ControllerName: "test-controller",
+		ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+	}
+
+	mocks := setupCmdMocks(c)
+	mocks.store.EXPECT().CurrentController().Return("test-controller", nil).AnyTimes()
+	mocks.store.EXPECT().ControllerByName("test-controller").Return(nil, errors.New("not found")).AnyTimes()
+	mocks.client.EXPECT().ModelControllerInfo("12345678-1234-1234-1234-123456789abc").Return(modelControllerInfo, nil).AnyTimes()
+
+	tests := []struct {
+		args           []string
+		expectedOutput string
+	}{{
+		args:           []string{"12345678-1234-1234-1234-123456789abc", "--format", "json"},
+		expectedOutput: `{"model-name":"test-model","model-uuid":"12345678-1234-1234-1234-123456789abc","controller-name":"test-controller","controller-uuid":"87654321-4321-4321-4321-cba987654321"}`,
+	}, {
+		args: []string{"12345678-1234-1234-1234-123456789abc", "--format", "yaml"},
+		expectedOutput: `model-name: test-model
+model-uuid: 12345678-1234-1234-1234-123456789abc
+controller-name: test-controller
+controller-uuid: 87654321-4321-4321-4321-cba987654321`,
+	}, {
+		args: []string{"12345678-1234-1234-1234-123456789abc", "--format", "tabular"},
+		expectedOutput: `Model name  Model UUID                            Controller name  Controller UUID
+test-model  12345678-1234-1234-1234-123456789abc  test-controller  87654321-4321-4321-4321-cba987654321`,
+	}}
+	for _, test := range tests {
+		output, err := runShowModelCommand(c, mocks, test.args...)
+		c.Assert(err, qt.IsNil)
+		output = strings.TrimRight(output, "\n")
+		c.Assert(output, qt.Equals, test.expectedOutput)
+	}
+}
+
+func TestShowModelError(t *testing.T) {
+	c := qt.New(t)
+
+	mocks := setupCmdMocks(c)
+	mocks.store.EXPECT().CurrentController().Return("test-controller", nil).AnyTimes()
+	mocks.store.EXPECT().ControllerByName("test-controller").Return(nil, errors.New("not found")).AnyTimes()
+	mocks.client.EXPECT().ModelControllerInfo("12345678-1234-1234-1234-123456789abc").Return(nil, errors.New("not found")).AnyTimes()
+
+	_, err := runShowModelCommand(c, mocks, "12345678-1234-1234-1234-123456789abc")
+	c.Assert(err, qt.ErrorMatches, "not found")
+}
+
+func TestShowModelArgsError(t *testing.T) {
+	c := qt.New(t)
+
+	mocks := setupCmdMocks(c)
+	mocks.store.EXPECT().CurrentController().Return("test-controller", nil).AnyTimes()
+	mocks.store.EXPECT().ControllerByName("test-controller").Return(nil, errors.New("not found")).AnyTimes()
+	mocks.client.EXPECT().ModelControllerInfo("12345678-1234-1234-1234-123456789abc").Return(nil, errors.New("not found")).AnyTimes()
+
+	_, err := runShowModelCommand(c, mocks)
+	c.Assert(err, qt.ErrorMatches, "missing model qualifier")
+
+	_, err = runShowModelCommand(c, mocks, "12345678-1234-1234-1234-123456789abc", "extra-arg")
+	c.Assert(err, qt.ErrorMatches, `unknown arguments: \[extra-arg\]`)
+}

--- a/cmd/jaas/cmd/utils_test.go
+++ b/cmd/jaas/cmd/utils_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"testing"
 
 	qt "github.com/frankban/quicktest"
 	jujucmd "github.com/juju/cmd/v3"
@@ -22,21 +21,21 @@ type cmdMocks struct {
 	store  *mocks.MockClientStore
 }
 
-func setupCmdMocks(t *testing.T) *cmdMocks {
-	t.Helper()
-	ctrl := gomock.NewController(t)
+func setupCmdMocks(c *qt.C) *cmdMocks {
+	c.Helper()
+	ctrl := gomock.NewController(c)
 	h := &cmdMocks{
 		client: mocks.NewMockJIMMAPI(ctrl),
 		store:  mocks.NewMockClientStore(ctrl),
 	}
-	t.Cleanup(ctrl.Finish)
+	c.Cleanup(ctrl.Finish)
 	return h
 }
 
-func newTestContext(t *testing.T) *jujucmd.Context {
+func newTestContext(c *qt.C) *jujucmd.Context {
 	return &jujucmd.Context{
-		Context: t.Context(),
-		Dir:     t.TempDir(),
+		Context: c.Context(),
+		Dir:     c.TempDir(),
 		Stdin:   &bytes.Buffer{},
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -55,6 +55,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewRenameRoleCommand())
 	jaasCmd.Register(cmd.NewRevokeAuditLogAccessCommand())
 	jaasCmd.Register(cmd.NewSetControllerDeprecatedCommand())
+	jaasCmd.Register(cmd.NewShowModelCommand())
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
 	jaasCmd.Register(cmd.NewUpgradeToCommand())

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -1283,6 +1283,41 @@ Sets controller deprecated status.
 Sets the deprecated status of a controller.
 
 
+(command-jaas-show-model)=
+# jaas show-model
+
+## Summary
+Displays information about a model and its controller
+
+## Usage
+```jaas show-model [options] <model>```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--format` | tabular | Specify output format (json&#x7c;tabular&#x7c;yaml) |
+| `-o`, `--output` |  | Specify an output file |
+
+## Examples
+
+    jaas show-model 2cb433a6-04eb-4ec4-9567-90426d20a004
+    jaas show-model alice@canonical.com/my-model
+    jaas show-model alice@canonical.com/my-model --format json
+    jaas show-model alice@canonical.com/my-model --format yaml
+
+
+## Details
+
+Displays information about which controller the specified model is running on.
+
+The model can be specified using either:
+  - Model UUID (e.g., "2cb433a6-04eb-4ec4-9567-90426d20a004")
+  - Owner and model name (e.g., "alice@canonical.com/my-model")
+
+The output includes the model name, model UUID, controller name, and controller UUID.
+
+
 (command-jaas-unregister-controller)=
 # jaas unregister-controller
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -241,6 +241,7 @@ type JujuManager interface {
 	ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error
 	ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelInfo, error)
+	ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error)
 	ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) (jujuparams.ModelSummaryResults, error)
 	ModelStatus(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelStatus, error)
 	QueryModelsJq(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/credentials"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 var (
@@ -329,7 +330,6 @@ func (j *JujuManager) PrepareModelMigration(
 // model could be migrated to. This includes controllers that support the model's
 // cloud region and version, but excludes the controller the model is already on.
 func (j *JujuManager) ListMigrationTargets(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error) {
-
 	if !user.JimmAdmin {
 		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
@@ -364,4 +364,54 @@ func (j *JujuManager) ListMigrationTargets(ctx context.Context, user *openfga.Us
 	}
 
 	return controllers, nil
+}
+
+// ModelControllerInfoQualifier specifies a qualifier for ModelControllerInfo.
+type ModelControllerInfoQualifier func(*dbmodel.Model)
+
+// WithModelUUID specifies the model by its UUID.
+func WithModelUUID(uuid string) ModelControllerInfoQualifier {
+	return func(o *dbmodel.Model) {
+		o.UUID = sql.NullString{
+			String: uuid,
+			Valid:  true,
+		}
+	}
+}
+
+// WithOwnerAndModelName specifies the model by owner and model name.
+func WithOwnerAndModelName(ownerName, modelName string) ModelControllerInfoQualifier {
+	return func(o *dbmodel.Model) {
+		o.OwnerIdentityName = ownerName
+		o.Name = modelName
+	}
+}
+
+// ModelControllerInfo returns information about a model.
+// The model can be specified using functional options:
+// - WithModelUUID(uuid) to specify by model UUID
+// - WithOwnerAndModelName(owner, name) to specify by owner and model name
+func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+	if !user.JimmAdmin {
+		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+
+	var model dbmodel.Model
+	qualifier(&model)
+
+	if !model.UUID.Valid && (model.OwnerIdentityName == "" || model.Name == "") {
+		return nil, errors.E("either model uuid or both model name and owner must be provided", errors.CodeBadRequest)
+	}
+
+	err := j.Database.GetModel(ctx, &model)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+
+	return &apiparams.ModelControllerInfo{
+		ModelName:      model.Name,
+		ModelUUID:      model.UUID.String,
+		ControllerName: model.Controller.Name,
+		ControllerUUID: model.Controller.UUID,
+	}, nil
 }

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -1102,3 +1102,193 @@ func TestListMigrationTargets(t *testing.T) {
 		})
 	}
 }
+
+const testModelControllerInfoEnv = `clouds:
+- name: test-cloud
+  type: test
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+- name: cred-1
+  owner: alice@canonical.com
+  cloud: test-cloud
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+- name: controller-2
+  uuid: 00000001-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: controller-1
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: alice@canonical.com
+  life: alive
+  users:
+  - user: alice@canonical.com
+    access: admin
+- name: model-2
+  uuid: 00000002-0000-0000-0000-000000000002
+  controller: controller-2
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: bob@canonical.com
+  life: alive
+  users:
+  - user: bob@canonical.com
+    access: admin
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+- username: bob@canonical.com
+  controller-access: login
+`
+
+func TestModelControllerInfo(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testModelControllerInfoEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	tests := []struct {
+		about         string
+		user          dbmodel.Identity
+		jimmAdmin     bool
+		useModelTag   bool
+		modelTag      string
+		ownerName     string
+		modelName     string
+		expectedInfo  *params.ModelControllerInfo
+		expectedError string
+	}{{
+		about:       "jimm admin can get model controller info by model uuid",
+		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:   true,
+		useModelTag: true,
+		modelTag:    "00000002-0000-0000-0000-000000000001",
+		expectedInfo: &params.ModelControllerInfo{
+			ModelName:      "model-1",
+			ModelUUID:      "00000002-0000-0000-0000-000000000001",
+			ControllerName: "controller-1",
+			ControllerUUID: "00000001-0000-0000-0000-000000000001",
+		},
+	}, {
+		about:       "jimm admin can get model controller info for different controller by model uuid",
+		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:   true,
+		useModelTag: true,
+		modelTag:    "00000002-0000-0000-0000-000000000002",
+		expectedInfo: &params.ModelControllerInfo{
+			ModelName:      "model-2",
+			ModelUUID:      "00000002-0000-0000-0000-000000000002",
+			ControllerName: "controller-2",
+			ControllerUUID: "00000001-0000-0000-0000-000000000002",
+		},
+	}, {
+		about:         "non-admin user cannot get model controller info by model uuid",
+		user:          env.User("bob@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     false,
+		useModelTag:   true,
+		modelTag:      "00000002-0000-0000-0000-000000000001",
+		expectedError: "unauthorized",
+	}, {
+		about:         "jimm admin fails for non-existent model by model uuid",
+		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     true,
+		useModelTag:   true,
+		modelTag:      "00000002-0000-0000-0000-000000000999",
+		expectedError: "model not found",
+	}, {
+		about:       "jimm admin can get model controller info by owner and name",
+		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:   true,
+		useModelTag: false,
+		ownerName:   "alice@canonical.com",
+		modelName:   "model-1",
+		expectedInfo: &params.ModelControllerInfo{
+			ModelName:      "model-1",
+			ModelUUID:      "00000002-0000-0000-0000-000000000001",
+			ControllerName: "controller-1",
+			ControllerUUID: "00000001-0000-0000-0000-000000000001",
+		},
+	}, {
+		about:       "jimm admin can get model controller info for different model by owner and name",
+		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:   true,
+		useModelTag: false,
+		ownerName:   "bob@canonical.com",
+		modelName:   "model-2",
+		expectedInfo: &params.ModelControllerInfo{
+			ModelName:      "model-2",
+			ModelUUID:      "00000002-0000-0000-0000-000000000002",
+			ControllerName: "controller-2",
+			ControllerUUID: "00000001-0000-0000-0000-000000000002",
+		},
+	}, {
+		about:         "non-admin user cannot get model controller info by owner and name",
+		user:          env.User("bob@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     false,
+		useModelTag:   false,
+		ownerName:     "alice@canonical.com",
+		modelName:     "model-1",
+		expectedError: "unauthorized",
+	}, {
+		about:         "jimm admin fails for non-existent model by owner and name",
+		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     true,
+		useModelTag:   false,
+		ownerName:     "alice@canonical.com",
+		modelName:     "non-existent-model",
+		expectedError: "model not found",
+	}, {
+		about:         "jimm admin fails when neither model uuid nor owner/name provided",
+		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     true,
+		useModelTag:   false,
+		ownerName:     "",
+		modelName:     "",
+		expectedError: "either model uuid or both model name and owner must be provided",
+	}, {
+		about:         "jimm admin fails when only owner name provided",
+		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
+		jimmAdmin:     true,
+		useModelTag:   false,
+		ownerName:     "alice@canonical.com",
+		modelName:     "",
+		expectedError: "either model uuid or both model name and owner must be provided",
+	}}
+
+	for _, test := range tests {
+		c.Run(test.about, func(c *qt.C) {
+			user := openfga.NewUser(&test.user, j.OpenFGAClient)
+			user.JimmAdmin = test.jimmAdmin
+
+			var info *params.ModelControllerInfo
+			var err error
+			if test.useModelTag {
+				info, err = j.ModelControllerInfo(ctx, user, juju.WithModelUUID(test.modelTag))
+			} else {
+				info, err = j.ModelControllerInfo(ctx, user, juju.WithOwnerAndModelName(test.ownerName, test.modelName))
+			}
+
+			if test.expectedError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				c.Assert(info, qt.IsNil)
+			} else {
+				c.Assert(err, qt.IsNil)
+				c.Assert(info, qt.DeepEquals, test.expectedInfo)
+			}
+		})
+	}
+}

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -72,6 +72,7 @@ func init() {
 		startDestroyControllerJob := rpc.Method(r.StartDestroyControllerJob)
 		upgradeToMethod := rpc.Method(r.UpgradeTo)
 		listUserCloudsMethod := rpc.Method(r.ListUserClouds)
+		modelControllerInfoMethod := rpc.Method(r.ModelControllerInfo)
 
 		// JIMM Generic RPC
 		r.AddMethod("JIMM", 4, "AddCloudToController", addCloudToControllerMethod)
@@ -85,6 +86,7 @@ func init() {
 		r.AddMethod("JIMM", 4, "ListControllers", listControllersMethod)
 		r.AddMethod("JIMM", 4, "ListUserClouds", listUserCloudsMethod)
 		r.AddMethod("JIMM", 4, "MigrateModel", migrateModel)
+		r.AddMethod("JIMM", 4, "ModelControllerInfo", modelControllerInfoMethod)
 		r.AddMethod("JIMM", 4, "PurgeLogs", purgeLogsMethod)
 		r.AddMethod("JIMM", 4, "RemoveCloudFromController", removeCloudFromControllerMethod)
 		r.AddMethod("JIMM", 4, "RemoveController", removeControllerMethod)
@@ -772,4 +774,33 @@ func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListU
 		return res, errors.E(err)
 	}
 	return res, nil
+}
+
+// ModelControllerInfo returns controller information about a model.
+// The model can be specified either by model UUID,
+// or by the combination of ownerName and modelName parameters.
+func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.ModelControllerInfoRequest) (apiparams.ModelControllerInfo, error) {
+	if !r.user.JimmAdmin {
+		return apiparams.ModelControllerInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+
+	var qualifier juju.ModelControllerInfoQualifier
+
+	tokens := strings.SplitN(req.ModelQualifier, "/", 2)
+	if len(tokens) == 2 && tokens[0] != "" && tokens[1] != "" {
+		qualifier = juju.WithOwnerAndModelName(tokens[0], tokens[1])
+	} else {
+		modelUUID, err := uuid.Parse(req.ModelQualifier)
+		if err != nil {
+			return apiparams.ModelControllerInfo{}, errors.E(fmt.Errorf("invalid model UUID: %w", err), errors.CodeBadRequest)
+		}
+		qualifier = juju.WithModelUUID(modelUUID.String())
+	}
+
+	response, err := r.jimm.JujuManager().ModelControllerInfo(ctx, r.user, qualifier)
+	if err != nil {
+		return apiparams.ModelControllerInfo{}, errors.E(err)
+	}
+
+	return *response, nil
 }

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -428,3 +428,140 @@ func TestAuditLogAPIParamsConversion(t *testing.T) {
 		}
 	}
 }
+
+func (s *jimmUnitTestSuite) TestModelControllerInfo(c *gc.C) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		about          string
+		admin          bool
+		modelQualifier string
+		jujuManager    func(*gc.C) jimm.JujuManager
+		expectedInfo   apiparams.ModelControllerInfo
+		expectedError  string
+	}{{
+		about:          "non-admin user with model uuid",
+		admin:          false,
+		modelQualifier: "12345678-1234-1234-1234-123456789abc",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{}
+		},
+		expectedError: "unauthorized",
+	}, {
+		about:          "invalid model uuid",
+		admin:          true,
+		modelQualifier: "invalid-model-uuid",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{}
+		},
+		expectedError: `invalid model UUID: invalid UUID length: 18`,
+	}, {
+		about:          "model not found with model tag",
+		admin:          true,
+		modelQualifier: "12345678-1234-1234-1234-123456789abc",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					return nil, errors.E("model not found")
+				},
+			}
+		},
+		expectedError: "model not found",
+	}, {
+		about:          "success with model tag",
+		admin:          true,
+		modelQualifier: "12345678-1234-1234-1234-123456789abc",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					c.Assert(user.JimmAdmin, gc.Equals, true)
+					return &apiparams.ModelControllerInfo{
+						ModelName:      "test-model",
+						ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+						ControllerName: "test-controller",
+						ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+					}, nil
+				},
+			}
+		},
+		expectedInfo: apiparams.ModelControllerInfo{
+			ModelName:      "test-model",
+			ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+			ControllerName: "test-controller",
+			ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+		},
+	}, {
+		about:          "success with owner and model name",
+		admin:          true,
+		modelQualifier: "alice@canonical.com/test-model",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					c.Assert(user.JimmAdmin, gc.Equals, true)
+					return &apiparams.ModelControllerInfo{
+						ModelName:      "test-model",
+						ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+						ControllerName: "test-controller",
+						ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+					}, nil
+				},
+			}
+		},
+		expectedInfo: apiparams.ModelControllerInfo{
+			ModelName:      "test-model",
+			ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+			ControllerName: "test-controller",
+			ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+		},
+	}, {
+		about:          "error with a partial model qualifier (only owner provided)",
+		admin:          true,
+		modelQualifier: "alice@canonical.com/",
+		jujuManager:    func(c *gc.C) jimm.JujuManager { return &mocks.JujuManager{} },
+		expectedError:  `invalid model UUID: invalid UUID length: 20`,
+	}, {
+		about:          "error with a partial model qualifier (only model name provided)",
+		admin:          true,
+		modelQualifier: "/test-model",
+		jujuManager:    func(c *gc.C) jimm.JujuManager { return &mocks.JujuManager{} },
+		expectedError:  `invalid model UUID: invalid UUID length: 11`,
+	}, {
+		about:          "non-admin user with owner and model name",
+		admin:          false,
+		modelQualifier: "alice@canonical.com/test-model",
+		jujuManager:    func(c *gc.C) jimm.JujuManager { return &mocks.JujuManager{} },
+		expectedError:  "unauthorized",
+	}, {
+		about:          "model not found with owner and model name",
+		admin:          true,
+		modelQualifier: "bob@canonical.com/non-existent",
+		jujuManager: func(c *gc.C) jimm.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					return nil, errors.E("model not found")
+				},
+			}
+		},
+		expectedError: "model not found",
+	}}
+
+	for _, test := range testCases {
+		c.Log(test.about)
+		jimm := &jimmtest.JIMM{
+			JujuManager_: func() jimm.JujuManager {
+				return test.jujuManager(c)
+			},
+		}
+		root := newTestControllerRoot(jimm, "alice@canonical.com", test.admin)
+
+		req := apiparams.ModelControllerInfoRequest{ModelQualifier: test.modelQualifier}
+		info, err := root.ModelControllerInfo(ctx, req)
+
+		if test.expectedError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectedError)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(info, gc.DeepEquals, test.expectedInfo)
+		}
+	}
+}

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -19,6 +19,7 @@ import (
 	jimmcreds "github.com/canonical/jimm/v3/internal/jimm/credentials"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 // JujuManager is a default implementation of the jimm.JujuManager interface.
@@ -30,8 +31,8 @@ type JujuManager struct {
 	AddAuditLogEntry_                  func(ale *dbmodel.AuditLogEntry)
 	AddCloudToController_              func(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
 	AddHostedCloud_                    func(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error
-	CopyCredential_                    func(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error)
 	CleanupPartialModelMigrations_     func(ctx context.Context) error
+	CopyCredential_                    func(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error)
 	DestroyOffer_                      func(ctx context.Context, user *openfga.User, offerURL string, force bool) error
 	FindApplicationOffers_             func(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
 	FindAuditEvents_                   func(ctx context.Context, user *openfga.User, filter db.AuditLogFilter) ([]dbmodel.AuditLogEntry, error)
@@ -44,22 +45,23 @@ type JujuManager struct {
 	GetCloudCredential_                func(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error)
 	GetCloudCredentialAttributes_      func(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error)
 	GetCredentialStore_                func() jimmcreds.CredentialStore
+	GrantOfferAccessOnController_      func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	InitiateInternalMigration_         func(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration_                 func(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)
 	ListApplicationOffers_             func(ctx context.Context, user *openfga.User, filters ...jujuparams.OfferFilter) ([]jujuparams.ApplicationOfferAdminDetailsV5, error)
+	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
 	ListResources_                     func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error)
+	ModelControllerInfo_               func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error)
 	Offer_                             func(ctx context.Context, user *openfga.User, offer juju.AddApplicationOfferParams) error
+	PrepareModelMigration_             func(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) (string, error)
 	PurgeLogs_                         func(ctx context.Context, user *openfga.User, before time.Time) (int64, error)
 	RemoveCloud_                       func(ctx context.Context, u *openfga.User, ct names.CloudTag) error
 	RemoveCloudFromController_         func(ctx context.Context, u *openfga.User, controllerName string, ct names.CloudTag) error
 	RevokeCloudCredential_             func(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error
+	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
 	UpdateApplicationOffer_            func(ctx context.Context, controller *dbmodel.Controller, offerUUID string, removed bool) error
 	UpdateCloud_                       func(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujucloud.Cloud) error
 	UpdateCloudCredential_             func(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error)
-	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
-	GrantOfferAccessOnController_      func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
-	RevokeOfferAccessOnController_     func(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error
-	PrepareModelMigration_             func(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) (string, error)
 	// These mocks can be removed soon once the jujuManager interface is updated.
 	UpdateMetrics_ func(ctx context.Context)
 	PollModels_    func(ctx context.Context) error
@@ -282,4 +284,11 @@ func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
 		return nil
 	}
 	return j.CleanupPartialModelMigrations_(ctx)
+}
+
+func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error) {
+	if j.ModelControllerInfo_ == nil {
+		return nil, errors.E(errors.CodeNotImplemented)
+	}
+	return j.ModelControllerInfo_(ctx, user, qualifier)
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -326,6 +326,17 @@ func (c *Client) ListUserClouds(req *params.ListUserCloudsRequest) (map[names.Cl
 	return clouds, err
 }
 
+// ModelControllerInfo returns information about a model and the controller hosting it.
+// The model parameter can be:
+//   - A model tag (e.g., "model-2cb433a6-04eb-4ec4-9567-90426d20a004")
+//   - Owner and model name (e.g., "alice@canonical.com/my-model")
+func (c *Client) ModelControllerInfo(modelQualifier string) (*params.ModelControllerInfo, error) {
+	req := params.ModelControllerInfoRequest{ModelQualifier: modelQualifier}
+	var resp params.ModelControllerInfo
+	err := c.caller.APICall("JIMM", 4, "", "ModelControllerInfo", req, &resp)
+	return &resp, err
+}
+
 func cloudFromParams(cloudName string, p jujuparams.Cloud) jujucloud.Cloud {
 	authTypes := make([]jujucloud.AuthType, len(p.AuthTypes))
 	for i, authType := range p.AuthTypes {

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -669,3 +669,24 @@ type ListUserCloudsRequest struct {
 	// UserTag is the tag of the user for which we are listing clouds.
 	UserTag string `json:"user"`
 }
+
+// ModelControllerInfoRequest is the request for ModelControllerInfo.
+// The Model field can be:
+//   - Model UUID (e.g., "2cb433a6-04eb-4ec4-9567-90426d20a004")
+//   - Owner and model name (e.g., "alice@canonical.com/my-model")
+type ModelControllerInfoRequest struct {
+	// ModelQualifier is the model qualifier string.
+	ModelQualifier string `json:"model"`
+}
+
+// ModelControllerInfo holds information about a model.
+type ModelControllerInfo struct {
+	// ModelName is the name of the model.
+	ModelName string `json:"model-name" yaml:"model-name"`
+	// ModelUUID is the UUID of the model.
+	ModelUUID string `json:"model-uuid" yaml:"model-uuid"`
+	// ControllerName is the name of the controller hosting the model.
+	ControllerName string `json:"controller-name" yaml:"controller-name"`
+	// ControllerUUID is the UUID of the controller hosting the model.
+	ControllerUUID string `json:"controller-uuid" yaml:"controller-uuid"`
+}

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -78,3 +78,4 @@ parts:
       ln -sf jaas bin/juju-bootstrap
       ln -sf jaas bin/juju-destroy-controller
       ln -sf jaas bin/juju-upgrade-to
+      ln -sf jaas bin/juju-show-model

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -5,6 +5,7 @@ package testing
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"slices"
 	"time"
 
@@ -1176,4 +1177,29 @@ func (s *jimmSuite) TestCreateModelOnTargetController(c *gc.C) {
 	ct, err := names.ParseCloudTag(cloudTag)
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(mi.CloudTag, gc.Equals, names.NewCloudTag(ct.Id()).String())
+}
+
+func (s *jimmSuite) TestModelControllerInfo(c *gc.C) {
+	conn := s.Open(c, nil, "alice", nil)
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+
+	modelControllerInfo, err := client.ModelControllerInfo(s.Model.UUID.String)
+	c.Assert(err, gc.IsNil)
+	c.Assert(modelControllerInfo, gc.DeepEquals, &apiparams.ModelControllerInfo{
+		ModelName:      s.Model.Name,
+		ModelUUID:      s.Model.UUID.String,
+		ControllerName: s.Model.Controller.Name,
+		ControllerUUID: s.Model.Controller.UUID,
+	})
+
+	modelControllerInfo, err = client.ModelControllerInfo(fmt.Sprintf("%s/%s", s.Model.OwnerIdentityName, s.Model.Name))
+	c.Assert(err, gc.IsNil)
+	c.Assert(modelControllerInfo, gc.DeepEquals, &apiparams.ModelControllerInfo{
+		ModelName:      s.Model.Name,
+		ModelUUID:      s.Model.UUID.String,
+		ControllerName: s.Model.Controller.Name,
+		ControllerUUID: s.Model.Controller.UUID,
+	})
 }


### PR DESCRIPTION
## Description

Implements the new show-model command that allows JIMM admins to see which controller hosts a specific model.

## Engineering checklist

- [x] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

1. make qa-lxd
2. juju add-model test
3. juju jaas show-model jimm-test@canonical.com/test
