### PR TITLE
docs: add metadata for SEO

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to contribute to JAAS documentation by opening issues, creating pull requests, and improving docs for the community."
+---
+
 # How to contribute to JAAS documentation
 
 Thanks for your interest in JAAS documentation -- contributions like yours make good projects

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to build and run JAAS documentation locally using make install and make run for development and contribution."
+---
+
 JAAS Documentation
 ==================
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Track missing and incomplete JAAS documentation including dashboard deployment, limitations, observability, and CLI extension coverage."
+---
+
 # Description
 
 The following document describes missing JAAS documentation as well as any docs that need to be modernized.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand JAAS concepts including reference architecture, authentication, authorization, ReBAC with OpenFGA, and security overview."
+---
+
 (explanation)=
 # Explanation
 

--- a/docs/explanation/jaas-architecture.md
+++ b/docs/explanation/jaas-architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand JAAS architecture with JIMM, ReBAC authorization, OpenFGA, PostgreSQL database, and Vault secure storage components."
+---
+
 (jaas-architecture)=
 # Architecture
 

--- a/docs/explanation/jaas-authentication.md
+++ b/docs/explanation/jaas-authentication.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand JAAS authentication with OAuth 2.0 and OIDC, external identity providers, and how it differs from Juju local users."
+---
+
 (jaas-authentication)=
 # Authentication
 

--- a/docs/explanation/jaas-authorization.md
+++ b/docs/explanation/jaas-authorization.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand JAAS authorization with Relationship-Based Access Control (ReBAC) for flexible user permissions on controllers, models, and resources."
+---
+
 (jaas-authorization)=
 # Authorization
 

--- a/docs/explanation/jaas-rebac-admin-backend.md
+++ b/docs/explanation/jaas-rebac-admin-backend.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn about the ReBAC Admin REST API for querying and manipulating relationships in JAAS authorization model with OpenAPI specification."
+---
+
 (jaas-rebac-admin-backend)=
 # ReBAC admin backend
 

--- a/docs/explanation/jaas-security-scope.md
+++ b/docs/explanation/jaas-security-scope.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand JAAS security scope including secure communication, TLS encryption, access control, authentication, and identity provider integration."
+---
+
 (jaas-security-scope)=
 # Security scope
 

--- a/docs/explanation/jaas-security.md
+++ b/docs/explanation/jaas-security.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Comprehensive JAAS security overview covering cloud credentials, Vault storage, TLS communication, asymmetric cryptography, and data protection."
+---
+
 (jaas-security-overview)=
 # Security overview
 

--- a/docs/explanation/reference-architecture.md
+++ b/docs/explanation/reference-architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "JAAS reference architecture covering automation, OAuth2/OIDC authentication, ReBAC authorization, Juju CLI, and Terraform Provider integration."
+---
+
 (reference-architecture)=
 # Reference architecture
 ## Introduction

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for JAAS operations including deployment management, controllers, clouds, models, users, groups, roles, and permissions."
+---
+
 (howtos)=
 # How-to guides
 

--- a/docs/howto/manage-clouds.md
+++ b/docs/howto/manage-clouds.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to manage clouds in JAAS, including controlling user access with permissions and configuring cloud administrators."
+---
+
 (manage-clouds)=
 # Manage clouds
 > See first: {ref}`cloud`

--- a/docs/howto/manage-groups.md
+++ b/docs/howto/manage-groups.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to create, rename, and manage groups in JAAS to organize users and control access to models, clouds, and controllers."
+---
+
 (manage-groups)=
 # Manage groups
 > Who: JIMM controller admin

--- a/docs/howto/manage-juju-controllers.md
+++ b/docs/howto/manage-juju-controllers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, remove, and manage Juju controllers in JAAS for centralized model management across multiple controllers."
+---
+
 (manage-juju-controllers)=
 # Manage Juju controllers
 > Who: JIMM controller admin

--- a/docs/howto/manage-models.md
+++ b/docs/howto/manage-models.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to create, deploy, and manage Juju models in JAAS with controller placement, access control, and model lifecycle operations."
+---
+
 (manage-models)=
 # Manage models
 

--- a/docs/howto/manage-offers.md
+++ b/docs/howto/manage-offers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to manage application offers in JAAS and control user access with reader, consumer, and administrator permissions."
+---
+
 (manage-offers)=
 # Manage offers
 > See also: {ref}`offer`

--- a/docs/howto/manage-permissions.md
+++ b/docs/howto/manage-permissions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add, revoke, and check permissions in JAAS for users, groups, roles, and resources including controllers, clouds, and models."
+---
+
 (manage-permissions)=
 # Manage permissions
 > See first: {external+juju:ref}`Juju | Juju access levels <user-access-levels>`

--- a/docs/howto/manage-roles.md
+++ b/docs/howto/manage-roles.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to create, rename, and manage roles in JAAS to grant users collections of permissions across resources and environments."
+---
+
 (manage-roles)=
 # Manage roles
 > Who: JIMM controller admin

--- a/docs/howto/manage-users.md
+++ b/docs/howto/manage-users.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to set up new users in JAAS, configure DNS addresses, manage login credentials, and control user access to resources."
+---
+
 (manage-users)=
 # Manage users
 > See first: {ref}`user`

--- a/docs/howto/manage-your-jaas-deployment.md
+++ b/docs/howto/manage-your-jaas-deployment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete guide to deploying and managing JAAS with JIMM controller, OpenFGA, PostgreSQL, Vault on Kubernetes with authentication configuration."
+---
+
 (manage-your-jaas-deployment)=
 # Manage your JAAS deployment
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
 ---
+myst:
+  html_meta:
+    description: "JAAS documentation covering the Juju Intelligent Model Manager (JIMM) with enterprise authentication, ReBAC authorization, and centralized Juju control."
 relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/), [Charmlibs](https://canonical-charmlibs.readthedocs-hosted.com/), [Concierge](https://github.com/canonical/concierge), [Jubilant](https://documentation.ubuntu.com/jubilant/), [Juju](https://documentation.ubuntu.com/juju/), [Ops](https://documentation.ubuntu.com/ops/), [Pebble](https://documentation.ubuntu.com/pebble/), [Terraform &nbsp; Provider &nbsp; for &nbsp; Juju](https://documentation.ubuntu.com/terraform-provider-juju/)"
 ---
 

--- a/docs/reference/audit-logs.md
+++ b/docs/reference/audit-logs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to filter, query, and analyze JIMM audit logs tracking all system requests and responses with configurable retention periods."
+---
+
 (audit-logs)=
 # Audit logs
 

--- a/docs/reference/cloud.md
+++ b/docs/reference/cloud.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS cloud entities including cloud tags, permissions like administrator and can_addmodel, and access control."
+---
+
 (cloud)=
 # Cloud
 > See first: {external+juju:ref}`Juju | Cloud <cloud>`

--- a/docs/reference/controller.md
+++ b/docs/reference/controller.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS controller entities including controller tags, permissions like administrator and audit-log-viewer."
+---
+
 (controller)=
 # Controller
 

--- a/docs/reference/group.md
+++ b/docs/reference/group.md
@@ -1,8 +1,14 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS groups including group tags, member permissions, and managing collections of users."
+---
+
 (group)=
 # Group
 > See also: {ref}`manage-groups`
 
-In JAAS, a group is a collection of users, service accounts, and/or groups.
+In JAAS, a group is a collection of users and/or groups.
 
 A group is referenced by name (which is internally matched to a unique ID).
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS including technical documentation, APIs, security, JAAS plugin commands, and entity specifications."
+---
+
 (reference)=
 # Reference
 

--- a/docs/reference/jaas-plugin.md
+++ b/docs/reference/jaas-plugin.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete guide to the JAAS plugin CLI tool for Juju including installation via Snap and extended functionality for JAAS systems."
+---
+
 (jaas-plugin)=
 # `jaas` plugin
 

--- a/docs/reference/jaas.md
+++ b/docs/reference/jaas.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "JAAS reference documentation including supported Juju versions for deployment, CLI usage, and controller compatibility requirements."
+---
+
 (jaas)=
 # JAAS
 

--- a/docs/reference/jaas/jaas-supported-juju-versions.md
+++ b/docs/reference/jaas/jaas-supported-juju-versions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn JAAS supported Juju versions for deployment, CLI usage, and controller compatibility with minimum version requirements and LTS support."
+---
+
 (jaas-supported-juju-versions)=
 # Supported Juju versions
 

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -26,7 +26,7 @@ Add cloud to specific controller in jimm
 
 Adds the specified cloud to a specific controller on JIMM.
 
-One can specify a cloud definition via a yaml file passed with the --cloud 
+One can specify a cloud definition via a yaml file passed with the --cloud
 flag. If the flag is missing, the command will assume the cloud definition
 is already known and will error otherwise.
 
@@ -80,7 +80,7 @@ Adds a model to a specific controller.
 ## Examples
 
     juju [jaas] add-model mymodel mycloud --target-controller jaas-controller-1
-    juju [jaas] add-model mymodel us-east-1 --target-controller jaas-controller-1 
+    juju [jaas] add-model mymodel us-east-1 --target-controller jaas-controller-1
 	juju [jaas] add-model mymodel aws/us-east-1 --target-controller jaas-controller-2 --credential mycred
     juju [jaas] add-model mymodel --target-controller jaas-controller-3 --config key=value
 
@@ -215,7 +215,7 @@ Add role to jimm.
 
 ## Examples
 
-    juju add-role myrole 
+    juju add-role myrole
 
 
 ## Details
@@ -253,10 +253,10 @@ Bootstrap a Juju controller via JIMM
 
 Requests the JIMM server to bootstrap a Juju controller.
 The controller will be created asychronously on the specificed
-cloud and region. 
+cloud and region.
 
 By default the command will wait for the bootstrap job to complete
-while printing the job logs. Note that the logs will not follow the 
+while printing the job logs. Note that the logs will not follow the
 --output flag and will always be printed to stdout. This can allow
 you to send the initial output with the job ID to a file, while the
 logs are streamed to stdout.
@@ -346,7 +346,7 @@ Lists all controllers known to JIMM.
 
 ## Examples
 
-    juju controllers 
+    juju controllers
     juju controllers --format json
 
 
@@ -386,7 +386,7 @@ Requests the JIMM server to destroy a Juju controller.
 The controller will be destroyed asynchronously.
 
 By default the command will wait for the destroy-controller job to complete
-while printing the job logs. Note that the logs will not follow the 
+while printing the job logs. Note that the logs will not follow the
 --output flag and will always be printed to stdout. This can allow
 you to send the initial output with the job ID to a file, while the
 logs are streamed to stdout.
@@ -402,7 +402,7 @@ Note that JIMM will internally do the following:
 - unregister the controller from JIMM
 
 Destroying controllers on k8s clouds will only work on uju 3.6.10 or newer.
-As a workaround, you can first unregister the controller and then destroy 
+As a workaround, you can first unregister the controller and then destroy
 it separately.
 
 
@@ -427,7 +427,7 @@ Generate the documentation for all commands
 ## Examples
 
     juju documentation
-    juju documentation --split 
+    juju documentation --split
     juju documentation --split --no-index --out /tmp/docs
 
 To render markdown documentation using a list of existing
@@ -470,7 +470,7 @@ Grants access to audit logs.
 
 ## Examples
 
-    juju grant-audit-log <username> 
+    juju grant-audit-log <username>
 
 
 ## Details
@@ -520,9 +520,9 @@ Import a model to jimm
 Imports a model running on a controller into JIMM's state.
 
 When importing, it is necessary for JIMM to contain a set of cloud credentials
-that represent a user's access to the incoming model's cloud. 
+that represent a user's access to the incoming model's cloud.
 
-The --owner command is necessary when importing a model created by a 
+The --owner command is necessary when importing a model created by a
 local user and it will switch the model owner to the desired external user.
 
 
@@ -543,7 +543,7 @@ Displays logs for a job
 
 ## Examples
 
-    juju job-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju job-status 2cb433a6-04eb-4ec4-9567-90426d20a004
 
 
 ## Details
@@ -567,7 +567,7 @@ Stop a job
 
 ## Examples
 
-    juju job-stop 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju job-stop 2cb433a6-04eb-4ec4-9567-90426d20a004
 
 
 ## Details
@@ -716,7 +716,7 @@ List permissions where the target object and relation match
 
 ## Details
 
-List permissions known to JIMM. Using the "target", "relation" and "object" flags, 
+List permissions known to JIMM. Using the "target", "relation" and "object" flags,
 only those permissions matching the filter will be returned.
 
 
@@ -782,9 +782,9 @@ and migrate it to JIMM. During this process JIMM will modify the details of the 
 to remove any local users with access to the model and replace the model owner with
 an external user i.e. from alice -&gt; alice@canonical.com.
 
-In order to determine the new model owner and to handle any existing application-offers 
+In order to determine the new model owner and to handle any existing application-offers
 that have already been consumed with local users, you must specify a user mapping file
-with the --user-mapping flag. This should point to a yaml file with a mapping of local 
+with the --user-mapping flag. This should point to a yaml file with a mapping of local
 users to external users.
 For example:
 
@@ -795,10 +795,10 @@ bob: bob@canonical.com
 '''
 
 The mapping must contain entries for all users that have access to the model and any offers
-hosted within that model. 
+hosted within that model.
 You can use the "juju show-model &lt;model-name&gt;" command to see the users that have access to
 the model.
-You can also use the "juju list-offers" command alongside "juju show-offer &lt;offer-name&gt;" 
+You can also use the "juju list-offers" command alongside "juju show-offer &lt;offer-name&gt;"
 to see the users that have access to each offer.
 
 Any users that you do not wish to be mapped must still be included with a null value or empty
@@ -816,9 +816,9 @@ Revoking access from "alice@canonical.com" will result in the relation encounter
 
 It may not be possible to know all users that have have consumed offers from a model, but using
 "juju show-offer &lt;offer-name&gt; --format yaml" you can see all users that have access to the
-offer. This list should help determine which users to map in the user mapping file. 
+offer. This list should help determine which users to map in the user mapping file.
 
-Any tools/scripts that refer to models by their full name (owner/name) will need to be 
+Any tools/scripts that refer to models by their full name (owner/name) will need to be
 updated after migration to use the new external username or refer to models by their UUID.
 
 
@@ -851,7 +851,7 @@ migrate models to another controller within JAAS
 The migrate-internal command migrates a model(s) between two controllers
 in your JAAS system. This performs a model migration, but is named
 "migrate-internal" to avoid confusion with the "migrate" command which migrates
-a model to JAAS. 
+a model to JAAS.
 
 You may specify a model name (of the form owner/name) or model UUID.
 
@@ -875,7 +875,7 @@ Displays full model status
 
 ## Examples
 
-    juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 
+    juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004
     juju model-status 2cb433a6-04eb-4ec4-9567-90426d20a004 --format yaml
 
 
@@ -904,7 +904,7 @@ purge audit logs from the database before the given date
 
     juju purge-audit-logs 2021-02-03
     juju purge-audit-logs 2021-02-03T00
-    juju purge-audit-logs 2021-02-03T15:04:05Z	
+    juju purge-audit-logs 2021-02-03T15:04:05Z
 
 
 ## Details
@@ -938,7 +938,7 @@ Query model statuses
 ## Details
 
 Queries all models available to the current user performing the
-query against each model status individually, returning the 
+query against each model status individually, returning the
 collated query responses for each model.
 
 The query runs against the output of "juju status --format json",
@@ -990,7 +990,7 @@ Use the --local flag if the server is not configured with a public address or to
 ignore the controller's public-hostname and use the custom CA of the controller.
 
 A yaml formatted file can also be used as input for cases where the controller
-is not available on the client. Using the --file will validate that the provided 
+is not available on the client. Using the --file will validate that the provided
 controller name matches the name in the yaml file.
 Using --file will ignore other flags like --public-address and --local.
 
@@ -1337,7 +1337,7 @@ Remove controller from jimm
 
 ## Examples
 
-    juju unregister-controller mycontroller 
+    juju unregister-controller mycontroller
     juju unregister-controller mycontroller --force
 
 

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS model entities including model tags, permissions like reader, writer, and administrator access levels."
+---
+
 (model)=
 # Model
 > See first: {external+juju:ref}`Juju | Model <model>`

--- a/docs/reference/offer.md
+++ b/docs/reference/offer.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS application offers including offer tags, permissions like administrator, consumer, and reader access."
+---
+
 (offer)=
 # Offer
 > See first: {external+juju:ref}`Juju | Offer <offer>`

--- a/docs/reference/role.md
+++ b/docs/reference/role.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS roles including role tags, assignee permissions, and managing entity capabilities in JIMM controllers."
+---
+
 (role)=
 # Role
 

--- a/docs/reference/user.md
+++ b/docs/reference/user.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for JAAS users including user tags, domain identification, external users, and group and role memberships."
+---
+
 (user)=
 # User
 > See first: {external+juju:ref}`Juju | User <user>`

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to deploy JIMM (the Juju Intelligent Model Manager) on MicroK8s with enterprise authentication and centralized Juju management."
+---
+
 (tutorial)=
 # Get started with JAAS
 
@@ -18,7 +24,7 @@ For this tutorial we will set up an isolated environment using [Multipass](https
 sudo snap install multipass --channel latest/stable
 ```
 
-To create a `jaas-workshop` Multipass instance we'll use throughout this tutorial run: 
+To create a `jaas-workshop` Multipass instance we'll use throughout this tutorial run:
 ```text
 multipass launch 24.04 \
   --name jaas-workshop  \
@@ -142,7 +148,7 @@ At the end of this tutorial you'll need to log in via a web browser. Given that 
 
 Locate the IP of your Multipass instance by running `multipass list` on your host machine, if you have multiple IPs pick **the first one**. You can do this by running on your host machine (in a different terminal window, not when shelled into the `jaas-workshop` VM):
 ```text
-multipass list --format json | yq  '.list | .[] | select(.name == "jaas-workshop") | .ipv4[0]' 
+multipass list --format json | yq  '.list | .[] | select(.name == "jaas-workshop") | .ipv4[0]'
 ```
 
 Then we configure the `traefik-public` in the `core` model:
@@ -363,7 +369,7 @@ Microk8s is a Juju built-in cloud and as such cannot be used to bootstrap contro
 microk8s config | juju add-k8s workshop-k8s --cluster-name microk8s-cluster --client
 ```
 
-To manually add a Juju controller we first need to bootstrap it. 
+To manually add a Juju controller we first need to bootstrap it.
 ```text
 juju bootstrap workshop-k8s controller-workshop-1 --config login-token-refresh-url=http://jimm-endpoints.jimm.svc.cluster.local:8080/.well-known/jwks.json
 ```
@@ -395,7 +401,7 @@ service_account=$(juju run hydra/0 create-oauth-client --quiet --format yaml red
 ```
 And then:
 ```text
-export TF_VAR_client_id=$(echo "$service_account" | yq '.["hydra/0"].results."client-id"') 
+export TF_VAR_client_id=$(echo "$service_account" | yq '.["hydra/0"].results."client-id"')
 export TF_VAR_client_secret=$(echo "$service_account" | yq '.["hydra/0"].results."client-secret"')
 export TF_VAR_client_key_data=$(microk8s config | yq '.users[0].user."client-key-data"')
 export TF_VAR_client_certificate_data=$(microk8s config | yq '.users[0].user."client-certificate-data"')
@@ -439,7 +445,7 @@ variable "client_secret" {
 
 provider "juju" {
     controller_addresses="$metallb_ip:443/jimm-jimm"
-    
+
     client_id=var.client_id
     client_secret=var.client_secret
 }
@@ -460,7 +466,7 @@ resource "juju_credential" "credential" {
 resource "juju_model" "workshop_model_1" {
   name = "workshop-model-1"
 
-  credential = juju_credential.credential.name 
+  credential = juju_credential.credential.name
 
   cloud {
     name = "workshop-k8s"
@@ -619,7 +625,7 @@ juju status
 ```
 
 If everything is configured correctly, `juju status` should report the applications deployed earlier (e.g. Wordpress and MySQL).
- 
+
 ### Cross-model queries
 
 When you manage many models, it’s often useful to run queries *across all models* without switching into each one.
@@ -679,7 +685,7 @@ variable "client_secret" {
 
 provider "juju" {
     controller_addresses="$metallb_ip:443/jimm-jimm"
-    
+
     client_id=var.client_id
     client_secret=var.client_secret
 }
@@ -700,7 +706,7 @@ resource "juju_credential" "credential" {
 resource "juju_model" "workshop_model_2" {
   name = "workshop-model-2"
 
-  credential = juju_credential.credential.name 
+  credential = juju_credential.credential.name
 
   cloud {
     name = "workshop-k8s"
@@ -827,7 +833,7 @@ Try `curl` the server again the certificate issue should be resolved.
 
 If JIMM is not responding to requests, run the following commands to check the logs.
 ```text
-microk8s kubectl logs jimm-0 -n jimm -c jimm -f 
+microk8s kubectl logs jimm-0 -n jimm -c jimm -f
 ```
 
 This will present the server logs and debug further.


### PR DESCRIPTION
One of our roadmap commitments this cycle is to get our docs in a better shape for SEO. Part of this is adding metadata to all of our docs. This PR adds them to all the non-autogenerated files.

Note 1: I used this AI prompt that we have in the documentation team for this purpose: https://github.com/canonical/AI-resources-for-docs/blob/main/docs/prompts/add-metadata-descriptions.md The results are not amazing but, imo, good enough.

Note 2: We probably don't need to worry about the autogenerated ones, as all the other docs link to them systematically as is.
