### PR TITLE
refactor: simplify test suites

### DIFF
--- a/cmd/jaas/cmd/migratemodel_test.go
+++ b/cmd/jaas/cmd/migratemodel_test.go
@@ -1,9 +1,5 @@
 // Copyright 2025 Canonical.
 
-// Note that this file is not an integration test
-// because of limitations with the JujuConnSuite
-// so it is placed under the cmd package.
-
 package cmd
 
 import (

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -1,9 +1,5 @@
 // Copyright 2025 Canonical.
 
-// Note that this file is not an integration test
-// because of limitations with the JujuConnSuite
-// so it is placed under the cmd package.
-
 package cmd
 
 import (

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -7,6 +7,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -37,6 +38,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm/config"
 	jimmcreds "github.com/canonical/jimm/v3/internal/jimm/credentials"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jimm/login"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
@@ -224,6 +226,67 @@ type Service struct {
 	cleanups []func() error
 }
 
+// ServiceDependencies contains initialized services and parameters used to construct a fully functional Service.
+// It allows callers to override specific dependencies (e.g. auth) before creating the service.
+type ServiceDependencies struct {
+	// Params
+	AuditLogRetentionDays         int
+	BootstrapLoginTokenRefreshURL string
+	ControllerConfig              config.ControllerConfig
+	ControllerUUID                string
+	CorsAllowedOrigins            []string
+	CrossModelQueryTimeout        time.Duration
+	DischargerPrivateKey          string
+	DischargerPublicKey           string
+	HostKeyFingerprints           map[string]string
+	IsLeader                      bool
+	MacaroonExpiryDuration        time.Duration
+	PublicDNSName                 string
+	PublicDNSHost                 string
+	// Clients/Services
+	Client                  juju.Dialer
+	CredentialStore         jimmcreds.CredentialStore
+	Database                *db.Database
+	RiverClient             *river.Client
+	MigrationTokenGenerator juju.MigrationTokenGenerator
+	JWKSService             *jimmjwx.JWKSService
+	JWTService              *jimmjwx.JWTService
+	OAuthAuthenticator      login.OAuthAuthenticator
+	OAuthHandler            *jimmhttp.OAuthHandler
+	OpenFGAClient           *openfga.OFGAClient
+	// Cleanup
+	cleanupFuncs []func() error
+}
+
+// Validate checks that all required dependencies are present and returns an error if any are missing.
+func (s *ServiceDependencies) Validate() error {
+	if s.Database == nil {
+		return errors.E("missing database")
+	}
+	if s.RiverClient == nil {
+		return errors.E("missing river client")
+	}
+	if s.OpenFGAClient == nil {
+		return errors.E("missing openfga client")
+	}
+	if s.CredentialStore == nil {
+		return errors.E("missing credential store")
+	}
+	if s.JWTService == nil {
+		return errors.E("missing jwt service")
+	}
+	if s.JWKSService == nil {
+		return errors.E("missing jwks service")
+	}
+	if s.OAuthAuthenticator == nil {
+		return errors.E("missing oauth authenticator")
+	}
+	if s.MigrationTokenGenerator == nil {
+		return errors.E("missing migration token generator")
+	}
+	return nil
+}
+
 func (s *Service) JIMM() *jimm.JIMM {
 	return s.jimm
 }
@@ -333,24 +396,14 @@ func (s *Service) AddCleanup(f func() error) {
 	s.cleanups = append(s.cleanups, f)
 }
 
-// NewService creates a new Service using the given params.
-//
-//nolint:gocognit // NewService function to be ignored.
-func NewService(ctx context.Context, p Params) (*Service, error) {
-
-	s := new(Service)
-
-	jimmParameters := jimm.Parameters{
-		UUID:                   p.ControllerUUID,
-		Pubsub:                 &pubsub.Hub{MaxConcurrency: 50},
-		ControllerConfig:       p.ControllerConfig,
-		CrossModelQueryTimeout: p.CrossModelQueryTimeout,
-	}
-	// Setup all dependency services
-	if jimmParameters.UUID == "" {
-		jimmParameters.UUID = uuid.NewString()
+// NewServiceDependencies creates the default dependency set used by NewService.
+func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies, error) {
+	controllerUUID := p.ControllerUUID
+	if controllerUUID == "" {
+		controllerUUID = uuid.NewString()
 	}
 
+	auditLogRetentionDays := 0
 	if p.AuditLogRetentionPeriodInDays != "" {
 		retentionPeriod, err := strconv.Atoi(p.AuditLogRetentionPeriodInDays)
 		if err != nil {
@@ -359,7 +412,16 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 		if retentionPeriod < 0 {
 			return nil, errors.E("retention period cannot be less than 0")
 		}
-		jimmParameters.AuditLogRetentionDays = retentionPeriod
+		auditLogRetentionDays = retentionPeriod
+	}
+
+	if _, err := url.Parse(p.DashboardFinalRedirectURL); err != nil {
+		return nil, errors.E(err, "failed to parse final redirect url for the dashboard")
+	}
+
+	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
+	if err != nil {
+		return nil, errors.E(fmt.Errorf("failed to parse public DNS name: %v", err))
 	}
 
 	if p.DSN == "" {
@@ -370,42 +432,71 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	db := &db.Database{
-		DB: database,
-	}
-	jimmParameters.Database = db
+	db := &db.Database{DB: database}
 
 	riverClient, err := river.NewRiverClient(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create river client: %w", err)
 	}
 
-	jimmParameters.RiverClient = riverClient
-
 	openFGAclient, err := newOpenFGAClient(ctx, p.OpenFGAParams)
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	jimmParameters.OpenFGAClient = openFGAclient
 
-	if err := ensureControllerAdministrators(ctx, openFGAclient, p.ControllerUUID, p.ControllerAdmins); err != nil {
+	if err := ensureControllerAdministrators(ctx, openFGAclient, controllerUUID, p.ControllerAdmins); err != nil {
 		return nil, errors.E(err, "failed to ensure controller admins")
 	}
 
-	credentialStore, err := s.setupCredentialStore(ctx, p, db)
+	credentialStore, err := setupCredentialStore(ctx, p, db)
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	jimmParameters.CredentialStore = credentialStore
 
-	sessionStore, err := s.setupSessionStore(ctx, p.CookieSessionKey, db)
+	jwtExpiry := p.JWTExpiryDuration
+	if jwtExpiry == 0 {
+		jwtExpiry = 24 * time.Hour
+	}
+
+	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
+		Host:   p.PublicDNSName,
+		Store:  credentialStore,
+		Expiry: jwtExpiry,
+	})
+
+	dialer := &jujuclient.Dialer{
+		ControllerCredentialsStore: credentialStore,
+		JWTService:                 jwtService,
+	}
+
+	deps := &ServiceDependencies{
+		ControllerUUID:                controllerUUID,
+		PublicDNSName:                 p.PublicDNSName,
+		PublicDNSHost:                 publicDNS.Host,
+		CorsAllowedOrigins:            append([]string(nil), p.CorsAllowedOrigins...),
+		HostKeyFingerprints:           maps.Clone(p.HostKeyFingerprints),
+		ControllerConfig:              p.ControllerConfig,
+		CrossModelQueryTimeout:        p.CrossModelQueryTimeout,
+		BootstrapLoginTokenRefreshURL: p.BootstrapLoginTokenRefreshURL,
+		AuditLogRetentionDays:         auditLogRetentionDays,
+		IsLeader:                      p.IsLeader,
+		MacaroonExpiryDuration:        p.MacaroonExpiryDuration,
+		DischargerPrivateKey:          p.PrivateKey,
+		DischargerPublicKey:           p.PublicKey,
+		Database:                      db,
+		Client:                        jimm.NewDialerAdapter(dialer),
+		RiverClient:                   riverClient,
+		OpenFGAClient:                 openFGAclient,
+		CredentialStore:               credentialStore,
+		JWTService:                    jwtService,
+		JWKSService:                   jimmjwx.NewJWKSService(credentialStore),
+	}
+
+	sessionStore, cleanupFuncs, err := setupSessionStore(p.CookieSessionKey, db)
 	if err != nil {
 		return nil, errors.E(err)
 	}
-	s.AddCleanup(func() error {
-		sessionStore.Close()
-		return nil
-	})
+	deps.cleanupFuncs = append(deps.cleanupFuncs, cleanupFuncs...)
 
 	redirectUrl := p.PublicDNSName + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint
 	if !strings.HasPrefix(redirectUrl, "https://") && !strings.HasPrefix(redirectUrl, "http://") {
@@ -429,34 +520,61 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 			RedirectURL:         redirectUrl,
 		},
 	)
-	jimmParameters.OAuthAuthenticator = authSvc
 	if err != nil {
 		return nil, errors.E(fmt.Errorf("failed to setup authentication service: %w", err))
 	}
-
-	if p.JWTExpiryDuration == 0 {
-		p.JWTExpiryDuration = 24 * time.Hour
+	deps.OAuthAuthenticator = authSvc
+	deps.MigrationTokenGenerator = authSvc
+	deps.OAuthHandler = nil
+	if p.DashboardFinalRedirectURL != "" {
+		var err error
+		deps.OAuthHandler, err = jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
+			Authenticator:             authSvc,
+			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
+		})
+		if err != nil {
+			return nil, errors.E(fmt.Errorf("failed to setup authentication handler: %w", err))
+		}
+	} else {
+		zapctx.Warn(ctx, "Dashboard final redirect URL not set, OAuth HTTP handler will not be configured")
 	}
 
-	s.jwkService = jimmjwx.NewJWKSService(credentialStore)
-	jimmParameters.JWTService = jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   p.PublicDNSName,
-		Store:  credentialStore,
-		Expiry: p.JWTExpiryDuration,
-	})
-	dialer := &jujuclient.Dialer{
-		ControllerCredentialsStore: credentialStore,
-		JWTService:                 jimmParameters.JWTService,
-	}
-	jimmParameters.MigrationTokenGenerator = authSvc
-	jimmParameters.Dialer = jimm.NewDialerAdapter(dialer)
+	return deps, nil
+}
 
-	if _, err := url.Parse(p.DashboardFinalRedirectURL); err != nil {
-		return nil, errors.E(err, "failed to parse final redirect url for the dashboard")
+// NewServiceFromDependencies creates a Service from a provided dependency set.
+// Callers can use this to inject mock dependencies while keeping handler setup identical.
+func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) (*Service, error) {
+	if deps == nil {
+		return nil, errors.E("missing service dependencies")
+	}
+	if err := deps.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid service dependencies: %w", err)
 	}
 
-	jimmParameters.BootstrapLoginTokenRefreshURL = p.BootstrapLoginTokenRefreshURL
+	s := &Service{
+		jwkService: deps.JWKSService,
+		cleanups:   append([]func() error(nil), deps.cleanupFuncs...),
+	}
 
+	jimmParameters := jimm.Parameters{
+		UUID:                          deps.ControllerUUID,
+		Database:                      deps.Database,
+		Dialer:                        deps.Client,
+		CredentialStore:               deps.CredentialStore,
+		Pubsub:                        &pubsub.Hub{MaxConcurrency: 50},
+		OpenFGAClient:                 deps.OpenFGAClient,
+		RiverClient:                   deps.RiverClient,
+		OAuthAuthenticator:            deps.OAuthAuthenticator,
+		MigrationTokenGenerator:       deps.MigrationTokenGenerator,
+		JWTService:                    deps.JWTService,
+		ControllerConfig:              deps.ControllerConfig,
+		CrossModelQueryTimeout:        deps.CrossModelQueryTimeout,
+		BootstrapLoginTokenRefreshURL: deps.BootstrapLoginTokenRefreshURL,
+	}
+	jimmParameters.AuditLogRetentionDays = deps.AuditLogRetentionDays
+
+	var err error
 	s.jimm, err = jimm.New(jimmParameters)
 	if err != nil {
 		return nil, errors.E(err)
@@ -468,7 +586,7 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 
 	// Setup CORS middleware
 	corsOpts := cors.New(cors.Options{
-		AllowedOrigins:   p.CorsAllowedOrigins,
+		AllowedOrigins:   deps.CorsAllowedOrigins,
 		AllowedMethods:   []string{"GET"},
 		AllowCredentials: true,
 	})
@@ -497,46 +615,33 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 		),
 	)
 
-	wellKnownPath := "/.well-known"
-	mountHandler(
-		wellKnownPath,
-		jimmhttp.NewWellKnownHandler(s.jimm.CredentialStore),
-	)
+	mountHandler("/.well-known", jimmhttp.NewWellKnownHandler(s.jimm.CredentialStore))
 
-	if p.DashboardFinalRedirectURL == "" {
-		zapctx.Warn(ctx, "OAuth handler not enabled, due to unset dashboard redirect URL")
+	if deps.OAuthHandler == nil {
+		zapctx.Warn(ctx, "OAuth HTTP handler not enabled, browser flow login disabled")
 	} else {
-		oauthHandler, err := jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
-			Authenticator:             authSvc,
-			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
-		})
-		if err != nil {
-			return nil, errors.E(fmt.Errorf("failed to setup authentication handler: %w", err))
-		}
-		mountHandler(
-			jimmhttp.AuthResourceBasePath,
-			oauthHandler,
-		)
+		mountHandler(jimmhttp.AuthResourceBasePath, deps.OAuthHandler)
 	}
 
-	macaroonDischarger, err := s.setupDischarger(p)
+	macaroonDischarger, err := discharger.NewMacaroonDischarger(discharger.MacaroonDischargerConfig{
+		PublicKey:              deps.DischargerPublicKey,
+		PrivateKey:             deps.DischargerPrivateKey,
+		MacaroonExpiryDuration: deps.MacaroonExpiryDuration,
+		ControllerUUID:         deps.ControllerUUID,
+	}, deps.Database, s.jimm.OfferAuthorizer)
 	if err != nil {
 		return nil, errors.E(fmt.Errorf("failed to set up discharger: %v", err))
 	}
 	s.mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
 
-	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
-	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to parse public DNS name: %v", err))
-	}
 	params := jujuapi.Params{
-		ControllerUUID: p.ControllerUUID,
-		PublicDNSName:  publicDNS.Host,
+		ControllerUUID: deps.ControllerUUID,
+		PublicDNSName:  deps.PublicDNSHost,
 	}
 
 	// Websockets require extra care when cookies are used for authentication
 	// to avoid CSRF attacks. https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking
-	websocketCors := middleware.NewWebsocketCors(p.CorsAllowedOrigins)
+	websocketCors := middleware.NewWebsocketCors(deps.CorsAllowedOrigins)
 	// Juju API handlers
 	s.mux.Handle("/api", websocketCors.Handler(jujuapi.APIHandler(ctx, s.jimm, params)))
 	s.mux.Handle("/model/*", websocketCors.Handler(http.StripPrefix("/model", jujuapi.ModelHandler(ctx, s.jimm, params))))
@@ -548,11 +653,20 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	s.mux.Handle("/migrate/logtransfer", jujuapi.LogTransferHandler(ctx, s.jimm, params))
 
 	// serve the ssh public key fingerprint
-	s.mux.Get("/ssh/public-key-fingerprints", jimmhttp.WriteFingerprints(p.HostKeyFingerprints))
+	s.mux.Get("/ssh/public-key-fingerprints", jimmhttp.WriteFingerprints(deps.HostKeyFingerprints))
 
-	s.isLeader = p.IsLeader
+	s.isLeader = deps.IsLeader
 
 	return s, nil
+}
+
+// NewService creates a new Service using the given params.
+func NewService(ctx context.Context, p Params) (*Service, error) {
+	deps, err := NewServiceDependencies(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return NewServiceFromDependencies(ctx, deps)
 }
 
 // parseURLWithOptionalScheme parses an input string
@@ -616,42 +730,30 @@ func (s *Service) StartServices(ctx context.Context, svc *service.Service) {
 	svc.Go(func() error { return s.WatchModelSummaries(ctx) })
 }
 
-// setupDischarger set JIMM up as a discharger of 3rd party caveats addressed to it. This is intended
-// to enable Juju controllers to check for permissions using a macaroon-based workflow (atm only
-// for cross model relations).
-func (s *Service) setupDischarger(p Params) (*discharger.MacaroonDischarger, error) {
-	cfg := discharger.MacaroonDischargerConfig{
-		PublicKey:              p.PublicKey,
-		PrivateKey:             p.PrivateKey,
-		MacaroonExpiryDuration: p.MacaroonExpiryDuration,
-		ControllerUUID:         p.ControllerUUID,
-	}
-	MacaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, s.jimm.Database, s.jimm.OfferAuthorizer)
-	if err != nil {
-		return nil, errors.E(err)
-	}
-	return MacaroonDischarger, nil
-}
-
-func (s *Service) setupSessionStore(ctx context.Context, sessionSecret []byte, db *db.Database) (*pgstore.PGStore, error) {
-
+func setupSessionStore(sessionSecret []byte, db *db.Database) (*pgstore.PGStore, []func() error, error) {
 	sqlDb, err := db.DB.DB()
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, nil, errors.E(err)
 	}
 
 	store, err := pgstore.NewPGStoreFromPool(sqlDb, sessionSecret)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to create session store: %w", err))
+		return nil, nil, errors.E(fmt.Errorf("failed to create session store: %w", err))
 	}
 
 	// Cleanup expired session every 30 minutes
 	cleanupQuit, cleanupDone := store.Cleanup(time.Minute * 30)
-	s.AddCleanup(func() error {
-		store.StopCleanup(cleanupQuit, cleanupDone)
-		return nil
-	})
-	return store, nil
+	cleanups := []func() error{
+		func() error {
+			store.StopCleanup(cleanupQuit, cleanupDone)
+			return nil
+		},
+		func() error {
+			store.Close()
+			return nil
+		},
+	}
+	return store, cleanups, nil
 }
 
 func openDB(ctx context.Context, dsn string, logSQL bool) (*gorm.DB, error) {
@@ -675,7 +777,7 @@ func openDB(ctx context.Context, dsn string, logSQL bool) (*gorm.DB, error) {
 	})
 }
 
-func (s *Service) setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmcreds.CredentialStore, error) {
+func setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmcreds.CredentialStore, error) {
 
 	// Only enable Postgres storage for secrets if explicitly enabled.
 	if p.InsecureSecretStorage {

--- a/go.mod
+++ b/go.mod
@@ -72,19 +72,7 @@ require (
 
 // Indirect
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.4.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.1.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
-	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1 // indirect
-	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/adrg/xdg v0.3.3 // indirect
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
@@ -104,11 +92,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17 // indirect
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
 	github.com/canonical/lxd v0.0.0-20251125210512-b190d213bd11
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cjlapao/common-go v0.0.39 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -119,7 +105,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
@@ -139,11 +124,8 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/renameio v1.0.1 // indirect
-	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -155,7 +137,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.6 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/im7mortal/kmutex v1.0.1 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -189,7 +170,6 @@ require (
 	github.com/juju/persistent-cookiejar v1.0.0
 	github.com/juju/proxy v1.0.0 // indirect
 	github.com/juju/pubsub/v2 v2.0.0 // indirect
-	github.com/juju/ratelimit v1.0.2 // indirect
 	github.com/juju/replicaset/v3 v3.0.1 // indirect
 	github.com/juju/retry v1.0.1
 	github.com/juju/rfc/v2 v2.0.0 // indirect
@@ -202,11 +182,8 @@ require (
 	github.com/juju/webbrowser v1.0.0 // indirect
 	github.com/juju/worker/v3 v3.5.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.3 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -225,26 +202,15 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
-	github.com/microsoft/kiota-abstractions-go v1.5.3 // indirect
-	github.com/microsoft/kiota-authentication-azure-go v1.0.1 // indirect
-	github.com/microsoft/kiota-http-go v1.1.1 // indirect
-	github.com/microsoft/kiota-serialization-form-go v1.0.0 // indirect
-	github.com/microsoft/kiota-serialization-json-go v1.0.4 // indirect
-	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
-	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go v1.28.0 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/mittwald/vaultgo v0.1.4 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
@@ -252,10 +218,7 @@ require (
 	github.com/openfga/api/proto v0.0.0-20251105142303-feed3db3d69d // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pkg/sftp v1.13.10 // indirect
-	github.com/pkg/xattr v0.4.12 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
@@ -273,7 +236,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
-	github.com/std-uritemplate/std-uritemplate/go v0.0.47 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/vishvananda/netlink v1.3.1 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
@@ -320,23 +282,61 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.1.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.1 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.1 // indirect
+	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
+	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
 	github.com/canonical/go-dqlite/v3 v3.0.3 // indirect
+	github.com/cjlapao/common-go v0.0.39 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
+	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/google/renameio v1.0.1 // indirect
+	github.com/gorilla/schema v1.4.1 // indirect
+	github.com/im7mortal/kmutex v1.0.1 // indirect
 	github.com/juju/packaging/v4 v4.0.0 // indirect
+	github.com/juju/ratelimit v1.0.2 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kr/fs v0.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/microsoft/kiota-abstractions-go v1.5.3 // indirect
+	github.com/microsoft/kiota-authentication-azure-go v1.0.1 // indirect
+	github.com/microsoft/kiota-http-go v1.1.1 // indirect
+	github.com/microsoft/kiota-serialization-form-go v1.0.0 // indirect
+	github.com/microsoft/kiota-serialization-json-go v1.0.4 // indirect
+	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
+	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
+	github.com/microsoftgraph/msgraph-sdk-go v1.28.0 // indirect
+	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.1 // indirect
+	github.com/mittwald/vaultgo v0.1.4 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/sftp v1.13.10 // indirect
+	github.com/pkg/xattr v0.4.12 // indirect
 	github.com/riverqueue/river/riverdriver v0.30.0 // indirect
 	github.com/riverqueue/river/rivershared v0.30.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/std-uritemplate/std-uritemplate/go v0.0.47 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/testutils/jimmtest/e2e_suite.go
+++ b/internal/testutils/jimmtest/e2e_suite.go
@@ -17,7 +17,6 @@ import (
 
 	cofga "github.com/canonical/ofga"
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/go-chi/chi/v5"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/cloud"
@@ -31,7 +30,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
@@ -166,22 +164,7 @@ func (s *WebsocketE2ESuite) SetUpTest(c *gc.C) {
 	s.E2ESuite.SetUpTest(c)
 
 	s.Params.ControllerUUID = ControllerUUID
-
-	mux := chi.NewRouter()
-	mountHandler := func(path string, h jimmhttp.JIMMHttpHandler) {
-		mux.Mount(path, h.Routes())
-	}
-	mux.Handle("/api", jujuapi.APIHandler(ctx, s.JIMM, s.Params))
-	mountHandler(
-		"/model/{uuid}/{type:charms|applications}",
-		jimmhttp.NewHTTPProxyHandler(s.JIMM.LoginManager, s.JIMM.JujuManager),
-	)
-	mux.Handle("/model/*", http.StripPrefix("/model", jujuapi.ModelHandler(ctx, s.JIMM, s.Params)))
-	jwks := jimmhttp.NewWellKnownHandler(s.JIMM.CredentialStore)
-	mux.HandleFunc("/.well-known/jwks.json", jwks.JWKS)
-	mux.Handle("/migrate/logtransfer", jujuapi.LogTransferHandler(ctx, s.JIMM, s.Params))
-
-	s.APIHandler = mux
+	s.APIHandler = s.service
 	s.HTTP = httptest.NewTLSServer(s.APIHandler)
 
 	s.AddAdminUser(c, "alice@canonical.com")

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -8,14 +8,12 @@ import (
 	_ "embed"
 	"encoding/pem"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/antonlindstrom/pgstore"
 	cofga "github.com/canonical/ofga"
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/go-chi/chi/v5"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/network"
 	corejujutesting "github.com/juju/juju/juju/testing"
@@ -24,21 +22,21 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	gc "gopkg.in/check.v1"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 
+	jimmsvc "github.com/canonical/jimm/v3/cmd/jimmsrv/service"
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/discharger"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
-	"github.com/canonical/jimm/v3/internal/jimm/login"
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
 	"github.com/canonical/jimm/v3/internal/jujuclient"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
-	"github.com/canonical/jimm/v3/internal/pubsub"
 	"github.com/canonical/jimm/v3/internal/river"
 	"github.com/canonical/jimm/v3/internal/testutils/testdb"
 )
@@ -86,11 +84,11 @@ type JIMMSuite struct {
 	COFGAClient *cofga.Client
 	COFGAParams *cofga.OpenFGAParams
 
-	Server          *httptest.Server
-	cancel          context.CancelFunc
-	deviceFlowChan  chan string
-	databaseName    string
-	databaseCleanup []func()
+	Server         *httptest.Server
+	cancel         context.CancelFunc
+	deviceFlowChan chan string
+	cleanup        []func()
+	service        *jimmsvc.Service
 
 	modifiers jimmModifiers
 }
@@ -108,67 +106,42 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 	gct := &GocheckTester{
 		C: c,
 		AddCleanup: func(f func()) {
-			s.databaseCleanup = append(s.databaseCleanup, f)
+			s.cleanup = append(s.cleanup, f)
 		},
 	}
 
-	pgdb, databaseName := testdb.PostgresDBWithDbName(gct, nil)
-	s.databaseName = databaseName
+	dsn := testdb.CreateEmptyDatabase(gct)
 
-	database := &db.Database{
-		DB: pgdb,
+	params := jimmsvc.Params{
+		ControllerUUID:                ControllerUUID,
+		PrivateKey:                    "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
+		PublicKey:                     "izcYsQy3TePp6bLjqOo3IRPFvkQd2IKtyODGqC6SdFk=",
+		MacaroonExpiryDuration:        time.Hour,
+		JWTExpiryDuration:             time.Minute,
+		PublicDNSName:                 "127.0.0.1",
+		CrossModelQueryTimeout:        time.Second * 5,
+		BootstrapLoginTokenRefreshURL: "https://jimm.localhost/.well-known/jwks.json",
+		DashboardFinalRedirectURL:     "localhost", // Can be any URL.
 	}
-	err = database.Migrate(ctx)
-	c.Assert(err, gc.Equals, nil)
 
-	alice, err := dbmodel.NewIdentity("alice@canonical.com")
+	gormDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	c.Assert(err, gc.IsNil)
-	alice.LastLogin = db.Now()
+	database := &db.Database{DB: gormDB}
 
-	err = database.GetIdentity(ctx, alice)
-	c.Assert(err, gc.Equals, nil)
-
-	s.AdminUser = openfga.NewUser(alice, s.OFGAClient)
-	s.AdminUser.JimmAdmin = true
+	riverClient, err := river.NewRiverClient(database)
+	c.Assert(err, gc.IsNil)
 
 	credentialStore := NewInMemoryCredentialStore()
-	if s.modifiers.useHardcodedJWKS {
-		set, privateKey, err := jwkSetFromPrivateKeyFile()
-		c.Assert(err, gc.IsNil)
-		err = credentialStore.PutJWKS(ctx, set)
-		c.Assert(err, gc.IsNil)
-		err = credentialStore.PutJWKSPrivateKey(ctx, privateKey)
-		c.Assert(err, gc.IsNil)
-		err = credentialStore.PutJWKSExpiry(ctx, time.Now().UTC().AddDate(10, 0, 0))
-		c.Assert(err, gc.IsNil)
-	}
-	var authenticator login.OAuthAuthenticator
-	if s.modifiers.useRealAuthN {
-		authenticator = s.realAuthenticationService(c, database)
-	} else {
-		s.deviceFlowChan = make(chan string, 1)
-		a := newMockOAuthAuthenticator(c, s.deviceFlowChan)
-		authenticator = &a
-	}
 
-	mux := chi.NewRouter()
-	mountHandler := func(path string, h jimmhttp.JIMMHttpHandler) {
-		mux.Mount(path, h.Routes())
+	jwtExpiry := params.JWTExpiryDuration
+	if jwtExpiry == 0 {
+		jwtExpiry = 24 * time.Hour
 	}
-
-	mountHandler(
-		"/.well-known",
-		jimmhttp.NewWellKnownHandler(credentialStore),
-	)
-
-	jwksService := jimmjwx.NewJWKSService(credentialStore)
-	err = jwksService.StartJWKSRotator(ctx, time.NewTicker(time.Hour).C, time.Now().UTC().AddDate(0, 3, 0))
-	c.Assert(err, gc.Equals, nil)
 
 	jwtService := jimmjwx.NewJWTService(jimmjwx.JWTServiceParams{
-		Host:   "127.0.0.1",
+		Host:   params.PublicDNSName,
 		Store:  credentialStore,
-		Expiry: time.Minute,
+		Expiry: jwtExpiry,
 	})
 
 	dialer := &jujuclient.Dialer{
@@ -176,31 +149,74 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 		JWTService:                 jwtService,
 	}
 
-	riverClient, err := river.NewRiverClient(database)
-	c.Assert(err, gc.IsNil)
-	err = river.MigrateRiver(ctx, database)
-	c.Assert(err, gc.IsNil)
-
-	s.JIMM, err = jimm.New(jimm.Parameters{
-		UUID:                          ControllerUUID,
+	deps := &jimmsvc.ServiceDependencies{
+		ControllerUUID:                params.ControllerUUID,
+		PublicDNSName:                 params.PublicDNSName,
+		PublicDNSHost:                 params.PublicDNSName,
+		CrossModelQueryTimeout:        params.CrossModelQueryTimeout,
+		BootstrapLoginTokenRefreshURL: params.BootstrapLoginTokenRefreshURL,
+		MacaroonExpiryDuration:        params.MacaroonExpiryDuration,
+		DischargerPrivateKey:          params.PrivateKey,
+		DischargerPublicKey:           params.PublicKey,
 		Database:                      database,
-		Dialer:                        jimm.NewDialerAdapter(dialer),
-		CredentialStore:               credentialStore,
-		Pubsub:                        &pubsub.Hub{MaxConcurrency: 10},
-		OpenFGAClient:                 s.OFGAClient,
+		Client:                        jimm.NewDialerAdapter(dialer),
 		RiverClient:                   riverClient,
-		OAuthAuthenticator:            authenticator,
-		MigrationTokenGenerator:       mockMigrationTokenGenerator{},
+		OpenFGAClient:                 s.OFGAClient,
+		CredentialStore:               credentialStore,
 		JWTService:                    jwtService,
-		CrossModelQueryTimeout:        time.Second * 5,
-		BootstrapLoginTokenRefreshURL: "https://jimm.localhost/.well-known/jwks.json",
-	})
+		JWKSService:                   jimmjwx.NewJWKSService(credentialStore),
+	}
+
+	if s.modifiers.useRealAuthN {
+		authSvc := s.realAuthenticationService(c, database)
+		deps.OAuthAuthenticator = authSvc
+		deps.MigrationTokenGenerator = authSvc
+
+		oauthHandler, err := jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
+			Authenticator:             authSvc,
+			DashboardFinalRedirectURL: params.DashboardFinalRedirectURL,
+		})
+		c.Assert(err, gc.IsNil)
+		deps.OAuthHandler = oauthHandler
+		s.deviceFlowChan = nil
+	} else {
+		s.deviceFlowChan = make(chan string, 1)
+		a := newMockOAuthAuthenticator(c, s.deviceFlowChan)
+		deps.OAuthAuthenticator = &a
+		deps.MigrationTokenGenerator = mockMigrationTokenGenerator{}
+		deps.OAuthHandler = nil // This field can be nil to disable browser auth.
+	}
+
+	s.service, err = jimmsvc.NewServiceFromDependencies(ctx, deps)
+	c.Assert(err, gc.IsNil)
+	s.JIMM = s.service.JIMM()
+	s.OFGAClient = s.JIMM.OpenFGAClient
+
+	err = river.MigrateRiver(ctx, s.JIMM.Database)
 	c.Assert(err, gc.IsNil)
 
-	macaroonDischarger := setupMacaroonDischarger(c, ControllerUUID, database, s.JIMM.OfferAuthorizer)
-	localDischargePath := "/macaroons"
-	mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
-	s.Server = httptest.NewServer(mux)
+	if s.modifiers.useHardcodedJWKS {
+		set, privateKey, err := jwkSetFromPrivateKeyFile()
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.CredentialStore.PutJWKS(ctx, set)
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.CredentialStore.PutJWKSPrivateKey(ctx, privateKey)
+		c.Assert(err, gc.IsNil)
+		err = s.JIMM.CredentialStore.PutJWKSExpiry(ctx, time.Now().UTC().AddDate(10, 0, 0))
+		c.Assert(err, gc.IsNil)
+	} else {
+		err = s.service.StartJWKSRotator(ctx, time.NewTicker(time.Hour).C, time.Now().UTC().AddDate(0, 3, 0))
+		c.Assert(err, gc.IsNil)
+	}
+
+	alice, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, gc.IsNil)
+	err = s.JIMM.Database.GetIdentity(ctx, alice)
+	c.Assert(err, gc.Equals, nil)
+
+	s.AdminUser = openfga.NewUser(alice, s.OFGAClient)
+	s.AdminUser.JimmAdmin = true
+	s.Server = httptest.NewServer(s.service)
 
 	err = s.AdminUser.SetControllerAccess(ctx, s.JIMM.ResourceTag(), ofganames.AdministratorRelation)
 	c.Assert(err, gc.Equals, nil)
@@ -256,24 +272,19 @@ func (s *JIMMSuite) TearDownTest(c *gc.C) {
 	if s.Server != nil {
 		s.Server.Close()
 	}
+	if s.service != nil {
+		s.service.Cleanup()
+	}
 	if s.JIMM != nil && s.JIMM.Database != nil {
 		if err := s.JIMM.Database.Close(); err != nil {
 			c.Logf("failed to close database connections at tear down: %s", err)
 		}
 	}
 
-	for _, cleanup := range s.databaseCleanup {
+	for _, cleanup := range s.cleanup {
 		cleanup()
 	}
 
-	// Only delete the DB after closing connections to it.
-	_, skipCleanup := os.LookupEnv("NO_DB_CLEANUP")
-	if !skipCleanup {
-		err := testdb.DeleteDatabase(s.databaseName)
-		if err != nil {
-			c.Logf("failed to delete database (%s): %s", s.databaseName, err)
-		}
-	}
 }
 
 func (s *JIMMSuite) UseRealAuthentication(c *gc.C) {
@@ -286,7 +297,7 @@ func (s *JIMMSuite) realAuthenticationService(c *gc.C, db *db.Database) *auth.Au
 
 	sessionStore, err := pgstore.NewPGStoreFromPool(sqldb, []byte("secretsecretdigletts"))
 	c.Assert(err, gc.IsNil)
-	s.databaseCleanup = append(s.databaseCleanup, func() {
+	s.cleanup = append(s.cleanup, func() {
 		sessionStore.Close()
 	})
 
@@ -304,18 +315,6 @@ func (s *JIMMSuite) realAuthenticationService(c *gc.C, db *db.Database) *auth.Au
 	})
 	c.Assert(err, gc.IsNil)
 	return authSvc
-}
-
-func setupMacaroonDischarger(c *gc.C, uuid string, db *db.Database, offerAuthorizer discharger.OfferAuthorizer) *discharger.MacaroonDischarger {
-	cfg := discharger.MacaroonDischargerConfig{
-		MacaroonExpiryDuration: 1 * time.Hour,
-		ControllerUUID:         uuid,
-		PrivateKey:             "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
-		PublicKey:              "izcYsQy3TePp6bLjqOo3IRPFvkQd2IKtyODGqC6SdFk=",
-	}
-	macaroonDischarger, err := discharger.NewMacaroonDischarger(cfg, db, offerAuthorizer)
-	c.Assert(err, gc.IsNil)
-	return macaroonDischarger
 }
 
 func (s *JIMMSuite) AddAdminUser(c *gc.C, email string) {

--- a/internal/testutils/jimmtest/suite.go
+++ b/internal/testutils/jimmtest/suite.go
@@ -35,6 +35,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
 	"github.com/canonical/jimm/v3/internal/jujuclient"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/river"
@@ -95,6 +96,7 @@ type JIMMSuite struct {
 
 func (s *JIMMSuite) SetUpTest(c *gc.C) {
 	var err error
+	s.cleanup = nil
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
@@ -124,7 +126,7 @@ func (s *JIMMSuite) SetUpTest(c *gc.C) {
 		DashboardFinalRedirectURL:     "localhost", // Can be any URL.
 	}
 
-	gormDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	gormDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.NewGormTestLogger(gct)})
 	c.Assert(err, gc.IsNil)
 	database := &db.Database{DB: gormDB}
 
@@ -281,10 +283,10 @@ func (s *JIMMSuite) TearDownTest(c *gc.C) {
 		}
 	}
 
-	for _, cleanup := range s.cleanup {
-		cleanup()
+	for i := len(s.cleanup) - 1; i >= 0; i-- {
+		s.cleanup[i]()
 	}
-
+	s.cleanup = nil
 }
 
 func (s *JIMMSuite) UseRealAuthentication(c *gc.C) {

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -331,6 +331,7 @@ func getOrCreateTemplateDatabase() (string, string, error) {
 }
 
 // CreateEmptyDatabase creates an empty Postgres database and returns the DSN.
+// Schedules the DB to be deleted when the test finishes.
 func CreateEmptyDatabase(t Tester) string {
 	databaseName, dsn, err := createEmptyDatabase("jimm_test_" + t.Name())
 	if err != nil {

--- a/testing/streammodelproxy_test.go
+++ b/testing/streammodelproxy_test.go
@@ -25,10 +25,14 @@ var _ = gc.Suite(&streamProxySuite{})
 func (s *streamProxySuite) TestDebugLogs(c *gc.C) {
 	conn := s.Open(c, &api.Info{ModelTag: s.Model.ResourceTag()}, "bob", nil)
 	defer conn.Close()
-	// Note this is enough to test that a client can make connection for streaming logs.
-	// No actual logs come through either because of the JujuConnSuite or the fact that there is no application deployed.
-	_, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{})
+	logs, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{})
 	c.Assert(err, gc.IsNil)
+	select {
+	case _, ok := <-logs:
+		c.Assert(ok, gc.Equals, true)
+	case <-time.After(5 * time.Second):
+		c.Fatal("expected to receive log message, but did not receive any after timeout")
+	}
 }
 
 func (s *streamProxySuite) TestDebugLogsWithParams(c *gc.C) {


### PR DESCRIPTION
## Description
This PR aims to simplify our test suites. Currently our test suites create an integration test environment by copying the logic in `cmd/jimmsrv/service/service.go` to create a JIMM domain service, setup the appropriate HTTP handlers, etc. Every time we add a new HTTP endpoint we need to update the suite logic to register the same endpoint.

This PR splits the large `NewService()` function within `cmd/jimmsrv/service/service.go` in two. The first part `NewServiceDependencies` creates all the dependencies and the second `NewServiceFromDependencies` accepts the dependencies and constructs the JIMM service, HTTP handlers, etc. 

In our test suite we can now construct all our dependencies (mock or real, as needed) and then call `NewServiceFromDependencies` to get a ready-to-use JIMM svc that already implements the HTTP handler interface. We pass it to an HTTP server and we're done.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
