### PR TITLE
refactor: improve river test retries

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -119,10 +119,6 @@ func (d *Database) migrateFromSource(ctx context.Context, fs embed.FS, sqlPath s
 	logger := logger.MigrationLogger{Logger: zapctx.Logger(ctx)}
 	m.Log = logger
 
-	if err := d.handleDeprecatedMigrations(ctx, m); err != nil {
-		return fmt.Errorf("failed to handle deprecated migrations: %w", err)
-	}
-
 	v, dirty, err := m.Version()
 	if err != nil {
 		if !stderr.Is(err, migrate.ErrNilVersion) {
@@ -146,30 +142,6 @@ func (d *Database) migrateFromSource(ctx context.Context, fs embed.FS, sqlPath s
 	}
 
 	atomic.StoreUint32(&d.migrated, 1)
-	return nil
-}
-
-// This method is used for handling deployments that are live when we made the
-// switch from a home-grown migration library to golang-migrate. To avoid running
-// migrations twice, we check if the old "versions" table exists and make golang-migrate
-// aware of which migrations have been run using the Force() method.
-func (d *Database) handleDeprecatedMigrations(ctx context.Context, m *migrate.Migrate) error {
-	var version int
-	err := d.DB.Raw("SELECT minor FROM versions;").Row().Scan(&version)
-	if err != nil {
-		// The versions table may already be deleted. Other errors are ignored intentionally.
-		zapctx.Debug(ctx, "no minor version from deprecated migrations table", zap.Error(err))
-		//nolint:nilerr
-		return nil
-	}
-	if version == 0 {
-		return nil
-	}
-	zapctx.Debug(ctx, "forcing db version", zap.Int("version", version))
-	err = m.Force(version)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/internal/river/migrationworker_test.go
+++ b/internal/river/migrationworker_test.go
@@ -24,9 +24,7 @@ func TestMigrationWorker(t *testing.T) {
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
-	db := setupTestDB(c)
-	sqlDb, err := db.SqlDB()
-	c.Assert(err, qt.IsNil)
+	db, sqlDb := setupTestDB(c)
 
 	openfgaClient := &openfga.OFGAClient{}
 	w, err := newMigrationWorker(openfgaClient, db, upgradeManager)
@@ -45,6 +43,7 @@ func TestMigrationWorker(t *testing.T) {
 
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
+	defer func() { _ = tx.Rollback() }()
 
 	result, err := testWorker.Work(
 		c.Context(),
@@ -71,9 +70,7 @@ func TestMigrationWorker_Error(t *testing.T) {
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
-	db := setupTestDB(c)
-	sqlDb, err := db.SqlDB()
-	c.Assert(err, qt.IsNil)
+	db, sqlDb := setupTestDB(c)
 
 	openfgaClient := &openfga.OFGAClient{}
 	w, err := newMigrationWorker(openfgaClient, db, upgradeManager)
@@ -92,8 +89,7 @@ func TestMigrationWorker_Error(t *testing.T) {
 
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
-
-	c.Assert(err, qt.IsNil)
+	defer func() { _ = tx.Rollback() }()
 	result, err := testWorker.Work(
 		c.Context(),
 		c.TB,

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -64,7 +64,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
@@ -111,7 +111,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.ID, qt.Equals, int64(1))
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
@@ -132,7 +132,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	row = waitForFinalisedJob(c, ctx, sub, insRes)
+	row = waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.ID, qt.Equals, int64(4))
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
@@ -198,7 +198,7 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
 	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
@@ -254,7 +254,7 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	}, &river.InsertOpts{MaxAttempts: 1})
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
 	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
@@ -323,7 +323,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	row := waitForFinalisedJob(c, ctx, sub, insRes)
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
@@ -384,7 +384,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 	}, nil)
 	c.Assert(err, qt.IsNil)
 
-	supervisingJobFailureUpdate := waitForSupervisingJob(c, ctx, sub, supervisingJobId)
+	supervisingJobFailureUpdate := waitForFinalisedJob(c, ctx, sub, supervisingJobId)
 
 	// At this point, our job is cancelled and we'll see it as "completed".
 	c.Assert(supervisingJobFailureUpdate.State, qt.Equals, rivertype.JobStateCompleted)
@@ -475,7 +475,7 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	// 5. Waits for the migrate to finalise, but this time, unblocks the migrate job just before waiting.
 	// 6. 2nd try of supervisor finally completes.
 	// And we expect to see the supervisor attempted twice, but migrate once.
-	supervisorRow := waitForFinalisedJob(c, ctx, sub, insRes)
+	supervisorRow := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(supervisorRow.State, qt.Equals, rivertype.JobStateCompleted)
 	c.Assert(supervisorRow.Attempt, qt.Equals, 2)
 
@@ -537,33 +537,16 @@ func setupWorkers(
 	return riverClient, u.Name
 }
 
-func waitForFinalisedJob(c *qt.C, ctx context.Context, sub <-chan *river.Event, insRes *rivertype.JobInsertResult) *rivertype.JobRow {
-loop:
+func waitForFinalisedJob(c *qt.C, ctx context.Context, sub <-chan *river.Event, jobID int64) *rivertype.JobRow {
 	for {
 		select {
 		case event := <-sub:
-			c.Logf("received job failed event for job ID %d", event.Job.ID)
-			if event.Job.ID != insRes.Job.ID {
-				continue loop
-			}
-			if event.Job.FinalizedAt != nil {
+			c.Logf("received job event for job ID %d", event.Job.ID)
+			if event.Job.ID == jobID && event.Job.FinalizedAt != nil {
 				return event.Job
 			}
 		case <-ctx.Done():
-			c.Fatal("timed out waiting for job failed event")
-		}
-	}
-}
-
-func waitForSupervisingJob(c *qt.C, ctx context.Context, sub <-chan *river.Event, supervisingJobId int64) *rivertype.JobRow {
-	for {
-		select {
-		case event := <-sub:
-			if event.Job.ID == supervisingJobId {
-				return event.Job
-			}
-		case <-ctx.Done():
-			c.Fatal("timed out waiting for job failed event")
+			c.Fatal("timed out waiting for job event")
 		}
 	}
 }

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -29,9 +29,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -41,7 +39,7 @@ func TestUpgradeToWorker_Success(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 1,
 			upgradeRetryCount: 1,
 			awaitFunc:         waitForJobToFinalise,
@@ -78,9 +76,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -90,7 +86,7 @@ func TestUpgradeToWorker_SuccessCanBeUpgradedToAgain(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 1,
 			upgradeRetryCount: 1,
 			awaitFunc:         waitForJobToFinalise,
@@ -164,9 +160,7 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -177,7 +171,7 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 3,
 			upgradeRetryCount: 1,
 			awaitFunc:         waitForJobToFinalise,
@@ -218,9 +212,7 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -231,7 +223,7 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 1,
 			upgradeRetryCount: 3,
 			awaitFunc:         waitForJobToFinalise,
@@ -277,9 +269,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -290,7 +280,7 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 2,
 			upgradeRetryCount: 2,
 			awaitFunc:         waitForJobToFinalise,
@@ -345,9 +335,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -359,7 +347,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 3,
 			upgradeRetryCount: 1,
 			awaitFunc:         waitForJobToFinalise,
@@ -388,7 +376,7 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 	sub, cancel := riverClient.Subscribe(river.EventKindJobFailed, river.EventKindJobCompleted)
 	c.Cleanup(cancel)
 
-	_, err = riverClient.Insert(ctx, UpgradeToArgs{
+	_, err := riverClient.Insert(ctx, UpgradeToArgs{
 		ModelUUID:            "model-uuid",
 		TargetVersion:        version.MustParse("2.0.0"),
 		Username:             username,
@@ -419,9 +407,7 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	database := setupTestDB(c)
-	sqlDB, err := database.SqlDB()
-	c.Assert(err, qt.IsNil)
+	database, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 
@@ -438,7 +424,7 @@ func TestUpgradeToWorker_SupervisorHandlesCrashMidway(t *testing.T) {
 		setupWorkerParams{
 			database:          database,
 			upgradeManager:    upgradeManager,
-			sqlDB:             sqlDB,
+			sqlDB:             sqlDb,
 			migrateRetryCount: 1,
 			upgradeRetryCount: 1,
 			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
@@ -537,7 +523,8 @@ func setupWorkers(
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 5},
 		},
-		Workers: workers,
+		Workers:     workers,
+		RetryPolicy: &testRetryPolicy{},
 	})
 	c.Assert(err, qt.IsNil)
 

--- a/internal/river/upgradeworker_test.go
+++ b/internal/river/upgradeworker_test.go
@@ -21,9 +21,7 @@ func TestUpgradeWorker(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	db := setupTestDB(c)
-	sqlDb, err := db.SqlDB()
-	c.Assert(err, qt.IsNil)
+	_, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 	w, err := newUpgradeWorker(upgradeManager)
@@ -37,6 +35,7 @@ func TestUpgradeWorker(t *testing.T) {
 
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
+	defer func() { _ = tx.Rollback() }()
 
 	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeWorkerArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)
@@ -51,9 +50,7 @@ func TestUpgradeWorker_Error(t *testing.T) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	db := setupTestDB(c)
-	sqlDb, err := db.SqlDB()
-	c.Assert(err, qt.IsNil)
+	_, sqlDb := setupTestDB(c)
 
 	upgradeManager := NewMockUpgradeManager(ctrl)
 	w, err := newUpgradeWorker(upgradeManager)
@@ -67,6 +64,7 @@ func TestUpgradeWorker_Error(t *testing.T) {
 
 	tx, err := sqlDb.Begin()
 	c.Assert(err, qt.IsNil)
+	defer func() { _ = tx.Rollback() }()
 
 	result, err := testWorker.Work(c.Context(), c.TB, tx, upgradeWorkerArgs{
 		ModelUUID: "test-string", TargetVersion: version.MustParse("2.0.0")}, nil)

--- a/internal/river/utils_test.go
+++ b/internal/river/utils_test.go
@@ -3,14 +3,16 @@
 package river
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	qt "github.com/frankban/quicktest"
+	"github.com/riverqueue/river/rivertype"
 )
 
-func setupTestDB(c *qt.C) *db.Database {
+func setupTestDB(c *qt.C) (*db.Database, *sql.DB) {
 	db := &db.Database{
 		DB: jimmtest.PostgresDB(c, time.Now),
 	}
@@ -18,5 +20,15 @@ func setupTestDB(c *qt.C) *db.Database {
 	c.Assert(err, qt.IsNil)
 	err = MigrateRiver(c.Context(), db)
 	c.Assert(err, qt.IsNil)
-	return db
+	sqlDB, err := db.SqlDB()
+	c.Assert(err, qt.IsNil)
+	return db, sqlDB
+}
+
+type testRetryPolicy struct{}
+
+// NextRetry implements the [river.ClientRetryPolicy] interface.
+// It ensures retries happen quickly during tests.
+func (p *testRetryPolicy) NextRetry(job *rivertype.JobRow) time.Time {
+	return time.Now().Add(1 * time.Millisecond)
 }

--- a/internal/river/utils_test.go
+++ b/internal/river/utils_test.go
@@ -22,6 +22,9 @@ func setupTestDB(c *qt.C) (*db.Database, *sql.DB) {
 	c.Assert(err, qt.IsNil)
 	sqlDB, err := db.SqlDB()
 	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(sqlDB.Close(), qt.IsNil)
+	})
 	return db, sqlDB
 }
 


### PR DESCRIPTION
## Description
This PR makes some minor improvements to our River tests and DB migrations:
1. Speeds up our River tests. 2 tests in the upgrade_test worker were taking 20s and 40s because they were retrying a job and River's default retry policy is 1s->16s->1m21s, etc. See https://riverqueue.com/docs/job-retries. Now running `go test ./internal/river -count=1` takes around 12s on my machine. Previously it was taking ~70s
2. When running the tests with verbose=true, one would see `ERROR: database "jimm_test_testmigrationworker_error_6fgoa36q" is being accessed by other users`. This was because we weren't commiting/rolling-back a tx we started with `tx, err := sqlDb.Begin()`. That's been fixed. I've also simplified the helper we use to create the test database.
3. I've removed `handleDeprecatedMigrations` which handled scenarios where a deployment was running a now very old version of JIMM that didn't use golang-migrate and then upgraded to a version of JIMM that did. We can be quite confident that no users are running this old release so the code can finally go. At the time we likely didn't have external users anyway and it was added out of an abundance of caution.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
