### PR TITLE
refactor(cmd): remove store field and fixes errors

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	jimmjujuapi "github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
@@ -42,8 +41,8 @@ is already known and will error otherwise.
 func NewAddCloudToControllerCommand() cmd.Command {
 	cmd := &addCloudToControllerCommand{
 		cloudByNameFunc: jujucmdcommon.CloudByName,
-		store:           jujuclient.NewFileClientStore(),
 	}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -68,7 +67,6 @@ type addCloudToControllerCommand struct {
 	// compatible with the cloud on which the controller is running.
 	force bool
 
-	store           jujuclient.ClientStore
 	dialOpts        *jujuapi.DialOpts
 	jimmAPIFunc     func() (JIMMAPI, error)
 	cloudByNameFunc func(string) (*cloud.Cloud, error)
@@ -100,18 +98,18 @@ func (c *addCloudToControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *addCloudToControllerCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("missing arguments")
+		return fmt.Errorf("missing arguments")
 	}
 	if len(args) > 2 {
-		return errors.E("too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 	c.dstControllerName = args[0]
 	if ok := names.IsValidControllerName(c.dstControllerName); !ok {
-		return errors.E("invalid controller name %q", c.dstControllerName)
+		return fmt.Errorf("invalid controller name %q", c.dstControllerName)
 	}
 	c.cloudName = args[1]
 	if ok := names.IsValidCloud(c.cloudName); !ok {
-		return errors.E("invalid cloud name %q", c.cloudName)
+		return fmt.Errorf("invalid cloud name %q", c.cloudName)
 	}
 
 	return nil
@@ -124,14 +122,14 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 	if c.cloudDefinitionFile != "" {
 		newCloud, err = c.readCloudFromFile()
 		if err != nil {
-			return errors.E(err, fmt.Sprintf("error reading cloud from file: %v", err))
+			return fmt.Errorf("error reading cloud from file: %w", err)
 		}
 	} else {
 		// It's possible that the user wants to add an existing cloud to a controller,
 		// so let's see if we can find the cloud.
 		newCloud, err = c.cloudByNameFunc(c.cloudName)
 		if err != nil {
-			return errors.E("could not find existing cloud, please provide a cloud file")
+			return fmt.Errorf("could not find existing cloud, please provide a cloud file")
 		}
 	}
 
@@ -146,7 +144,7 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 
 	jimmAPI, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E(err, "could not create JIMM API client")
+		return fmt.Errorf("could not create JIMM API client: %w", err)
 	}
 	defer jimmAPI.Close()
 
@@ -158,7 +156,7 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 			Force: &c.force,
 		},
 	}); err != nil {
-		return errors.E(err)
+		return err
 	}
 	ctxt.Infof("Cloud %q added to controller %q.", c.cloudName, c.dstControllerName)
 
@@ -168,31 +166,31 @@ func (c *addCloudToControllerCommand) Run(ctxt *cmd.Context) error {
 func (c *addCloudToControllerCommand) readCloudFromFile() (*cloud.Cloud, error) {
 	cloudDefinitionData, err := os.ReadFile(c.cloudDefinitionFile)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	specifiedClouds, err := cloud.ParseCloudMetadata(cloudDefinitionData)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	if len(specifiedClouds) == 0 {
-		return nil, errors.E("no clouds found in parsed yaml, please validate yaml keys")
+		return nil, fmt.Errorf("no clouds found in parsed yaml, please validate yaml keys")
 	}
 	var ok bool
 	foundCloud, ok := specifiedClouds[c.cloudName]
 	if !ok {
-		return nil, errors.E(fmt.Sprintf("cloud %q not found in file %q", c.cloudName, c.cloudDefinitionFile))
+		return nil, fmt.Errorf("cloud %q not found in file %q", c.cloudName, c.cloudDefinitionFile)
 	}
 
 	return &foundCloud, nil
 }
 
 func (c *addCloudToControllerCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -82,7 +82,6 @@ type bootstrapCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store            jujuclient.ClientStore
 	bootstrapAPIFunc func() (JIMMAPI, error)
 
 	cloud             string
@@ -100,9 +99,8 @@ type bootstrapCommand struct {
 // NewBootstrapStartCommand returns a command to start a job
 // that will bootstrap a Juju controller.
 func NewBootstrapStartCommand() cmd.Command {
-	cmd := &bootstrapCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &bootstrapCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.bootstrapAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -161,7 +159,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return fmt.Errorf("failed to get cloud %q: %w", c.cloud, err)
 	}
 
-	cloudCreds, err := c.store.CredentialForCloud(c.cloud)
+	cloudCreds, err := c.ClientStore().CredentialForCloud(c.cloud)
 	if err != nil {
 		return fmt.Errorf("failed to get credential for cloud %q: %w", c.cloud, err)
 	}
@@ -271,12 +269,12 @@ Should you cancel this process, you can track the progress via job-status with t
 }
 
 func (c *bootstrapCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %v", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/bootstrap_unit_test.go
+++ b/cmd/jaas/cmd/bootstrap_unit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/gnuflag"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"go.uber.org/mock/gomock"
@@ -122,11 +123,11 @@ func TestBootstrapRunDetached(t *testing.T) {
 	s.client.EXPECT().Close().Return(nil)
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 
 	configOpts := common.ConfigFlag{}
 	err := configOpts.Set("bootstrap-timeout=60")
@@ -144,7 +145,8 @@ func TestBootstrapRunDetached(t *testing.T) {
 	command.detach = true
 
 	ctx := newTestContext(c)
-	err = command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err = mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -169,17 +171,18 @@ func TestBootstrapWatchLogs(t *testing.T) {
 	}, nil)
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	command.SetFlags(f)
 	command.cloud = "aws"
 
 	ctx := newTestContext(c)
-	err := command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -190,11 +193,11 @@ func TestBootstrapFailsToGetCredential(t *testing.T) {
 	s.store.EXPECT().CredentialForCloud("aws").Return(nil, errors.New("credential not found"))
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	command.SetFlags(f)
 	command.controllerName = "controller-name"
@@ -203,7 +206,8 @@ func TestBootstrapFailsToGetCredential(t *testing.T) {
 	command.controllerVersion = "controller-version"
 
 	ctx := newTestContext(c)
-	err := command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `failed to get credential for cloud "aws": credential not found`)
 }
 
@@ -219,11 +223,11 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 	}, nil).Times(2)
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	command.SetFlags(f)
 	command.controllerName = "controller-name"
@@ -232,7 +236,8 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 	command.controllerVersion = "controller-version"
 
 	ctx := newTestContext(c)
-	err := command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `multiple credentials found for cloud "aws", please set a default or specify one using --credential`)
 
 	// Now specify a credential and verify the command works.
@@ -249,7 +254,7 @@ func TestBootstrapMultipleCredentials(t *testing.T) {
 		Watermark: 2,
 	}, nil)
 
-	err = command.Run(ctx)
+	err = mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -271,11 +276,11 @@ func TestBootstrapWithDefaultCredential(t *testing.T) {
 	s.client.EXPECT().Close().Return(nil)
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	command.SetFlags(f)
 	command.controllerName = "controller-name"
@@ -285,7 +290,8 @@ func TestBootstrapWithDefaultCredential(t *testing.T) {
 	command.detach = true
 
 	ctx := newTestContext(c)
-	err := command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 
@@ -304,11 +310,11 @@ func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 	}, nil)
 
 	command := &bootstrapCommand{
-		store: s.store,
 		bootstrapAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	command.SetFlags(f)
 	command.controllerName = "controller-name"
@@ -319,6 +325,7 @@ func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 	command.credentialName = "cred-3" // Use a different credential than the default.
 
 	ctx := newTestContext(c)
-	err := command.Run(ctx)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `no credential found with name "cred-3"`)
 }

--- a/cmd/jaas/cmd/crossmodelquery.go
+++ b/cmd/jaas/cmd/crossmodelquery.go
@@ -42,7 +42,6 @@ type crossModelQueryCommand struct {
 	// queryType holds the type of query the user wishes to use.
 	queryType string
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 	file     cmd.FileVar
 
@@ -52,9 +51,8 @@ type crossModelQueryCommand struct {
 // NewCrossModelQueryCommand returns a command to query all of the models
 // available to the current user.
 func NewCrossModelQueryCommand() cmd.Command {
-	cmd := &crossModelQueryCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &crossModelQueryCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.crossModelQueryAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -120,12 +118,12 @@ func (c *crossModelQueryCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *crossModelQueryCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, errors.Annotate(err, "could not determine controller")
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/destroycontroller.go
+++ b/cmd/jaas/cmd/destroycontroller.go
@@ -52,7 +52,6 @@ type destroyControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store                    jujuclient.ClientStore
 	destroyControllerAPIFunc func() (JIMMAPI, error)
 
 	controllerName string
@@ -65,9 +64,8 @@ type destroyControllerCommand struct {
 // NewDestroyControllerStartCommand returns a command to start a job
 // that will destroy a Juju controller.
 func NewDestroyControllerStartCommand() cmd.Command {
-	cmd := &destroyControllerCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &destroyControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.destroyControllerAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -171,12 +169,12 @@ Should you cancel this process, you can track the progress via job-status with t
 }
 
 func (c *destroyControllerCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %v", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/destroycontroller_test.go
+++ b/cmd/jaas/cmd/destroycontroller_test.go
@@ -77,11 +77,11 @@ func TestRunDetached(t *testing.T) {
 	s.client.EXPECT().Close().Return(nil)
 
 	command := &destroyControllerCommand{
-		store: s.store,
 		destroyControllerAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 
 	initCommand(c, command, "controller-name", "--detach", "--no-prompt")
 
@@ -107,11 +107,11 @@ func TestWatchLogs(t *testing.T) {
 	}, nil)
 
 	command := &destroyControllerCommand{
-		store: s.store,
 		destroyControllerAPIFunc: func() (JIMMAPI, error) {
 			return s.client, nil
 		},
 	}
+	command.SetClientStore(s.store)
 
 	initCommand(c, command, "controller-name", "--no-prompt")
 

--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -22,27 +22,26 @@ var (
 type AccessResult = accessResult
 
 func NewListControllersCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &listControllersCommand{
-		store: store,
-	}
+	cmd := &listControllersCommand{}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewModelStatusCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &modelStatusCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewRevokeAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &revokeAuditLogAccessCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -51,10 +50,10 @@ type RemoveCloudFromControllerAPI = removeCloudFromControllerAPI
 
 func NewRemoveCloudFromControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider, removeCloudFromControllerAPIFunc func() (RemoveCloudFromControllerAPI, error)) cmd.Command {
 	cmd := &removeCloudFromControllerCommand{
-		store:                            store,
 		dialOpts:                         cmdtest.TestDialOpts(lp),
 		removeCloudFromControllerAPIFunc: removeCloudFromControllerAPIFunc,
 	}
+	cmd.SetClientStore(store)
 	if removeCloudFromControllerAPIFunc == nil {
 		cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
 	}
@@ -64,135 +63,135 @@ func NewRemoveCloudFromControllerCommandForTesting(store jujuclient.ClientStore,
 
 func NewRegisterControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &registerControllerCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewUnregisterControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &unregisterControllerCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &setControllerDeprecatedCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewImportModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &importModelCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewUpdateMigratedModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &updateMigratedModelCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewAddRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addRoleCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewRenameRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &renameRoleCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewRemoveRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &removeRoleCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewListRolesCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &listRolesCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewAddGroupCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addGroupCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewAddRelationCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addPermission{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewRemovePermissionCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &removePermissionCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewListPermissionsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &listPermissionsCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewCheckPermissionCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &checkPermissionCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewCrossModelQueryCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &crossModelQueryCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 	cmd.crossModelQueryAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -200,23 +199,25 @@ func NewCrossModelQueryCommandForTesting(store jujuclient.ClientStore, lp jujuap
 
 func NewPurgeLogsCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &purgeLogsCommand{
-		store:    store,
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
 
 	return modelcmd.WrapBase(cmd)
 }
 
 func NewMigrateModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) *migrateModelCommand {
-	return &migrateModelCommand{
-		store:    store,
+	cmd := &migrateModelCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
+	return cmd
 }
 
 func NewUpgradeToCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) *upgradeToCommand {
-	return &upgradeToCommand{
-		store:    store,
+	cmd := &upgradeToCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),
 	}
+	cmd.SetClientStore(store)
+	return cmd
 }

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -30,9 +30,8 @@ Grants a user access to read audit logs.
 // NewGrantAuditLogAccessCommand returns a command used to grant
 // users access to audit logs.
 func NewGrantAuditLogAccessCommand() cmd.Command {
-	cmd := &grantAuditLogAccessCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &grantAuditLogAccessCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -45,7 +44,6 @@ type grantAuditLogAccessCommand struct {
 
 	username string
 
-	store       jujuclient.ClientStore
 	jimmAPIFunc func() (JIMMAPI, error)
 }
 
@@ -104,12 +102,12 @@ func (c *grantAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *grantAuditLogAccessCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/group.go
+++ b/cmd/jaas/cmd/group.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -50,9 +49,8 @@ Lists all groups.
 
 // NewAddGroupCommand returns a command to add a group.
 func NewAddGroupCommand() cmd.Command {
-	cmd := &addGroupCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &addGroupCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -63,7 +61,6 @@ type addGroupCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store       jujuclient.ClientStore
 	dialOpts    *jujuapi.DialOpts
 	jimmAPIFunc func() (JIMMAPI, error)
 
@@ -93,11 +90,11 @@ func (c *addGroupCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *addGroupCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("group name not specified")
+		return fmt.Errorf("group name not specified")
 	}
 	c.name, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -109,7 +106,7 @@ func (c *addGroupCommand) Run(ctxt *cmd.Context) error {
 	}
 	client, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E(fmt.Errorf("could not create JIMM client: %v", err))
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 
@@ -117,23 +114,23 @@ func (c *addGroupCommand) Run(ctxt *cmd.Context) error {
 		Name: c.name,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, resp)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
 
 func (c *addGroupCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -143,9 +140,8 @@ func (c *addGroupCommand) newClient() (JIMMAPI, error) {
 
 // NewRenameGroupCommand returns a command to rename a group.
 func NewRenameGroupCommand() cmd.Command {
-	cmd := &renameGroupCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &renameGroupCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -155,7 +151,6 @@ func NewRenameGroupCommand() cmd.Command {
 type renameGroupCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store       jujuclient.ClientStore
 	dialOpts    *jujuapi.DialOpts
 	jimmAPIFunc func() (JIMMAPI, error)
 
@@ -177,11 +172,11 @@ func (c *renameGroupCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *renameGroupCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("group name not specified")
+		return fmt.Errorf("group name not specified")
 	}
 	c.name, c.newName, args = args[0], args[1], args[2:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -193,7 +188,7 @@ func (c *renameGroupCommand) Run(ctxt *cmd.Context) error {
 	}
 	client, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E("could not create JIMM client: %v", err)
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 
@@ -204,19 +199,19 @@ func (c *renameGroupCommand) Run(ctxt *cmd.Context) error {
 
 	err = client.RenameGroup(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
 }
 
 func (c *renameGroupCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -226,9 +221,8 @@ func (c *renameGroupCommand) newClient() (JIMMAPI, error) {
 
 // NewRemoveGroupCommand returns a command to Remove a group.
 func NewRemoveGroupCommand() cmd.Command {
-	cmd := &removeGroupCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &removeGroupCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -239,7 +233,6 @@ type removeGroupCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store       jujuclient.ClientStore
 	dialOpts    *jujuapi.DialOpts
 	jimmAPIFunc func() (JIMMAPI, error)
 
@@ -261,11 +254,11 @@ func (c *removeGroupCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *removeGroupCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("group name not specified")
+		return fmt.Errorf("group name not specified")
 	}
 	c.name, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -290,7 +283,7 @@ func (c *removeGroupCommand) Run(ctxt *cmd.Context) error {
 		}
 		text, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.E(err, "Failed to read from input.")
+			return fmt.Errorf("failed to read from input: %w", err)
 		}
 		text = strings.ReplaceAll(text, "\n", "")
 		if text != "y" && text != "Y" {
@@ -303,7 +296,7 @@ func (c *removeGroupCommand) Run(ctxt *cmd.Context) error {
 
 	client, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E(fmt.Errorf("could not create JIMM client: %v", err))
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 
@@ -313,19 +306,19 @@ func (c *removeGroupCommand) Run(ctxt *cmd.Context) error {
 
 	err = client.RemoveGroup(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
 }
 
 func (c *removeGroupCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -335,9 +328,8 @@ func (c *removeGroupCommand) newClient() (JIMMAPI, error) {
 
 // NewListGroupsCommand returns a command to list all groups.
 func NewListGroupsCommand() cmd.Command {
-	cmd := &listGroupsCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listGroupsCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -348,7 +340,6 @@ type listGroupsCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store       jujuclient.ClientStore
 	dialOpts    *jujuapi.DialOpts
 	jimmAPIFunc func() (JIMMAPI, error)
 
@@ -370,7 +361,7 @@ func (c *listGroupsCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *listGroupsCommand) Init(args []string) error {
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -393,31 +384,31 @@ func (c *listGroupsCommand) Run(ctxt *cmd.Context) error {
 	}
 	client, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E("could not create JIMM client: %v", err)
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 
 	req := apiparams.ListGroupsRequest{Limit: c.limit, Offset: c.offset}
 	groups, err := client.ListGroups(&req)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, groups)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
 }
 
 func (c *listGroupsCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/importmodel.go
+++ b/cmd/jaas/cmd/importmodel.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -11,7 +13,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -34,9 +35,8 @@ local user and it will switch the model owner to the desired external user.
 
 // NewImportModelCommand returns a command to import a model.
 func NewImportModelCommand() cmd.Command {
-	cmd := &importModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &importModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -44,7 +44,6 @@ func NewImportModelCommand() cmd.Command {
 // importModelCommand imports a model.
 type importModelCommand struct {
 	modelcmd.ControllerCommandBase
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	req apiparams.ImportModelRequest
@@ -72,17 +71,17 @@ func (c *importModelCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *importModelCommand) Init(args []string) error {
 	switch len(args) {
 	default:
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	case 0:
-		return errors.E("controller not specified")
+		return fmt.Errorf("controller not specified")
 	case 1:
-		return errors.E("model uuid not specified")
+		return fmt.Errorf("model uuid not specified")
 	case 2:
 	}
 
 	c.req.Controller = args[0]
 	if !names.IsValidModel(args[1]) {
-		return errors.E("invalid model uuid")
+		return fmt.Errorf("invalid model uuid")
 	}
 	c.req.ModelTag = names.NewModelTag(args[1]).String()
 	return nil
@@ -90,19 +89,19 @@ func (c *importModelCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *importModelCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
 
 	client := api.NewClient(apiCaller)
 	if err := client.ImportModel(&c.req); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/jobstatus.go
+++ b/cmd/jaas/cmd/jobstatus.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	jimmAPI "github.com/canonical/jimm/v3/pkg/api"
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -33,9 +32,8 @@ const sleepBetweenGetLogs = 1 * time.Second
 
 // NewJobStatusCommand returns a command to display logs for a job.
 func NewJobStatusCommand() cmd.Command {
-	cmd := &jobStatusCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &jobStatusCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jobAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -45,7 +43,6 @@ func NewJobStatusCommand() cmd.Command {
 type jobStatusCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store      jujuclient.ClientStore
 	dialOpts   *jujuapi.DialOpts
 	jobId      string
 	jobAPIFunc func() (JIMMAPI, error)
@@ -74,11 +71,11 @@ func (c *jobStatusCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *jobStatusCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("missing job id")
+		return fmt.Errorf("missing job id")
 	}
 	c.jobId, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return fmt.Errorf("unknown arguments")
 	}
 
 	c.sleepBetweenGetLogs = sleepBetweenGetLogs
@@ -120,12 +117,12 @@ func (p logPoller) watchJobLogs() error {
 			Watermark: watermark,
 		})
 		if err != nil {
-			return errors.E(err, "failed to get job info")
+			return fmt.Errorf("failed to get job info: %w", err)
 		}
 		for _, log := range response.Logs {
 			_, err = p.out.Write([]byte(log + "\n"))
 			if err != nil {
-				return errors.E(err, "failed to write job log")
+				return fmt.Errorf("failed to write job log: %w", err)
 			}
 		}
 		watermark = response.Watermark
@@ -135,22 +132,22 @@ func (p logPoller) watchJobLogs() error {
 		case params.StatusSuccessful:
 			_, err = p.out.Write([]byte("Job completed successfully.\n"))
 			if err != nil {
-				return errors.E(err, "failed to write job success message")
+				return fmt.Errorf("failed to write job success message: %w", err)
 			}
 			return nil
 		case params.StatusFailed:
 			_, err = p.out.Write([]byte("Job failed: " + response.Error + "\n"))
 			if err != nil {
-				return errors.E(err, "failed to write job error")
+				return fmt.Errorf("failed to write job error: %w", err)
 			}
 			return nil
 		case params.StatusPending:
 			_, err := p.out.Write([]byte("Job is pending...\n"))
 			if err != nil {
-				return errors.E(err, "failed to write job pending message")
+				return fmt.Errorf("failed to write job pending message: %w", err)
 			}
 		default:
-			return errors.E("unknown job status: %s", response.Status)
+			return fmt.Errorf("unknown job status: %s", response.Status)
 		}
 		if !p.follow {
 			return nil
@@ -160,12 +157,12 @@ func (p logPoller) watchJobLogs() error {
 }
 
 func (s *jobStatusCommand) newClient() (JIMMAPI, error) {
-	currentController, err := s.store.CurrentController()
+	currentController, err := s.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(err, "could not determine controller")
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := s.NewAPIRootWithDialOpts(s.store, currentController, "", s.dialOpts)
+	apiCaller, err := s.NewAPIRootWithDialOpts(s.ClientStore(), currentController, "", s.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/jobstop.go
+++ b/cmd/jaas/cmd/jobstop.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	jimmAPI "github.com/canonical/jimm/v3/pkg/api"
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -27,9 +26,8 @@ Stop a job.
 
 // NewJobStopCommand returns a command to stop a job.
 func NewJobStopCommand() cmd.Command {
-	cmd := &jobStopCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &jobStopCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jobAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -39,7 +37,6 @@ func NewJobStopCommand() cmd.Command {
 type jobStopCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store      jujuclient.ClientStore
 	dialOpts   *jujuapi.DialOpts
 	jobId      string
 	jobAPIFunc func() (JIMMAPI, error)
@@ -59,11 +56,11 @@ func (c *jobStopCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *jobStopCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("missing job id")
+		return fmt.Errorf("missing job id")
 	}
 	c.jobId, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return fmt.Errorf("unknown arguments")
 	}
 
 	return nil
@@ -90,12 +87,12 @@ func (c *jobStopCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (s *jobStopCommand) newClient() (JIMMAPI, error) {
-	currentController, err := s.store.CurrentController()
+	currentController, err := s.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(err, "could not determine controller")
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := s.NewAPIRootWithDialOpts(s.store, currentController, "", s.dialOpts)
+	apiCaller, err := s.NewAPIRootWithDialOpts(s.ClientStore(), currentController, "", s.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/listauditevents.go
+++ b/cmd/jaas/cmd/listauditevents.go
@@ -33,9 +33,8 @@ Returns audit log events.
 // NewListAuditEventsCommand returns a command to list audit events matching
 // specified criteria.
 func NewListAuditEventsCommand() cmd.Command {
-	cmd := &listAuditEventsCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listAuditEventsCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -49,7 +48,6 @@ type listAuditEventsCommand struct {
 
 	args apiparams.FindAuditEventsRequest
 
-	store       jujuclient.ClientStore
 	jimmAPIFunc func() (JIMMAPI, error)
 }
 
@@ -115,12 +113,12 @@ func (c *listAuditEventsCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *listAuditEventsCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/listcontrollers.go
+++ b/cmd/jaas/cmd/listcontrollers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 )
 
@@ -27,9 +26,8 @@ Displays controller information for all controllers known to JIMM.
 
 // NewListControllersCommand returns a command to list controller information.
 func NewListControllersCommand() cmd.Command {
-	cmd := &listControllersCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listControllersCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -40,8 +38,6 @@ func NewListControllersCommand() cmd.Command {
 type listControllersCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
-
-	store jujuclient.ClientStore
 
 	jimmAPIFunc func() (JIMMAPI, error)
 }
@@ -79,23 +75,23 @@ func (c *listControllersCommand) Run(ctxt *cmd.Context) error {
 
 	controllers, err := client.ListControllers()
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, controllers)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
 
 func (c *listControllersCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("could not determine controller: %v", err))
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -54,11 +54,11 @@ func TestListControllersSuperuser(t *testing.T) {
 	cmdMocks.client.EXPECT().Close().Return(nil)
 
 	command := &listControllersCommand{
-		store: cmdMocks.store,
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return cmdMocks.client, nil
 		},
 	}
+	command.SetClientStore(cmdMocks.store)
 
 	initCommand(c, command)
 
@@ -82,11 +82,11 @@ func TestListControllersEmpty(t *testing.T) {
 	cmdMocks.client.EXPECT().Close().Return(nil)
 
 	command := &listControllersCommand{
-		store: cmdMocks.store,
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return cmdMocks.client, nil
 		},
 	}
+	command.SetClientStore(cmdMocks.store)
 
 	initCommand(c, command)
 

--- a/cmd/jaas/cmd/listmigrationtargets.go
+++ b/cmd/jaas/cmd/listmigrationtargets.go
@@ -37,7 +37,6 @@ type listMigrationTargetsCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store                       jujuclient.ClientStore
 	listMigrationTargetsAPIFunc func() (JIMMAPI, error)
 
 	modelTag string
@@ -46,9 +45,8 @@ type listMigrationTargetsCommand struct {
 // NewListMigrationTargetsCommand returns a command to list
 // valid migration targets for an internal model migration.
 func NewListMigrationTargetsCommand() cmd.Command {
-	cmd := &listMigrationTargetsCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listMigrationTargetsCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.listMigrationTargetsAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -113,12 +111,12 @@ func (c *listMigrationTargetsCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *listMigrationTargetsCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %v", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/migrateinternalmodel.go
+++ b/cmd/jaas/cmd/migrateinternalmodel.go
@@ -36,10 +36,8 @@ You may specify a model name (of the form owner/name) or model UUID.
 
 // NewMigrateInternalModelCommand returns a command to migrate internal models.
 func NewMigrateInternalModelCommand() cmd.Command {
-	cmd := &migrateInternalModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
-
+	cmd := &migrateInternalModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -50,7 +48,6 @@ type migrateInternalModelCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store            jujuclient.ClientStore
 	targetController string
 	modelTargets     []string
 
@@ -122,12 +119,12 @@ func (c *migrateInternalModelCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *migrateInternalModelCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -90,9 +90,8 @@ type MigrateAPI interface {
 
 // NewMigrateModelCommand returns a command to migrate models.
 func NewMigrateModelCommand() cmd.Command {
-	cmd := &migrateModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &migrateModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newJIMMClient
 	cmd.jujuApiFunc = cmd.newJujuClient
 	cmd.everyoneUser = "everyone@external"
@@ -104,12 +103,12 @@ func NewMigrateModelCommand() cmd.Command {
 // a controller that isn't registered with JAAS.
 type migrateModelCommand struct {
 	modelcmd.ControllerCommandBase
+
 	out          cmd.Output
 	jimmAPIFunc  func() (JIMMAPI, error)
 	jujuApiFunc  func() (MigrateAPI, error)
 	everyoneUser string
 
-	store             jujuclient.ClientStore
 	dialOpts          *jujuapi.DialOpts
 	targetController  string
 	modelName         string
@@ -157,13 +156,13 @@ func (c *migrateModelCommand) Init(args []string) error {
 func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
 	// Validate that the current controller exists.
 	// This is the controller where the model currently resides.
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return fmt.Errorf("could not determine current controller: %w", err)
 	}
 
 	// Get the model info from the current controller.
-	modelInfo, err := c.store.ModelByName(currentController, c.modelName)
+	modelInfo, err := c.ClientStore().ModelByName(currentController, c.modelName)
 	if err != nil {
 		return fmt.Errorf("could not find model %q on controller %q: %v", c.modelName, currentController, err)
 	}
@@ -244,7 +243,7 @@ func (c *migrateModelCommand) parseUserMappingFile() (map[string]string, error) 
 
 // getMigrationSpec creates the migration spec that will be used to initiate the migration.
 func (c *migrateModelCommand) getMigrationSpec(token string, modelUUID string) (controllerapi.MigrationSpec, error) {
-	store := c.store
+	store := c.ClientStore()
 	accountDetails, err := store.AccountDetails(c.targetController)
 	if err != nil {
 		return controllerapi.MigrationSpec{}, fmt.Errorf("could not get account details for controller %q: %w", c.targetController, err)
@@ -327,12 +326,12 @@ func (c *migrateModelCommand) validateUserMapping(userMapping map[string]string,
 }
 
 func (c *migrateModelCommand) newJujuClient() (MigrateAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %v", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +371,7 @@ func (j jujuMigrateAPI) ListOffers(filters ...crossmodel.ApplicationOfferFilter)
 // newJIMMClient creates a new JIMM client for the migration command.
 // It assumes the target controller is a JIMM controller.
 func (c *migrateModelCommand) newJIMMClient() (JIMMAPI, error) {
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, c.targetController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), c.targetController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/migratemodel_test.go
+++ b/cmd/jaas/cmd/migratemodel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/gnuflag"
 	controllerapi "github.com/juju/juju/api/controller/controller"
+	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/permission"
 	jjclient "github.com/juju/juju/jujuclient"
@@ -34,7 +35,8 @@ func setupMigrateAPIMock(c *qt.C) *mocks.MockMigrateAPI {
 
 func TestMigrate(t *testing.T) {
 	c := qt.New(t)
-	s := setupCmdMocks(c)
+
+	mocks := setupCmdMocks(c)
 	migrateClient := setupMigrateAPIMock(c)
 
 	userMappingFile, err := os.CreateTemp(c.TempDir(), "")
@@ -50,8 +52,8 @@ bob: bob@canonical.com
 
 	testUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
 
-	s.store.EXPECT().CurrentController().Return("target-controller", nil)
-	s.store.EXPECT().ModelByName("target-controller", "owner/test-model").Return(&jjclient.ModelDetails{
+	mocks.store.EXPECT().CurrentController().Return("target-controller", nil)
+	mocks.store.EXPECT().ModelByName("target-controller", "owner/test-model").Return(&jjclient.ModelDetails{
 		ModelUUID: testUUID,
 	}, nil)
 
@@ -76,15 +78,15 @@ bob: bob@canonical.com
 		UserMapping:           map[string]string{"alice": "alice@canonical.com", "bob": "bob@canonical.com"},
 		ModelTag:              "model-" + testUUID,
 	}
-	s.client.EXPECT().PrepareModelMigration(prepareMigrateParams).Return(apiparams.PrepareModelMigrationResponse{
+	mocks.client.EXPECT().PrepareModelMigration(prepareMigrateParams).Return(apiparams.PrepareModelMigrationResponse{
 		Token: "migration-token",
 	}, nil)
-	s.client.EXPECT().Close().Return(nil)
+	mocks.client.EXPECT().Close().Return(nil)
 
-	s.store.EXPECT().AccountDetails("target-controller").Return(&jjclient.AccountDetails{
+	mocks.store.EXPECT().AccountDetails("target-controller").Return(&jjclient.AccountDetails{
 		User: "test-user",
 	}, nil)
-	s.store.EXPECT().ControllerByName("target-controller").Return(&jjclient.ControllerDetails{
+	mocks.store.EXPECT().ControllerByName("target-controller").Return(&jjclient.ControllerDetails{
 		ControllerUUID: "target-controller-uuid",
 		APIEndpoints:   []string{"endpoint1"},
 		CACert:         "test-ca-cert",
@@ -104,13 +106,13 @@ bob: bob@canonical.com
 
 	migrateCmd := &migrateModelCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
-			return s.client, nil
+			return mocks.client, nil
 		},
 		jujuApiFunc: func() (MigrateAPI, error) {
 			return migrateClient, nil
 		},
-		store: s.store,
 	}
+	migrateCmd.SetClientStore(mocks.store)
 
 	initCommand(c, migrateCmd, "owner/test-model",
 		"target-controller",
@@ -119,7 +121,9 @@ bob: bob@canonical.com
 	)
 
 	ctx := newTestContext(c)
-	err = migrateCmd.Run(ctx)
+
+	mcmd := modelcmd.WrapBase(migrateCmd)
+	err = mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 
 	res := cmdtesting.Stdout(ctx)

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -30,9 +29,8 @@ Displays full model status.
 
 // NewModelStatusCommand returns a command to display full model status.
 func NewModelStatusCommand() cmd.Command {
-	cmd := &modelStatusCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &modelStatusCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -43,7 +41,6 @@ type modelStatusCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store     jujuclient.ClientStore
 	dialOpts  *jujuapi.DialOpts
 	modelUUID string
 
@@ -72,11 +69,11 @@ func (c *modelStatusCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *modelStatusCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("missing model uuid")
+		return fmt.Errorf("missing model uuid")
 	}
 	c.modelUUID, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return fmt.Errorf("unknown arguments")
 	}
 	return nil
 }
@@ -98,23 +95,23 @@ func (c *modelStatusCommand) Run(ctxt *cmd.Context) error {
 		ModelTag: modelTag.String(),
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, status)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
 
 func (c *modelStatusCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", nil)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -160,9 +159,8 @@ List permissions where the target object and relation match
 
 // NewAddPermissionCommand returns a command to grant access.
 func NewAddPermissionCommand() cmd.Command {
-	cmd := &addPermission{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &addPermission{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -172,7 +170,6 @@ type addPermission struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	object       string
@@ -200,7 +197,7 @@ func (c *addPermission) Init(args []string) error {
 	}
 	err := verifyTupleArguments(args)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	c.object, c.relation, c.targetObject = args[0], args[1], args[2]
 	return nil
@@ -218,12 +215,12 @@ func (c *addPermission) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *addPermission) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -245,7 +242,7 @@ func (c *addPermission) Run(ctxt *cmd.Context) error {
 	client := api.NewClient(apiCaller)
 	err = client.AddRelation(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -253,9 +250,8 @@ func (c *addPermission) Run(ctxt *cmd.Context) error {
 
 // NewRemovePermissionCommand returns a command to remove access.
 func NewRemovePermissionCommand() cmd.Command {
-	cmd := &removePermissionCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &removePermissionCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -265,7 +261,6 @@ type removePermissionCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	object       string
@@ -293,7 +288,7 @@ func (c *removePermissionCommand) Init(args []string) error {
 	}
 	err := verifyTupleArguments(args)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	c.object, c.relation, c.targetObject = args[0], args[1], args[2]
 	return nil
@@ -311,12 +306,12 @@ func (c *removePermissionCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *removePermissionCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -338,7 +333,7 @@ func (c *removePermissionCommand) Run(ctxt *cmd.Context) error {
 	client := api.NewClient(apiCaller)
 	err = client.RemoveRelation(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -348,7 +343,6 @@ func (c *removePermissionCommand) Run(ctxt *cmd.Context) error {
 type checkPermissionCommand struct {
 	modelcmd.ControllerCommandBase
 	out      cmd.Output
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	tuple apiparams.RelationshipTuple
@@ -374,9 +368,8 @@ func (ar *accessResult) setMessage() *accessResult {
 
 // NewCheckPermissionCommand
 func NewCheckPermissionCommand() cmd.Command {
-	cmd := &checkPermissionCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &checkPermissionCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -406,7 +399,7 @@ func (c *checkPermissionCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *checkPermissionCommand) Init(args []string) error {
 	err := verifyTupleArguments(args)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	c.tuple = apiparams.RelationshipTuple{
 		Object:       args[0],
@@ -419,23 +412,23 @@ func (c *checkPermissionCommand) Init(args []string) error {
 func formatCheckRelationString(writer io.Writer, value interface{}) error {
 	accessResult, ok := value.(accessResult)
 	if !ok {
-		return errors.E("failed to parse access result")
+		return fmt.Errorf("failed to parse access result")
 	}
 	_, err := writer.Write([]byte((&accessResult).setMessage().Msg))
 	if err != nil {
-		return errors.E("failed to write access result", err)
+		return fmt.Errorf("failed to write access result: %w", err)
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *checkPermissionCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -477,13 +470,13 @@ func readTupleFile(filename string) ([]apiparams.RelationshipTuple, error) {
 func verifyTupleArguments(args []string) error {
 	switch len(args) {
 	default:
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	case 0:
-		return errors.E("object not specified")
+		return fmt.Errorf("object not specified")
 	case 1:
-		return errors.E("relation not specified")
+		return fmt.Errorf("relation not specified")
 	case 2:
-		return errors.E("target object not specified")
+		return fmt.Errorf("target object not specified")
 	case 3:
 	}
 	return nil
@@ -491,9 +484,8 @@ func verifyTupleArguments(args []string) error {
 
 // NewListPermissionsCommand returns a command to list permissions.
 func NewListPermissionsCommand() cmd.Command {
-	cmd := &listPermissionsCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listPermissionsCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -503,7 +495,6 @@ type listPermissionsCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	tuple        apiparams.RelationshipTuple
@@ -524,7 +515,7 @@ func (c *listPermissionsCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *listPermissionsCommand) Init(args []string) error {
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -545,12 +536,12 @@ func (c *listPermissionsCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *listPermissionsCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -563,14 +554,14 @@ func (c *listPermissionsCommand) Run(ctxt *cmd.Context) error {
 	}
 	result, err := fetchRelations(client, params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// Ensure continutation token is empty so that we don't print it.
 	result.ContinuationToken = ""
 	err = c.out.Write(ctxt, result)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -581,7 +572,7 @@ func fetchRelations(client *api.Client, params apiparams.ListRelationshipTuplesR
 	for {
 		response, err := client.ListRelationshipTuples(&params)
 		if err != nil {
-			return nil, errors.E(fmt.Sprintf("failed to fetch list of relationship tuples: %s", err.Error()))
+			return nil, fmt.Errorf("failed to fetch list of relationship tuples: %w", err)
 		}
 		tuples = append(tuples, response.Tuples...)
 
@@ -595,7 +586,7 @@ func fetchRelations(client *api.Client, params apiparams.ListRelationshipTuplesR
 func formatRelationsTabular(writer io.Writer, value interface{}) error {
 	resp, ok := value.(*apiparams.ListRelationshipTuplesResponse)
 	if !ok {
-		return errors.E(fmt.Sprintf("expected value of type %T, got %T", resp, value))
+		return fmt.Errorf("expected value of type %T, got %T", resp, value)
 	}
 
 	table := uitable.New()

--- a/cmd/jaas/cmd/purge_logs.go
+++ b/cmd/jaas/cmd/purge_logs.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -12,7 +13,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -32,16 +32,14 @@ The provided date must be formatted as an ISO8601 date string.
 
 // NewPurgeLogsCommand returns a command to purge logs.
 func NewPurgeLogsCommand() cmd.Command {
-	cmd := &purgeLogsCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &purgeLogsCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	return modelcmd.WrapBase(cmd)
 }
 
 // purgeLogsCommand purges logs.
 type purgeLogsCommand struct {
 	modelcmd.ControllerCommandBase
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 	out      cmd.Output
 
@@ -63,13 +61,13 @@ func (c *purgeLogsCommand) Info() *cmd.Info {
 // the date.
 func (c *purgeLogsCommand) Init(args []string) error {
 	if len(args) != 1 {
-		return errors.E("expected one argument (ISO8601 date)")
+		return fmt.Errorf("expected one argument (ISO8601 date)")
 	}
 	// validate date
 	var err error
 	c.date, err = parseDate(args[0])
 	if err != nil {
-		return errors.E("invalid date. Expected ISO8601 date")
+		return fmt.Errorf("invalid date. Expected ISO8601 date")
 	}
 	return nil
 }
@@ -86,12 +84,12 @@ func (c *purgeLogsCommand) SetFlags(f *gnuflag.FlagSet) {
 // Run implements Command.Run. It purges logs from the database before the given
 // date.
 func (c *purgeLogsCommand) Run(ctx *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -101,11 +99,11 @@ func (c *purgeLogsCommand) Run(ctx *cmd.Context) error {
 		Date: c.date,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	err = c.out.Write(ctx, response)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -133,5 +131,5 @@ func parseDate(date string) (time.Time, error) {
 	}
 
 	// If none of the layouts match, the date is not in the correct format
-	return time.Time{}, errors.E("invalid date. Expected ISO8601 date")
+	return time.Time{}, fmt.Errorf("invalid date. Expected ISO8601 date")
 }

--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -52,9 +52,8 @@ This can be used later as input to register-controller.
 
 // NewRegisterControllerCommand returns a command to register a controller.
 func NewRegisterControllerCommand() cmd.Command {
-	cmd := &registerControllerCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &registerControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -64,7 +63,6 @@ type registerControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store          jujuclient.ClientStore
 	dialOpts       *jujuapi.DialOpts
 	file           cmd.FileVar
 	local          bool
@@ -128,12 +126,12 @@ func (c *registerControllerCommand) Run(ctxt *cmd.Context) error {
 		return c.out.Write(ctxt, params)
 	}
 
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
 		return errors.Annotate(err, "could not determine controller")
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -164,12 +162,12 @@ func (c *registerControllerCommand) getControllerDetails(ctxt *cmd.Context) ([]b
 		return c.file.Read(ctxt)
 	}
 
-	controller, err := c.store.ControllerByName(c.controllerName)
+	controller, err := c.ClientStore().ControllerByName(c.controllerName)
 	if err != nil {
 		return nil, errors.Mask(err)
 	}
 
-	accountDetails, err := c.store.AccountDetails(c.controllerName)
+	accountDetails, err := c.ClientStore().AccountDetails(c.controllerName)
 	if err != nil {
 		return nil, errors.Mask(err)
 	}

--- a/cmd/jaas/cmd/removecloudfromcontroller.go
+++ b/cmd/jaas/cmd/removecloudfromcontroller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -31,9 +30,8 @@ Removes the specified cloud from the specified controller in JIMM.
 // NewRemoveCloudFromControllerCommand returns a command to
 // remove a cloud from a specific controller in JIMM.
 func NewRemoveCloudFromControllerCommand() cmd.Command {
-	cmd := &removeCloudFromControllerCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &removeCloudFromControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
 
 	return modelcmd.WrapBase(cmd)
@@ -52,7 +50,6 @@ type removeCloudFromControllerCommand struct {
 	targetControllerName string
 
 	removeCloudFromControllerAPIFunc func() (removeCloudFromControllerAPI, error)
-	store                            jujuclient.ClientStore
 	dialOpts                         *jujuapi.DialOpts
 }
 
@@ -83,18 +80,18 @@ func (c *removeCloudFromControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *removeCloudFromControllerCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("missing arguments")
+		return fmt.Errorf("missing arguments")
 	}
 	if len(args) > 2 {
-		return errors.E("too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 	c.targetControllerName = args[0]
 	if ok := names.IsValidControllerName(c.targetControllerName); !ok {
-		return errors.E("invalid controller name %q", c.targetControllerName)
+		return fmt.Errorf("invalid controller name %q", c.targetControllerName)
 	}
 	c.cloudName = args[1]
 	if ok := names.IsValidCloud(c.cloudName); !ok {
-		return errors.E("invalid cloud name %q", c.cloudName)
+		return fmt.Errorf("invalid cloud name %q", c.cloudName)
 	}
 
 	return nil
@@ -104,7 +101,7 @@ func (c *removeCloudFromControllerCommand) Init(args []string) error {
 func (c *removeCloudFromControllerCommand) Run(ctxt *cmd.Context) error {
 	err := c.removeCloudFromController(ctxt)
 	if err != nil {
-		return errors.E(err, fmt.Sprintf("error removing cloud from controller: %v", err))
+		return fmt.Errorf("error removing cloud from controller: %w", err)
 	}
 
 	return nil
@@ -113,7 +110,7 @@ func (c *removeCloudFromControllerCommand) Run(ctxt *cmd.Context) error {
 func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.Context) error {
 	client, err := c.removeCloudFromControllerAPIFunc()
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	params := &apiparams.RemoveCloudFromControllerRequest{
@@ -123,7 +120,7 @@ func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.C
 
 	err = client.RemoveCloudFromController(params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	ctxt.Infof("Cloud %q removed from controller %q.", c.cloudName, c.targetControllerName)
@@ -131,11 +128,11 @@ func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.C
 }
 
 func (c *removeCloudFromControllerCommand) cloudAPI() (removeCloudFromControllerAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(err, "could not determine the current controller")
+		return nil, fmt.Errorf("could not determine the current controller: %w", err)
 	}
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/revokeauditlogaccess.go
+++ b/cmd/jaas/cmd/revokeauditlogaccess.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -11,7 +13,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -28,9 +29,8 @@ Revokes user access to audit logs.
 // NewrevokeAuditLogAccess returns a command used to revoke
 // users access to audit logs.
 func NewRevokeAuditLogAccessCommand() cmd.Command {
-	cmd := &revokeAuditLogAccessCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &revokeAuditLogAccessCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -40,7 +40,6 @@ func NewRevokeAuditLogAccessCommand() cmd.Command {
 type revokeAuditLogAccessCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 	username string
 }
@@ -63,24 +62,24 @@ func (c *revokeAuditLogAccessCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *revokeAuditLogAccessCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return errors.E("missing username")
+		return fmt.Errorf("missing username")
 	}
 	c.username, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return fmt.Errorf("unknown arguments")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *revokeAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
 	userTag := names.NewUserTag(c.username)
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -90,7 +89,7 @@ func (c *revokeAuditLogAccessCommand) Run(ctxt *cmd.Context) error {
 		UserTag: userTag.String(),
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil

--- a/cmd/jaas/cmd/role.go
+++ b/cmd/jaas/cmd/role.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -53,9 +52,8 @@ Lists all roles.
 
 // NewAddRoleCommand returns a command to add a role.
 func NewAddRoleCommand() cmd.Command {
-	cmd := &addRoleCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &addRoleCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -65,7 +63,6 @@ type addRoleCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	name string
@@ -94,23 +91,23 @@ func (c *addRoleCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *addRoleCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("role name not specified")
+		return fmt.Errorf("role name not specified")
 	}
 	c.name, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *addRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -120,21 +117,20 @@ func (c *addRoleCommand) Run(ctxt *cmd.Context) error {
 		Name: c.name,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, resp)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
 
 // NewRenameRoleCommand returns a command to rename a role.
 func NewRenameRoleCommand() cmd.Command {
-	cmd := &renameRoleCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &renameRoleCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -143,7 +139,6 @@ func NewRenameRoleCommand() cmd.Command {
 type renameRoleCommand struct {
 	modelcmd.ControllerCommandBase
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	name    string
@@ -164,23 +159,23 @@ func (c *renameRoleCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *renameRoleCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("role name not specified")
+		return fmt.Errorf("role name not specified")
 	}
 	c.name, c.newName, args = args[0], args[1], args[2:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *renameRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -193,7 +188,7 @@ func (c *renameRoleCommand) Run(ctxt *cmd.Context) error {
 	client := api.NewClient(apiCaller)
 	err = client.RenameRole(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -201,9 +196,8 @@ func (c *renameRoleCommand) Run(ctxt *cmd.Context) error {
 
 // NewRemoveRoleCommand returns a command to Remove a role.
 func NewRemoveRoleCommand() cmd.Command {
-	cmd := &removeRoleCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &removeRoleCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -213,7 +207,6 @@ type removeRoleCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	name  string
@@ -234,11 +227,11 @@ func (c *removeRoleCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *removeRoleCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("role name not specified")
+		return fmt.Errorf("role name not specified")
 	}
 	c.name, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -254,9 +247,9 @@ func (c *removeRoleCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
 	if !c.force {
@@ -268,7 +261,7 @@ func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
 		}
 		text, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.E(err, "Failed to read from input.")
+			return fmt.Errorf("failed to read from input: %w", err)
 		}
 		text = strings.ReplaceAll(text, "\n", "")
 		if text != "y" && text != "Y" {
@@ -276,7 +269,7 @@ func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -288,7 +281,7 @@ func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
 	client := api.NewClient(apiCaller)
 	err = client.RemoveRole(&params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -296,9 +289,8 @@ func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
 
 // NewListRolesCommand returns a command to list all roles.
 func NewListRolesCommand() cmd.Command {
-	cmd := &listRolesCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &listRolesCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -308,7 +300,6 @@ type listRolesCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	limit  int
@@ -329,7 +320,7 @@ func (c *listRolesCommand) Info() *cmd.Info {
 // Init implements the cmd.Command interface.
 func (c *listRolesCommand) Init(args []string) error {
 	if len(args) > 1 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
@@ -347,12 +338,12 @@ func (c *listRolesCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *listRolesCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -361,12 +352,12 @@ func (c *listRolesCommand) Run(ctxt *cmd.Context) error {
 	req := apiparams.ListRolesRequest{Limit: c.limit, Offset: c.offset}
 	roles, err := client.ListRoles(&req)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, roles)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil

--- a/cmd/jaas/cmd/role_test.go
+++ b/cmd/jaas/cmd/role_test.go
@@ -90,7 +90,7 @@ func (s *roleSuite) TestRemoveRoleWithoutFlag(c *gc.C) {
 	bClient := s.SetupCLIAccess(c, "alice")
 
 	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err.Error(), gc.Matches, "Failed to read from input.")
+	c.Assert(err.Error(), gc.Matches, "failed to read from input: EOF")
 }
 
 func (s *roleSuite) TestRemoveRole(c *gc.C) {

--- a/cmd/jaas/cmd/setcontrollerdeprecated.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -10,7 +12,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -27,9 +28,8 @@ Sets the deprecated status of a controller.
 // NewSetControllerDeprecatedCommand returns a command used to grant
 // users access to audit logs.
 func NewSetControllerDeprecatedCommand() cmd.Command {
-	cmd := &setControllerDeprecatedCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &setControllerDeprecatedCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -40,7 +40,6 @@ type setControllerDeprecatedCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	controllerName string
@@ -68,23 +67,23 @@ func (c *setControllerDeprecatedCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *setControllerDeprecatedCommand) Init(args []string) error {
 	if len(args) == 0 {
-		return errors.E("missing controller name")
+		return fmt.Errorf("missing controller name")
 	}
 	c.controllerName, args = args[0], args[1:]
 	if len(args) > 0 {
-		return errors.E("unknown arguments")
+		return fmt.Errorf("unknown arguments")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *setControllerDeprecatedCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
@@ -96,12 +95,12 @@ func (c *setControllerDeprecatedCommand) Run(ctxt *cmd.Context) error {
 		Deprecated: true,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, info)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/showmodel.go
+++ b/cmd/jaas/cmd/showmodel.go
@@ -38,9 +38,8 @@ The output includes the model name, model UUID, controller name, and controller 
 
 // NewShowModelCommand returns a command to display model controller information.
 func NewShowModelCommand() cmd.Command {
-	cmd := &showModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &showModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -51,7 +50,6 @@ type showModelCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store          jujuclient.ClientStore
 	dialOpts       *jujuapi.DialOpts
 	modelQualifier string
 	client         JIMMAPI
@@ -95,12 +93,12 @@ func (c *showModelCommand) Run(ctxt *cmd.Context) error {
 	if c.client != nil {
 		client = c.client
 	} else {
-		currentController, err := c.store.CurrentController()
+		currentController, err := c.ClientStore().CurrentController()
 		if err != nil {
 			return fmt.Errorf("could not determine controller: %w", err)
 		}
 
-		apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+		apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 		if err != nil {
 			return err
 		}

--- a/cmd/jaas/cmd/showmodel_test.go
+++ b/cmd/jaas/cmd/showmodel_test.go
@@ -18,9 +18,9 @@ import (
 
 func runShowModelCommand(c *qt.C, mocks *cmdMocks, args ...string) (string, error) {
 	showCmd := showModelCommand{
-		store:  mocks.store,
 		client: mocks.client,
 	}
+	showCmd.SetClientStore(mocks.store)
 
 	ctx := newTestContext(c)
 	f := gnuflag.NewFlagSetWithFlagKnownAs(showCmd.Info().Name, gnuflag.ContinueOnError, cmd.FlagAlias(&showCmd, "flag"))

--- a/cmd/jaas/cmd/unregistercontroller.go
+++ b/cmd/jaas/cmd/unregistercontroller.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -10,7 +12,6 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -28,9 +29,8 @@ Deregisters a controller from JIMM.
 
 // NewUnregisterControllerCommand returns a command to unregister a controller.
 func NewUnregisterControllerCommand() cmd.Command {
-	cmd := &unregisterControllerCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &unregisterControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -40,7 +40,6 @@ type unregisterControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 	params   apiparams.RemoveControllerRequest
 }
@@ -68,35 +67,35 @@ func (c *unregisterControllerCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *unregisterControllerCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.E("controller name not specified")
+		return fmt.Errorf("controller name not specified")
 	}
 	c.params.Name = args[0]
 	if len(args) > 1 {
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	}
 	return nil
 }
 
 // Run implements Command.Run.
 func (c *unregisterControllerCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
 	client := api.NewClient(apiCaller)
 	info, err := client.RemoveController(&c.params)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = c.out.Write(ctxt, info)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/updatemigratedmodel.go
+++ b/cmd/jaas/cmd/updatemigratedmodel.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
@@ -10,7 +12,6 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/names/v5"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -28,9 +29,8 @@ externally to a different JAAS controller.
 // NewUpdateMigratedModelCommand returns a command to update the controller
 // running a model.
 func NewUpdateMigratedModelCommand() cmd.Command {
-	cmd := &updateMigratedModelCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &updateMigratedModelCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -38,7 +38,6 @@ func NewUpdateMigratedModelCommand() cmd.Command {
 // updateMigratedModelCommand updates the controller running a model.
 type updateMigratedModelCommand struct {
 	modelcmd.ControllerCommandBase
-	store    jujuclient.ClientStore
 	dialOpts *jujuapi.DialOpts
 
 	req apiparams.UpdateMigratedModelRequest
@@ -59,17 +58,17 @@ func (c *updateMigratedModelCommand) Info() *cmd.Info {
 func (c *updateMigratedModelCommand) Init(args []string) error {
 	switch len(args) {
 	default:
-		return errors.E("too many args")
+		return fmt.Errorf("too many args")
 	case 0:
-		return errors.E("controller not specified")
+		return fmt.Errorf("controller not specified")
 	case 1:
-		return errors.E("model uuid not specified")
+		return fmt.Errorf("model uuid not specified")
 	case 2:
 	}
 
 	c.req.TargetController = args[0]
 	if !names.IsValidModel(args[1]) {
-		return errors.E("invalid model uuid")
+		return fmt.Errorf("invalid model uuid")
 	}
 	c.req.ModelTag = names.NewModelTag(args[1]).String()
 	return nil
@@ -77,19 +76,19 @@ func (c *updateMigratedModelCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *updateMigratedModelCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return errors.E(err, "could not determine controller")
+		return fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return err
 	}
 
 	client := api.NewClient(apiCaller)
 	if err := client.UpdateMigratedModel(&c.req); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 	jujuapi "github.com/juju/juju/api"
@@ -12,7 +14,6 @@ import (
 	"github.com/juju/names/v5"
 	jujuversion "github.com/juju/version/v2"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -28,9 +29,8 @@ Upgrades a controller to a specified version.
 
 // NewUpgradeToCommand returns a command to upgrade a controller to a specified version.
 func NewUpgradeToCommand() cmd.Command {
-	cmd := &upgradeToCommand{
-		store: jujuclient.NewFileClientStore(),
-	}
+	cmd := &upgradeToCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
 	cmd.jimmAPIFunc = cmd.newClient
 
 	return modelcmd.WrapBase(cmd)
@@ -41,7 +41,6 @@ type upgradeToCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	store       jujuclient.ClientStore
 	dialOpts    *jujuapi.DialOpts
 	version     string
 	modelUUID   string
@@ -70,22 +69,22 @@ func (c *upgradeToCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements the cmd.Command interface.
 func (c *upgradeToCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.E("missing required arguments: version and model UUID")
+		return fmt.Errorf("missing required arguments: version and model UUID")
 	}
 	if len(args) > 2 {
-		return errors.E("too many arguments")
+		return fmt.Errorf("too many arguments")
 	}
 	c.version = args[0]
 	c.modelUUID = args[1]
 
 	// Validate version format
 	if _, err := jujuversion.Parse(c.version); err != nil {
-		return errors.E("invalid version format: " + c.version)
+		return fmt.Errorf("invalid version format: %s", c.version)
 	}
 
 	// Validate model UUID format
 	if !names.IsValidModel(c.modelUUID) {
-		return errors.E("invalid model UUID: " + c.modelUUID)
+		return fmt.Errorf("invalid model UUID: %s", c.modelUUID)
 	}
 
 	return nil
@@ -95,7 +94,7 @@ func (c *upgradeToCommand) Init(args []string) error {
 func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
 	client, err := c.jimmAPIFunc()
 	if err != nil {
-		return errors.E(err, "failed to create JIMM client")
+		return fmt.Errorf("failed to create JIMM client: %w", err)
 	}
 	defer client.Close()
 
@@ -105,12 +104,12 @@ func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
 		ModelTag:                modelTag.String(),
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !resp.Success {
 		err = c.out.Write(ctxt, resp)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 	}
 	return nil
@@ -118,12 +117,12 @@ func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
 
 // newClient creates a new JIMM API client.
 func (c *upgradeToCommand) newClient() (JIMMAPI, error) {
-	currentController, err := c.store.CurrentController()
+	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, errors.E(err, "could not determine controller")
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.store, currentController, "", c.dialOpts)
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -60,8 +60,8 @@ func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return s.jimmClient, nil
 		},
-		store: s.store,
 	}
+	upgradeToCmd.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	f.SetOutput(s.writer)
 	upgradeToCmd.SetFlags(f)
@@ -99,8 +99,8 @@ func (s *upgradeToSuite) TestUpgradeToWithFailureResponse(c *gc.C) {
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return s.jimmClient, nil
 		},
-		store: s.store,
 	}
+	upgradeToCmd.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	f.SetOutput(s.writer)
 	upgradeToCmd.SetFlags(f)
@@ -135,8 +135,8 @@ func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return s.jimmClient, nil
 		},
-		store: s.store,
 	}
+	upgradeToCmd.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	f.SetOutput(s.writer)
 	upgradeToCmd.SetFlags(f)
@@ -194,8 +194,8 @@ func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
 		jimmAPIFunc: func() (JIMMAPI, error) {
 			return s.jimmClient, nil
 		},
-		store: s.store,
 	}
+	upgradeToCmd.SetClientStore(s.store)
 	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
 	f.SetOutput(s.writer)
 	upgradeToCmd.SetFlags(f)


### PR DESCRIPTION
## Description

Removes the `store` field, because there already is one in the `ControllerCommandBase`, and improves the returned errors.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
