### PR TITLE
fix(middleware): added client credential login to middleware

### DIFF
--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -42,7 +42,7 @@ func (hph *HTTPProxyHandler) Routes() chi.Router {
 // SetupMiddleware applies authn and authz middlewares.
 func (hph *HTTPProxyHandler) SetupMiddleware() {
 	hph.Router.Use(func(h http.Handler) http.Handler {
-		return middleware.AuthenticateWithSessionTokenViaBasicAuth(h, hph.jimm.LoginManager())
+		return middleware.AuthenticateViaBasicAuth(h, hph.jimm.LoginManager())
 	})
 	hph.Router.Use(func(h http.Handler) http.Handler {
 		return middleware.AuthorizeUserForModelAccess(h, ofganames.WriterRelation)

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -49,7 +49,7 @@ func (hph *MigrationHTTPProxyHandler) Routes() chi.Router {
 // SetupMiddleware applies authn and authz middlewares.
 func (hph *MigrationHTTPProxyHandler) SetupMiddleware() {
 	hph.Router.Use(func(h http.Handler) http.Handler {
-		return middleware.AuthenticateWithSessionTokenViaBasicAuth(h, hph.jimm.LoginManager())
+		return middleware.AuthenticateViaBasicAuth(h, hph.jimm.LoginManager())
 	})
 	hph.Router.Use(middleware.AuthorizeUserAsJIMMAdmin)
 }

--- a/internal/middleware/authn.go
+++ b/internal/middleware/authn.go
@@ -19,15 +19,16 @@ import (
 // identityContextKey is the unique key to extract user from context for basic-auth authentication
 type identityContextKey struct{}
 
-// JIMMAuthner is an interface that requires authentication methods from JIMM.
-type JIMMAuthner interface {
+// Authenticator is an interface that requires authentication methods from JIMM.
+type Authenticator interface {
 	AuthenticateBrowserSession(context.Context, http.ResponseWriter, *http.Request) (context.Context, error)
+	LoginClientCredentials(ctx context.Context, clientID string, clientSecret string) (*openfga.User, error)
 	LoginWithSessionToken(ctx context.Context, sessionToken string) (*openfga.User, error)
 	UserLogin(ctx context.Context, identityName string) (*openfga.User, error)
 }
 
 // AuthenticateViaCookie performs browser session authentication and puts an identity in the request's context
-func AuthenticateViaCookie(next http.Handler, jimm JIMMAuthner) http.Handler {
+func AuthenticateViaCookie(next http.Handler, jimm Authenticator) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, err := jimm.AuthenticateBrowserSession(r.Context(), w, r)
 		if err != nil {
@@ -50,7 +51,7 @@ var unauthenticatedEndpoints = map[string]struct{}{
 // verifies that the user is a JIMM admin. Note that the method needs the base
 // URL to decide if the request does not require authentication; this is to
 // safeguard against conflicting/similar endpoint names in the future.
-func AuthenticateRebac(baseURL string, next http.Handler, jimm JIMMAuthner) http.Handler {
+func AuthenticateRebac(baseURL string, next http.Handler, jimm Authenticator) http.Handler {
 	cookieAuthenticator := AuthenticateViaCookie(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -87,25 +88,42 @@ func AuthenticateRebac(baseURL string, next http.Handler, jimm JIMMAuthner) http
 	})
 }
 
-// AuthenticateWithSessionTokenViaBasicAuth performs basic auth authentication and puts an identity in the request's context.
-// The basic-auth is composed of an empty user, and as a password a jwt token that we parse and use to authenticate the user.
-func AuthenticateWithSessionTokenViaBasicAuth(next http.Handler, jimm JIMMAuthner) http.Handler {
+// AuthenticateViaBasicAuth performs basic auth authentication and puts an identity in the request's context.
+// For basic auth, we support two modes:
+// 1. Client Credentials: where the username is the client ID, and the password is the client secret.
+// 2. Session Token: where the username is empty, and the password is a session token.
+func AuthenticateViaBasicAuth(next http.Handler, jimm Authenticator) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		// extract auth token
-		_, password, ok := r.BasicAuth()
+		username, password, ok := r.BasicAuth()
 		if !ok {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte("authentication missing"))
 			return
 		}
-		user, err := jimm.LoginWithSessionToken(ctx, password)
-		if err != nil {
+
+		// if username is set, we assume client credentials authentication
+		if username != "" {
+			// then try client credentials authentication
+			user, err := jimm.LoginClientCredentials(ctx, username, password)
+			if err == nil {
+				next.ServeHTTP(w, r.WithContext(withIdentity(ctx, user)))
+				return
+			}
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte("error authenticating the user"))
 			return
 		}
-		next.ServeHTTP(w, r.WithContext(withIdentity(ctx, user)))
+
+		user, err := jimm.LoginWithSessionToken(ctx, password)
+		if err == nil {
+			next.ServeHTTP(w, r.WithContext(withIdentity(ctx, user)))
+			return
+		}
+
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("error authenticating the user"))
 	})
 }
 

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -12,6 +12,7 @@ import (
 
 	rebac_handlers "github.com/canonical/rebac-admin-ui-handlers/v1"
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -185,7 +186,74 @@ func TestAuthenticateViaBasicAuth(t *testing.T) {
 				c.Assert(user.Name, qt.Equals, testUser)
 				w.WriteHeader(http.StatusOK)
 			})
-			middleware := middleware.AuthenticateWithSessionTokenViaBasicAuth(handler, &loginManager)
+			middleware := middleware.AuthenticateViaBasicAuth(handler, &loginManager)
+			middleware.ServeHTTP(w, req)
+			c.Assert(w.Code, qt.Equals, tt.expectedStatus)
+			b := w.Result().Body
+			defer b.Close()
+			body, err := io.ReadAll(b)
+			c.Assert(err, qt.IsNil)
+			if tt.errorExpected != "" {
+				c.Assert(string(body), qt.Matches, tt.errorExpected)
+			}
+
+		})
+	}
+}
+
+func TestAuthenticateViaBasicAuthServiceAccount(t *testing.T) {
+	testClientID := uuid.NewString()
+	testClientSecret := uuid.NewString()
+
+	loginManager := mocks.LoginManager{
+		LoginClientCredentials_: func(ctx context.Context, clientID, clientSecret string) (*openfga.User, error) {
+			if clientID == testClientID && clientSecret == testClientSecret {
+				user := dbmodel.Identity{
+					Name: clientID,
+				}
+				return &openfga.User{Identity: &user}, nil
+			}
+			return nil, jimm_errors.E(jimm_errors.CodeUnauthorized)
+		},
+	}
+	tests := []struct {
+		name              string
+		basicAuthUsername string
+		basicAuthPassword string
+		expectedStatus    int
+		errorExpected     string
+	}{{
+		name:              "success",
+		basicAuthUsername: testClientID,
+		basicAuthPassword: testClientSecret,
+		expectedStatus:    http.StatusOK,
+	}, {
+		name:              "failure",
+		basicAuthUsername: "bad_user",
+		basicAuthPassword: "bad_pass",
+		expectedStatus:    http.StatusUnauthorized,
+		errorExpected:     "error authenticating the user",
+	}, {
+		name:           "no basic auth",
+		expectedStatus: http.StatusUnauthorized,
+		errorExpected:  "authentication missing",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			if tt.basicAuthUsername != "" && tt.basicAuthPassword != "" {
+				req.SetBasicAuth(tt.basicAuthUsername, tt.basicAuthPassword)
+			}
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				user, err := middleware.IdentityFromContext(r.Context())
+				c.Assert(err, qt.IsNil)
+				c.Assert(user.Name, qt.Equals, tt.basicAuthUsername)
+				w.WriteHeader(http.StatusOK)
+			})
+			middleware := middleware.AuthenticateViaBasicAuth(handler, &loginManager)
 			middleware.ServeHTTP(w, req)
 			c.Assert(w.Code, qt.Equals, tt.expectedStatus)
 			b := w.Result().Body


### PR DESCRIPTION
## Description

Enables client credential login to http endpoints we proxy.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

1. apply the plan below
2. change resource revision to 2 and reapply the plan
3. 
```
terraform {
	required_providers {
		juju = {
			source  = "juju/juju"
			version = "1.2.0"
		}
	}
	required_version = ">= 1.5.0"
}


provider "juju" {
	client_id     = "test-client-id"
	client_secret = "2M2blFbO4GX4zfggQpivQSxwWX1XGgNf"
	controller_addresses = "jimm.localhost:443"
}

# Pull existing cloud credential for LXD from local Juju file store
resource "juju_credential" "lxd" {
	name   = "lxd-credential"

    cloud {
      name = "lxd"
    }

	auth_type = "certificate"

	attributes = {
		client-cert = <<-EOT
<REDACTED>
		EOT
		client-key  = <<-EOK
<REDACTED>
		EOK
		server-cert = <<-EOS
<REDACTED>
		EOS
	}
}


resource "juju_model" "test-model" {
	name        = "test-model"

	credential = juju_credential.lxd.name

    cloud {
      name = "lxd"
    }
}

resource "juju_application" "test" {
	name 	 = "test-app"
	model_uuid = juju_model.test-model.uuid

	charm {
		name = "juju-qa-test"
		revision = 26
		channel = "latest/stable"
	}

	resources = {
		"foo-file" = "1"
	}
}
```

