### PR TITLE
refactor: make updateMigratedModel cmd unit-tested

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -88,15 +88,6 @@ func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, l
 	return modelcmd.WrapBase(cmd)
 }
 
-func NewUpdateMigratedModelCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &updateMigratedModelCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
 func NewAddRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addRoleCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),

--- a/cmd/jaas/cmd/updatemigratedmodel.go
+++ b/cmd/jaas/cmd/updatemigratedmodel.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/juju/cmd/v3"
-	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -38,9 +37,10 @@ func NewUpdateMigratedModelCommand() cmd.Command {
 // updateMigratedModelCommand updates the controller running a model.
 type updateMigratedModelCommand struct {
 	modelcmd.ControllerCommandBase
-	dialOpts *jujuapi.DialOpts
 
 	req apiparams.UpdateMigratedModelRequest
+
+	jimmAPIFunc func() (JIMMAPI, error)
 }
 
 // Info implements the cmd.Command interface.
@@ -76,19 +76,32 @@ func (c *updateMigratedModelCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *updateMigratedModelCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
-	client := api.NewClient(apiCaller)
 	if err := client.UpdateMigratedModel(&c.req); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (c *updateMigratedModelCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }

--- a/cmd/jaas/cmd/updatemigratedmodel_test.go
+++ b/cmd/jaas/cmd/updatemigratedmodel_test.go
@@ -1,85 +1,71 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"context"
+	"testing"
 
-	"github.com/juju/cmd/v3/cmdtesting"
-	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v5"
-	gc "gopkg.in/check.v1"
-
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
-	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+	qt "github.com/frankban/quicktest"
 )
 
-type updateMigratedModelSuite struct {
-	cmdtest.JimmCmdSuite
+func TestUpdateMigratedModel(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
+
+	cmdMocks.client.EXPECT().UpdateMigratedModel(&apiparams.UpdateMigratedModelRequest{
+		ModelTag:         "model-2f54eaf8-0608-42e7-9f69-d85d6e1369b0",
+		TargetController: "mycontroller",
+	}).Return(nil)
+	cmdMocks.client.EXPECT().Close().Return(nil)
+
+	command := &updateMigratedModelCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+	command.SetClientStore(cmdMocks.store)
+
+	initCommand(c, command, "mycontroller", "2f54eaf8-0608-42e7-9f69-d85d6e1369b0")
+
+	ctx := newTestContext(c)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
 }
 
-var _ = gc.Suite(&updateMigratedModelSuite{})
+func TestUpdateMigratedModelNoController(t *testing.T) {
+	c := qt.New(t)
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelSuperuser(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+	command := &updateMigratedModelCommand{}
 
-	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/alice@canonical.com/cred")
-	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
-	mt := s.AddModel(c, names.NewUserTag("alice@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
-	var model dbmodel.Model
-	model.SetTag(mt)
-	err := s.JIMM.Database.GetModel(context.Background(), &model)
-	c.Assert(err, gc.Equals, nil)
-	s.AddController(c, "controller-2", s.APIInfo(c))
-
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	_, err = cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-2", mt.Id())
-	c.Assert(err, gc.IsNil)
-
-	// Check the model has moved controller.
-	var model2 dbmodel.Model
-	model2.SetTag(mt)
-	err = s.JIMM.Database.GetModel(context.Background(), &model2)
-	c.Assert(err, gc.Equals, nil)
-	c.Check(model2.ControllerID, gc.Not(gc.Equals), model.ControllerID)
+	err := initCommandWithError(command)
+	c.Assert(err, qt.ErrorMatches, `controller not specified`)
 }
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelUnauthorized(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+func TestUpdateMigratedModelNoModelUUID(t *testing.T) {
+	c := qt.New(t)
 
-	cct := names.NewCloudCredentialTag(jimmtest.TestCloudName + "/alice@canonical.com/cred")
-	s.UpdateCloudCredential(c, cct, jujuparams.CloudCredential{AuthType: "empty"})
-	mt := s.AddModel(c, names.NewUserTag("alice@canonical.com"), "model-2", names.NewCloudTag(jimmtest.TestCloudName), jimmtest.TestCloudRegionName, cct)
+	command := &updateMigratedModelCommand{}
 
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-1", mt.Id())
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	err := initCommandWithError(command, "mycontroller")
+	c.Assert(err, qt.ErrorMatches, `model uuid not specified`)
 }
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelNoController(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient))
-	c.Assert(err, gc.ErrorMatches, `controller not specified`)
+func TestUpdateMigratedModelInvalidModelUUID(t *testing.T) {
+	c := qt.New(t)
+
+	command := &updateMigratedModelCommand{}
+
+	err := initCommandWithError(command, "mycontroller", "not-a-uuid")
+	c.Assert(err, qt.ErrorMatches, `invalid model uuid`)
 }
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelNoModelUUID(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id")
-	c.Assert(err, gc.ErrorMatches, `model uuid not specified`)
-}
+func TestUpdateMigratedModelTooManyArgs(t *testing.T) {
+	c := qt.New(t)
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelInvalidModelUUID(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid")
-	c.Assert(err, gc.ErrorMatches, `invalid model uuid`)
-}
+	command := &updateMigratedModelCommand{}
 
-func (s *updateMigratedModelSuite) TestUpdateMigratedModelTooManyArgs(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUpdateMigratedModelCommandForTesting(s.ClientStore(), bClient), "controller-id", "not-a-uuid", "spare-argument")
-	c.Assert(err, gc.ErrorMatches, `too many args`)
+	err := initCommandWithError(command, "controller-id", "not-a-uuid", "spare-argument")
+	c.Assert(err, qt.ErrorMatches, `too many args`)
 }


### PR DESCRIPTION
## Description
This PR refactors the `updateMigratedModelCommand` to make it unit testable. There exists an integration test `TestUpdateMigratedModel` in `testing/jimm_test.go` so I haven't added one.

Fixes [JUJU-9026](https://warthogs.atlassian.net/browse/JUJU-9026)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-9026]: https://warthogs.atlassian.net/browse/JUJU-9026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ