### PR TITLE
refactor: make removeCloud command unit tested

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -46,21 +46,6 @@ func NewRevokeAuditLogAccessCommandForTesting(store jujuclient.ClientStore, lp j
 	return modelcmd.WrapBase(cmd)
 }
 
-type RemoveCloudFromControllerAPI = removeCloudFromControllerAPI
-
-func NewRemoveCloudFromControllerCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider, removeCloudFromControllerAPIFunc func() (RemoveCloudFromControllerAPI, error)) cmd.Command {
-	cmd := &removeCloudFromControllerCommand{
-		dialOpts:                         cmdtest.TestDialOpts(lp),
-		removeCloudFromControllerAPIFunc: removeCloudFromControllerAPIFunc,
-	}
-	cmd.SetClientStore(store)
-	if removeCloudFromControllerAPIFunc == nil {
-		cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
-	}
-
-	return modelcmd.WrapBase(cmd)
-}
-
 func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &setControllerDeprecatedCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),

--- a/cmd/jaas/cmd/removecloudfromcontroller.go
+++ b/cmd/jaas/cmd/removecloudfromcontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 
@@ -7,7 +7,6 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
-	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -32,7 +31,6 @@ Removes the specified cloud from the specified controller in JIMM.
 func NewRemoveCloudFromControllerCommand() cmd.Command {
 	cmd := &removeCloudFromControllerCommand{}
 	cmd.SetClientStore(jujuclient.NewFileClientStore())
-	cmd.removeCloudFromControllerAPIFunc = cmd.cloudAPI
 
 	return modelcmd.WrapBase(cmd)
 }
@@ -49,12 +47,7 @@ type removeCloudFromControllerCommand struct {
 	// should be removed from.
 	targetControllerName string
 
-	removeCloudFromControllerAPIFunc func() (removeCloudFromControllerAPI, error)
-	dialOpts                         *jujuapi.DialOpts
-}
-
-type removeCloudFromControllerAPI interface {
-	RemoveCloudFromController(params *apiparams.RemoveCloudFromControllerRequest) error
+	jimmAPIFunc func() (JIMMAPI, error)
 }
 
 // Info implements Command.Info.
@@ -108,10 +101,15 @@ func (c *removeCloudFromControllerCommand) Run(ctxt *cmd.Context) error {
 }
 
 func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.Context) error {
-	client, err := c.removeCloudFromControllerAPIFunc()
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
+	}
+
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	params := &apiparams.RemoveCloudFromControllerRequest{
 		CloudTag:       "cloud-" + c.cloudName,
@@ -127,12 +125,13 @@ func (c *removeCloudFromControllerCommand) removeCloudFromController(ctxt *cmd.C
 	return nil
 }
 
-func (c *removeCloudFromControllerCommand) cloudAPI() (removeCloudFromControllerAPI, error) {
+func (c *removeCloudFromControllerCommand) newClient() (JIMMAPI, error) {
 	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, fmt.Errorf("could not determine the current controller: %w", err)
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jaas/cmd/removecloudfromcontroller_test.go
+++ b/cmd/jaas/cmd/removecloudfromcontroller_test.go
@@ -1,88 +1,69 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"github.com/juju/cmd/v3/cmdtesting"
-	jujutesting "github.com/juju/testing"
-	gc "gopkg.in/check.v1"
+	"fmt"
+	"testing"
 
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"go.uber.org/mock/gomock"
+
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
-type removeCloudFromControllerSuite struct {
-	cmdtest.JimmCmdSuite
+func TestRemoveCloudFromController(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
-	api *fakeRemoveCloudFromControllerAPI
-}
-
-var _ = gc.Suite(&removeCloudFromControllerSuite{})
-
-func (s *removeCloudFromControllerSuite) SetUpTest(c *gc.C) {
-	s.JimmCmdSuite.SetUpTest(c)
-	s.api = &fakeRemoveCloudFromControllerAPI{}
-}
-
-func (s *removeCloudFromControllerSuite) TestRemoveCloudFromController(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
-
-	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
-		s.ClientStore(),
-		bClient,
-		func() (cmd.RemoveCloudFromControllerAPI, error) {
-			return s.api, nil
+	s.client.EXPECT().RemoveCloudFromController(gomock.Any()).DoAndReturn(
+		func(rcfcr *apiparams.RemoveCloudFromControllerRequest) error {
+			c.Check(rcfcr.ControllerName, qt.Equals, "controller-1")
+			c.Check(rcfcr.CloudTag, qt.Equals, "cloud-test-cloud")
+			return nil
 		})
-	ctx, err := cmdtesting.RunCommand(c, command, "controller-1", "test-cloud")
-	c.Assert(err, gc.IsNil)
-	s.api.CheckCallNames(c, "RemoveCloudFromController")
-	s.api.CheckCalls(c, []jujutesting.StubCall{{
-		FuncName: "RemoveCloudFromController",
-		Args: []interface{}{&apiparams.RemoveCloudFromControllerRequest{
-			ControllerName: "controller-1",
-			CloudTag:       "cloud-test-cloud",
-		}},
-	}})
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Cloud \"test-cloud\" removed from controller \"controller-1\".\n")
+	s.client.EXPECT().Close()
+
+	command := &removeCloudFromControllerCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+
+	initCommand(c, command, "controller-1", "test-cloud")
+	ctx := newTestContext(c)
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cmdtesting.Stderr(ctx), qt.Equals, "Cloud \"test-cloud\" removed from controller \"controller-1\".\n")
 }
 
-func (s *removeCloudFromControllerSuite) TestRemoveCloudFromControllerWrongArguments(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
+func TestRemoveCloudFromControllerWrongArguments(t *testing.T) {
+	c := qt.New(t)
 
-	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
-		s.ClientStore(),
-		bClient,
-		func() (cmd.RemoveCloudFromControllerAPI, error) {
-			return s.api, nil
-		})
-	_, err := cmdtesting.RunCommand(c, command, "controller-1")
-	c.Assert(err, gc.ErrorMatches, "missing arguments")
-	_, err = cmdtesting.RunCommand(c, command, "controller-1", "cloud", "fake-arg")
-	c.Assert(err, gc.ErrorMatches, "too many arguments")
+	command := &removeCloudFromControllerCommand{}
+
+	err := initCommandWithError(command, "controller-1")
+	c.Assert(err, qt.ErrorMatches, "missing arguments")
+
+	err = initCommandWithError(command, "controller-1", "cloud", "fake-arg")
+	c.Assert(err, qt.ErrorMatches, "too many arguments")
 }
 
-func (s *removeCloudFromControllerSuite) TestRemoveCloudFromControllerCloudNotFound(c *gc.C) {
-	bClient := s.SetupCLIAccess(c, "alice@canonical.com")
+func TestRemoveCloudFromControllerCloudNotFound(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
 
-	command := cmd.NewRemoveCloudFromControllerCommandForTesting(
-		s.ClientStore(),
-		bClient,
-		nil)
-	_, err := cmdtesting.RunCommand(c, command, "controller-1", "test-cloud")
-	c.Assert(err, gc.ErrorMatches, ".*cloud \"test-cloud\" not found.*")
-}
+	s.client.EXPECT().RemoveCloudFromController(gomock.Any()).Return(fmt.Errorf("cloud \"test-cloud\" not found"))
+	command := &removeCloudFromControllerCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return s.client, nil
+		},
+	}
+	s.client.EXPECT().Close()
 
-type fakeRemoveCloudFromControllerAPI struct {
-	jujutesting.Stub
-}
-
-func (api *fakeRemoveCloudFromControllerAPI) Close() error {
-	api.AddCall("Close", nil)
-	return api.NextErr()
-}
-
-func (api *fakeRemoveCloudFromControllerAPI) RemoveCloudFromController(params *apiparams.RemoveCloudFromControllerRequest) error {
-	api.AddCall("RemoveCloudFromController", params)
-	return api.NextErr()
+	initCommand(c, command, "controller-1", "test-cloud")
+	ctx := newTestContext(c)
+	err := command.Run(ctx)
+	c.Assert(err, qt.ErrorMatches, ".*cloud \"test-cloud\" not found")
 }


### PR DESCRIPTION
## Description
This PR refactors the `removeCloudFromController` command to make its already existing unit tests resemble our other tests, using quicktest instead of gocheck.

Fixes [JUJU-9021](https://warthogs.atlassian.net/browse/JUJU-9021)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9021]: https://warthogs.atlassian.net/browse/JUJU-9021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ