### PR TITLE
chore: update copyright header

### DIFF
--- a/cmd/jaas/cmd/addcloudtocontroller.go
+++ b/cmd/jaas/cmd/addcloudtocontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/addcloudtocontroller_test.go
+++ b/cmd/jaas/cmd/addcloudtocontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/crossmodelquery.go
+++ b/cmd/jaas/cmd/crossmodelquery.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/crossmodelquery_test.go
+++ b/cmd/jaas/cmd/crossmodelquery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/destroycontroller.go
+++ b/cmd/jaas/cmd/destroycontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/destroycontroller_test.go
+++ b/cmd/jaas/cmd/destroycontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/grantauditlogaccess.go
+++ b/cmd/jaas/cmd/grantauditlogaccess.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/group.go
+++ b/cmd/jaas/cmd/group.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/group_test.go
+++ b/cmd/jaas/cmd/group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/importmodel.go
+++ b/cmd/jaas/cmd/importmodel.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/importmodel_test.go
+++ b/cmd/jaas/cmd/importmodel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/jobstatus.go
+++ b/cmd/jaas/cmd/jobstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/jobstatus_unit_test.go
+++ b/cmd/jaas/cmd/jobstatus_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/jobstop.go
+++ b/cmd/jaas/cmd/jobstop.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/jobstop_test.go
+++ b/cmd/jaas/cmd/jobstop_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listauditevents.go
+++ b/cmd/jaas/cmd/listauditevents.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listauditevents_test.go
+++ b/cmd/jaas/cmd/listauditevents_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listcontrollers.go
+++ b/cmd/jaas/cmd/listcontrollers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listmigrationtargets.go
+++ b/cmd/jaas/cmd/listmigrationtargets.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/listmigrationtargets_test.go
+++ b/cmd/jaas/cmd/listmigrationtargets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/migrateinternalmodel.go
+++ b/cmd/jaas/cmd/migrateinternalmodel.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/migrateinternalmodel_test.go
+++ b/cmd/jaas/cmd/migrateinternalmodel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/migratemodel_test.go
+++ b/cmd/jaas/cmd/migratemodel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Note that this file is not an integration test
 // because of limitations with the JujuConnSuite

--- a/cmd/jaas/cmd/modelstatus.go
+++ b/cmd/jaas/cmd/modelstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/modelstatus_test.go
+++ b/cmd/jaas/cmd/modelstatus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/permission_test.go
+++ b/cmd/jaas/cmd/permission_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/purge_logs.go
+++ b/cmd/jaas/cmd/purge_logs.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/purge_logs_test.go
+++ b/cmd/jaas/cmd/purge_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package cmd
 
 import (

--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/registercontroller_test.go
+++ b/cmd/jaas/cmd/registercontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/revokeauditlogaccess.go
+++ b/cmd/jaas/cmd/revokeauditlogaccess.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/revokeauditlogaccess_test.go
+++ b/cmd/jaas/cmd/revokeauditlogaccess_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/role.go
+++ b/cmd/jaas/cmd/role.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/role_test.go
+++ b/cmd/jaas/cmd/role_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/setcontrollerdeprecated.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/setcontrollerdeprecated_test.go
+++ b/cmd/jaas/cmd/setcontrollerdeprecated_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/unregistercontroller.go
+++ b/cmd/jaas/cmd/unregistercontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/unregistercontroller_test.go
+++ b/cmd/jaas/cmd/unregistercontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/updatemigratedmodel.go
+++ b/cmd/jaas/cmd/updatemigratedmodel.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/updatemigratedmodel_test.go
+++ b/cmd/jaas/cmd/updatemigratedmodel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Note that this file is not an integration test
 // because of limitations with the JujuConnSuite

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package main
 

--- a/cmd/jimmsrv/service/export_test.go
+++ b/cmd/jimmsrv/service/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package service
 

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // service defines the methods necessary to start a JIMM server
 // alongside all the config options that can be supplied to configure JIMM.

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package service_test
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auth_test
 

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auth
 

--- a/internal/common/pagination/entitlement.go
+++ b/internal/common/pagination/entitlement.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package pagination
 

--- a/internal/common/pagination/entitlement_test.go
+++ b/internal/common/pagination/entitlement_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package pagination_test
 

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/applicationoffer_test.go
+++ b/internal/db/applicationoffer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/auditlog_test.go
+++ b/internal/db/auditlog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/clouddefaults_test.go
+++ b/internal/db/clouddefaults_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package db contains routines to store and retrieve data from a database.
 package db

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/export_test.go
+++ b/internal/db/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/identity_test.go
+++ b/internal/db/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/job_logs_test.go
+++ b/internal/db/job_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/modifiers.go
+++ b/internal/db/modifiers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/pgx_test.go
+++ b/internal/db/pgx_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/resource_test.go
+++ b/internal/db/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package db_test
 
 import (

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/role_test.go
+++ b/internal/db/role_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/rootkeys_test.go
+++ b/internal/db/rootkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/secrets_test.go
+++ b/internal/db/secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/sshkeys_test.go
+++ b/internal/db/sshkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db
 

--- a/internal/db/usermapping_test.go
+++ b/internal/db/usermapping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package db_test
 

--- a/internal/dbmodel/cloud.go
+++ b/internal/dbmodel/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/cloud_test.go
+++ b/internal/dbmodel/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/cloudcredential.go
+++ b/internal/dbmodel/cloudcredential.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/cloudcredential_test.go
+++ b/internal/dbmodel/cloudcredential_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/controller_test.go
+++ b/internal/dbmodel/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/gorm_test.go
+++ b/internal/dbmodel/gorm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/identity.go
+++ b/internal/dbmodel/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/identity_test.go
+++ b/internal/dbmodel/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/job_logs.go
+++ b/internal/dbmodel/job_logs.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/job_logs_test.go
+++ b/internal/dbmodel/job_logs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/model_test.go
+++ b/internal/dbmodel/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/modelmigration.go
+++ b/internal/dbmodel/modelmigration.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/modelmigration_test.go
+++ b/internal/dbmodel/modelmigration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/sql.go
+++ b/internal/dbmodel/sql.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/sshkeys.go
+++ b/internal/dbmodel/sshkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/sshkeys_test.go
+++ b/internal/dbmodel/sshkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/dbmodel/usermapping.go
+++ b/internal/dbmodel/usermapping.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel
 

--- a/internal/dbmodel/usermapping_test.go
+++ b/internal/dbmodel/usermapping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package dbmodel_test
 

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package description provides version-agnostic wrappers around major versions
 // of `github.com/juju/description` which hold Juju model descriptions, to

--- a/internal/description/description_test.go
+++ b/internal/description/description_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package description
 

--- a/internal/description/v10.go
+++ b/internal/description/v10.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package description
 

--- a/internal/description/v9.go
+++ b/internal/description/v9.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package description
 

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package discharger
 

--- a/internal/discharger/discharger_test.go
+++ b/internal/discharger/discharger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package discharger_test
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package errors_test
 

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // The auditlog package provides business logic for handling audit log related methods.
 package auditlog

--- a/internal/jimm/auditlog/auditlog_test.go
+++ b/internal/jimm/auditlog/auditlog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auditlog_test
 

--- a/internal/jimm/auditlog/cleanup.go
+++ b/internal/jimm/auditlog/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auditlog
 

--- a/internal/jimm/auditlog/cleanup_test.go
+++ b/internal/jimm/auditlog/cleanup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auditlog_test
 

--- a/internal/jimm/auditlog/export_test.go
+++ b/internal/jimm/auditlog/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package auditlog
 

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // bootstrap package provides functionality to manage the bootstrap process
 // for controllers in JIMM.

--- a/internal/jimm/bootstrap/export_test.go
+++ b/internal/jimm/bootstrap/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package bootstrap
 

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package bootstrap
 

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package bootstrap
 

--- a/internal/jimm/cloudcred/cloudcred.go
+++ b/internal/jimm/cloudcred/cloudcred.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cloudcred
 

--- a/internal/jimm/config/config.go
+++ b/internal/jimm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package config
 

--- a/internal/jimm/credentials/credentials.go
+++ b/internal/jimm/credentials/credentials.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package credentials provides abstractions/definitions for credential storage
 // backends and caching mechanisms.

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // The group package provides business logic for handling group related methods..
 package group

--- a/internal/jimm/group/group_test.go
+++ b/internal/jimm/group/group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package group_test
 

--- a/internal/jimm/identity/export_test.go
+++ b/internal/jimm/identity/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package identity
 

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package identity
 

--- a/internal/jimm/identity/identity_test.go
+++ b/internal/jimm/identity/identity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package identity_test
 

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package jimm contains the business logic used to manage clouds,
 // cloudcredentials and models.

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/clouddefaults_test.go
+++ b/internal/jimm/juju/clouddefaults_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/export_test.go
+++ b/internal/jimm/juju/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/juju_test.go
+++ b/internal/jimm/juju/juju_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/juju/modelbuilder_internal_test.go
+++ b/internal/jimm/juju/modelbuilder_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/monitoring.go
+++ b/internal/jimm/juju/monitoring.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/runner.go
+++ b/internal/jimm/juju/runner.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/runner_internal_test.go
+++ b/internal/jimm/juju/runner_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/types.go
+++ b/internal/jimm/juju/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/utils.go
+++ b/internal/jimm/juju/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju
 

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package juju_test
 

--- a/internal/jimm/jujuauth/factory.go
+++ b/internal/jimm/jujuauth/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuauth
 

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package jujuauth generates JWT tokens to
 // authenticate and authorize messages to Juju controllers.

--- a/internal/jimm/jujuauth/logintokens_test.go
+++ b/internal/jimm/jujuauth/logintokens_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuauth_test
 

--- a/internal/jimm/jujuauth/sshtokens.go
+++ b/internal/jimm/jujuauth/sshtokens.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuauth
 

--- a/internal/jimm/jujuauth/sshtokens_test.go
+++ b/internal/jimm/jujuauth/sshtokens_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuauth_test
 

--- a/internal/jimm/login/export_test.go
+++ b/internal/jimm/login/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package login
 

--- a/internal/jimm/login/login_test.go
+++ b/internal/jimm/login/login_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package login_test
 

--- a/internal/jimm/offer/authorizer.go
+++ b/internal/jimm/offer/authorizer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package offer
 

--- a/internal/jimm/offer/authorizer_test.go
+++ b/internal/jimm/offer/authorizer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package offer_test
 

--- a/internal/jimm/offer/export_test.go
+++ b/internal/jimm/offer/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package offer
 

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions
 

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions_test
 

--- a/internal/jimm/permissions/export_test.go
+++ b/internal/jimm/permissions/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions
 

--- a/internal/jimm/permissions/permissionmanager.go
+++ b/internal/jimm/permissions/permissionmanager.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // The permissions package provides business logic for handling user permissions.
 package permissions

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions
 

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions_test
 

--- a/internal/jimm/permissions/suite_test.go
+++ b/internal/jimm/permissions/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions_test
 

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package permissions
 

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package role
 

--- a/internal/jimm/role/role_test.go
+++ b/internal/jimm/role/role_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package role_test
 

--- a/internal/jimm/ssh/export_test.go
+++ b/internal/jimm/ssh/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh
 

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh
 

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh_test
 

--- a/internal/jimm/sshkeys/export_test.go
+++ b/internal/jimm/sshkeys/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package sshkeys
 

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package sshkeys
 

--- a/internal/jimm/sshkeys/sshkeys_test.go
+++ b/internal/jimm/sshkeys/sshkeys_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package sshkeys_test
 

--- a/internal/jimm/sshkeys/types.go
+++ b/internal/jimm/sshkeys/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package sshkeys
 

--- a/internal/jimm/upgrade/types.go
+++ b/internal/jimm/upgrade/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package upgrade
 

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package jimmhttp_test
 
 import (

--- a/internal/jimmhttp/fingerprint.go
+++ b/internal/jimmhttp/fingerprint.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp
 

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp
 

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp_test
 

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp
 

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp_test
 

--- a/internal/jimmhttp/rebac_admin/backend.go
+++ b/internal/jimmhttp/rebac_admin/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/capabilities_test.go
+++ b/internal/jimmhttp/rebac_admin/capabilities_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/entitlements.go
+++ b/internal/jimmhttp/rebac_admin/entitlements.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/entitlements_test.go
+++ b/internal/jimmhttp/rebac_admin/entitlements_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package rebac_admin_test
 
 import (

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/resources.go
+++ b/internal/jimmhttp/rebac_admin/resources.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/resources_test.go
+++ b/internal/jimmhttp/rebac_admin/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/rebac_admin/roles.go
+++ b/internal/jimmhttp/rebac_admin/roles.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin
 

--- a/internal/jimmhttp/rebac_admin/roles_test.go
+++ b/internal/jimmhttp/rebac_admin/roles_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rebac_admin_test
 

--- a/internal/jimmhttp/utils_test.go
+++ b/internal/jimmhttp/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp_test
 

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp
 

--- a/internal/jimmhttp/wellknown_handler_test.go
+++ b/internal/jimmhttp/wellknown_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmhttp_test
 

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmjwx
 

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmjwx
 

--- a/internal/jimmjwx/jwt_test.go
+++ b/internal/jimmjwx/jwt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmjwx_test
 

--- a/internal/jimmjwx/utils_test.go
+++ b/internal/jimmjwx/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmjwx_test
 

--- a/internal/jujuapi/accesscontrol.go
+++ b/internal/jujuapi/accesscontrol.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/api.go
+++ b/internal/jujuapi/api.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package jujuapi implements API endpoints for the juju API.
 package jujuapi

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/jimm_unit_test.go
+++ b/internal/jujuapi/jimm_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/migrationtarget_unit_test.go
+++ b/internal/jujuapi/migrationtarget_unit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/modelsummarywatcher_test.go
+++ b/internal/jujuapi/modelsummarywatcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/recorder.go
+++ b/internal/jujuapi/recorder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuapi/rpc/method_test.go
+++ b/internal/jujuapi/rpc/method_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc_test
 

--- a/internal/jujuapi/unittest_utils_test.go
+++ b/internal/jujuapi/unittest_utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi
 

--- a/internal/jujuclient/applicationoffers.go
+++ b/internal/jujuclient/applicationoffers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/client.go
+++ b/internal/jujuclient/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/client_test.go
+++ b/internal/jujuclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/cloud.go
+++ b/internal/jujuclient/cloud.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/cloud_test.go
+++ b/internal/jujuclient/cloud_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/controller.go
+++ b/internal/jujuclient/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/controller_test.go
+++ b/internal/jujuclient/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/dial_test.go
+++ b/internal/jujuclient/dial_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/modelsummarywatcher.go
+++ b/internal/jujuclient/modelsummarywatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/modelupgrader.go
+++ b/internal/jujuclient/modelupgrader.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/ping.go
+++ b/internal/jujuclient/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/ping_test.go
+++ b/internal/jujuclient/ping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclient/storage.go
+++ b/internal/jujuclient/storage.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient
 

--- a/internal/jujuclient/storage_test.go
+++ b/internal/jujuclient/storage_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclient_test
 

--- a/internal/jujuclistore/export_test.go
+++ b/internal/jujuclistore/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclistore
 

--- a/internal/jujuclistore/store.go
+++ b/internal/jujuclistore/store.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclistore
 

--- a/internal/jujuclistore/store_test.go
+++ b/internal/jujuclistore/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuclistore
 

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujucommands
 

--- a/internal/jujucommands/bootstrap_test.go
+++ b/internal/jujucommands/bootstrap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujucommands_test
 

--- a/internal/jujucommands/destroycontroller.go
+++ b/internal/jujucommands/destroycontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujucommands
 

--- a/internal/jujucommands/destroycontroller_test.go
+++ b/internal/jujucommands/destroycontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujucommands_test
 

--- a/internal/jujucommands/interface.go
+++ b/internal/jujucommands/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujucommands
 

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package jujucommands provides functions run juju cmds from a JIMM instance.
 // Each command function is run with its own isolated in-mem store.

--- a/internal/logger/default_logger.go
+++ b/internal/logger/default_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package logger
 

--- a/internal/logger/migration_logger.go
+++ b/internal/logger/migration_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package logger
 

--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package logger
 

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package middleware_test
 

--- a/internal/middleware/authz.go
+++ b/internal/middleware/authz.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package middleware
 

--- a/internal/middleware/authz_test.go
+++ b/internal/middleware/authz_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package middleware_test
 

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package names holds functions used by other jimm components to
 // create valid OpenFGA tags.

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package openfga
 

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package openfga_test
 

--- a/internal/openfga/user_test.go
+++ b/internal/openfga/user_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package openfga_test
 

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc
 

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc_test
 

--- a/internal/rpc/export_test.go
+++ b/internal/rpc/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc
 

--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc
 

--- a/internal/rpc/httpproxy_test.go
+++ b/internal/rpc/httpproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc_test
 

--- a/internal/rpc/multitransport.go
+++ b/internal/rpc/multitransport.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc
 

--- a/internal/rpc/multitransport_test.go
+++ b/internal/rpc/multitransport_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpc_test
 

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package rpc implements the juju RPC protocol. The main difference
 // between this implementation and the implementation in

--- a/internal/rpcproxy/export_test.go
+++ b/internal/rpcproxy/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpcproxy
 

--- a/internal/rpcproxy/message.go
+++ b/internal/rpcproxy/message.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpcproxy
 

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package rpcproxy implements a proxy for Juju's RPC messages.
 // The rpcproxy is used to proxy messages between jimm and model facades

--- a/internal/rpcproxy/rpcproxy_test.go
+++ b/internal/rpcproxy/rpcproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpcproxy_test
 

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpcproxy_test
 

--- a/internal/servermon/monitoring.go
+++ b/internal/servermon/monitoring.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // The servermon package is used to update statistics used
 // for monitoring the API server.

--- a/internal/ssh/export_test.go
+++ b/internal/ssh/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh
 

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh_test
 

--- a/internal/ssh/utils.go
+++ b/internal/ssh/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package ssh
 

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package streamproxy
 

--- a/internal/streamproxy/streamproxy_test.go
+++ b/internal/streamproxy/streamproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package streamproxy_test
 

--- a/internal/testutils/cmdtest/jimmsuite.go
+++ b/internal/testutils/cmdtest/jimmsuite.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package cmdtest provides the test suite used for CLI tests
 // as well as helper functions used for integration based CLI tests.

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/cmp.go
+++ b/internal/testutils/jimmtest/cmp.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/keys.go
+++ b/internal/testutils/jimmtest/keys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/mocks/jimm_auditlog_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_auditlog_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package mocks
 
 import (

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package mocks
 
 import (

--- a/internal/testutils/jimmtest/mocks/jimm_login_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_login_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package mocks
 
 import (

--- a/internal/testutils/jimmtest/mocks/jimm_offerauthorizer_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_offerauthorizer_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package mocks
 

--- a/internal/testutils/jimmtest/mocks/jwt_service_mock.go
+++ b/internal/testutils/jimmtest/mocks/jwt_service_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package mocks
 
 import (

--- a/internal/testutils/jimmtest/openfga.go
+++ b/internal/testutils/jimmtest/openfga.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jimmtest
 

--- a/internal/testutils/rpctest/server.go
+++ b/internal/testutils/rpctest/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package rpctest
 

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // Package testdb contains useful helpers for creating and managing test databases.
 package testdb

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package vault
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package vault_test
 

--- a/local/seed_db/main.go
+++ b/local/seed_db/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 package main
 
 import (

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package names
 

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package names_test
 

--- a/pkg/names/service_account.go
+++ b/pkg/names/service_account.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package names
 

--- a/pkg/names/service_account_test.go
+++ b/pkg/names/service_account_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package names_test
 

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/admin_test.go
+++ b/testing/admin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/api_test.go
+++ b/testing/api_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/applicationoffers_test.go
+++ b/testing/applicationoffers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/package_test.go
+++ b/testing/package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/testing/role_test.go
+++ b/testing/role_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package testing
 

--- a/version/default.go
+++ b/version/default.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 //go:build !version
 


### PR DESCRIPTION
## Description
Update the copyright header of all files to 2026. Avoids issues with the linter from constantly updating them during dev.
