### PR TITLE
refactor: use quicktest in upgradeto cmd tests

### DIFF
--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -7,40 +7,17 @@
 package cmd
 
 import (
-	"context"
 	"errors"
+	"testing"
 
-	"github.com/juju/cmd/v3"
-	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/gnuflag"
-	jjclient "github.com/juju/juju/jujuclient"
-	"go.uber.org/mock/gomock"
-	gc "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd/mocks"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-// upgradeToSuite is a test suite for the upgrade-to command.
-type upgradeToSuite struct {
-	jimmClient *mocks.MockJIMMAPI
-	writer     *mocks.MockWriter
-	store      *mocks.MockClientStore
-}
-
-var _ = gc.Suite(&upgradeToSuite{})
-
-func (s *upgradeToSuite) SetupMocks(c *gc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-	s.jimmClient = mocks.NewMockJIMMAPI(ctrl)
-	s.writer = mocks.NewMockWriter(ctrl)
-	s.store = mocks.NewMockClientStore(ctrl)
-
-	return ctrl
-}
-
-func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
-	defer s.SetupMocks(c).Finish()
+func TestUpgradeTo(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
 	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
@@ -51,35 +28,27 @@ func (s *upgradeToSuite) TestUpgradeTo(c *gc.C) {
 		ModelTag:                testModelTag,
 	}
 
-	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
+	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
 		Success: true,
 	}, nil)
-	s.jimmClient.EXPECT().Close().Return(nil)
+	s.client.EXPECT().Close().Return(nil)
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
-			return s.jimmClient, nil
+			return s.client, nil
 		},
 	}
 	upgradeToCmd.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	f.SetOutput(s.writer)
-	upgradeToCmd.SetFlags(f)
+	initCommand(c, upgradeToCmd, testTargetVersion, testModelUUID)
 
-	// Set args after setting flags to avoid resetting them.
-	upgradeToCmd.version = testTargetVersion
-	upgradeToCmd.modelUUID = testModelUUID
-
-	ctx := &cmd.Context{
-		Context: context.Background(),
-		Stdout:  s.writer,
-	}
+	ctx := newTestContext(c)
 	err := upgradeToCmd.Run(ctx)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.IsNil)
 }
 
-func (s *upgradeToSuite) TestUpgradeToWithFailureResponse(c *gc.C) {
-	defer s.SetupMocks(c).Finish()
+func TestUpgradeToWithFailureResponse(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
 	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
@@ -92,32 +61,24 @@ func (s *upgradeToSuite) TestUpgradeToWithFailureResponse(c *gc.C) {
 	}
 
 	// Now the error is returned directly by UpgradeTo instead of embedded in the response.
-	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errors.New(testErrorMessage))
-	s.jimmClient.EXPECT().Close().Return(nil)
+	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errors.New(testErrorMessage))
+	s.client.EXPECT().Close().Return(nil)
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
-			return s.jimmClient, nil
+			return s.client, nil
 		},
 	}
-	upgradeToCmd.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	f.SetOutput(s.writer)
-	upgradeToCmd.SetFlags(f)
+	initCommand(c, upgradeToCmd, testTargetVersion, testModelUUID)
 
-	upgradeToCmd.version = testTargetVersion
-	upgradeToCmd.modelUUID = testModelUUID
-
-	ctx := &cmd.Context{
-		Context: context.Background(),
-		Stdout:  s.writer,
-	}
+	ctx := newTestContext(c)
 	err := upgradeToCmd.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, ".*"+testErrorMessage+".*")
+	c.Assert(err, qt.ErrorMatches, ".*"+testErrorMessage+".*")
 }
 
-func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
-	defer s.SetupMocks(c).Finish()
+func TestUpgradeToWithError(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
 	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
@@ -128,53 +89,52 @@ func (s *upgradeToSuite) TestUpgradeToWithError(c *gc.C) {
 		ModelTag:                testModelTag,
 	}
 	errorToReturn := errors.New("failed to initiate upgrade")
-	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errorToReturn)
-	s.jimmClient.EXPECT().Close().Return(nil)
+	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errorToReturn)
+	s.client.EXPECT().Close().Return(nil)
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
-			return s.jimmClient, nil
+			return s.client, nil
 		},
 	}
-	upgradeToCmd.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	f.SetOutput(s.writer)
-	upgradeToCmd.SetFlags(f)
+	initCommand(c, upgradeToCmd, testTargetVersion, testModelUUID)
 
-	// Set args after setting flags to avoid resetting them.
-	upgradeToCmd.version = testTargetVersion
-	upgradeToCmd.modelUUID = testModelUUID
-
-	ctx := &cmd.Context{
-		Context: context.Background(),
-		Stdout:  s.writer,
-	}
+	ctx := newTestContext(c)
 	err := upgradeToCmd.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, ".*failed to initiate upgrade.*")
+	c.Assert(err, qt.ErrorMatches, ".*failed to initiate upgrade.*")
 }
 
-func (s *upgradeToSuite) TestCommandsFailsWithMissingArgs(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil))
-	c.Assert(err, gc.ErrorMatches, "missing required arguments: version and model UUID")
+func TestUpgradeToFailsWithMissingArgs(t *testing.T) {
+	c := qt.New(t)
+	upgradeToCmd := &upgradeToCommand{}
+	err := initCommandWithError(upgradeToCmd)
+	c.Assert(err, qt.ErrorMatches, "missing required arguments: version and model UUID")
 }
 
-func (s *upgradeToSuite) TestCommandsFailsWithOnlyOneArg(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "3.5.0")
-	c.Assert(err, gc.ErrorMatches, "missing required arguments: version and model UUID")
+func TestUpgradeToFailsWithOnlyOneArg(t *testing.T) {
+	c := qt.New(t)
+	upgradeToCmd := &upgradeToCommand{}
+	err := initCommandWithError(upgradeToCmd, "3.5.0")
+	c.Assert(err, qt.ErrorMatches, "missing required arguments: version and model UUID")
 }
 
-func (s *upgradeToSuite) TestCommandsFailsWithInvalidVersion(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "invalid-version", "93608db4-f1cb-4da5-9926-8233981aef0a")
-	c.Assert(err, gc.ErrorMatches, "invalid version format: invalid-version")
+func TestUpgradeToFailsWithInvalidVersion(t *testing.T) {
+	c := qt.New(t)
+	upgradeToCmd := &upgradeToCommand{}
+	err := initCommandWithError(upgradeToCmd, "invalid-version", "93608db4-f1cb-4da5-9926-8233981aef0a")
+	c.Assert(err, qt.ErrorMatches, "invalid version format: invalid-version")
 }
 
-func (s *upgradeToSuite) TestCommandsFailsWithInvalidModelUUID(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, NewUpgradeToCommandForTesting(jjclient.NewMemStore(), nil), "3.5.0", "invalid-uuid")
-	c.Assert(err, gc.ErrorMatches, "invalid model UUID: invalid-uuid")
+func TestUpgradeToFailsWithInvalidModelUUID(t *testing.T) {
+	c := qt.New(t)
+	upgradeToCmd := &upgradeToCommand{}
+	err := initCommandWithError(upgradeToCmd, "3.5.0", "invalid-uuid")
+	c.Assert(err, qt.ErrorMatches, "invalid model UUID: invalid-uuid")
 }
 
-func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
-	defer s.SetupMocks(c).Finish()
+func TestUpgradeToWithPositionalArgs(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
 	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
@@ -185,28 +145,20 @@ func (s *upgradeToSuite) TestCommandWithPositionalArgs(c *gc.C) {
 		ModelTag:                testModelTag,
 	}
 
-	s.jimmClient.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
+	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
 		Success: true,
 	}, nil)
-	s.jimmClient.EXPECT().Close().Return(nil)
+	s.client.EXPECT().Close().Return(nil)
 
 	upgradeToCmd := &upgradeToCommand{
 		jimmAPIFunc: func() (JIMMAPI, error) {
-			return s.jimmClient, nil
+			return s.client, nil
 		},
 	}
 	upgradeToCmd.SetClientStore(s.store)
-	f := gnuflag.NewFlagSet("test", gnuflag.ExitOnError)
-	f.SetOutput(s.writer)
-	upgradeToCmd.SetFlags(f)
+	initCommand(c, upgradeToCmd, testTargetVersion, testModelUUID)
 
-	err := upgradeToCmd.Init([]string{testTargetVersion, testModelUUID})
-	c.Assert(err, gc.IsNil)
-
-	ctx := &cmd.Context{
-		Context: context.Background(),
-		Stdout:  s.writer,
-	}
-	err = upgradeToCmd.Run(ctx)
-	c.Assert(err, gc.IsNil)
+	ctx := newTestContext(c)
+	err := upgradeToCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
 }


### PR DESCRIPTION
## Description
Updates the `upgradeTo` cmd tests away from gocheck in favour of quicktest. The tests were already unit tests and we have separate integration tests.

Fixes [JUJU-9027](https://warthogs.atlassian.net/browse/JUJU-9027)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9027]: https://warthogs.atlassian.net/browse/JUJU-9027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ