### PR TITLE
feat: introduce supervising worker for upgrade-to

### DIFF
--- a/internal/river/generate.go
+++ b/internal/river/generate.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 //go:generate go tool mockgen -package river -typed -destination ./river_mock_test.go github.com/canonical/jimm/v3/internal/river UpgradeManager

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 // newMigrationWorker creates a new upgradeMigrationWorker.
@@ -41,6 +42,22 @@ type migrationWorkerArgs struct {
 
 // Kind implements the [river.JobArgs] interface.
 func (migrationWorkerArgs) Kind() string { return "upgrade-migration" }
+
+// InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
+func (migrationWorkerArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
 
 type migrationWorker struct {
 	// An embedded WorkerDefaults sets up default methods to fulfill the rest of

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -44,6 +44,9 @@ type migrationWorkerArgs struct {
 func (migrationWorkerArgs) Kind() string { return "upgrade-migration" }
 
 // InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
+//
+// A job is considered unique by it's model uuid argument, and if it hasn't reached a completed state.
+// Once it reaches completed, this job may be launched for the same model uuid again.
 func (migrationWorkerArgs) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{
 		UniqueOpts: river.UniqueOpts{

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -30,8 +30,10 @@ func newMigrationWorker(openfgaClient *openfga.OFGAClient, store Store, upgradeM
 
 // migrationWorkerArgs defines the arguments for the migrationWorker job.
 type migrationWorkerArgs struct {
-	Username             string `json:"username"`
-	UUID                 string `json:"uuid"`
+	Username string `json:"username"`
+	// UUID is the model UUID to migrate. We treat this as unique to prevent
+	// multiple concurrent migrations of the same model to many controllers.
+	UUID                 string `json:"uuid" river:"unique"`
 	TargetControllerName string `json:"target_controller_name"`
 }
 

--- a/internal/river/migrationworker_test.go
+++ b/internal/river/migrationworker_test.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (

--- a/internal/river/migrationworker_test.go
+++ b/internal/river/migrationworker_test.go
@@ -44,7 +44,6 @@ func TestMigrationWorker(t *testing.T) {
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(err, qt.IsNil)
 	result, err := testWorker.Work(
 		c.Context(),
 		c.TB,

--- a/internal/river/package_test.go
+++ b/internal/river/package_test.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 //go:generate go tool mockgen -package river -typed -destination ./river_mock_test.go github.com/canonical/jimm/v3/internal/river UpgradeManager

--- a/internal/river/river.go
+++ b/internal/river/river.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -35,11 +35,6 @@ type upgradeToWorker struct {
 	upgradeRetries int
 }
 
-// Migrate the model
-// Wait for job - handle crash
-// Upgrade the model
-// Wait for job
-// Done
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
 

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -147,24 +147,26 @@ func waitForJobToFinalise(ctx context.Context, result *rivertype.JobInsertResult
 			if !ok {
 				return errors.New("event channel closed unexpectedly")
 			}
-			if event.Job.ID == result.Job.ID {
-				if event.Job.FinalizedAt != nil {
-					switch event.Kind {
-					// Because we've finalised, this isn't an attempt failure, but the final state.
-					case river.EventKindJobFailed:
-						// Job failed, return the last error.
-						if len(event.Job.Errors) != 0 {
-							return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
-						}
-						return errors.New("job failed without error details")
-					case river.EventKindJobCancelled:
-						return errors.New("job was cancelled")
-					case river.EventKindJobCompleted:
-						// Completed successfully.
-						return nil
-					}
-				}
+
+			if event.Job.ID != result.Job.ID || event.Job.FinalizedAt == nil {
+				continue
 			}
+
+			switch event.Kind {
+			// Because we've finalised, this isn't an attempt failure, but the final state.
+			case river.EventKindJobFailed:
+				// Job failed, return the last error.
+				if len(event.Job.Errors) != 0 {
+					return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
+				}
+				return errors.New("job failed without error details")
+			case river.EventKindJobCancelled:
+				return errors.New("job was cancelled")
+			case river.EventKindJobCompleted:
+				// Completed successfully.
+				return nil
+			}
+
 		}
 	}
 }

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -79,7 +79,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.waitForJobToFinalise(migRes, eventCh); err != nil {
+	if err := w.waitForJobToFinalise(ctx, migRes, eventCh); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.waitForJobToFinalise(upgradeRes, eventCh); err != nil {
+	if err := w.waitForJobToFinalise(ctx, upgradeRes, eventCh); err != nil {
 		return err
 	}
 
@@ -108,7 +108,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 	return nil
 }
 
-func (w *upgradeToWorker) waitForJobToFinalise(result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+func (w *upgradeToWorker) waitForJobToFinalise(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
 	// It may be a duplicate, so check if it has finalised. If not, wait for it to do so.
 	if result.Job.FinalizedAt != nil {
 		// It has finalised, check it's state, if it failed return error.
@@ -120,21 +120,29 @@ func (w *upgradeToWorker) waitForJobToFinalise(result *rivertype.JobInsertResult
 			return errors.New(result.Job.Errors[len(result.Job.Errors)-1].Error)
 		}
 	} else {
-		for event := range eventCh {
-			if event.Job.ID == result.Job.ID {
-				if event.Job.FinalizedAt != nil {
-					switch event.Kind {
-					// Because we've finalised, this isn't an attempt failure, but the final state.
-					case river.EventKindJobFailed:
-						// Job failed, return the last error.
-						if len(event.Job.Errors) != 0 {
-							return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case event, ok := <-eventCh:
+				if !ok {
+					return nil
+				}
+				if event.Job.ID == result.Job.ID {
+					if event.Job.FinalizedAt != nil {
+						switch event.Kind {
+						// Because we've finalised, this isn't an attempt failure, but the final state.
+						case river.EventKindJobFailed:
+							// Job failed, return the last error.
+							if len(event.Job.Errors) != 0 {
+								return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
+							}
+						case river.EventKindJobCancelled:
+							return errors.New("job was cancelled")
+						case river.EventKindJobCompleted:
+							// Completed successfully.
+							return nil
 						}
-					case river.EventKindJobCancelled:
-						return errors.New("job was cancelled")
-					case river.EventKindJobCompleted:
-						// Completed successfully.
-						return nil
 					}
 				}
 			}

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (
@@ -10,13 +12,18 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-func newUpgradeToWorker(migrateRetries int, upgradeRetries int) *upgradeToWorker {
+// waitForJobFinalisationFunc is a function that waits for a job to finalise.
+type waitForJobFinalisationFunc func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error
+
+func newUpgradeToWorker(migrateRetries int, upgradeRetries int, finaliser waitForJobFinalisationFunc) *upgradeToWorker {
 	return &upgradeToWorker{
 		migrateRetries: migrateRetries,
 		upgradeRetries: upgradeRetries,
+		finaliser:      finaliser,
 	}
 }
 
+// UpgradeToArgs are the arguments for the upgrade-to worker.
 type UpgradeToArgs struct {
 	ModelUUID            string         `json:"model-uuid" river:"unique"`
 	TargetVersion        version.Number `json:"target-version"`
@@ -24,6 +31,7 @@ type UpgradeToArgs struct {
 	TargetControllerName string         `json:"target_controller_name"`
 }
 
+// Kind implements the [river.JobArgs] interface.
 func (UpgradeToArgs) Kind() string { return "upgrade-to" }
 
 type upgradeToWorker struct {
@@ -33,8 +41,11 @@ type upgradeToWorker struct {
 	migrateRetries int
 	// upgradeRetries is the number of times to retry the upgrade step.
 	upgradeRetries int
+	// finaliser is a function that waits for a job to finalise.
+	finaliser waitForJobFinalisationFunc
 }
 
+// Work implements the [river.Worker] interface.
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
 
@@ -79,7 +90,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.waitForJobToFinalise(ctx, migRes, eventCh); err != nil {
+	if err := w.finaliser(ctx, migRes, eventCh); err != nil {
 		return err
 	}
 
@@ -100,7 +111,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.waitForJobToFinalise(ctx, upgradeRes, eventCh); err != nil {
+	if err := w.finaliser(ctx, upgradeRes, eventCh); err != nil {
 		return err
 	}
 
@@ -108,7 +119,13 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 	return nil
 }
 
-func (w *upgradeToWorker) waitForJobToFinalise(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+// waitForJobToFinalise waits for the job to finalise, that is, a job that will no longer
+// be retried but could have succeeded or failed after all attempts. It does so by checking
+// the event channel for updates.
+//
+// If the job has been inserted already on a previous attempt, it checks if it's finalised already,
+// and if not, waits for it to do so.
+func waitForJobToFinalise(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
 	// It may be a duplicate, so check if it has finalised. If not, wait for it to do so.
 	if result.Job.FinalizedAt != nil {
 		// It has finalised, check it's state, if it failed return error.
@@ -150,6 +167,4 @@ func (w *upgradeToWorker) waitForJobToFinalise(ctx context.Context, result *rive
 			}
 		}
 	}
-
-	return nil
 }

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -12,14 +12,14 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-// waitForJobFinalisationFunc is a function that waits for a job to finalise.
-type waitForJobFinalisationFunc func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error
+// awaitCompletionFunc is a function that waits for a job to finalise.
+type awaitCompletionFunc func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error
 
-func newUpgradeToWorker(migrateRetries int, upgradeRetries int, finaliser waitForJobFinalisationFunc) *upgradeToWorker {
+func newUpgradeToWorker(migrateRetries int, upgradeRetries int, awaitFunc awaitCompletionFunc) *upgradeToWorker {
 	return &upgradeToWorker{
-		migrateRetries: migrateRetries,
-		upgradeRetries: upgradeRetries,
-		finaliser:      finaliser,
+		migrateRetries:  migrateRetries,
+		upgradeRetries:  upgradeRetries,
+		awaitCompletion: awaitFunc,
 	}
 }
 
@@ -34,6 +34,23 @@ type UpgradeToArgs struct {
 // Kind implements the [river.JobArgs] interface.
 func (UpgradeToArgs) Kind() string { return "upgrade-to" }
 
+// InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
+func (UpgradeToArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		MaxAttempts: 3,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
+
 type upgradeToWorker struct {
 	river.WorkerDefaults[UpgradeToArgs]
 
@@ -41,8 +58,8 @@ type upgradeToWorker struct {
 	migrateRetries int
 	// upgradeRetries is the number of times to retry the upgrade step.
 	upgradeRetries int
-	// finaliser is a function that waits for a job to finalise.
-	finaliser waitForJobFinalisationFunc
+	// awaitCompletion is a function that waits for a job to finalise.
+	awaitCompletion awaitCompletionFunc
 }
 
 // Work implements the [river.Worker] interface.
@@ -56,7 +73,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 	)
 	defer cancel()
 
-	migRes, err := client.Insert(
+	migrateInsertResponse, err := client.Insert(
 		ctx,
 		migrationWorkerArgs{
 			Username:             job.Args.Username,
@@ -81,14 +98,14 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.finaliser(ctx, migRes, eventCh); err != nil {
+	if err := w.awaitCompletion(ctx, migrateInsertResponse, eventCh); err != nil {
 		return err
 	}
 
 	// We need not worry about a crash here and the migrate completing, as a new job will be inserted, sure,
 	// but our idempotency of the migrate service will ensure it is a no-op.
 
-	upgradeRes, err := client.Insert(
+	upgradeInsertResponse, err := client.Insert(
 		ctx,
 		upgradeArgs{
 			ModelUUID:     job.Args.ModelUUID,
@@ -112,7 +129,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	if err := w.finaliser(ctx, upgradeRes, eventCh); err != nil {
+	if err := w.awaitCompletion(ctx, upgradeInsertResponse, eventCh); err != nil {
 		return err
 	}
 

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -1,0 +1,149 @@
+package river
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/juju/version/v2"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func newUpgradeToWorker(migrateRetries int, upgradeRetries int) *upgradeToWorker {
+	return &upgradeToWorker{
+		migrateRetries: migrateRetries,
+		upgradeRetries: upgradeRetries,
+	}
+}
+
+type UpgradeToArgs struct {
+	ModelUUID            string         `json:"model-uuid"`
+	TargetVersion        version.Number `json:"target-version"`
+	Username             string         `json:"username"`
+	TargetControllerName string         `json:"target_controller_name"`
+}
+
+func (UpgradeToArgs) Kind() string { return "upgrade-to" }
+
+type upgradeToWorker struct {
+	river.WorkerDefaults[UpgradeToArgs]
+
+	// migrateRetries is the number of times to retry the migration step.
+	migrateRetries int
+	// upgradeRetries is the number of times to retry the upgrade step.
+	upgradeRetries int
+}
+
+// Migrate the model
+// Wait for job - handle crash
+// Upgrade the model
+// Wait for job
+// Done
+func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
+	client := river.ClientFromContext[*sql.Tx](ctx)
+
+	// PR Note:
+	// Subscribe to job events immediately to prevent duplicate completion race as we'll catch it when inserting it
+	// in a moment.
+	//
+	// River's initial buffer size for the subscription channel is 1000 [river.subscribeChanSizeDefault].
+	// River does the following when pushing events:
+	// select {
+	// case sub.Chan <- event:
+	// default:
+	// }
+	// Which can lead to dropped events. However, since we check the job state after insertion, we will not miss
+	// any completions and process it in a timely manner.
+	//
+	// We could poll the job, as well as use subscriptions for quick wake ups between polls, but that adds complexity for
+	// what might be an impossible scenario for us.
+	//
+	// It would look something like: tick on X seconds, and pull from ticker & sub channel together, whichever is first determines
+	// if the job has completed. This covers us for dropped subscriptions.
+	//
+	// Open for discussion within the PR.
+	eventCh, cancel := client.Subscribe(river.EventKindJobCompleted, river.EventKindJobCancelled, river.EventKindJobFailed)
+	defer cancel()
+
+	migRes, err := client.Insert(
+		ctx,
+		migrationWorkerArgs{
+			Username:             job.Args.Username,
+			UUID:                 job.Args.ModelUUID,
+			TargetControllerName: job.Args.TargetControllerName,
+		},
+		&river.InsertOpts{
+			MaxAttempts: w.migrateRetries,
+			UniqueOpts: river.UniqueOpts{
+				ByArgs: true,
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := w.waitForJobToFinalise(migRes, eventCh); err != nil {
+		return err
+	}
+
+	upgradeRes, err := client.Insert(
+		ctx,
+		upgradeArgs{
+			ModelUUID:     job.Args.ModelUUID,
+			TargetVersion: job.Args.TargetVersion,
+		},
+		&river.InsertOpts{
+			MaxAttempts: w.upgradeRetries,
+			UniqueOpts: river.UniqueOpts{
+				ByArgs: true,
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := w.waitForJobToFinalise(upgradeRes, eventCh); err != nil {
+		return err
+	}
+
+	// All done.
+	return nil
+}
+
+func (w *upgradeToWorker) waitForJobToFinalise(result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+	// It may be a duplicate, so check if it has finalised. If not, wait for it to do so.
+	if result.Job.FinalizedAt != nil {
+		// It has finalised, check it's state, if it failed return error.
+		//
+		// TODO: We should report all errors from all attempts and their details (i.e., timestamps)
+		// For now, simply take the last failure attempt.
+		// This should be completed in Phase 3.
+		if len(result.Job.Errors) != 0 {
+			return errors.New(result.Job.Errors[len(result.Job.Errors)-1].Error)
+		}
+	} else {
+		for event := range eventCh {
+			if event.Job.ID == result.Job.ID {
+				if event.Job.FinalizedAt != nil {
+					switch event.Kind {
+					// Because we've finalised, this isn't an attempt failure, but the final state.
+					case river.EventKindJobFailed:
+						// Job failed, return the last error.
+						if len(event.Job.Errors) != 0 {
+							return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
+						}
+					case river.EventKindJobCancelled:
+						return errors.New("job was cancelled")
+					case river.EventKindJobCompleted:
+						// Completed successfully.
+						return nil
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -18,7 +18,7 @@ func newUpgradeToWorker(migrateRetries int, upgradeRetries int) *upgradeToWorker
 }
 
 type UpgradeToArgs struct {
-	ModelUUID            string         `json:"model-uuid"`
+	ModelUUID            string         `json:"model-uuid" river:"unique"`
 	TargetVersion        version.Number `json:"target-version"`
 	Username             string         `json:"username"`
 	TargetControllerName string         `json:"target_controller_name"`
@@ -119,34 +119,37 @@ func (w *upgradeToWorker) waitForJobToFinalise(ctx context.Context, result *rive
 		if len(result.Job.Errors) != 0 {
 			return errors.New(result.Job.Errors[len(result.Job.Errors)-1].Error)
 		}
-	} else {
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case event, ok := <-eventCh:
-				if !ok {
-					return nil
-				}
-				if event.Job.ID == result.Job.ID {
-					if event.Job.FinalizedAt != nil {
-						switch event.Kind {
-						// Because we've finalised, this isn't an attempt failure, but the final state.
-						case river.EventKindJobFailed:
-							// Job failed, return the last error.
-							if len(event.Job.Errors) != 0 {
-								return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
-							}
-						case river.EventKindJobCancelled:
-							return errors.New("job was cancelled")
-						case river.EventKindJobCompleted:
-							// Completed successfully.
-							return nil
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-eventCh:
+			if !ok {
+				return errors.New("event channel closed unexpectedly")
+			}
+			if event.Job.ID == result.Job.ID {
+				if event.Job.FinalizedAt != nil {
+					switch event.Kind {
+					// Because we've finalised, this isn't an attempt failure, but the final state.
+					case river.EventKindJobFailed:
+						// Job failed, return the last error.
+						if len(event.Job.Errors) != 0 {
+							return errors.New(event.Job.Errors[len(event.Job.Errors)-1].Error)
 						}
+						return errors.New("job failed without error details")
+					case river.EventKindJobCancelled:
+						return errors.New("job was cancelled")
+					case river.EventKindJobCompleted:
+						// Completed successfully.
+						return nil
 					}
 				}
 			}
 		}
 	}
+
 	return nil
 }

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -63,6 +63,16 @@ type upgradeToWorker struct {
 }
 
 // Work implements the [river.Worker] interface.
+//
+// Each upgradeTo job acts as a orchestrator of two child jobs, starting them and waiting for their
+// completion sequentially.
+//
+// River's unique-job args and states are setup to ensure that in-progress jobs are not re-inserted,
+// keyed by the model UUID and job state.
+//
+// Each child job is expected to be idempotent so that in certain edge cases where an orchestrator
+// restart would cause re-insertion of a completed job, no changes are made. (Like between the completion
+// of the migration job and the insertion of the upgrade job).
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
 

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -49,26 +49,6 @@ type upgradeToWorker struct {
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
 
-	// PR Note:
-	// Subscribe to job events immediately to prevent duplicate completion race as we'll catch it when inserting it
-	// in a moment.
-	//
-	// River's initial buffer size for the subscription channel is 1000 [river.subscribeChanSizeDefault].
-	// River does the following when pushing events:
-	// select {
-	// case sub.Chan <- event:
-	// default:
-	// }
-	// Which can lead to dropped events. However, since we check the job state after insertion, we will not miss
-	// any completions and process it in a timely manner.
-	//
-	// We could poll the job, as well as use subscriptions for quick wake ups between polls, but that adds complexity for
-	// what might be an impossible scenario for us.
-	//
-	// It would look something like: tick on X seconds, and pull from ticker & sub channel together, whichever is first determines
-	// if the job has completed. This covers us for dropped subscriptions.
-	//
-	// Open for discussion within the PR.
 	eventCh, cancel := client.Subscribe(river.EventKindJobCompleted, river.EventKindJobCancelled, river.EventKindJobFailed)
 	defer cancel()
 
@@ -83,6 +63,13 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 			MaxAttempts: w.migrateRetries,
 			UniqueOpts: river.UniqueOpts{
 				ByArgs: true,
+				ByState: []rivertype.JobState{
+					rivertype.JobStateAvailable,
+					rivertype.JobStatePending,
+					rivertype.JobStateRunning,
+					rivertype.JobStateRetryable,
+					rivertype.JobStateScheduled,
+				},
 			},
 		},
 	)
@@ -104,6 +91,13 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 			MaxAttempts: w.upgradeRetries,
 			UniqueOpts: river.UniqueOpts{
 				ByArgs: true,
+				ByState: []rivertype.JobState{
+					rivertype.JobStateAvailable,
+					rivertype.JobStatePending,
+					rivertype.JobStateRunning,
+					rivertype.JobStateRetryable,
+					rivertype.JobStateScheduled,
+				},
 			},
 		},
 	)

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -102,9 +102,6 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		return err
 	}
 
-	// We need not worry about a crash here and the migrate completing, as a new job will be inserted, sure,
-	// but our idempotency of the migrate service will ensure it is a no-op.
-
 	upgradeInsertResponse, err := client.Insert(
 		ctx,
 		upgradeWorkerArgs{

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -49,7 +49,11 @@ type upgradeToWorker struct {
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
 
-	eventCh, cancel := client.Subscribe(river.EventKindJobCompleted, river.EventKindJobCancelled, river.EventKindJobFailed)
+	eventCh, cancel := client.Subscribe(
+		river.EventKindJobCompleted,
+		river.EventKindJobCancelled,
+		river.EventKindJobFailed,
+	)
 	defer cancel()
 
 	migRes, err := client.Insert(
@@ -80,6 +84,9 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 	if err := w.finaliser(ctx, migRes, eventCh); err != nil {
 		return err
 	}
+
+	// We need not worry about a crash here and the migrate completing, as a new job will be inserted, sure,
+	// but our idempotency of the migrate service will ensure it is a no-op.
 
 	upgradeRes, err := client.Insert(
 		ctx,

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -82,16 +82,6 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 		},
 		&river.InsertOpts{
 			MaxAttempts: w.migrateRetries,
-			UniqueOpts: river.UniqueOpts{
-				ByArgs: true,
-				ByState: []rivertype.JobState{
-					rivertype.JobStateAvailable,
-					rivertype.JobStatePending,
-					rivertype.JobStateRunning,
-					rivertype.JobStateRetryable,
-					rivertype.JobStateScheduled,
-				},
-			},
 		},
 	)
 	if err != nil {
@@ -107,22 +97,12 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[UpgradeToArgs
 
 	upgradeInsertResponse, err := client.Insert(
 		ctx,
-		upgradeArgs{
+		upgradeWorkerArgs{
 			ModelUUID:     job.Args.ModelUUID,
 			TargetVersion: job.Args.TargetVersion,
 		},
 		&river.InsertOpts{
 			MaxAttempts: w.upgradeRetries,
-			UniqueOpts: river.UniqueOpts{
-				ByArgs: true,
-				ByState: []rivertype.JobState{
-					rivertype.JobStateAvailable,
-					rivertype.JobStatePending,
-					rivertype.JobStateRunning,
-					rivertype.JobStateRetryable,
-					rivertype.JobStateScheduled,
-				},
-			},
 		},
 	)
 	if err != nil {
@@ -147,10 +127,6 @@ func waitForJobToFinalise(ctx context.Context, result *rivertype.JobInsertResult
 	// It may be a duplicate, so check if it has finalised. If not, wait for it to do so.
 	if result.Job.FinalizedAt != nil {
 		// It has finalised, check it's state, if it failed return error.
-		//
-		// TODO: We should report all errors from all attempts and their details (i.e., timestamps)
-		// For now, simply take the last failure attempt.
-		// This should be completed in Phase 3.
 		if len(result.Job.Errors) != 0 {
 			return errors.New(result.Job.Errors[len(result.Job.Errors)-1].Error)
 		}

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
-	"time"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -40,6 +40,9 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
 		Return(nil)
 
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
 	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
 		ModelUUID:            "model-uuid",
 		TargetVersion:        version.MustParse("2.0.0"),
@@ -48,7 +51,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	row := waitForFinalisedJob(c, ctx, sub, insRes)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
@@ -74,18 +77,12 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
 		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
 			attempt++
-			switch attempt {
-			case 1:
-				return errors.New("unexpected-error")
-			case 2:
-				return errors.New("unexpected-error")
-			case 3:
-				return errors.New("migration-failed3")
-			default:
-				return errors.New("unexpected-error")
-			}
+			return fmt.Errorf("unexpected-error-%d", attempt)
 		}).
 		MinTimes(3)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobFailed)
+	c.Cleanup(cancel)
 
 	insRes, err := riverClient.Insert(
 		ctx,
@@ -97,13 +94,11 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 		}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	row := waitForFinalisedJob(c, ctx, sub, insRes)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
-	c.Assert(len(row.Errors) > 0, qt.IsTrue)
-
 	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
-	c.Assert(upgradeToJobFinalError, qt.Equals, "migration-failed3")
+	c.Assert(upgradeToJobFinalError, qt.Equals, "unexpected-error-3")
 }
 
 func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
@@ -131,18 +126,12 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
 		DoAndReturn(func(context.Context, string, version.Number) error {
 			attempt++
-			switch attempt {
-			case 1:
-				return errors.New("unexpected-error")
-			case 2:
-				return errors.New("unexpected-error")
-			case 3:
-				return errors.New("upgrade-failed3")
-			default:
-				return errors.New("unexpected-error")
-			}
+			return fmt.Errorf("unexpected-error-%d", attempt)
 		}).
 		MinTimes(3)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobFailed)
+	c.Cleanup(cancel)
 
 	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
 		ModelUUID:            "model-uuid",
@@ -152,13 +141,11 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	row := waitForFinalisedJob(c, ctx, sub, insRes)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
-	c.Assert(len(row.Errors) > 0, qt.IsTrue)
-
-	// Ensure we capture the last error only from the upgrade job, and that it is surfaced to the upgrade to job.
+	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
-	c.Assert(upgradeToJobFinalError, qt.Equals, "upgrade-failed3")
+	c.Assert(upgradeToJobFinalError, qt.Equals, "unexpected-error-3")
 }
 
 // This test is particularly valuable because it ensures we're checking the jobs finalised state AND event kind.
@@ -203,6 +190,9 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 		}).
 		Times(2)
 
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
 	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
 		ModelUUID:            "model-uuid",
 		TargetVersion:        version.MustParse("2.0.0"),
@@ -211,9 +201,97 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	row := waitForFinalisedJob(c, ctx, sub, insRes)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
+}
+
+// This test simulates a crash of the supervisor between the migration and upgrade steps.
+// And ensures that when retried, the migration job picks up where it left off uniquely
+// resulting in 2 attempts.
+//
+// It relies on the fact that jobs are inserted in an ascending postgres sequence
+// as we don't know the job id of the supervisor ahead of time otherwise. So,
+// as we know it'll be the first job inserted, it's job id should always be 1.
+func TestUpgradeToWorker_SupervisorResumesSuccessfullyAfterCrash(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	supervisingJobId := int64(1)
+
+	// Setup migrate job to retry up to 3 times, we're expecting 2 after the supervising job crash.
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1)
+
+	attempt := 0
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
+			attempt++
+			if attempt == 1 {
+				// We sneakily cancel the supervisor (lol) to simulate a crash.
+				// As it's context has cancelled now, when it attempts to wait
+				// for the migrate job to finish it is going to error out.
+				_, err := riverClient.JobCancel(ctx, supervisingJobId)
+				if err != nil {
+					return err
+				}
+			}
+			// We'll be returning nil on restart, and expect the job to complete successfully.
+			return nil
+		})
+
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobFailed, river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	_, err = riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	var supervisingJobFailureUpdate *rivertype.JobRow
+
+loop:
+	for {
+		select {
+		case event := <-sub:
+			if event.Job.ID != supervisingJobId {
+				continue loop
+			}
+			// We've caught the suppervising job entering "some state".
+			// Capture it, and break out.
+			supervisingJobFailureUpdate = event.Job
+			break loop
+		case <-ctx.Done():
+			c.Fatal("timed out waiting for job failed event")
+		}
+	}
+
+	// At this point, our job is cancelled and we'll see it as "completed".
+	c.Assert(supervisingJobFailureUpdate.State, qt.Equals, rivertype.JobStateCompleted)
+	// We're expecting to capture this specific singular job, and upon restarting the supervisor
+	// we should see the supervisor succeeds and the attempts increase for this job.
+	// We're pureposefully asking for more than we expect to ensure no other jobs are lurking.
+	params := river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(10)
+	listRes, err := riverClient.JobList(ctx, params)
+	c.Assert(err, qt.IsNil)
+	c.Assert(listRes.Jobs, qt.HasLen, 1)
+	// WIP
 }
 
 func setupWorkers(
@@ -260,21 +338,20 @@ func setupWorkers(
 	return riverClient, u.Name
 }
 
-func waitForFinalisedJob(c *qt.C, ctx context.Context, client *river.Client[*sql.Tx], jobID int64) *rivertype.JobRow {
-	for i := 0; i < 20; i++ {
-		row, err := client.JobGet(ctx, jobID)
-		c.Assert(err, qt.IsNil)
-		if row.FinalizedAt != nil {
-			return row
-		}
-
+func waitForFinalisedJob(c *qt.C, ctx context.Context, sub <-chan *river.Event, insRes *rivertype.JobInsertResult) *rivertype.JobRow {
+loop:
+	for {
 		select {
+		case event := <-sub:
+			c.Logf("received job failed event for job ID %d", event.Job.ID)
+			if event.Job.ID != insRes.Job.ID {
+				continue loop
+			}
+			if event.Job.FinalizedAt != nil {
+				return event.Job
+			}
 		case <-ctx.Done():
-			c.Fatalf("context done while waiting for job %d to finalize: %v", jobID, ctx.Err())
-		case <-time.After(1 * time.Second):
+			c.Fatal("timed out waiting for job failed event")
 		}
 	}
-
-	c.Fatalf("timed out waiting for job %d to finalize", jobID)
-	return nil
 }

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -252,7 +252,10 @@ func setupWorkers(
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(riverClient.Start(ctx), qt.IsNil)
-	c.Cleanup(func() { _ = riverClient.Stop(ctx) })
+	c.Cleanup(func() {
+		err := riverClient.Stop(context.Background())
+		c.Check(err, qt.IsNil)
+	})
 
 	return riverClient, u.Name
 }

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -108,8 +108,7 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 
 func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	c := qt.New(t)
-	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
-	defer cancel()
+	ctx := c.Context()
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -165,8 +164,7 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 // This test is particularly valuable because it ensures we're checking the jobs finalised state AND event kind.
 func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	c := qt.New(t)
-	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
-	defer cancel()
+	ctx := c.Context()
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -396,23 +396,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	var supervisingJobFailureUpdate *rivertype.JobRow
-
-loop:
-	for {
-		select {
-		case event := <-sub:
-			if event.Job.ID != supervisingJobId {
-				continue loop
-			}
-			// We've caught the suppervising job entering "some state".
-			// Capture it, and break out.
-			supervisingJobFailureUpdate = event.Job
-			break loop
-		case <-ctx.Done():
-			c.Fatal("timed out waiting for job failed event")
-		}
-	}
+	supervisingJobFailureUpdate := waitForSupervisingJob(c, ctx, sub, supervisingJobId)
 
 	// At this point, our job is cancelled and we'll see it as "completed".
 	c.Assert(supervisingJobFailureUpdate.State, qt.Equals, rivertype.JobStateCompleted)
@@ -578,6 +562,22 @@ loop:
 			if event.Job.FinalizedAt != nil {
 				return event.Job
 			}
+		case <-ctx.Done():
+			c.Fatal("timed out waiting for job failed event")
+		}
+	}
+}
+
+func waitForSupervisingJob(c *qt.C, ctx context.Context, sub <-chan *river.Event, supervisingJobId int64) *rivertype.JobRow {
+	for {
+		select {
+		case event := <-sub:
+			if event.Job.ID != supervisingJobId {
+				continue
+			}
+			// We've caught the suppervising job entering "some state".
+			// Capture it, and break out.
+			return event.Job
 		case <-ctx.Done():
 			c.Fatal("timed out waiting for job failed event")
 		}

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -1,0 +1,279 @@
+package river
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/version/v2"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
+	"github.com/riverqueue/river/rivertype"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestUpgradeToWorker_Success(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1)
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(row.Errors, qt.HasLen, 0)
+}
+
+func TestUpgradeToWorker_MigrationFails(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	// Retry a few times to ensure retries work as expected and surface the LAST error.
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1)
+
+	attempt := 0
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
+			attempt++
+			switch attempt {
+			case 1:
+				return errors.New("unexpected-error")
+			case 2:
+				return errors.New("unexpected-error")
+			case 3:
+				return errors.New("migration-failed3")
+			default:
+				return errors.New("unexpected-error")
+			}
+		}).
+		MinTimes(3)
+
+	insRes, err := riverClient.Insert(
+		ctx,
+		UpgradeToArgs{
+			ModelUUID:            "model-uuid",
+			TargetVersion:        version.MustParse("2.0.0"),
+			Username:             username,
+			TargetControllerName: "target-controller",
+		}, &river.InsertOpts{MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
+	c.Assert(len(row.Errors) > 0, qt.IsTrue)
+
+	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
+	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
+	c.Assert(upgradeToJobFinalError, qt.Equals, "migration-failed3")
+}
+
+func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	// Retry a few times to ensure retries work as expected and surface the LAST error.
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 3)
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil)
+
+	attempt := 0
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		DoAndReturn(func(context.Context, string, version.Number) error {
+			attempt++
+			switch attempt {
+			case 1:
+				return errors.New("unexpected-error")
+			case 2:
+				return errors.New("unexpected-error")
+			case 3:
+				return errors.New("upgrade-failed3")
+			default:
+				return errors.New("unexpected-error")
+			}
+		}).
+		MinTimes(3)
+
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
+	c.Assert(len(row.Errors) > 0, qt.IsTrue)
+
+	// Ensure we capture the last error only from the upgrade job, and that it is surfaced to the upgrade to job.
+	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
+	c.Assert(upgradeToJobFinalError, qt.Equals, "upgrade-failed3")
+}
+
+// This test is particularly valuable because it ensures we're checking the jobs finalised state AND event kind.
+func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
+	defer cancel()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	// Allow each child to fail once and then succeed.
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 2, 2)
+
+	migAttempt := 0
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
+			migAttempt++
+			if migAttempt == 1 {
+				return errors.New("migration-transient")
+			}
+			// Any subsequent invocation should succeed so the job can finalize as completed.
+			return nil
+		}).
+		MinTimes(2)
+
+	upAttempt := 0
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		DoAndReturn(func(context.Context, string, version.Number) error {
+			upAttempt++
+			if upAttempt == 1 {
+				return errors.New("upgrade-transient")
+			}
+			return nil
+		}).
+		Times(2)
+
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	row := waitForFinalisedJob(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(row.Errors, qt.HasLen, 0)
+}
+
+func setupWorkers(
+	c *qt.C,
+	ctx context.Context,
+	database *db.Database,
+	upgradeManager UpgradeManager,
+	sqlDB *sql.DB,
+	migrateRetryCount int,
+	upgradeRetryCount int,
+) (*river.Client[*sql.Tx], string) {
+	// Prepare identity needed by migrationWorker.
+	u, err := dbmodel.NewIdentity("ash@catchum.com")
+	c.Assert(err, qt.IsNil)
+	err = database.GetIdentity(c.Context(), u)
+	c.Assert(err, qt.IsNil)
+
+	openfgaClient := &openfga.OFGAClient{}
+	migrationW, err := newMigrationWorker(openfgaClient, database, upgradeManager)
+	c.Assert(err, qt.IsNil)
+	upgradeW, err := newUpgradeWorker(upgradeManager)
+	c.Assert(err, qt.IsNil)
+	upgradeToW := newUpgradeToWorker(migrateRetryCount, upgradeRetryCount)
+
+	workers := river.NewWorkers()
+	c.Assert(river.AddWorkerSafely(workers, migrationW), qt.IsNil)
+	c.Assert(river.AddWorkerSafely(workers, upgradeW), qt.IsNil)
+	c.Assert(river.AddWorkerSafely(workers, upgradeToW), qt.IsNil)
+
+	riverClient, err := river.NewClient(riverdatabasesql.New(sqlDB), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 5},
+		},
+		Workers: workers,
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(riverClient.Start(ctx), qt.IsNil)
+	c.Cleanup(func() { _ = riverClient.Stop(ctx) })
+
+	return riverClient, u.Name
+}
+
+func waitForFinalisedJob(c *qt.C, ctx context.Context, client *river.Client[*sql.Tx], jobID int64) *rivertype.JobRow {
+	for i := 0; i < 20; i++ {
+		row, err := client.JobGet(ctx, jobID)
+		c.Assert(err, qt.IsNil)
+		if row.FinalizedAt != nil {
+			return row
+		}
+
+		select {
+		case <-ctx.Done():
+			c.Fatalf("context done while waiting for job %d to finalize: %v", jobID, ctx.Err())
+		case <-time.After(1 * time.Second):
+		}
+	}
+
+	c.Fatalf("timed out waiting for job %d to finalize", jobID)
+	return nil
+}

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -381,6 +381,7 @@ loop:
 // The aim of this test is to ensure that only 1 migrate job is inserted, even after a crash.
 func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	c := qt.New(t)
+
 	ctx := c.Context()
 
 	ctrl := gomock.NewController(c)
@@ -408,12 +409,12 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 		1,
 		1,
 		func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
-			defer once.Do(func() { close(migrateWaitToComplete) })
-
 			if crash {
 				crash = false
-				panic("simulated crash")
+				return errors.New("simulated crash")
 			}
+
+			once.Do(func() { close(migrateWaitToComplete) })
 
 			return waitForJobToFinalise(ctx, result, eventCh)
 		},
@@ -438,14 +439,22 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	c.Cleanup(cancel)
 
-	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
-		ModelUUID:            "model-uuid",
-		TargetVersion:        version.MustParse("2.0.0"),
-		Username:             username,
-		TargetControllerName: "target-controller",
-	},
+	insRes, err := riverClient.Insert(
+		ctx,
+		UpgradeToArgs{
+			ModelUUID:            "model-uuid",
+			TargetVersion:        version.MustParse("2.0.0"),
+			Username:             username,
+			TargetControllerName: "target-controller",
+		},
 		// Set max attempts to 2 so it can retry once after the crash.
-		&river.InsertOpts{MaxAttempts: 2},
+		&river.InsertOpts{
+			MaxAttempts: 2,
+			UniqueOpts: river.UniqueOpts{
+				ByArgs:  true,
+				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
+			},
+		},
 	)
 	c.Assert(err, qt.IsNil)
 

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (
@@ -5,11 +7,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/version/v2"
 	"github.com/riverqueue/river"
@@ -31,7 +35,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1)
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1, waitForJobToFinalise)
 
 	upgradeManager.EXPECT().
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
@@ -70,7 +74,7 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Retry a few times to ensure retries work as expected and surface the LAST error.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1)
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1, waitForJobToFinalise)
 
 	attempt := 0
 	upgradeManager.EXPECT().
@@ -115,7 +119,7 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Retry a few times to ensure retries work as expected and surface the LAST error.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 3)
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 3, waitForJobToFinalise)
 
 	upgradeManager.EXPECT().
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
@@ -163,7 +167,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Allow each child to fail once and then succeed.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 2, 2)
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 2, 2, waitForJobToFinalise)
 
 	migAttempt := 0
 	upgradeManager.EXPECT().
@@ -206,14 +210,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
 
-// This test simulates a crash of the supervisor between the migration and upgrade steps.
-// And ensures that when retried, the migration job picks up where it left off uniquely
-// resulting in 2 attempts.
-//
-// It relies on the fact that jobs are inserted in an ascending postgres sequence
-// as we don't know the job id of the supervisor ahead of time otherwise. So,
-// as we know it'll be the first job inserted, it's job id should always be 1.
-func TestUpgradeToWorker_SupervisorResumesSuccessfullyAfterCrash(t *testing.T) {
+func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *testing.T) {
 	c := qt.New(t)
 	ctx := c.Context()
 
@@ -228,8 +225,7 @@ func TestUpgradeToWorker_SupervisorResumesSuccessfullyAfterCrash(t *testing.T) {
 
 	supervisingJobId := int64(1)
 
-	// Setup migrate job to retry up to 3 times, we're expecting 2 after the supervising job crash.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1)
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1, waitForJobToFinalise)
 
 	attempt := 0
 	upgradeManager.EXPECT().
@@ -237,9 +233,6 @@ func TestUpgradeToWorker_SupervisorResumesSuccessfullyAfterCrash(t *testing.T) {
 		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
 			attempt++
 			if attempt == 1 {
-				// We sneakily cancel the supervisor (lol) to simulate a crash.
-				// As it's context has cancelled now, when it attempts to wait
-				// for the migrate job to finish it is going to error out.
 				_, err := riverClient.JobCancel(ctx, supervisingJobId)
 				if err != nil {
 					return err
@@ -284,14 +277,104 @@ loop:
 
 	// At this point, our job is cancelled and we'll see it as "completed".
 	c.Assert(supervisingJobFailureUpdate.State, qt.Equals, rivertype.JobStateCompleted)
-	// We're expecting to capture this specific singular job, and upon restarting the supervisor
-	// we should see the supervisor succeeds and the attempts increase for this job.
-	// We're pureposefully asking for more than we expect to ensure no other jobs are lurking.
+
 	params := river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(10)
 	listRes, err := riverClient.JobList(ctx, params)
 	c.Assert(err, qt.IsNil)
 	c.Assert(listRes.Jobs, qt.HasLen, 1)
-	// WIP
+	// Check the nested migrate job has finalised successfully because the context
+	// was cancelled for the root job.
+	c.Assert(listRes.Jobs[0].FinalizedAt, qt.IsNotNil)
+}
+
+// The aim of this test is to ensure that only 1 migrate job is inserted, even after a crash.
+func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	migrateWaitToComplete := make(chan struct{})
+
+	// It'll crash once after the migrate job is inserted.
+	// We'll check the attempts of the migrate job after success of the supervisor.
+	crash := true
+	var once sync.Once
+
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		database,
+		upgradeManager,
+		sqlDB,
+		1,
+		1,
+		func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+			defer once.Do(func() { close(migrateWaitToComplete) })
+
+			if crash {
+				crash = false
+				panic("simulated crash")
+			}
+
+			return waitForJobToFinalise(ctx, result, eventCh)
+		},
+	)
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		DoAndReturn(func(context.Context, *openfga.User, string, string) error {
+			// We have to prevent the migrate worker from finalising
+			// so we can see that upon restart of the supervisor, it isn't
+			// inserting a duplicate and is as such crash resillient.
+			//
+			// Wait here until the supervisor restarts to send the signal to complete.
+			<-migrateWaitToComplete
+			return nil
+		})
+
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	},
+		// Set max attempts to 2 so it can retry once after the crash.
+		&river.InsertOpts{MaxAttempts: 2},
+	)
+	c.Assert(err, qt.IsNil)
+
+	// The flow of what is happening here is:
+	// 1. Supervisor starts
+	// 2. Inserts migrate job which is blocked by channel.
+	// 3. Supervisor panics first time waiting on the migrate.
+	// 4. Supervisor restarts, and attempts to insert migrate job again, but it's a duplicate.
+	// 5. Waits for the migrate to finalise, but this time, unblocks the migrate job just before waiting.
+	// 6. 2nd try of supervisor finally completes.
+	// And we expect to see the supervisor attempted twice, but migrate once.
+	supervisorRow := waitForFinalisedJob(c, ctx, sub, insRes)
+	c.Assert(supervisorRow.State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(supervisorRow.Attempt, qt.Equals, 2)
+
+	// Check the migrate was inserted only once.
+	migrateParams := river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(2)
+	migrateListRes, err := riverClient.JobList(ctx, migrateParams)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrateListRes.Jobs, qt.HasLen, 1)
 }
 
 func setupWorkers(
@@ -302,6 +385,7 @@ func setupWorkers(
 	sqlDB *sql.DB,
 	migrateRetryCount int,
 	upgradeRetryCount int,
+	finaliser waitForJobFinalisationFunc,
 ) (*river.Client[*sql.Tx], string) {
 	// Prepare identity needed by migrationWorker.
 	u, err := dbmodel.NewIdentity("ash@catchum.com")
@@ -314,7 +398,7 @@ func setupWorkers(
 	c.Assert(err, qt.IsNil)
 	upgradeW, err := newUpgradeWorker(upgradeManager)
 	c.Assert(err, qt.IsNil)
-	upgradeToW := newUpgradeToWorker(migrateRetryCount, upgradeRetryCount)
+	upgradeToW := newUpgradeToWorker(migrateRetryCount, upgradeRetryCount, finaliser)
 
 	workers := river.NewWorkers()
 	c.Assert(river.AddWorkerSafely(workers, migrationW), qt.IsNil)
@@ -322,6 +406,7 @@ func setupWorkers(
 	c.Assert(river.AddWorkerSafely(workers, upgradeToW), qt.IsNil)
 
 	riverClient, err := river.NewClient(riverdatabasesql.New(sqlDB), &river.Config{
+		TestOnly: true,
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 5},
 		},

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -10,16 +10,16 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/canonical/jimm/v3/internal/db"
-	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/openfga"
-
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/version/v2"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
 	"github.com/riverqueue/river/rivertype"
 	gomock "go.uber.org/mock/gomock"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
 func TestUpgradeToWorker_Success(t *testing.T) {
@@ -572,12 +572,9 @@ func waitForSupervisingJob(c *qt.C, ctx context.Context, sub <-chan *river.Event
 	for {
 		select {
 		case event := <-sub:
-			if event.Job.ID != supervisingJobId {
-				continue
+			if event.Job.ID == supervisingJobId {
+				return event.Job
 			}
-			// We've caught the suppervising job entering "some state".
-			// Capture it, and break out.
-			return event.Job
 		case <-ctx.Done():
 			c.Fatal("timed out waiting for job failed event")
 		}

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -35,7 +35,18 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	upgradeManager.EXPECT().
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
@@ -52,7 +63,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 		TargetVersion:        version.MustParse("2.0.0"),
 		Username:             username,
 		TargetControllerName: "target-controller",
-	}, &river.InsertOpts{MaxAttempts: 1})
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes)
@@ -73,7 +84,18 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	upgradeManager.EXPECT().
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
@@ -90,15 +112,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 		TargetVersion:        version.MustParse("2.0.0"),
 		Username:             username,
 		TargetControllerName: "target-controller",
-	},
-		&river.InsertOpts{
-			MaxAttempts: 1,
-			UniqueOpts: river.UniqueOpts{
-				ByArgs:  true,
-				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
-			},
-		},
-	)
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes)
@@ -119,15 +133,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 		TargetVersion:        version.MustParse("3.0.0"),
 		Username:             username,
 		TargetControllerName: "target-controller2",
-	},
-		&river.InsertOpts{
-			MaxAttempts: 1,
-			UniqueOpts: river.UniqueOpts{
-				ByArgs:  true,
-				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
-			},
-		},
-	)
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	row = waitForFinalisedJob(c, ctx, sub, insRes)
@@ -165,7 +171,18 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Retry a few times to ensure retries work as expected and surface the LAST error.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 3,
+			upgradeRetryCount: 1,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	attempt := 0
 	upgradeManager.EXPECT().
@@ -179,14 +196,12 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	sub, cancel := riverClient.Subscribe(river.EventKindJobFailed)
 	c.Cleanup(cancel)
 
-	insRes, err := riverClient.Insert(
-		ctx,
-		UpgradeToArgs{
-			ModelUUID:            "model-uuid",
-			TargetVersion:        version.MustParse("2.0.0"),
-			Username:             username,
-			TargetControllerName: "target-controller",
-		}, &river.InsertOpts{MaxAttempts: 1})
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes)
@@ -210,7 +225,18 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Retry a few times to ensure retries work as expected and surface the LAST error.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 3, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 1,
+			upgradeRetryCount: 3,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	upgradeManager.EXPECT().
 		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
@@ -258,7 +284,18 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
 	// Allow each child to fail once and then succeed.
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 2, 2, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 2,
+			upgradeRetryCount: 2,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	migAttempt := 0
 	upgradeManager.EXPECT().
@@ -293,7 +330,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 		TargetVersion:        version.MustParse("2.0.0"),
 		Username:             username,
 		TargetControllerName: "target-controller",
-	}, &river.InsertOpts{MaxAttempts: 1})
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes)
@@ -316,7 +353,18 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 
 	supervisingJobId := int64(1)
 
-	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 3, 1, waitForJobToFinalise)
+	riverClient, username := setupWorkers(
+		c,
+		ctx,
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 3,
+			upgradeRetryCount: 1,
+			awaitFunc:         waitForJobToFinalise,
+		},
+	)
 
 	attempt := 0
 	upgradeManager.EXPECT().
@@ -345,7 +393,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 		TargetVersion:        version.MustParse("2.0.0"),
 		Username:             username,
 		TargetControllerName: "target-controller",
-	}, &river.InsertOpts{MaxAttempts: 1})
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	var supervisingJobFailureUpdate *rivertype.JobRow
@@ -403,20 +451,22 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	riverClient, username := setupWorkers(
 		c,
 		ctx,
-		database,
-		upgradeManager,
-		sqlDB,
-		1,
-		1,
-		func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
-			if crash {
-				crash = false
-				return errors.New("simulated crash")
-			}
+		setupWorkerParams{
+			database:          database,
+			upgradeManager:    upgradeManager,
+			sqlDB:             sqlDB,
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+				if crash {
+					crash = false
+					return errors.New("simulated crash")
+				}
 
-			once.Do(func() { close(migrateWaitToComplete) })
+				once.Do(func() { close(migrateWaitToComplete) })
 
-			return waitForJobToFinalise(ctx, result, eventCh)
+				return waitForJobToFinalise(ctx, result, eventCh)
+			},
 		},
 	)
 
@@ -439,23 +489,12 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	c.Cleanup(cancel)
 
-	insRes, err := riverClient.Insert(
-		ctx,
-		UpgradeToArgs{
-			ModelUUID:            "model-uuid",
-			TargetVersion:        version.MustParse("2.0.0"),
-			Username:             username,
-			TargetControllerName: "target-controller",
-		},
-		// Set max attempts to 2 so it can retry once after the crash.
-		&river.InsertOpts{
-			MaxAttempts: 2,
-			UniqueOpts: river.UniqueOpts{
-				ByArgs:  true,
-				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
-			},
-		},
-	)
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, nil)
 	c.Assert(err, qt.IsNil)
 
 	// The flow of what is happening here is:
@@ -477,35 +516,39 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	c.Assert(migrateListRes.Jobs, qt.HasLen, 1)
 }
 
+type setupWorkerParams struct {
+	database          *db.Database
+	upgradeManager    UpgradeManager
+	sqlDB             *sql.DB
+	migrateRetryCount int
+	upgradeRetryCount int
+	awaitFunc         awaitCompletionFunc
+}
+
 func setupWorkers(
 	c *qt.C,
 	ctx context.Context,
-	database *db.Database,
-	upgradeManager UpgradeManager,
-	sqlDB *sql.DB,
-	migrateRetryCount int,
-	upgradeRetryCount int,
-	finaliser waitForJobFinalisationFunc,
+	p setupWorkerParams,
 ) (*river.Client[*sql.Tx], string) {
 	// Prepare identity needed by migrationWorker.
 	u, err := dbmodel.NewIdentity("ash@catchum.com")
 	c.Assert(err, qt.IsNil)
-	err = database.GetIdentity(c.Context(), u)
+	err = p.database.GetIdentity(c.Context(), u)
 	c.Assert(err, qt.IsNil)
 
 	openfgaClient := &openfga.OFGAClient{}
-	migrationW, err := newMigrationWorker(openfgaClient, database, upgradeManager)
+	migrationW, err := newMigrationWorker(openfgaClient, p.database, p.upgradeManager)
 	c.Assert(err, qt.IsNil)
-	upgradeW, err := newUpgradeWorker(upgradeManager)
+	upgradeW, err := newUpgradeWorker(p.upgradeManager)
 	c.Assert(err, qt.IsNil)
-	upgradeToW := newUpgradeToWorker(migrateRetryCount, upgradeRetryCount, finaliser)
+	upgradeToW := newUpgradeToWorker(p.migrateRetryCount, p.upgradeRetryCount, p.awaitFunc)
 
 	workers := river.NewWorkers()
 	c.Assert(river.AddWorkerSafely(workers, migrationW), qt.IsNil)
 	c.Assert(river.AddWorkerSafely(workers, upgradeW), qt.IsNil)
 	c.Assert(river.AddWorkerSafely(workers, upgradeToW), qt.IsNil)
 
-	riverClient, err := river.NewClient(riverdatabasesql.New(sqlDB), &river.Config{
+	riverClient, err := river.NewClient(riverdatabasesql.New(p.sqlDB), &river.Config{
 		TestOnly: true,
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 5},

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -60,6 +60,97 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
 
+func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	database := setupTestDB(c)
+	sqlDB, err := database.SqlDB()
+	c.Assert(err, qt.IsNil)
+
+	upgradeManager := NewMockUpgradeManager(ctrl)
+
+	riverClient, username := setupWorkers(c, ctx, database, upgradeManager, sqlDB, 1, 1, waitForJobToFinalise)
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	insRes, err := riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	},
+		&river.InsertOpts{
+			MaxAttempts: 1,
+			UniqueOpts: river.UniqueOpts{
+				ByArgs:  true,
+				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
+			},
+		},
+	)
+	c.Assert(err, qt.IsNil)
+
+	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	c.Assert(row.ID, qt.Equals, int64(1))
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(row.Errors, qt.HasLen, 0)
+
+	// Now we'll upgrade again to a new controller and new version, but the same model.
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller2").
+		Return(nil)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("3.0.0")).
+		Return(nil)
+
+	insRes, err = riverClient.Insert(ctx, UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("3.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller2",
+	},
+		&river.InsertOpts{
+			MaxAttempts: 1,
+			UniqueOpts: river.UniqueOpts{
+				ByArgs:  true,
+				ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled},
+			},
+		},
+	)
+	c.Assert(err, qt.IsNil)
+
+	row = waitForFinalisedJob(c, ctx, sub, insRes)
+	c.Assert(row.ID, qt.Equals, int64(4))
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(row.Errors, qt.HasLen, 0)
+
+	// We can see two distinct jobs now because the first one entered a completed state.
+	c.Assert(insRes.UniqueSkippedAsDuplicate, qt.IsFalse)
+
+	// Finally, verify further that there's two migrate and two upgrade jobs now, so we know
+	// it re-created them for the second run of UpgradeTo.
+	listRes, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(listRes.Jobs[0].State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(listRes.Jobs, qt.HasLen, 2)
+
+	listRes, err = riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(listRes.Jobs[0].State, qt.Equals, rivertype.JobStateCompleted)
+	c.Assert(listRes.Jobs, qt.HasLen, 2)
+}
+
 func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	c := qt.New(t)
 	ctx := c.Context()

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -151,7 +151,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 	c.Assert(listRes.Jobs[0].State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(listRes.Jobs, qt.HasLen, 2)
 
-	listRes, err = riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeArgs{}.Kind()).First(10))
+	listRes, err = riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeWorkerArgs{}.Kind()).First(10))
 	c.Assert(err, qt.IsNil)
 	c.Assert(listRes.Jobs[0].State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(listRes.Jobs, qt.HasLen, 2)

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -18,25 +18,27 @@ func newUpgradeWorker(upgradeManager UpgradeManager) (*upgradeWorker, error) {
 	}, nil
 }
 
-// UpgradeArgs defines the arguments for the upgradeWorker job.
-type UpgradeArgs struct {
-	ModelUUID     string         `json:"model-uuid"`
+// upgradeArgs defines the arguments for the upgradeWorker job.
+type upgradeArgs struct {
+	// ModelUUID is the model UUID to migrate. We treat this as unique to prevent
+	// multiple concurrent migrations of the same model to many controllers.
+	ModelUUID     string         `json:"model-uuid" river:"unique"`
 	TargetVersion version.Number `json:"target-version"`
 }
 
 // Kind returns the kind of the job.
-func (UpgradeArgs) Kind() string { return "upgrade" }
+func (upgradeArgs) Kind() string { return "upgrade" }
 
 type upgradeWorker struct {
 	// An embedded WorkerDefaults sets up default methods to fulfill the rest of
 	// the Worker interface:
-	river.WorkerDefaults[UpgradeArgs]
+	river.WorkerDefaults[upgradeArgs]
 
 	upgradeManager UpgradeManager
 }
 
 // Work performs the upgrade operation receiving the job with UpgradeArgs.
-func (w *upgradeWorker) Work(ctx context.Context, job *river.Job[UpgradeArgs]) error {
+func (w *upgradeWorker) Work(ctx context.Context, job *river.Job[upgradeArgs]) error {
 	err := w.upgradeManager.UpgradeModel(ctx, job.Args.ModelUUID, job.Args.TargetVersion)
 	if err != nil {
 		return err

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -33,6 +33,9 @@ type upgradeWorkerArgs struct {
 func (upgradeWorkerArgs) Kind() string { return "upgrade" }
 
 // InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
+//
+// A job is considered unique by it's model uuid argument, and if it hasn't reached a completed state.
+// Once it reaches completed, this job may be launched for the same model uuid again.
 func (upgradeWorkerArgs) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{
 		UniqueOpts: river.UniqueOpts{

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -8,11 +8,12 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/juju/version/v2"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 func newUpgradeWorker(upgradeManager UpgradeManager) (*upgradeWorker, error) {
 	if upgradeManager == nil {
-		return nil, errors.E("migrationManager is required")
+		return nil, errors.E("upgradeManager is required")
 	}
 
 	return &upgradeWorker{
@@ -20,8 +21,8 @@ func newUpgradeWorker(upgradeManager UpgradeManager) (*upgradeWorker, error) {
 	}, nil
 }
 
-// upgradeArgs defines the arguments for the upgradeWorker job.
-type upgradeArgs struct {
+// upgradeWorkerArgs defines the arguments for the upgradeWorker job.
+type upgradeWorkerArgs struct {
 	// ModelUUID is the model UUID to migrate. We treat this as unique to prevent
 	// multiple concurrent migrations of the same model to many controllers.
 	ModelUUID     string         `json:"model-uuid" river:"unique"`
@@ -29,18 +30,34 @@ type upgradeArgs struct {
 }
 
 // Kind returns the kind of the job.
-func (upgradeArgs) Kind() string { return "upgrade" }
+func (upgradeWorkerArgs) Kind() string { return "upgrade" }
+
+// InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
+func (upgradeWorkerArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
 
 type upgradeWorker struct {
 	// An embedded WorkerDefaults sets up default methods to fulfill the rest of
 	// the Worker interface:
-	river.WorkerDefaults[upgradeArgs]
+	river.WorkerDefaults[upgradeWorkerArgs]
 
 	upgradeManager UpgradeManager
 }
 
 // Work performs the upgrade operation receiving the job with UpgradeArgs.
-func (w *upgradeWorker) Work(ctx context.Context, job *river.Job[upgradeArgs]) error {
+func (w *upgradeWorker) Work(ctx context.Context, job *river.Job[upgradeWorkerArgs]) error {
 	err := w.upgradeManager.UpgradeModel(ctx, job.Args.ModelUUID, job.Args.TargetVersion)
 	if err != nil {
 		return err

--- a/internal/river/upgradeworker_test.go
+++ b/internal/river/upgradeworker_test.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (

--- a/internal/river/upgradeworker_test.go
+++ b/internal/river/upgradeworker_test.go
@@ -38,7 +38,7 @@ func TestUpgradeWorker(t *testing.T) {
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
 
-	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeArgs{
+	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeWorkerArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.EventKind, qt.Equals, river.EventKindJobCompleted)
@@ -68,7 +68,7 @@ func TestUpgradeWorker_Error(t *testing.T) {
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
 
-	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeArgs{
+	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeWorkerArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)
 	c.Assert(err, qt.ErrorMatches, "some-error")
 	c.Assert(result.EventKind, qt.Equals, river.EventKindJobFailed)

--- a/internal/river/upgradeworker_test.go
+++ b/internal/river/upgradeworker_test.go
@@ -36,7 +36,7 @@ func TestUpgradeWorker(t *testing.T) {
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
 
-	result, err := testWorker.Work(c.Context(), c.TB, tx, UpgradeArgs{
+	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.EventKind, qt.Equals, river.EventKindJobCompleted)
@@ -66,7 +66,7 @@ func TestUpgradeWorker_Error(t *testing.T) {
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
 
-	result, err := testWorker.Work(c.Context(), c.TB, tx, UpgradeArgs{
+	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)
 	c.Assert(err, qt.ErrorMatches, "some-error")
 	c.Assert(result.EventKind, qt.Equals, river.EventKindJobFailed)

--- a/internal/river/utils_test.go
+++ b/internal/river/utils_test.go
@@ -1,3 +1,5 @@
+// Copyright 2026 Canonical.
+
 package river
 
 import (


### PR DESCRIPTION
## Description
Introduces a supervising worker for upgrade-to within river. I had to integration test this because rivers utilities don't facilitate the use of  the river client within work functions. As such, we're running river integration style and testing the flow of the job. Namely, a straight success, failure modes after all retries on both nested jobs and finally transitive successes after N failures.

I guess the negative is that we're polling the database within the tests to wait for finalisation, but the benefit here is we're pretty darn sure it is working as expected - ultimately meaning in callers of this worker need not test the worker semantics of river.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests


