### PR TITLE
fix(login): return CodeSessionTokenInvalid error code when the token can't be decoded

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -410,7 +410,7 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 		if stderrors.Is(err, jwt.ErrTokenExpired()) {
 			return nil, errors.E(errors.CodeSessionTokenInvalid, "JIMM session token expired")
 		}
-		return nil, err
+		return nil, errors.E(errors.CodeSessionTokenInvalid, fmt.Errorf("failed to parse jwt: %v", err))
 	}
 
 	if _, err = mail.ParseAddress(parsedToken.Subject()); err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -402,7 +402,7 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
-		return nil, errors.E(err, "failed to decode token")
+		return nil, errors.E(errors.CodeSessionTokenInvalid, fmt.Errorf("failed to decode token; %v", err))
 	}
 
 	parsedToken, err := jwt.Parse(decodedToken, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -217,6 +217,25 @@ func TestSessionTokenRejectsExpiredToken(t *testing.T) {
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeSessionTokenInvalid)
 }
 
+func TestSessionTokenRejectsBadlyDecoded(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := context.Background()
+
+	noDuration := time.Duration(0)
+	authSvc, _, _, cleanup := setupTestAuthSvc(ctx, c, noDuration)
+	defer cleanup()
+
+	token, err := authSvc.MintSessionToken("jimm-test@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(token) > 0, qt.IsTrue)
+
+	token += "invalidstuff"
+	_, err = authSvc.VerifySessionToken(token)
+	c.Assert(err, qt.ErrorMatches, `failed to decode token; illegal base64 data at input byte 200`)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeSessionTokenInvalid)
+}
+
 func TestSessionTokenRejectsEmptyToken(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -217,7 +217,7 @@ func TestSessionTokenRejectsExpiredToken(t *testing.T) {
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeSessionTokenInvalid)
 }
 
-func TestSessionTokenRejectsBadlyDecoded(t *testing.T) {
+func TestSessionTokenRejectsBadlyDecodedBase64(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
@@ -233,6 +233,25 @@ func TestSessionTokenRejectsBadlyDecoded(t *testing.T) {
 	token += "invalidstuff"
 	_, err = authSvc.VerifySessionToken(token)
 	c.Assert(err, qt.ErrorMatches, `failed to decode token; illegal base64 data at input byte 200`)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeSessionTokenInvalid)
+}
+
+func TestSessionTokenRejectsBadlyDecodedJwt(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := context.Background()
+
+	noDuration := time.Duration(0)
+	authSvc, _, _, cleanup := setupTestAuthSvc(ctx, c, noDuration)
+	defer cleanup()
+
+	token, err := authSvc.MintSessionToken("jimm-test@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(token) > 0, qt.IsTrue)
+
+	token = token[:9] + "a" + token[10:]
+	_, err = authSvc.VerifySessionToken(token)
+	c.Assert(err, qt.ErrorMatches, `failed to parse jwt: .*`)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeSessionTokenInvalid)
 }
 


### PR DESCRIPTION
# Description

Before the "failed to decode token" error was considered fatal, however it seems it was useful to re-trigger a login, so we set the `CodeSessionTokenInvalid` code for this error as well.
Add a test as well to prevent changing this error code in the future

# QA

`make dev-env`

`juju login jimm.localhost -c jimm-dev`
Do the login.
Change the token: `vi ~/.local/share/juju/accounts.yaml`
`juju models`
Before:
`ERROR failed to decode token; illegal base64 data at input byte 198 (fatal login error)`

Now:
it triggers a re-login:
```
juju login jimm.localhost -c jimm-dev
Please visit http://keycloak.localhost:8082/realms/jimm/device and enter code NXHL-YQLA to log in.
```