### PR TITLE
refactor: make unregisterControllerCommand unit tested

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -61,15 +61,6 @@ func NewRemoveCloudFromControllerCommandForTesting(store jujuclient.ClientStore,
 	return modelcmd.WrapBase(cmd)
 }
 
-func NewUnregisterControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &unregisterControllerCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
 func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &setControllerDeprecatedCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),

--- a/cmd/jaas/cmd/unregistercontroller.go
+++ b/cmd/jaas/cmd/unregistercontroller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
-	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -40,8 +39,9 @@ type unregisterControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	dialOpts *jujuapi.DialOpts
-	params   apiparams.RemoveControllerRequest
+	params apiparams.RemoveControllerRequest
+
+	jimmAPIFunc func() (JIMMAPI, error)
 }
 
 func (c *unregisterControllerCommand) Info() *cmd.Info {
@@ -78,16 +78,16 @@ func (c *unregisterControllerCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *unregisterControllerCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
-	client := api.NewClient(apiCaller)
+	defer client.Close()
+
 	info, err := client.RemoveController(&c.params)
 	if err != nil {
 		return err
@@ -98,4 +98,18 @@ func (c *unregisterControllerCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (c *unregisterControllerCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }

--- a/cmd/jaas/cmd/unregistercontroller_test.go
+++ b/cmd/jaas/cmd/unregistercontroller_test.go
@@ -1,76 +1,60 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"github.com/juju/cmd/v3/cmdtesting"
-	gc "gopkg.in/check.v1"
+	"testing"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
-	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/juju/rpc/params"
+	"gopkg.in/yaml.v3"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type unregisterControllerSuite struct {
-	cmdtest.JimmCmdSuite
-}
+func TestUnregisterControllerSuperuser(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
 
-var _ = gc.Suite(&unregisterControllerSuite{})
+	fakeCtrl := apiparams.ControllerInfo{
+		Name:          "mycontroller",
+		UUID:          "some-uuid",
+		PublicAddress: "public-addr",
+		APIAddresses:  []string{"ep-1", "ep-2"},
+		CACertificate: "ca-cert",
+		CloudTag:      "cloud-openstack",
+		CloudRegion:   "private-region",
+		AgentVersion:  "v1.0.0",
+		Status: params.EntityStatus{
+			Data: map[string]any{},
+		},
+	}
 
-func (s *unregisterControllerSuite) TestUnregisterControllerSuperuser(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+	cmdMocks.client.EXPECT().RemoveController(&apiparams.RemoveControllerRequest{
+		Name:  "mycontroller",
+		Force: true,
+	}).Return(fakeCtrl, nil)
+	cmdMocks.client.EXPECT().Close().Return(nil)
 
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	context, err := cmdtesting.RunCommand(c, cmd.NewUnregisterControllerCommandForTesting(s.ClientStore(), bClient), "controller-1", "--force")
-	c.Assert(err, gc.IsNil)
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, `name: controller-1
-uuid: deadbeef-1bad-500d-9000-4b1d0d06f00d
-publicaddress: \"\"
-apiaddresses:
-- localhost:.*
-cacertificate: |
-  -----BEGIN CERTIFICATE-----
-  MIID/jCCAmagAwIBAgIVANxsMrzsXrdpjjUoxWQm1RCkmWcqMA0GCSqGSIb3DQEB
-  CwUAMCYxDTALBgNVBAoTBEp1anUxFTATBgNVBAMTDGp1anUgdGVzdGluZzAeFw0y
-  MDA0MDgwNTI3NTBaFw0zMDA0MDgwNTMyNTBaMCYxDTALBgNVBAoTBEp1anUxFTAT
-  BgNVBAMTDGp1anUgdGVzdGluZzCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoC
-  ggGBAOW4k2bmXXU3tJ8H5AsGkp8ENLJXzU4SCOCB+X0jPQRVpFtywBVD96z+l+qW
-  ndGLIg5zMQTtZm71CaOw+8Sl03XU0f28Xrjf+FZCAPID1c7NBttUShbu84euFoCS
-  C8yobj6JzLz7QswvkshYQ7JEZ88UXtVHqg6MGYFdu+cX/dE1jC7aHg9bus/P6bFH
-  PVFcHVVxNbLy98Id1iB7i0s97H17nu9O7ZKMrAQAX6dfAELAFQVicdN3WpfwNXEj
-  M2KIrqttpM8s6/57mi9UJFYGdAEDNkJr/dI506VdGLpiqTFhQK6ztfDfY08QbWk6
-  iJn8vzWvNW8WthmBtEDpv+DL+a5SJSLSAIZn9sbuBBpiX+csZb66fYhKFFIUrIa5
-  lrjw8yiHJ4kgsEZJSYaAn7guqmOv8clvy1E2JjsOfGycest6+1/mNdMRFgrMxdzD
-  0M2yZ96zrdfF/QXpi7Hk7jFLzimuujNUpKFv7k+XObQFxeXnoFrYVkj3YT8hhYF0
-  mGRkAwIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAN
-  BgkqhkiG9w0BAQsFAAOCAYEAd7GrziPRmjoK3HDF10S+5NgoKYvkOuk2jDap2Qaq
-  ZFjDvrDA2tr6U0FGY+Hz+QfvtgT+YpJB5IvABvSXdq37llwKGsiSOZSrpHyTsOB0
-  VcZAF3GMk1nHYMr0o1xRV2gm/ax+vUEStj0k2gTs/p57uhKcCUXR0p3PWXKcRj9a
-  nVf5bdVkt6ghGs7/uEvj303raUFSf5dJ4C9RTgBK2E9/wlBYNyj5vcsshNpz8kt6
-  RuARM6Boq2EwKkpRlbvImDM8ZJJLwtpijYrx3egfOSEA7Wfwgwn+B359XcosOee5
-  n5BC62EjaP85cM9HCtp2DwKjNSosxja723qZPY6Z0Y7IVn3JVjgC2kWP6GViwb+v
-  l9uwx9ASHPz9ilh6gpjgIifOKZYCaBSS9g8VxHpO5Izxj4vi4AX5cebDg3SzDVik
-  hZuWHpuOT120okoutwuUSU9448cXLGZfoCZjjdMKXmOj8EEec1diDP4mhegYGezD
-  LQRNNlaY2ajLt0paowf/Xxb8
-  -----END CERTIFICATE-----
-cloudtag: cloud-`+jimmtest.TestCloudName+`
-cloudregion: `+jimmtest.TestCloudRegionName+`
-username: admin
-agentversion: .*
-status:
-  status: available
-  info: ""
-  data: .*
-  since: null
-`)
-}
+	command := &unregisterControllerCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+	command.SetClientStore(cmdMocks.store)
 
-func (s *unregisterControllerSuite) TestUnregisterController(c *gc.C) {
-	s.AddController(c, "controller-1", s.APIInfo(c))
+	initCommand(c, command, "mycontroller", "--force")
 
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewUnregisterControllerCommandForTesting(s.ClientStore(), bClient), "controller-1", "--force")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+	ctx := newTestContext(c)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// Unmarshal to verify output.
+	var info apiparams.ControllerInfo
+	err = yaml.Unmarshal([]byte(cmdtesting.Stdout(ctx)), &info)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(info, qt.DeepEquals, fakeCtrl)
 }


### PR DESCRIPTION
## Description
This PR refactors the `unregisterControllerCommand` to make it unit testable. There are already integration tests in `testing/jimm_test.go` so I haven't added any.

Fixes [JUJU-9025](https://warthogs.atlassian.net/browse/JUJU-9025)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9025]: https://warthogs.atlassian.net/browse/JUJU-9025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ