### PR TITLE
refactor: add unit tests to modelstatus command

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -27,7 +27,7 @@ const (
 	addCloudToControllerCommandDoc = `
 Adds the specified cloud to a specific controller on JIMM.
 
-One can specify a cloud definition via a yaml file passed with the --cloud 
+One can specify a cloud definition via a yaml file passed with the --cloud
 flag. If the flag is missing, the command will assume the cloud definition
 is already known and will error otherwise.
 `

--- a/cmd/jaas/cmd/addmodel.go
+++ b/cmd/jaas/cmd/addmodel.go
@@ -83,7 +83,7 @@ This command creates a new hosted model on the specified controller.
 
 const addModelHelpExamples = `
     juju [jaas] add-model mymodel mycloud --target-controller jaas-controller-1
-    juju [jaas] add-model mymodel us-east-1 --target-controller jaas-controller-1 
+    juju [jaas] add-model mymodel us-east-1 --target-controller jaas-controller-1
 	juju [jaas] add-model mymodel aws/us-east-1 --target-controller jaas-controller-2 --credential mycred
     juju [jaas] add-model mymodel --target-controller jaas-controller-3 --config key=value
 `

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -24,10 +24,10 @@ const (
 	bootstrapDoc = `
 Requests the JIMM server to bootstrap a Juju controller.
 The controller will be created asychronously on the specificed
-cloud and region. 
+cloud and region.
 
 By default the command will wait for the bootstrap job to complete
-while printing the job logs. Note that the logs will not follow the 
+while printing the job logs. Note that the logs will not follow the
 --output flag and will always be printed to stdout. This can allow
 you to send the initial output with the job ID to a file, while the
 logs are streamed to stdout.

--- a/cmd/jaas/cmd/crossmodelquery.go
+++ b/cmd/jaas/cmd/crossmodelquery.go
@@ -19,7 +19,7 @@ const (
 	// stdinMarkers contains file names that are taken to be stdin.
 	crossModelQueryDoc = `
 Queries all models available to the current user performing the
-query against each model status individually, returning the 
+query against each model status individually, returning the
 collated query responses for each model.
 
 The query runs against the output of "juju status --format json",

--- a/cmd/jaas/cmd/destroycontroller.go
+++ b/cmd/jaas/cmd/destroycontroller.go
@@ -21,7 +21,7 @@ Requests the JIMM server to destroy a Juju controller.
 The controller will be destroyed asynchronously.
 
 By default the command will wait for the destroy-controller job to complete
-while printing the job logs. Note that the logs will not follow the 
+while printing the job logs. Note that the logs will not follow the
 --output flag and will always be printed to stdout. This can allow
 you to send the initial output with the job ID to a file, while the
 logs are streamed to stdout.
@@ -37,7 +37,7 @@ Note that JIMM will internally do the following:
 - unregister the controller from JIMM
 
 Destroying controllers on k8s clouds will only work on uju 3.6.10 or newer.
-As a workaround, you can first unregister the controller and then destroy 
+As a workaround, you can first unregister the controller and then destroy
 it separately.
 `
 	destroyControllerExamples = `

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -23,7 +23,7 @@ Grants a user access to read audit logs.
 `
 
 	grantAuditLogAccessExamples = `
-    juju grant-audit-log <username> 
+    juju grant-audit-log <username>
 `
 )
 

--- a/cmd/jaas/cmd/importmodel.go
+++ b/cmd/jaas/cmd/importmodel.go
@@ -21,9 +21,9 @@ const (
 Imports a model running on a controller into JIMM's state.
 
 When importing, it is necessary for JIMM to contain a set of cloud credentials
-that represent a user's access to the incoming model's cloud. 
+that represent a user's access to the incoming model's cloud.
 
-The --owner command is necessary when importing a model created by a 
+The --owner command is necessary when importing a model created by a
 local user and it will switch the model owner to the desired external user.
 `
 	importModelCommandExample = `

--- a/cmd/jaas/cmd/jobstatus.go
+++ b/cmd/jaas/cmd/jobstatus.go
@@ -24,7 +24,7 @@ const (
 Displays logs for a job.
 `
 	jobStatusCommandExample = `
-    juju job-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju job-status 2cb433a6-04eb-4ec4-9567-90426d20a004
 `
 )
 

--- a/cmd/jaas/cmd/jobstop.go
+++ b/cmd/jaas/cmd/jobstop.go
@@ -21,7 +21,7 @@ const (
 Stop a job.
 `
 	jobStopCommandExample = `
-    juju job-stop 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju job-stop 2cb433a6-04eb-4ec4-9567-90426d20a004
 `
 )
 

--- a/cmd/jaas/cmd/listcontrollers.go
+++ b/cmd/jaas/cmd/listcontrollers.go
@@ -20,7 +20,7 @@ const (
 Displays controller information for all controllers known to JIMM.
 `
 	listControllersCommandExample = `
-    juju controllers 
+    juju controllers
     juju controllers --format json
 `
 )

--- a/cmd/jaas/cmd/migrateinternalmodel.go
+++ b/cmd/jaas/cmd/migrateinternalmodel.go
@@ -21,7 +21,7 @@ const (
 The migrate-internal command migrates a model(s) between two controllers
 in your JAAS system. This performs a model migration, but is named
 "migrate-internal" to avoid confusion with the "migrate" command which migrates
-a model to JAAS. 
+a model to JAAS.
 
 You may specify a model name (of the form owner/name) or model UUID.
 

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -36,9 +36,9 @@ and migrate it to JIMM. During this process JIMM will modify the details of the 
 to remove any local users with access to the model and replace the model owner with
 an external user i.e. from alice -> alice@canonical.com.
 
-In order to determine the new model owner and to handle any existing application-offers 
+In order to determine the new model owner and to handle any existing application-offers
 that have already been consumed with local users, you must specify a user mapping file
-with the --user-mapping flag. This should point to a yaml file with a mapping of local 
+with the --user-mapping flag. This should point to a yaml file with a mapping of local
 users to external users.
 For example:
 
@@ -49,10 +49,10 @@ bob: bob@canonical.com
 '''
 
 The mapping must contain entries for all users that have access to the model and any offers
-hosted within that model. 
+hosted within that model.
 You can use the "juju show-model <model-name>" command to see the users that have access to
 the model.
-You can also use the "juju list-offers" command alongside "juju show-offer <offer-name>" 
+You can also use the "juju list-offers" command alongside "juju show-offer <offer-name>"
 to see the users that have access to each offer.
 
 Any users that you do not wish to be mapped must still be included with a null value or empty
@@ -70,9 +70,9 @@ Revoking access from "alice@canonical.com" will result in the relation encounter
 
 It may not be possible to know all users that have have consumed offers from a model, but using
 "juju show-offer <offer-name> --format yaml" you can see all users that have access to the
-offer. This list should help determine which users to map in the user mapping file. 
+offer. This list should help determine which users to map in the user mapping file.
 
-Any tools/scripts that refer to models by their full name (owner/name) will need to be 
+Any tools/scripts that refer to models by their full name (owner/name) will need to be
 updated after migration to use the new external username or refer to models by their UUID.
 `
 	migrateModelCommandExample = `

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -23,7 +23,7 @@ const (
 Displays full model status.
 `
 	modelStatusCommandExample = `
-    juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004
     juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 --format yaml
 `
 )

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -32,6 +34,8 @@ func NewModelStatusCommand() cmd.Command {
 		store: jujuclient.NewFileClientStore(),
 	}
 
+	cmd.jimmAPIFunc = cmd.newClient
+
 	return modelcmd.WrapBase(cmd)
 }
 
@@ -44,6 +48,8 @@ type modelStatusCommand struct {
 	store     jujuclient.ClientStore
 	dialOpts  *jujuapi.DialOpts
 	modelUUID string
+
+	jimmAPIFunc func() (JIMMAPI, error)
 }
 
 func (c *modelStatusCommand) Info() *cmd.Info {
@@ -79,18 +85,17 @@ func (c *modelStatusCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *modelStatusCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
-	if err != nil {
-		return errors.E(err, "could not determine controller")
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
 
-	modelTag := names.NewModelTag(c.modelUUID)
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
-	client := api.NewClient(apiCaller)
+	modelTag := names.NewModelTag(c.modelUUID)
 	status, err := client.FullModelStatus(&apiparams.FullModelStatusRequest{
 		ModelTag: modelTag.String(),
 	})
@@ -103,4 +108,18 @@ func (c *modelStatusCommand) Run(ctxt *cmd.Context) error {
 		return errors.E(err)
 	}
 	return nil
+}
+
+func (c *modelStatusCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.store.CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -34,8 +34,6 @@ func NewModelStatusCommand() cmd.Command {
 		store: jujuclient.NewFileClientStore(),
 	}
 
-	cmd.jimmAPIFunc = cmd.newClient
-
 	return modelcmd.WrapBase(cmd)
 }
 

--- a/cmd/jaas/cmd/modelstatus_test.go
+++ b/cmd/jaas/cmd/modelstatus_test.go
@@ -3,10 +3,10 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/juju/rpc/params"
 	"go.uber.org/mock/gomock"
 	"gopkg.in/yaml.v3"
@@ -15,8 +15,8 @@ import (
 )
 
 func TestModelStatusSuperuser(t *testing.T) {
-	s := setupCmdMocks(t)
 	c := qt.New(t)
+	s := setupCmdMocks(c)
 
 	fullStatus := params.FullStatus{
 		Model: params.ModelStatusInfo{
@@ -48,12 +48,12 @@ func TestModelStatusSuperuser(t *testing.T) {
 	}
 	initCommand(c, statusCmd, "2cb433a6-04eb-4ec4-9567-90426d20a004")
 
-	ctx := newTestContext(t)
+	ctx := newTestContext(c)
 	err := statusCmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
-	res := ctx.Stdout.(*bytes.Buffer).String()
-	gotStatus := params.FullStatus{}
+	res := cmdtesting.Stdout(ctx)
+	var gotStatus params.FullStatus
 	err = yaml.Unmarshal([]byte(res), &gotStatus)
 	c.Assert(err, qt.IsNil)
 

--- a/cmd/jaas/cmd/modelstatus_test.go
+++ b/cmd/jaas/cmd/modelstatus_test.go
@@ -1,83 +1,61 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"github.com/juju/cmd/v3/cmdtesting"
-	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v5"
-	gc "gopkg.in/check.v1"
+	"bytes"
+	"testing"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/rpc/params"
+	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v3"
+
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
 
-var (
-	expectedModelStatusOutput = `model:
-  name: model-2
-  type: iaas
-  cloudtag: cloud-` + jimmtest.TestCloudName + `
-  cloudregion: ` + jimmtest.TestCloudRegionName + `
-  version: .*
-  availableversion: ""
-  modelstatus:
-    status: available
-    info: ""
-    data: {}
-    since: .*
-    kind: ""
-    version: ""
-    life: ""
-    err: null
-  meterstatus:
-    color: ""
-    message: ""
-  sla: unsupported
-machines: {}
-applications: {}
-remoteapplications: {}
-offers: {}
-relations: \[\]
-controllertimestamp: .*
-branches: {}
-storage: \[\]
-filesystems: \[\]
-volumes: \[\]
-`
-)
+func TestModelStatusSuperuser(t *testing.T) {
+	s := setupCmdMocks(t)
+	c := qt.New(t)
 
-type modelStatusSuite struct {
-	cmdtest.JimmCmdSuite
-}
+	fullStatus := params.FullStatus{
+		Model: params.ModelStatusInfo{
+			CloudTag:    "cloud-" + jimmtest.TestCloudName,
+			CloudRegion: jimmtest.TestCloudRegionName,
+			ModelStatus: params.DetailedStatus{
+				Data: map[string]any{},
+			},
+		},
+		Machines:           map[string]params.MachineStatus{},
+		Applications:       map[string]params.ApplicationStatus{},
+		RemoteApplications: map[string]params.RemoteApplicationStatus{},
+		Offers:             map[string]params.ApplicationOfferStatus{},
+		Branches:           map[string]params.BranchStatus{},
+		Storage:            []params.StorageDetails{},
+		Filesystems:        []params.FilesystemDetails{},
+		Volumes:            []params.VolumeDetails{},
+		Relations:          []params.RelationStatus{},
+	}
 
-var _ = gc.Suite(&modelStatusSuite{})
+	s.client.EXPECT().FullModelStatus(gomock.Any()).
+		Return(fullStatus, nil)
+	s.client.EXPECT().Close()
 
-func (s *modelStatusSuite) TestModelStatusSuperuser(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+	statusCmd := &modelStatusCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	initCommand(c, statusCmd, "2cb433a6-04eb-4ec4-9567-90426d20a004")
 
-	s.AddAdminUser(c, "charlie@canonical.com")
-	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
-	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty", Attributes: map[string]string{"key": "value"}})
-	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	ctx := newTestContext(t)
+	err := statusCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
 
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	context, err := cmdtesting.RunCommand(c, cmd.NewModelStatusCommandForTesting(s.ClientStore(), bClient), mt.Id())
-	c.Assert(err, gc.IsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, expectedModelStatusOutput)
-}
+	res := ctx.Stdout.(*bytes.Buffer).String()
+	gotStatus := params.FullStatus{}
+	err = yaml.Unmarshal([]byte(res), &gotStatus)
+	c.Assert(err, qt.IsNil)
 
-func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
-
-	s.AddAdminUser(c, "charlie@canonical.com")
-	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/charlie@canonical.com/cred")
-	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty", Attributes: map[string]string{"key": "value"}})
-	mt := s.AddModel(c, names.NewUserTag("charlie@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
-
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewModelStatusCommandForTesting(s.ClientStore(), bClient), mt.Id())
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	c.Assert(gotStatus, qt.DeepEquals, fullStatus)
 }

--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -139,7 +139,7 @@ Verifies access to a resource.
 `
 
 	listPermissionsDoc = `
-List permissions known to JIMM. Using the "target", "relation" and "object" flags, 
+List permissions known to JIMM. Using the "target", "relation" and "object" flags,
 only those permissions matching the filter will be returned.
 `
 

--- a/cmd/jaas/cmd/purge_logs.go
+++ b/cmd/jaas/cmd/purge_logs.go
@@ -26,7 +26,7 @@ The provided date must be formatted as an ISO8601 date string.
 	purgeLogsExample = `
     juju purge-audit-logs 2021-02-03
     juju purge-audit-logs 2021-02-03T00
-    juju purge-audit-logs 2021-02-03T15:04:05Z	
+    juju purge-audit-logs 2021-02-03T15:04:05Z
 `
 )
 

--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -37,7 +37,7 @@ Use the --local flag if the server is not configured with a public address or to
 ignore the controller's public-hostname and use the custom CA of the controller.
 
 A yaml formatted file can also be used as input for cases where the controller
-is not available on the client. Using the --file will validate that the provided 
+is not available on the client. Using the --file will validate that the provided
 controller name matches the name in the yaml file.
 Using --file will ignore other flags like --public-address and --local.
 

--- a/cmd/jaas/cmd/role.go
+++ b/cmd/jaas/cmd/role.go
@@ -25,7 +25,7 @@ Adds a role.
 `
 
 	addRoleExample = `
-    juju add-role myrole 
+    juju add-role myrole
 `
 
 	renameRoleDoc = `

--- a/cmd/jaas/cmd/unregistercontroller.go
+++ b/cmd/jaas/cmd/unregistercontroller.go
@@ -21,7 +21,7 @@ Deregisters a controller from JIMM.
 `
 
 	unregisterControllerCommandExample = `
-    juju unregister-controller mycontroller 
+    juju unregister-controller mycontroller
     juju unregister-controller mycontroller --force
 `
 )

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -427,7 +427,7 @@ Generate the documentation for all commands
 ## Examples
 
     juju documentation
-    juju documentation --split
+    juju documentation --split 
     juju documentation --split --no-index --out /tmp/docs
 
 To render markdown documentation using a list of existing


### PR DESCRIPTION
## Description
This PR refactors the `modelstatus` command and its tests to unit tests from integration tests.

Fixes [JUJU-9016](https://warthogs.atlassian.net/browse/JUJU-9016)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9016]: https://warthogs.atlassian.net/browse/JUJU-9016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ