### PR TITLE
refactor: move to mocked unit tests for roles cmd

### DIFF
--- a/cmd/jaas/cmd/export_test.go
+++ b/cmd/jaas/cmd/export_test.go
@@ -55,42 +55,6 @@ func NewSetControllerDeprecatedCommandForTesting(store jujuclient.ClientStore, l
 	return modelcmd.WrapBase(cmd)
 }
 
-func NewAddRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &addRoleCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
-func NewRenameRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &renameRoleCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
-func NewRemoveRoleCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &removeRoleCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
-func NewListRolesCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
-	cmd := &listRolesCommand{
-		dialOpts: cmdtest.TestDialOpts(lp),
-	}
-	cmd.SetClientStore(store)
-
-	return modelcmd.WrapBase(cmd)
-}
-
 func NewAddGroupCommandForTesting(store jujuclient.ClientStore, lp jujuapi.LoginProvider) cmd.Command {
 	cmd := &addGroupCommand{
 		dialOpts: cmdtest.TestDialOpts(lp),

--- a/cmd/jaas/cmd/role.go
+++ b/cmd/jaas/cmd/role.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
-	jujuapi "github.com/juju/juju/api"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/jujuclient"
@@ -63,7 +62,7 @@ type addRoleCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	dialOpts *jujuapi.DialOpts
+	jimmAPIFunc func() (JIMMAPI, error)
 
 	name string
 }
@@ -102,17 +101,15 @@ func (c *addRoleCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *addRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
-
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
-	client := api.NewClient(apiCaller)
 	resp, err := client.AddRole(&apiparams.AddRoleRequest{
 		Name: c.name,
 	})
@@ -127,6 +124,20 @@ func (c *addRoleCommand) Run(ctxt *cmd.Context) error {
 	return nil
 }
 
+func (c *addRoleCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
+}
+
 // NewRenameRoleCommand returns a command to rename a role.
 func NewRenameRoleCommand() cmd.Command {
 	cmd := &renameRoleCommand{}
@@ -139,7 +150,7 @@ func NewRenameRoleCommand() cmd.Command {
 type renameRoleCommand struct {
 	modelcmd.ControllerCommandBase
 
-	dialOpts *jujuapi.DialOpts
+	jimmAPIFunc func() (JIMMAPI, error)
 
 	name    string
 	newName string
@@ -170,28 +181,40 @@ func (c *renameRoleCommand) Init(args []string) error {
 
 // Run implements Command.Run.
 func (c *renameRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
-
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	params := apiparams.RenameRoleRequest{
 		Name:    c.name,
 		NewName: c.newName,
 	}
 
-	client := api.NewClient(apiCaller)
 	err = client.RenameRole(&params)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (c *renameRoleCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }
 
 // NewRemoveRoleCommand returns a command to Remove a role.
@@ -207,7 +230,7 @@ type removeRoleCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	dialOpts *jujuapi.DialOpts
+	jimmAPIFunc func() (JIMMAPI, error)
 
 	name  string
 	force bool
@@ -247,11 +270,6 @@ func (c *removeRoleCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
-	}
-
 	if !c.force {
 		reader := bufio.NewReader(ctxt.Stdin)
 		// Using Fprintf over c.out.write to avoid printing a new line.
@@ -269,22 +287,39 @@ func (c *removeRoleCommand) Run(ctxt *cmd.Context) error {
 		}
 	}
 
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
+	}
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	params := apiparams.RemoveRoleRequest{
 		Name: c.name,
 	}
 
-	client := api.NewClient(apiCaller)
 	err = client.RemoveRole(&params)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (c *removeRoleCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }
 
 // NewListRolesCommand returns a command to list all roles.
@@ -300,7 +335,7 @@ type listRolesCommand struct {
 	modelcmd.ControllerCommandBase
 	out cmd.Output
 
-	dialOpts *jujuapi.DialOpts
+	jimmAPIFunc func() (JIMMAPI, error)
 
 	limit  int
 	offset int
@@ -338,17 +373,15 @@ func (c *listRolesCommand) SetFlags(f *gnuflag.FlagSet) {
 
 // Run implements Command.Run.
 func (c *listRolesCommand) Run(ctxt *cmd.Context) error {
-	currentController, err := c.ClientStore().CurrentController()
-	if err != nil {
-		return fmt.Errorf("could not determine controller: %w", err)
+	if c.jimmAPIFunc == nil {
+		c.jimmAPIFunc = c.newClient
 	}
-
-	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", c.dialOpts)
+	client, err := c.jimmAPIFunc()
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
-	client := api.NewClient(apiCaller)
 	req := apiparams.ListRolesRequest{Limit: c.limit, Offset: c.offset}
 	roles, err := client.ListRoles(&req)
 	if err != nil {
@@ -361,4 +394,18 @@ func (c *listRolesCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	return nil
+}
+
+func (c *listRolesCommand) newClient() (JIMMAPI, error) {
+	currentController, err := c.ClientStore().CurrentController()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine controller: %w", err)
+	}
+
+	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewClient(apiCaller), nil
 }

--- a/cmd/jaas/cmd/role_test.go
+++ b/cmd/jaas/cmd/role_test.go
@@ -1,145 +1,134 @@
 // Copyright 2025 Canonical.
 
-package cmd_test
+package cmd
 
 import (
-	"context"
-	"fmt"
-	"strings"
+	"bytes"
+	"testing"
 
-	"github.com/juju/cmd/v3/cmdtesting"
-	gc "gopkg.in/check.v1"
-	"gopkg.in/yaml.v3"
-
-	"github.com/canonical/jimm/v3/cmd/jaas/cmd"
-	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/testutils/cmdtest"
 	"github.com/canonical/jimm/v3/pkg/api/params"
+	qt "github.com/frankban/quicktest"
+	"go.uber.org/mock/gomock"
 )
 
-type roleSuite struct {
-	cmdtest.JimmCmdSuite
-}
+func TestAddRole(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
 
-var _ = gc.Suite(&roleSuite{})
-
-func (s *roleSuite) TestAddRoleSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-	ctx, err := cmdtesting.RunCommand(c, cmd.NewAddRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err, gc.IsNil)
-
-	role := &dbmodel.RoleEntry{Name: "test-role"}
-	err = s.JIMM.Database.GetRole(context.Background(), role)
-	c.Assert(err, gc.IsNil)
-	c.Assert(role.ID, gc.Equals, uint(1))
-	c.Assert(role.Name, gc.Equals, "test-role")
-
-	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, fmt.Sprintf(`(?s).*uuid: %s\n.*`, role.UUID))
-}
-
-func (s *roleSuite) TestAddRole(c *gc.C) {
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewAddRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err, gc.ErrorMatches, `failed to add role: unauthorized \(unauthorized access\)`)
-}
-
-func (s *roleSuite) TestRenameRoleSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-
-	roleEntry, err := s.JIMM.Database.AddRole(context.TODO(), "test-role")
-	c.Assert(err, gc.IsNil)
-	c.Assert(roleEntry.UUID, gc.Not(gc.Equals), "")
-
-	_, err = cmdtesting.RunCommand(c, cmd.NewRenameRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "renamed-role")
-	c.Assert(err, gc.IsNil)
-
-	role := &dbmodel.RoleEntry{Name: "renamed-role"}
-	err = s.JIMM.Database.GetRole(context.TODO(), role)
-	c.Assert(err, gc.IsNil)
-	c.Assert(role.ID, gc.Equals, uint(1))
-	c.Assert(role.Name, gc.Equals, "renamed-role")
-}
-
-func (s *roleSuite) TestRenameRole(c *gc.C) {
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewRenameRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "renamed-role")
-	c.Assert(err, gc.ErrorMatches, `failed to rename role: unauthorized \(unauthorized access\)`)
-}
-
-func (s *roleSuite) TestRemoveRoleSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-
-	_, err := s.JIMM.Database.AddRole(context.TODO(), "test-role")
-	c.Assert(err, gc.IsNil)
-
-	_, err = cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "-y")
-	c.Assert(err, gc.IsNil)
-
-	role := &dbmodel.RoleEntry{Name: "test-role"}
-	err = s.JIMM.Database.GetRole(context.TODO(), role)
-	c.Assert(err, gc.ErrorMatches, "record not found")
-}
-
-func (s *roleSuite) TestRemoveRoleWithoutFlag(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-
-	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err.Error(), gc.Matches, "failed to read from input: EOF")
-}
-
-func (s *roleSuite) TestRemoveRole(c *gc.C) {
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewRemoveRoleCommandForTesting(s.ClientStore(), bClient), "test-role", "-y")
-	c.Assert(err, gc.ErrorMatches, `failed to remove role: unauthorized \(unauthorized access\)`)
-}
-
-func (s *roleSuite) TestListRolesSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
-
-	for i := 0; i < 3; i++ {
-		_, err := s.JIMM.Database.AddRole(context.TODO(), fmt.Sprint("test-role", i))
-		c.Assert(err, gc.IsNil)
+	command := &addRoleCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
 	}
+	command.SetClientStore(cmdMocks.store)
 
-	ctx, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err, gc.IsNil)
-	output := cmdtesting.Stdout(ctx)
-	c.Assert(strings.Contains(output, "test-role0"), gc.Equals, true)
-	c.Assert(strings.Contains(output, "test-role1"), gc.Equals, true)
-	c.Assert(strings.Contains(output, "test-role2"), gc.Equals, true)
+	initCommand(c, command, "myrole")
+
+	ctx := newTestContext(c)
+
+	cmdMocks.client.EXPECT().
+		AddRole(gomock.Any()).
+		DoAndReturn(func(req *params.AddRoleRequest) (params.AddRoleResponse, error) {
+			c.Check(req.Name, qt.Equals, "myrole")
+			return params.AddRoleResponse{
+				Role: params.Role{
+					Name: "myrole",
+				},
+			}, nil
+		}).Times(1)
+	cmdMocks.client.EXPECT().Close().Times(1)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Contains, "myrole")
 }
 
-func (s *roleSuite) TestListRolesLimitSuperuser(c *gc.C) {
-	// alice is superuser
-	bClient := s.SetupCLIAccess(c, "alice")
+func TestRenameRole(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
 
-	for i := 0; i < 3; i++ {
-		_, err := s.JIMM.Database.AddRole(context.TODO(), fmt.Sprint("test-role", i))
-		c.Assert(err, gc.IsNil)
+	command := &renameRoleCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
 	}
+	command.SetClientStore(cmdMocks.store)
 
-	ctx, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role", "--limit", "1", "--offset", "1")
-	c.Assert(err, gc.IsNil)
-	output := cmdtesting.Stdout(ctx)
-	roles := []params.Role{}
-	err = yaml.Unmarshal([]byte(output), &roles)
-	c.Assert(err, gc.IsNil)
-	c.Assert(roles, gc.HasLen, 1)
-	c.Assert(roles[0].Name, gc.Equals, "test-role1")
-	c.Assert(roles[0].UUID, gc.Not(gc.Equals), "")
+	initCommand(c, command, "myrole", "yourrole")
+
+	ctx := newTestContext(c)
+
+	cmdMocks.client.EXPECT().
+		RenameRole(gomock.Any()).
+		DoAndReturn(func(req *params.RenameRoleRequest) error {
+			c.Check(req.Name, qt.Equals, "myrole")
+			return nil
+		}).Times(1)
+	cmdMocks.client.EXPECT().Close().Times(1)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
 }
 
-func (s *roleSuite) TestListRoles(c *gc.C) {
-	// bob is not superuser
-	bClient := s.SetupCLIAccess(c, "bob")
-	_, err := cmdtesting.RunCommand(c, cmd.NewListRolesCommandForTesting(s.ClientStore(), bClient), "test-role")
-	c.Assert(err, gc.ErrorMatches, `unauthorized \(unauthorized access\)`)
+func TestRemoveRole(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
+
+	command := &removeRoleCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+	command.SetClientStore(cmdMocks.store)
+
+	initCommand(c, command, "myrole", "-y")
+
+	ctx := newTestContext(c)
+
+	cmdMocks.client.EXPECT().
+		RemoveRole(gomock.Any()).
+		DoAndReturn(func(req *params.RemoveRoleRequest) error {
+			c.Check(req.Name, qt.Equals, "myrole")
+			return nil
+		}).Times(1)
+	cmdMocks.client.EXPECT().Close().Times(1)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestListRoles(t *testing.T) {
+	c := qt.New(t)
+	cmdMocks := setupCmdMocks(c)
+
+	command := &listRolesCommand{
+		jimmAPIFunc: func() (JIMMAPI, error) {
+			return cmdMocks.client, nil
+		},
+	}
+	command.SetClientStore(cmdMocks.store)
+
+	initCommand(c, command, "--limit", "10", "--offset", "5")
+
+	ctx := newTestContext(c)
+
+	cmdMocks.client.EXPECT().
+		ListRoles(gomock.Any()).
+		DoAndReturn(func(req *params.ListRolesRequest) ([]params.Role, error) {
+			c.Check(req.Limit, qt.Equals, 10)
+			c.Check(req.Offset, qt.Equals, 5)
+			return []params.Role{
+				{Name: "myrole"},
+				{Name: "yourrole"},
+			}, nil
+		}).Times(1)
+	cmdMocks.client.EXPECT().Close().Times(1)
+
+	err := command.Run(ctx)
+	c.Assert(err, qt.IsNil)
+
+	output := ctx.Stdout.(*bytes.Buffer).String()
+	c.Assert(output, qt.Contains, "myrole")
+	c.Assert(output, qt.Contains, "yourrole")
 }


### PR DESCRIPTION
## Description
Refactor the role-related commands to unit tests. There already are integration tests for the endpoints.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

