### PR TITLE
fix(show-model): removes the store field from the show-model command

### DIFF
--- a/cmd/jaas/cmd/showmodel.go
+++ b/cmd/jaas/cmd/showmodel.go
@@ -38,10 +38,8 @@ The output includes the model name, model UUID, controller name, and controller 
 
 // NewShowModelCommand returns a command to display model controller information.
 func NewShowModelCommand() cmd.Command {
-	cmd := &showModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
-
+	cmd := &showModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	return modelcmd.WrapBase(cmd)
 }
 
@@ -51,7 +49,6 @@ type showModelCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store          jujuclient.ClientStore
 	dialOpts       *jujuapi.DialOpts
 	modelQualifier string
 	client         JIMMAPI
@@ -95,12 +92,12 @@ func (c *showModelCommand) Run(ctxt *cmd.Context) error {
 	if c.client != nil {
 		client = c.client
 	} else {
-		currentController, err := c.store.CurrentController()
+		currentController, err := c.ClientStore().CurrentController()
 		if err != nil {
 			return fmt.Errorf("could not determine controller: %w", err)
 		}
 
-		apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+		apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 		if err != nil {
 			return err
 		}

--- a/cmd/jaas/cmd/showmodel_test.go
+++ b/cmd/jaas/cmd/showmodel_test.go
@@ -18,9 +18,9 @@ import (
 
 func runShowModelCommand(c *qt.C, mocks *cmdMocks, args ...string) (string, error) {
 	showCmd := showModelCommand{
-		store:  mocks.store,
 		client: mocks.client,
 	}
+	showCmd.SetClientStore(mocks.store)
 
 	ctx := newTestContext(c)
 	f := gnuflag.NewFlagSetWithFlagKnownAs(showCmd.Info().Name, gnuflag.ContinueOnError, cmd.FlagAlias(&showCmd, "flag"))


### PR DESCRIPTION
## Description

The embedded `ControllerCommandBase` already has a `store` field, so we do not need an additional one.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

1. make qa-lxd
2. juju add-model test
3. juju jaas show-model jimm-test@canonical.com/test
