### PR TITLE
feat: return error when job is duplicate

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -137,6 +137,7 @@ const (
 	CodeServerError                  Code = "server error"
 	CodeSessionTokenInvalid          Code = jujuparams.CodeSessionTokenInvalid
 	CodeUpgradeInProgress            Code = jujuparams.CodeUpgradeInProgress
+	CodeInProgress                   Code = "in progress"
 	CodeFailedToParseTupleKey        Code = "failed to parse tuple"
 	CodeFailedToResolveTupleResource Code = "failed resolve resource"
 	CodeOpenFGARequestFailed         Code = "failed request to OpenFGA"

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 // bootstrap package provides functionality to manage the bootstrap process
 // for controllers in JIMM.
@@ -57,8 +57,8 @@ type Store interface {
 
 // JobQueue defines the method to enqueue a bootstrap/destroy-controller job.
 type JobQueue interface {
-	EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (int64, error)
-	EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (int64, error)
+	EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)
+	EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error)
 	WaitForJobCompletion(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
 	GetJobInfo(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
 	CancelJob(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
@@ -263,12 +263,15 @@ func (b *bootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		// User defined config
 		UserConfig: params.UserConfig,
 	}
-	jobID, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs)
+	job, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs)
 	if err != nil {
 		return 0, errors.E(fmt.Errorf("failed to enqueue bootstrap job: %w", err))
 	}
+	if job.UniqueSkippedAsDuplicate {
+		return 0, errors.E(fmt.Errorf("a bootstrap job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
+	}
 
-	return jobID, nil
+	return job.Job.ID, nil
 }
 
 type command struct {
@@ -544,12 +547,15 @@ func (b *bootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 		PublicAddress:  params.PublicAddress,
 	}
 
-	jobID, err := b.jobQueue.EnqueueDestroyController(ctx, destroyArgs)
+	job, err := b.jobQueue.EnqueueDestroyController(ctx, destroyArgs)
 	if err != nil {
 		return 0, errors.E(fmt.Errorf("failed to start bootstrap job: %w", err))
 	}
+	if job.UniqueSkippedAsDuplicate {
+		return 0, errors.E(fmt.Errorf("a destroy job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
+	}
 
-	return jobID, nil
+	return job.Job.ID, nil
 }
 
 // DestroyController destroys a Juju controller and removes it from JIMM.

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -153,7 +153,11 @@ func (s *bootstrapManagerSuite) TestStartBootstrapJob_EnqueuesJob(c *qt.C) {
 		Cloud:                requested.Cloud,
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,
 		UserConfig:           requested.UserConfig,
-	}).Return(int64(99), nil)
+	}).Return(&rivertype.JobInsertResult{
+		Job: &rivertype.JobRow{
+			ID: 99,
+		},
+	}, nil)
 
 	jobID, err := manager.StartBootstrapJob(ctx, user, requested)
 	c.Assert(err, qt.IsNil)
@@ -1174,7 +1178,7 @@ func (s *bootstrapManagerSuite) TestStartDestroyControllerJob(c *qt.C) {
 	mocks.jobQueue.EXPECT().EnqueueDestroyController(
 		gomock.Any(),
 		gomock.Any(),
-	).DoAndReturn(func(ctx context.Context, dca rivertypes.DestroyControllerArgs) (int64, error) {
+	).DoAndReturn(func(ctx context.Context, dca rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error) {
 		c.Check(dca.Username, qt.Equals, user.Name)
 		c.Check(dca.ControllerName, qt.Equals, "controller-foo")
 		c.Check(dca.AgentVersion, qt.Equals, "3.6.9")
@@ -1184,7 +1188,9 @@ func (s *bootstrapManagerSuite) TestStartDestroyControllerJob(c *qt.C) {
 		c.Check(dca.APIEndpoints, qt.DeepEquals, []string{"ep-1", "ep-2"})
 		c.Check(dca.PublicAddress, qt.Equals, "public-address")
 		c.Check(dca.CACertificate, qt.Equals, "ca-cert")
-		return 456, nil
+		return &rivertype.JobInsertResult{
+			Job: &rivertype.JobRow{ID: 456},
+		}, nil
 	})
 
 	jobID, err := manager.StartDestroyControllerJob(testCtx, user, args)

--- a/internal/jimm/bootstrap/mocks/queue.go
+++ b/internal/jimm/bootstrap/mocks/queue.go
@@ -82,10 +82,10 @@ func (c *MockJobQueueCancelJobCall) DoAndReturn(f func(context.Context, int64) (
 }
 
 // EnqueueBootstrap mocks base method.
-func (m *MockJobQueue) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (int64, error) {
+func (m *MockJobQueue) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnqueueBootstrap", ctx, args)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(*rivertype.JobInsertResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -103,28 +103,28 @@ type MockJobQueueEnqueueBootstrapCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockJobQueueEnqueueBootstrapCall) Return(arg0 int64, arg1 error) *MockJobQueueEnqueueBootstrapCall {
+func (c *MockJobQueueEnqueueBootstrapCall) Return(arg0 *rivertype.JobInsertResult, arg1 error) *MockJobQueueEnqueueBootstrapCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJobQueueEnqueueBootstrapCall) Do(f func(context.Context, rivertypes.BootstrapArgs) (int64, error)) *MockJobQueueEnqueueBootstrapCall {
+func (c *MockJobQueueEnqueueBootstrapCall) Do(f func(context.Context, rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJobQueueEnqueueBootstrapCall) DoAndReturn(f func(context.Context, rivertypes.BootstrapArgs) (int64, error)) *MockJobQueueEnqueueBootstrapCall {
+func (c *MockJobQueueEnqueueBootstrapCall) DoAndReturn(f func(context.Context, rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EnqueueDestroyController mocks base method.
-func (m *MockJobQueue) EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (int64, error) {
+func (m *MockJobQueue) EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnqueueDestroyController", ctx, args)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(*rivertype.JobInsertResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -142,19 +142,19 @@ type MockJobQueueEnqueueDestroyControllerCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockJobQueueEnqueueDestroyControllerCall) Return(arg0 int64, arg1 error) *MockJobQueueEnqueueDestroyControllerCall {
+func (c *MockJobQueueEnqueueDestroyControllerCall) Return(arg0 *rivertype.JobInsertResult, arg1 error) *MockJobQueueEnqueueDestroyControllerCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJobQueueEnqueueDestroyControllerCall) Do(f func(context.Context, rivertypes.DestroyControllerArgs) (int64, error)) *MockJobQueueEnqueueDestroyControllerCall {
+func (c *MockJobQueueEnqueueDestroyControllerCall) Do(f func(context.Context, rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueDestroyControllerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJobQueueEnqueueDestroyControllerCall) DoAndReturn(f func(context.Context, rivertypes.DestroyControllerArgs) (int64, error)) *MockJobQueueEnqueueDestroyControllerCall {
+func (c *MockJobQueueEnqueueDestroyControllerCall) DoAndReturn(f func(context.Context, rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueDestroyControllerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/mocks/enqueuer.go
+++ b/internal/jimm/upgrade/mocks/enqueuer.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	rivertypes "github.com/canonical/jimm/v3/internal/rivertypes"
+	rivertype "github.com/riverqueue/river/rivertype"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,10 +43,10 @@ func (m *MockUpgradeEnqueuer) EXPECT() *MockUpgradeEnqueuerMockRecorder {
 }
 
 // EnqueueUpgradeTo mocks base method.
-func (m *MockUpgradeEnqueuer) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (int64, error) {
+func (m *MockUpgradeEnqueuer) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnqueueUpgradeTo", ctx, args)
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(*rivertype.JobInsertResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -63,19 +64,19 @@ type MockUpgradeEnqueuerEnqueueUpgradeToCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Return(arg0 int64, arg1 error) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Return(arg0 *rivertype.JobInsertResult, arg1 error) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Do(f func(context.Context, rivertypes.UpgradeToArgs) (int64, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Do(f func(context.Context, rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) DoAndReturn(f func(context.Context, rivertypes.UpgradeToArgs) (int64, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) DoAndReturn(f func(context.Context, rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -7,10 +7,9 @@ package upgrade
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"time"
-
-	stderrors "errors"
 
 	"github.com/juju/clock"
 	jujuerrors "github.com/juju/errors"
@@ -20,6 +19,7 @@ import (
 	"github.com/juju/retry"
 	"github.com/juju/version/v2"
 	"github.com/juju/zaputil/zapctx"
+	"github.com/riverqueue/river/rivertype"
 	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -55,7 +55,7 @@ type Store interface {
 
 // UpgradeEnqueuer defines the method to enqueue an upgrade job.
 type UpgradeEnqueuer interface {
-	EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (int64, error)
+	EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)
 }
 
 // upgradeManager provides a means to manage controller upgrades within JIMM.
@@ -312,7 +312,7 @@ func (u *upgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		return 0, errors.E(fmt.Errorf("failed to clone controller: %w", err))
 	}
 
-	id, err := u.enqueuer.EnqueueUpgradeTo(ctx, rivertypes.UpgradeToArgs{
+	job, err := u.enqueuer.EnqueueUpgradeTo(ctx, rivertypes.UpgradeToArgs{
 		ModelUUID:            modelUUID,
 		TargetVersion:        targetVersion,
 		Username:             user.Name,
@@ -321,8 +321,11 @@ func (u *upgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 	if err != nil {
 		return 0, errors.E(fmt.Errorf("failed to enqueue model migration and upgrade job: %w", err))
 	}
+	if job.UniqueSkippedAsDuplicate {
+		return 0, errors.E("an upgrade job for this model is already in progress", errors.CodeInProgress)
+	}
 
-	return id, nil
+	return job.Job.ID, nil
 }
 
 // MigrateModel migrates a model to a new controller without upgrading the model's agent.
@@ -367,7 +370,7 @@ func (u *upgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 			Attempts: 30,
 			Delay:    10 * time.Second,
 			Func: func() error {
-				_, err = u.jujuManager.ModelInfo(ctx, user, mt)
+				mi, err := u.jujuManager.ModelInfo(ctx, user, mt)
 				if err != nil {
 					return err
 				}
@@ -377,12 +380,16 @@ func (u *upgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 					return err
 				}
 
-				// It hasn't migrated yet, so error out.
-				if m.Controller.Name != targetControllerName {
-					return modelNotMigratedErr
+				if m.Controller.Name == targetControllerName {
+					return nil
 				}
 
-				return nil
+				if mi.Migration != nil && mi.Migration.End != nil {
+					endUTC := mi.Migration.End.UTC().Format(time.RFC3339)
+					return fmt.Errorf("model migration failed: migration ended at %s with status %s", endUTC, mi.Migration.Status)
+				}
+
+				return modelNotMigratedErr
 			},
 			NotifyFunc: func(lastError error, attempt int) {
 				zapctx.Debug(ctx, "model migrate attempt", zap.Error(lastError), zap.Int("attempt", attempt))

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -18,6 +18,7 @@ import (
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
+	"github.com/riverqueue/river/rivertype"
 	"go.uber.org/mock/gomock"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -313,12 +314,14 @@ func TestUpgradeTo_Success(t *testing.T) {
 		Return(nil)
 
 	// Migration expectations.
-	s.enqueuer.EXPECT().EnqueueUpgradeTo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, uta rivertypes.UpgradeToArgs) (int64, error) {
+	s.enqueuer.EXPECT().EnqueueUpgradeTo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, uta rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
 		c.Check(uta.ModelUUID, qt.Equals, modelUUID)
 		c.Check(uta.TargetVersion, qt.Equals, targetVersion)
 		c.Check(uta.Username, qt.Equals, user.Name)
 		// Don't check target controller name since that is currently generated based on the current time.
-		return 1, nil
+		return &rivertype.JobInsertResult{
+			Job: &rivertype.JobRow{ID: 1},
+		}, nil
 	})
 
 	jobID, err := upgradeMgr.UpgradeTo(ctx, user, modelUUID, targetVersion)
@@ -416,6 +419,55 @@ func TestMigrateModel_Success(t *testing.T) {
 
 	err = upgradeMgr.MigrateModel(ctx, &openfga.User{}, targetMt.Id(), targetController)
 	c.Assert(err, qt.IsNil)
+}
+
+func TestMigrateModel_EndsEarly(t *testing.T) {
+	s := setupTest(t)
+	c := qt.New(t)
+
+	ctx := c.Context()
+
+	upgradeMgr, err := upgrade.NewUpgradeManager(s.bootstrapManager, s.jujuManager, s.store, s.dialer, s.enqueuer)
+	c.Assert(err, qt.IsNil)
+
+	targetMt := names.NewModelTag("93608db4-f1cb-4da5-9926-8233981aef0a")
+	targetController := "4.0controller"
+
+	s.jujuManager.EXPECT().InitiateInternalMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(jujuparams.InitiateMigrationResult{}, nil)
+
+	s.jujuManager.EXPECT().
+		GetModel(gomock.Any(), targetMt.Id()).
+		Return(
+			dbmodel.Model{Controller: dbmodel.Controller{Name: "source controller"}},
+			nil,
+		)
+
+	timeFailed := time.Date(2026, 2, 13, 13, 31, 2, 983062723, time.FixedZone("SAST", 2*60*60))
+	expectedEndUTC := timeFailed.UTC().Format(time.RFC3339)
+	gomock.InOrder(
+		s.jujuManager.EXPECT().
+			ModelInfo(gomock.Any(), gomock.Any(), targetMt).
+			Return(&jujuparams.ModelInfo{}, nil),
+		s.jujuManager.EXPECT().
+			ModelInfo(gomock.Any(), gomock.Any(), targetMt).
+			Return(&jujuparams.ModelInfo{
+				UUID: targetMt.Id(),
+				Migration: &jujuparams.ModelMigrationStatus{
+					Status: "some-status",
+					End:    &timeFailed,
+				},
+			}, nil),
+	)
+
+	s.jujuManager.EXPECT().GetModel(gomock.Any(), targetMt.Id()).Return(
+		dbmodel.Model{Controller: dbmodel.Controller{
+			Name: "source controller",
+		}}, nil,
+	)
+
+	err = upgradeMgr.MigrateModel(ctx, &openfga.User{}, targetMt.Id(), targetController)
+	c.Assert(err, qt.ErrorMatches, ".*model migration failed: migration ended at "+regexp.QuoteMeta(expectedEndUTC)+" with status some-status")
 }
 
 func TestMigrateModel_Retries2Times(t *testing.T) {

--- a/internal/river/client.go
+++ b/internal/river/client.go
@@ -35,24 +35,21 @@ func NewRiverClient(db *db.Database) (*Client, error) {
 
 // EnqueueUpgradeTo inserts a River job to upgrade a model to the specified version
 // by migrating and upgrading it.
-func (c *Client) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (int64, error) {
+func (c *Client) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
 	job, err := c.client.Insert(ctx, args, nil)
-	return job.Job.ID, err
+	return job, err
 }
 
-// TODO(Kian JUJU-9159): Return the isDuplicate flag so we can either return an error to callers
-// or at least inform them that a bootstrap is in-progress and their request was ignored.
-
 // EnqueueBootstrap inserts a River job to bootstrap a new controller.
-func (c *Client) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (int64, error) {
+func (c *Client) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error) {
 	job, err := c.client.Insert(ctx, args, nil)
-	return job.Job.ID, err
+	return job, err
 }
 
 // EnqueueDestroyController inserts a River job to destroy an existing controller.
-func (c *Client) EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (int64, error) {
+func (c *Client) EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error) {
 	job, err := c.client.Insert(ctx, args, nil)
-	return job.Job.ID, err
+	return job, err
 }
 
 // GetJobInfo returns the current state of the specified job.

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -4,6 +4,7 @@ package river
 
 import (
 	"context"
+	"time"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -85,4 +86,9 @@ func (w *migrationWorker) Work(ctx context.Context, job *river.Job[migrationWork
 	}
 
 	return nil
+}
+
+// Timeout implements the [river.Worker] interface.
+func (w *migrationWorker) Timeout(*river.Job[migrationWorkerArgs]) time.Duration {
+	return 10 * time.Minute
 }

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -33,6 +34,11 @@ type upgradeToWorker struct {
 	upgradeRetries int
 	// awaitCompletion is a function that waits for a job to finalise.
 	awaitCompletion awaitCompletionFunc
+}
+
+// Timeout implements the [river.Worker] interface.
+func (w *upgradeToWorker) Timeout(*river.Job[rivertypes.UpgradeToArgs]) time.Duration {
+	return 20 * time.Minute
 }
 
 // Work implements the [river.Worker] interface.

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -37,6 +37,8 @@ type upgradeToWorker struct {
 }
 
 // Timeout implements the [river.Worker] interface.
+// To determine the timeout duration, we consider the maximum time
+// for both the migration and upgrade steps, including retries.
 func (w *upgradeToWorker) Timeout(*river.Job[rivertypes.UpgradeToArgs]) time.Duration {
 	return 20 * time.Minute
 }

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -4,6 +4,7 @@ package river
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/version/v2"
 	"github.com/riverqueue/river"
@@ -67,4 +68,9 @@ func (w *upgradeWorker) Work(ctx context.Context, job *river.Job[upgradeWorkerAr
 		return err
 	}
 	return nil
+}
+
+// Timeout implements the [river.Worker] interface.
+func (w *upgradeWorker) Timeout(*river.Job[upgradeWorkerArgs]) time.Duration {
+	return 10 * time.Minute
 }


### PR DESCRIPTION
## Description
This PR ensures that when a client requests a bootstrap/controller-destroy/upgrade-to job, we return an error if the job inserted was a duplicate (i.e. if a job was still busy running).

As a drive-by I also made 2 other changes,
- Added timeouts to the upgrade/migrate/upgrade-to River workers (to avoid the default timeout of 1m).
- Added a check to the migrate logic that returns early if the migration failed.

Fixes [JUJU-9159](https://warthogs.atlassian.net/browse/JUJU-9159)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9159]: https://warthogs.atlassian.net/browse/JUJU-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ