### PR TITLE
refactor(set-controller-deprecated): refactors tests for the set-controller-deprecated command

### DIFF
--- a/cmd/jaas/cmd/setcontrollerdeprecated.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated.go
@@ -41,6 +41,7 @@ type setControllerDeprecatedCommand struct {
 	out cmd.Output
 
 	dialOpts *jujuapi.DialOpts
+	client   JIMMAPI
 
 	controllerName string
 }
@@ -78,17 +79,22 @@ func (c *setControllerDeprecatedCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *setControllerDeprecatedCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
-	}
+	var client JIMMAPI
+	if c.client != nil {
+		client = c.client
+	} else {
+		currentController, err := c.ClientStore().CurrentController()
+		if err != nil {
+			return fmt.Errorf("could not determine controller: %w", err)
+		}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
-	if err != nil {
-		return err
-	}
+		apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+		if err != nil {
+			return err
+		}
 
-	client := api.NewClient(apiCaller)
+		client = api.NewClient(apiCaller)
+	}
 
 	info, err := client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
 		Name:       c.controllerName,

--- a/cmd/jaas/cmd/setcontrollerdeprecated_test.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated_test.go
@@ -1,36 +1,48 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"github.com/juju/cmd/v3/cmdtesting"
-	gc "gopkg.in/check.v1"
+	"testing"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/errors"
+	jujuparams "github.com/juju/juju/rpc/params"
+
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type setControllerDeprecatedSuite struct {
-	cmdtest.JimmCmdSuite
+func runSetControllerDeprecatedCommand(c *qt.C, mocks *cmdMocks, args ...string) (string, error) {
+	setControllerDeprecatedCmd := setControllerDeprecatedCommand{
+		client: mocks.client,
+	}
+	setControllerDeprecatedCmd.SetClientStore(mocks.store)
+
+	ctx := newTestContext(c)
+	err := initCommandWithError(&setControllerDeprecatedCmd, args...)
+	if err != nil {
+		return "", err
+	}
+
+	err = setControllerDeprecatedCmd.Run(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return cmdtesting.Stdout(ctx), nil
 }
 
-var _ = gc.Suite(&setControllerDeprecatedSuite{})
+func TestSetControllerDeprecatedSuperuser(t *testing.T) {
+	c := qt.New(t)
 
-func (s *setControllerDeprecatedSuite) TestSetControllerDeprecatedSuperuser(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
-
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	context, err := cmdtesting.RunCommand(c, cmd.NewSetControllerDeprecatedCommandForTesting(s.ClientStore(), bClient), "controller-1")
-	c.Assert(err, gc.IsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `name: controller-1
-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
-publicaddress: ""
-apiaddresses:
-- .*
-cacertificate: |
-  -----BEGIN CERTIFICATE-----
+	controllerInfo := apiparams.ControllerInfo{
+		Name:          "controller-1",
+		UUID:          "deadbeef-1bad-500d-9000-4b1d0d06f00d",
+		PublicAddress: "",
+		APIAddresses:  []string{"10.31.11.125:17070"},
+		CACertificate: `-----BEGIN CERTIFICATE-----
   MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
   CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
   MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
@@ -53,24 +65,68 @@ cacertificate: |
   l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
   hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
   LQRNNlaY2ajLt0paowf/Xxb8
-  -----END CERTIFICATE-----
-cloudtag: cloud-`+jimmtest.TestCloudName+`
-cloudregion: `+jimmtest.TestCloudRegionName+`
-username: admin
-agentversion: .*
+  -----END CERTIFICATE-----`,
+		CloudTag:     "cloud-" + jimmtest.TestCloudName,
+		CloudRegion:  jimmtest.TestCloudRegionName,
+		AgentVersion: "3.6.14",
+		Status: jujuparams.EntityStatus{
+			Status: "deprecated",
+		},
+	}
+
+	mocks := setupCmdMocks(c)
+	mocks.client.EXPECT().SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
+		Name:       "controller-1",
+		Deprecated: true,
+	}).Return(controllerInfo, nil)
+
+	output, err := runSetControllerDeprecatedCommand(c, mocks, "controller-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(output, qt.Equals, `name: controller-1
+uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
+publicaddress: ""
+apiaddresses:
+- 10.31.11.125:17070
+cacertificate: |-
+  -----BEGIN CERTIFICATE-----
+    MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
+    CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
+    MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
+    BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
+    ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
+    ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
+    C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
+    PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
+    M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
+    iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
+    lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
+    0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
+    mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
+    BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
+    ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
+    VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
+    nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
+    RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
+    n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
+    l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
+    hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
+    LQRNNlaY2ajLt0paowf/Xxb8
+    -----END CERTIFICATE-----
+cloudtag: cloud-dummy
+cloudregion: dummy-region
+agentversion: 3.6.14
 status:
   status: deprecated
   info: ""
   data: {}
   since: null
 `)
-}
 
-func (s *setControllerDeprecatedSuite) TestSetControllerDeprecated(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+	mocks.client.EXPECT().SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
+		Name:       "controller-1",
+		Deprecated: true,
+	}).Return(apiparams.ControllerInfo{}, errors.Unauthorizedf("unauthorized"))
 
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewSetControllerDeprecatedCommandForTesting(s.ClientStore(), bClient), "controller-1")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	_, err = runSetControllerDeprecatedCommand(c, mocks, "controller-1")
+	c.Assert(err, qt.ErrorMatches, "unauthorized")
 }


### PR DESCRIPTION
## Description

Refactors tests for the `set-controller-deprecated` command.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
