### PR TITLE
feat: implement state based jwt rotation

### DIFF
--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
+	"github.com/canonical/jimm/v3/internal/vault"
 )
 
 const (
@@ -27,6 +28,7 @@ const (
 	jwksPublicKeyTag  = "jwksPublicKey"
 	jwksPrivateKeyTag = "jwksPrivateKey"
 	jwksExpiryTag     = "jwksExpiry"
+	jwksMetadataTag   = "jwksKeyMetadata"
 	oauthKind         = "oauth"
 	oauthKeyTag       = "oauthKey"
 	//nolint:gosec // Thinks credentials hardcoded.
@@ -404,4 +406,53 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 		return errors.E(fmt.Errorf("failed to cleanup OAuth session store secret: %w", err))
 	}
 	return nil
+}
+
+// GetKeyMetadata retrieves the key metadata for rotation tracking.
+func (d *Database) GetKeyMetadata(ctx context.Context) (_ vault.KeyMetadata, err error) {
+	const op = "database.GetKeyMetadata"
+
+	if err := d.ready(); err != nil {
+		return vault.KeyMetadata{}, errors.E(err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
+	secret := dbmodel.NewSecret(jwksKind, jwksMetadataTag, nil)
+	if err := d.GetSecret(ctx, &secret); err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return vault.KeyMetadata{}, nil
+		}
+		return vault.KeyMetadata{}, errors.E(fmt.Errorf("failed to get key metadata: %w", err))
+	}
+
+	var metadata vault.KeyMetadata
+	if err := json.Unmarshal(secret.Data, &metadata); err != nil {
+		return vault.KeyMetadata{}, errors.E(fmt.Errorf("failed to unmarshal key metadata: %w", err))
+	}
+
+	return metadata, nil
+}
+
+// PutKeyMetadata stores the key metadata for rotation tracking.
+func (d *Database) PutKeyMetadata(ctx context.Context, metadata vault.KeyMetadata) (err error) {
+	const op = "database.PutKeyMetadata"
+
+	if err := d.ready(); err != nil {
+		return errors.E(err)
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return errors.E(fmt.Errorf("failed to marshal key metadata: %w", err))
+	}
+
+	secret := dbmodel.NewSecret(jwksKind, jwksMetadataTag, metadataJSON)
+	return d.UpsertSecret(ctx, &secret)
 }

--- a/internal/db/secrets_test.go
+++ b/internal/db/secrets_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/vault"
 )
 
 var testTime = time.Date(2013, 7, 26, 0, 0, 0, 0, time.UTC)
@@ -278,4 +279,47 @@ func (s *dbSuite) TestCleanupJWKS(c *qt.C) {
 	c.Assert(s.Database.CleanupJWKS(ctx), qt.IsNil)
 	c.Assert(s.Database.DB.Model(&dbmodel.Secret{}).Count(&count).Error, qt.IsNil)
 	c.Assert(count, qt.Equals, int64(0))
+}
+
+func (s *dbSuite) TestGetKeyMetadataEmpty(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	metadata, err := s.Database.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(metadata, qt.DeepEquals, vault.KeyMetadata{})
+}
+
+func (s *dbSuite) TestPutAndGetKeyMetadata(c *qt.C) {
+	err := s.Database.Migrate(context.Background())
+	c.Assert(err, qt.Equals, nil)
+	ctx := context.Background()
+
+	activatedAt := testTime.Add(5 * time.Minute)
+	metadata := vault.KeyMetadata{
+		Keys: []vault.KeyInfo{{
+			KID:         "kid-1",
+			PrivateKey:  "priv-1",
+			PublicJWK:   "pub-1",
+			ActivatedAt: &activatedAt,
+		}},
+		CurrentActiveKID: "kid-1",
+		RotationInterval: 24 * time.Hour,
+		GracePeriod:      15 * time.Minute,
+		MaxTokenLifetime: time.Hour,
+	}
+
+	c.Assert(s.Database.PutKeyMetadata(ctx, metadata), qt.IsNil)
+
+	// Verify the type/tag stored in secrets table for sanity.
+	secret := dbmodel.Secret{}
+	tx := s.Database.DB.First(&secret)
+	c.Assert(tx.Error, qt.IsNil)
+	c.Assert(secret.Type, qt.Equals, "jwks")
+	c.Assert(secret.Tag, qt.Equals, "jwksKeyMetadata")
+
+	got, err := s.Database.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, metadata)
 }

--- a/internal/jimm/credentials/credentials.go
+++ b/internal/jimm/credentials/credentials.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/juju/names/v5"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+
+	"github.com/canonical/jimm/v3/internal/vault"
 )
 
 // A CredentialStore is a store for the attributes of:
@@ -19,6 +21,7 @@ import (
 //   - JWK expiry
 //   - JWK private key
 //   - OAuth session signing secret
+//   - Key metadata (rotation lifecycle)
 type CredentialStore interface {
 	// Get retrieves the stored attributes of a cloud credential.
 	Get(context.Context, names.CloudCredentialTag) (map[string]string, error)
@@ -54,4 +57,10 @@ type CredentialStore interface {
 
 	// PutJWKSExpiry sets the expiry time for the current JWKS within the store.
 	PutJWKSExpiry(ctx context.Context, expiry time.Time) error
+
+	// GetKeyMetadata retrieves the key metadata for rotation tracking.
+	GetKeyMetadata(ctx context.Context) (vault.KeyMetadata, error)
+
+	// PutKeyMetadata stores the key metadata for rotation tracking.
+	PutKeyMetadata(ctx context.Context, metadata vault.KeyMetadata) error
 }

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1786,6 +1786,16 @@ func (s testCloudCredentialAttributeStore) PutOAuthSecret(ctx context.Context, r
 	return errors.E(errors.CodeNotImplemented)
 }
 
+// GetKeyMetadata retrieves the key metadata for rotation tracking.
+func (s testCloudCredentialAttributeStore) GetKeyMetadata(ctx context.Context) (vault.KeyMetadata, error) {
+	return vault.KeyMetadata{}, errors.E(errors.CodeNotImplemented)
+}
+
+// PutKeyMetadata stores the key metadata for rotation tracking.
+func (s testCloudCredentialAttributeStore) PutKeyMetadata(ctx context.Context, metadata vault.KeyMetadata) error {
+	return errors.E(errors.CodeNotImplemented)
+}
+
 func TestCopyCredential(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/vault"
 )
 
 // CredentialStore defines the interface for a store that can manage
@@ -45,6 +47,12 @@ type CredentialStore interface {
 
 	// PutJWKSExpiry sets the expiry time for the current JWKS within the store.
 	PutJWKSExpiry(ctx context.Context, expiry time.Time) error
+
+	// GetKeyMetadata retrieves the key metadata for rotation tracking.
+	GetKeyMetadata(ctx context.Context) (vault.KeyMetadata, error)
+
+	// PutKeyMetadata stores the key metadata for rotation tracking.
+	PutKeyMetadata(ctx context.Context, metadata vault.KeyMetadata) error
 }
 
 // JWKSService handles the creation, rotation and retrieval of JWKS for JIMM.
@@ -58,76 +66,6 @@ func NewJWKSService(credStore CredentialStore) *JWKSService {
 	return &JWKSService{credentialStore: credStore}
 }
 
-func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTime time.Time) error {
-	// putJwks simply attempts the process of setting up the JWKS suite
-	// and all secrets required for JIMM to sign JWTs and clients to verify
-	// JWTs from JIMM.
-	putJwks := func(expires time.Time) error {
-		set, key, err := generateJWK(ctx)
-		if err != nil {
-			return err
-		}
-
-		err = credStore.PutJWKS(ctx, set)
-		if err != nil {
-			return err
-		}
-
-		err = credStore.PutJWKSPrivateKey(ctx, key)
-		if err != nil {
-			return err
-		}
-
-		err = credStore.PutJWKSExpiry(ctx, expires)
-		if err != nil {
-			return err
-		}
-
-		zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
-		return nil
-	}
-
-	expires, err := credStore.GetJWKSExpiry(ctx)
-	if err != nil {
-		zapctx.Debug(ctx, "failed to get expiry", zap.Error(err))
-		zapctx.Debug(ctx, "setting initial expiry", zap.Time("time", initialExpiryTime))
-		err = putJwks(initialExpiryTime)
-		if err != nil {
-			if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
-				zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
-			}
-			return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
-		}
-	} else {
-		// Check it has expired.
-		now := time.Now().UTC()
-		if now.After(expires) {
-			// In theory, an error should not happen anymore as the necessary
-			// components exist from the previous failed expiry attempt.
-			err = putJwks(time.Now().UTC().AddDate(0, 3, 0))
-			if err != nil {
-				if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
-					zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
-				}
-				return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
-			}
-			zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
-		}
-	}
-	return nil
-}
-
-// StartJWKSRotator starts a simple routine which checks the vaults TTL for the JWKS on a ticker.C.
-// It is expected that this routine will be cleaned up alongside other background services sharing
-// the same cancellable context.
-//
-// TODO(ale8k)[possibly?]:
-// For now, there's a single key, and this is probably OK. But possibly extend
-// this to contain many at some point differentiated by KIDs.
-//
-// We also currently don't use x5c and x5t for validation and expect users
-// to use e and n for validation.
-// https://stackoverflow.com/questions/61395261/how-to-validate-signature-of-jwt-from-jwks-without-x5c
 func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequired <-chan time.Time, initialRotateRequiredTime time.Time) error {
 
 	credStore := jwks.credentialStore
@@ -210,4 +148,493 @@ func generateJWK(ctx context.Context) (jwk.Set, []byte, error) {
 	}
 
 	return ks, privateKeyPEM, nil
+}
+
+// rotateJWKS is the legacy rotation function. Use rotateKeysV2 instead.
+func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTime time.Time) error {
+	// putJwks simply attempts the process of setting up the JWKS suite
+	// and all secrets required for JIMM to sign JWTs and clients to verify
+	// JWTs from JIMM.
+	putJwks := func(expires time.Time) error {
+		set, key, err := generateJWK(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = credStore.PutJWKS(ctx, set)
+		if err != nil {
+			return err
+		}
+
+		err = credStore.PutJWKSPrivateKey(ctx, key)
+		if err != nil {
+			return err
+		}
+
+		err = credStore.PutJWKSExpiry(ctx, expires)
+		if err != nil {
+			return err
+		}
+
+		zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
+		return nil
+	}
+
+	expires, err := credStore.GetJWKSExpiry(ctx)
+	if err != nil {
+		zapctx.Debug(ctx, "failed to get expiry", zap.Error(err))
+		zapctx.Debug(ctx, "setting initial expiry", zap.Time("time", initialExpiryTime))
+		err = putJwks(initialExpiryTime)
+		if err != nil {
+			if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
+				zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
+			}
+			return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
+		}
+	} else {
+		// Check it has expired.
+		now := time.Now().UTC()
+		if now.After(expires) {
+			// In theory, an error should not happen anymore as the necessary
+			// components exist from the previous failed expiry attempt.
+			err = putJwks(time.Now().UTC().AddDate(0, 3, 0))
+			if err != nil {
+				if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
+					zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
+				}
+				return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
+			}
+			zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
+		}
+	}
+	return nil
+}
+
+// StartJWKSRotatorParams holds the params to start the JWKS rotator.
+type StartJWKSRotatorParams struct {
+	CheckRotateRequired <-chan time.Time
+	RotationInterval    time.Duration
+	GracePeriod         time.Duration
+	MaxTokenLifetime    time.Duration
+}
+
+// StartJWKSRotatorV2 starts the new key rotation routine using the Zalando pattern.
+// It periodically checks if rotation is due and performs the full rotation cycle.
+//
+// We also currently don't use x5c and x5t for validation and expect users
+// to use e and n for validation.
+// https://stackoverflow.com/questions/61395261/how-to-validate-signature-of-jwt-from-jwks-without-x5c
+func (jwks *JWKSService) StartJWKSRotatorV2(
+	ctx context.Context,
+	p StartJWKSRotatorParams,
+) error {
+	credStore := jwks.credentialStore
+
+	// Perform initial rotation/migration
+	if err := rotateKeysV2(ctx, credStore, p); err != nil {
+		zapctx.Error(ctx, "initial rotation failed", zap.Error(err))
+		return errors.E(fmt.Errorf("initial key rotation: %w", err))
+	}
+
+	// Start background rotation goroutine
+	go func() {
+		for {
+			select {
+			case <-p.CheckRotateRequired:
+				if err := rotateKeysV2(ctx, credStore, p); err != nil {
+					zapctx.Error(ctx, "key rotation failed", zap.Error(err))
+				}
+			case <-ctx.Done():
+				zapctx.Debug(ctx, "JWKS rotator shutdown complete")
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// rotateKeysV2 runs one rotation tick using a small state machine over
+// KeyMetadata. The state is derived from timestamps and CurrentActiveKID:
+//
+// 1) Initialize/Migrate
+//   - If metadata is empty, migrate legacy JWKS if present.
+//   - If truly fresh, create an active key immediately (no initial grace wait).
+//
+// 2) Retire expired keys
+//   - Remove keys with ActivatedAt + MaxTokenLifetime + GracePeriod < now.
+//
+// 3) Promote pre-active key
+//   - If any key has ActivatedAt <= now and is not active, set it as active.
+//
+// 4) Generate pre-active key when rotation is due
+//   - When the active key's ActivatedAt + RotationInterval < now, create a new
+//     key with ActivatedAt = now + GracePeriod (overlap window).
+//
+// 5) Persist metadata
+//   - Updated metadata is stored; JWKS serving and signing read from it.
+func rotateKeysV2(ctx context.Context, credStore CredentialStore, p StartJWKSRotatorParams) error {
+	now := time.Now()
+
+	// Load existing metadata.
+	meta, err := credStore.GetKeyMetadata(ctx)
+	if err != nil {
+		zapctx.Error(ctx, "failed to get key metadata", zap.Error(err))
+		return errors.E(fmt.Errorf("get key metadata: %w", err))
+	}
+
+	// Check if metadata has been initialised, if it hasn't, we know
+	// this is an older JIMM deployment without the newer graceful rotation implemented.
+	// And we'll pull the old key information into the new format, and set it as active,
+	// with the same ActivatedAt time as the old key.
+	//
+	// Once we know all older deployments should have rotated at least once,
+	// we can remove the legacy migrate and just start with an empty metadata
+	// and set the defaults gor grace, rotate, and token TTL.
+	if !metadataInitialised(&meta) {
+		if err := migrateFromLegacyKeys(ctx, credStore, &meta, p.RotationInterval, p.GracePeriod, p.MaxTokenLifetime); err != nil {
+			zapctx.Error(ctx, "failed to migrate legacy keys", zap.Error(err))
+			return errors.E(fmt.Errorf("migrate legacy keys: %w", err))
+		}
+	}
+
+	// Retire keys that have expired.
+	retireExpiredKeys(&meta, now)
+
+	// Promote any keys that were previously set to preactive.
+	promotePreActiveKey(&meta, now)
+
+	// Generate a preactive key if rotation has passed.
+	if needsRotation(&meta, now) {
+		if err := generatePreActiveKey(&meta, now); err != nil {
+			return errors.E(fmt.Errorf("generate pre-active key: %w", err))
+		}
+	}
+
+	// Update metadata.
+	if err := credStore.PutKeyMetadata(ctx, meta); err != nil {
+		return errors.E(fmt.Errorf("put key metadata: %w", err))
+	}
+
+	zapctx.Debug(ctx,
+		"key rotation cycle complete",
+		zap.String("active_kid", meta.CurrentActiveKID),
+		zap.Int("total_keys", len(meta.Keys)),
+	)
+
+	return nil
+}
+
+// migrateFromLegacyKeys reads the existing JWKS and private key from legacy storage
+// and converts them to the new KeyMetadata format.
+func migrateFromLegacyKeys(
+	ctx context.Context,
+	credStore CredentialStore,
+	meta *vault.KeyMetadata,
+	defaultRotationInterval,
+	defaultGracePeriod,
+	defaultMaxTokenLifetime time.Duration,
+) error {
+	// Get old JWKS
+	legacyJWKS, err := credStore.GetJWKS(ctx)
+	if err != nil {
+		// No legacy JWKS yet, this is truly first initialisation
+		// Not the best place to put this, but we need to know
+		// if there's an old JWKS.
+		zapctx.Debug(ctx, "no legacy JWKS found, starting fresh")
+		meta.RotationInterval = defaultRotationInterval
+		meta.GracePeriod = defaultGracePeriod
+		meta.MaxTokenLifetime = defaultMaxTokenLifetime
+		if err := generateActiveKey(meta, time.Now()); err != nil {
+			return errors.E(fmt.Errorf("generate initial active key: %w", err))
+		}
+		return nil
+	}
+
+	// Read legacy private key
+	legacyPrivateKey, err := credStore.GetJWKSPrivateKey(ctx)
+	if err != nil {
+		return errors.E(fmt.Errorf("get legacy private key: %w", err))
+	}
+
+	// Extract KID from the legacy JWKS
+	keys := legacyJWKS.Keys(ctx)
+	if !keys.Next(ctx) {
+		return errors.E("legacy JWKS has no keys")
+	}
+
+	legacyKey := keys.Pair().Value.(jwk.Key)
+
+	kid, ok := legacyKey.Get(jwk.KeyIDKey)
+	if !ok {
+		kid = uuid.New().String() // Generate KID if not present
+	}
+	kidStr := fmt.Sprintf("%v", kid)
+
+	// Convert legacy key to PublicJWK format using JSON marshalling
+	buf, err := json.Marshal(legacyKey)
+	if err != nil {
+		return errors.E(fmt.Errorf("marshal legacy public key: %w", err))
+	}
+
+	// Create KeyInfo from legacy key
+	now := time.Now()
+	keyInfo := vault.KeyInfo{
+		KID:         kidStr,
+		PrivateKey:  string(legacyPrivateKey),
+		PublicJWK:   string(buf),
+		ActivatedAt: &now, // Mark as activated now
+	}
+
+	meta.Keys = []vault.KeyInfo{keyInfo}
+	meta.CurrentActiveKID = kidStr
+	meta.RotationInterval = defaultRotationInterval
+	meta.GracePeriod = defaultGracePeriod
+	meta.MaxTokenLifetime = defaultMaxTokenLifetime
+
+	zapctx.Debug(ctx, "migrated legacy key to metadata",
+		zap.String("kid", kidStr))
+
+	return nil
+}
+
+// metadataInitialised checks if metadata has been populated (has an active key).
+func metadataInitialised(meta *vault.KeyMetadata) bool {
+	// If this is first pass, we may have a pregenerated key, but it isn't set to active yet.
+	return meta.CurrentActiveKID != "" || len(meta.Keys) > 0
+}
+
+// retireExpiredKeys removes keys that are fully expired (past MaxTokenLifetime + GracePeriod).
+// These keys can no longer be used for signing or verification.
+func retireExpiredKeys(meta *vault.KeyMetadata, now time.Time) {
+	var activeKeys []vault.KeyInfo
+
+	for _, k := range meta.Keys {
+		// We know it is an active key.
+		if k.ActivatedAt != nil {
+
+			// Expiry is when it was activated + a max jwt + grace.
+			expiry := k.ActivatedAt.Add(meta.MaxTokenLifetime + meta.GracePeriod)
+
+			// At this point we know it is definitely safe to remove, so skip over it and
+			// exclude it from this metadata update.
+			if now.After(expiry) {
+				zapctx.Debug(
+					context.Background(),
+					"removing fully expired key",
+					zap.String("kid", k.KID),
+				)
+				continue
+			}
+		}
+
+		// These keys are active, or preactive, and safe to keep for now.
+		activeKeys = append(activeKeys, k)
+	}
+
+	meta.Keys = activeKeys
+}
+
+// promotePreActiveKey finds a pre-active key whose ActivatedAt <= now and makes it active.
+// Only one key is promoted per call.
+//
+// These keys are generated in a later step under generatePreActiveKey after a needsRotation check.
+func promotePreActiveKey(meta *vault.KeyMetadata, now time.Time) {
+	for i := range meta.Keys {
+		k := &meta.Keys[i]
+
+		// Key is acive.
+		if k.KID == meta.CurrentActiveKID {
+			continue
+		}
+
+		// Skip if not yet scheduled for activation.
+		// k.ActivatedAt.After includes the grace period, so we won't activate it until
+		// the grace has arrived.
+		if k.ActivatedAt == nil || k.ActivatedAt.After(now) {
+			continue
+		}
+
+		meta.CurrentActiveKID = k.KID
+
+		zapctx.Debug(
+			context.Background(),
+			"promoting pre-active key to active",
+			zap.String("kid", k.KID),
+		)
+
+		break
+	}
+}
+
+// needsRotation checks if the current active key is past its rotation deadline.
+func needsRotation(meta *vault.KeyMetadata, now time.Time) bool {
+	// If a pre-active key is already queued for future activation, do not create another.
+	// This should only happen during initialisation.
+	if hasPendingPreActiveKey(meta, now) {
+		return false
+	}
+
+	// No active key yet: only rotate if there are no keys at all.
+	// This avoids generating many pre-active keys while waiting for grace period.
+	if meta.CurrentActiveKID == "" {
+		return len(meta.Keys) == 0
+	}
+
+	// Find the active key and check if it's past the rotation deadline.
+	for _, k := range meta.Keys {
+		if k.KID == meta.CurrentActiveKID && k.ActivatedAt != nil {
+			rotationDeadline := k.ActivatedAt.Add(meta.RotationInterval)
+			return now.After(rotationDeadline)
+		}
+	}
+
+	// No active key found, so we should rotate to create one.
+	return true
+}
+
+// hasPendingPreActiveKey checks if there is a non active key with an ActivatedAt in the future.
+func hasPendingPreActiveKey(meta *vault.KeyMetadata, now time.Time) bool {
+	for _, k := range meta.Keys {
+		if k.KID == meta.CurrentActiveKID {
+			continue
+		}
+		if k.ActivatedAt != nil && k.ActivatedAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// generatePreActiveKey creates a new key with ActivatedAt = now + GracePeriod.
+func generatePreActiveKey(meta *vault.KeyMetadata, now time.Time) error {
+	activationTime := now.Add(meta.GracePeriod)
+	newKey, err := generateJWKvv2(activationTime)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	meta.Keys = append(meta.Keys, newKey)
+
+	zapctx.Debug(
+		context.Background(),
+		"generated new pre-active key",
+		zap.String("kid", newKey.KID),
+		zap.Time("activation_time", activationTime),
+	)
+
+	return nil
+}
+
+// generateActiveKey creates and sets a key as the current active key immediately.
+// This is for first time initialisation.
+func generateActiveKey(meta *vault.KeyMetadata, now time.Time) error {
+	newKey, err := generateJWKvv2(now)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	meta.Keys = append(meta.Keys, newKey)
+	meta.CurrentActiveKID = newKey.KID
+
+	zapctx.Debug(
+		context.Background(),
+		"generated new active key",
+		zap.String("kid", newKey.KID),
+		zap.Time("activation_time", now),
+	)
+
+	return nil
+}
+
+func generateJWKvv2(activationTime time.Time) (vault.KeyInfo, error) {
+	// Generate RSA key
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+
+	privPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+
+	pubJWK, err := jwk.FromRaw(priv.PublicKey)
+	if err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+
+	kid := uuid.New().String()
+	if err := pubJWK.Set(jwk.KeyIDKey, kid); err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+	if err := pubJWK.Set(jwk.KeyUsageKey, "sig"); err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+	if err := pubJWK.Set(jwk.AlgorithmKey, jwa.RS256); err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+
+	pubJWKJSON, err := json.Marshal(pubJWK)
+	if err != nil {
+		return vault.KeyInfo{}, errors.E(err)
+	}
+
+	newKey := vault.KeyInfo{
+		KID:         kid,
+		PrivateKey:  string(privPEM),
+		PublicJWK:   string(pubJWKJSON),
+		ActivatedAt: &activationTime,
+	}
+
+	return newKey, nil
+}
+
+// buildPublishableJWKS constructs a jwk.Set from metadata, including only publishable keys.
+func buildPublishableJWKS(meta *vault.KeyMetadata, now time.Time) (jwk.Set, error) {
+	ks := jwk.NewSet()
+
+	for _, k := range meta.Keys {
+		if !isKeyStillPublishable(&k, meta, now) {
+			continue
+		}
+
+		key, err := jwk.ParseKey([]byte(k.PublicJWK))
+		if err != nil {
+			zapctx.Warn(context.Background(), "failed to parse public key",
+				zap.String("kid", k.KID),
+				zap.Error(err))
+			continue
+		}
+
+		if err := ks.AddKey(key); err != nil {
+			zapctx.Warn(context.Background(), "failed to add key to JWKS",
+				zap.String("kid", k.KID),
+				zap.Error(err))
+			continue
+		}
+	}
+
+	return ks, nil
+}
+
+// isKeyStillPublishable checks if a key should be included in our JWKS endpoint response.
+func isKeyStillPublishable(k *vault.KeyInfo, meta *vault.KeyMetadata, now time.Time) bool {
+	if k.ActivatedAt == nil {
+		// Shouldn't happen.
+		return true
+	}
+
+	// For activated keys, check if still within the safe window
+	expiry := k.ActivatedAt.Add(meta.MaxTokenLifetime + meta.GracePeriod)
+	return now.Before(expiry)
+}
+
+func getActiveJWKSigningKey(ctx context.Context, meta *vault.KeyMetadata) ([]byte, error) {
+	for _, k := range meta.Keys {
+		if k.KID == meta.CurrentActiveKID {
+			return []byte(k.PrivateKey), nil
+		}
+	}
+	return nil, errors.E("no active key found")
 }

--- a/internal/jimmjwx/jwks_test.go
+++ b/internal/jimmjwx/jwks_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	qt "github.com/frankban/quicktest"
@@ -95,4 +96,121 @@ func TestStartJWKSRotatorRotatesAJWKS(t *testing.T) {
 			break
 		}
 	}
+}
+
+func TestStartJWKSRotatorV2_InitialisesFromLegacy(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	store := setupCredentialStore(ctx, c)
+	err := store.CleanupJWKS(ctx)
+	c.Assert(err, qt.IsNil)
+
+	legacyJWKS, legacyPrivateKey, err := jimmjwx.GenerateJWK(ctx)
+	c.Assert(err, qt.IsNil)
+
+	err = store.PutJWKS(ctx, legacyJWKS)
+	c.Assert(err, qt.IsNil)
+	err = store.PutJWKSPrivateKey(ctx, legacyPrivateKey)
+	c.Assert(err, qt.IsNil)
+
+	legacyKey, ok := legacyJWKS.Key(0)
+	c.Assert(ok, qt.IsTrue)
+
+	svc := jimmjwx.NewJWKSService(store)
+	err = svc.StartJWKSRotatorV2(ctx, jimmjwx.StartJWKSRotatorParams{
+		CheckRotateRequired: make(chan time.Time),
+		RotationInterval:    24 * time.Hour,
+		GracePeriod:         15 * time.Minute,
+		MaxTokenLifetime:    time.Hour,
+	})
+	c.Assert(err, qt.IsNil)
+
+	meta, err := store.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(meta.CurrentActiveKID, qt.Equals, legacyKey.KeyID())
+	c.Assert(meta.Keys, qt.HasLen, 1)
+	c.Assert(meta.Keys[0].KID, qt.Equals, legacyKey.KeyID())
+	c.Assert(meta.Keys[0].PrivateKey, qt.Equals, string(legacyPrivateKey))
+	c.Assert(meta.Keys[0].ActivatedAt, qt.IsNotNil)
+}
+
+// This test tests the rotator from an empty state, into a full rotation verifying that the grace
+// period is honoured.
+func TestStartJWKSRotatorV2_FullRunFromUninitialised(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := qt.New(t)
+		ctx, cancelCtx := context.WithCancel(context.Background())
+		defer cancelCtx()
+
+		store := setupCredentialStore(ctx, c)
+
+		svc := jimmjwx.NewJWKSService(store)
+		checkRotateRequired := make(chan time.Time, 1)
+		p := jimmjwx.StartJWKSRotatorParams{
+			CheckRotateRequired: checkRotateRequired,
+			RotationInterval:    24 * time.Hour,
+			GracePeriod:         15 * time.Minute,
+			// Keep old key publishable beyond rotation interval so we can observe
+			// old(active)+new(pre-active) overlap.
+			MaxTokenLifetime: 48 * time.Hour,
+		}
+		err := svc.StartJWKSRotatorV2(ctx, p)
+		c.Assert(err, qt.IsNil)
+
+		// Fresh init should create one key and make it active immediately.
+		meta, err := store.GetKeyMetadata(ctx)
+		c.Assert(err, qt.IsNil)
+		// Expect just the one.
+		c.Assert(meta.Keys, qt.HasLen, 1)
+		// And it is active and good to go.
+		c.Assert(meta.CurrentActiveKID, qt.Equals, meta.Keys[0].KID)
+		c.Assert(meta.Keys[0].KID, qt.Not(qt.Equals), "")
+		c.Assert(meta.Keys[0].PrivateKey, qt.Contains, "BEGIN RSA PRIVATE KEY")
+		c.Assert(meta.Keys[0].PublicJWK, qt.Not(qt.Equals), "")
+		c.Assert(meta.Keys[0].ActivatedAt, qt.IsNotNil)
+		c.Assert(meta.RotationInterval, qt.Equals, 24*time.Hour)
+		c.Assert(meta.GracePeriod, qt.Equals, 15*time.Minute)
+		c.Assert(meta.MaxTokenLifetime, qt.Equals, 48*time.Hour)
+
+		ogKID := meta.CurrentActiveKID
+
+		// Now we fast forward over the rotation period, but before the next key is set active. (grace peroiod)
+		time.Sleep(p.RotationInterval + time.Second)
+		checkRotateRequired <- time.Now()
+		synctest.Wait()
+
+		meta, err = store.GetKeyMetadata(ctx)
+		c.Assert(err, qt.IsNil)
+		// We should have two keys now, one active and one preactive and we expect
+		// the OG key to be the active one still, as we are in the grace period.
+		c.Assert(meta.Keys, qt.HasLen, 2)
+		c.Assert(meta.CurrentActiveKID, qt.Equals, ogKID)
+
+		expectedNewActiveKID := ""
+		// Retrieve the preactive key to check it is defo the active key after retirement.
+		for _, key := range meta.Keys {
+			if key.KID != ogKID {
+				expectedNewActiveKID = key.KID
+				break
+			}
+		}
+
+		// Now wefast forward to just after the original key expiry (ActivatedAt + max token lifetime + grace).
+		// We subtract the first jump we already did, and add a small epsilon so retirement condition is strictly true.
+		// This avoids usovershooting into another rotation window.
+		// For reference: (24hr + 15m) - (24hr + 1s) + 500ms = 14m59s500ms, and we jumped rotate +1second.
+		// As such we're 500ms after the retirement condition is satisfied, but not so far as to have triggered another rotation window.
+		secondJump := (p.MaxTokenLifetime + p.GracePeriod) - (p.RotationInterval + time.Second) + 500*time.Millisecond
+		time.Sleep(secondJump)
+		checkRotateRequired <- time.Now()
+		synctest.Wait()
+
+		meta, err = store.GetKeyMetadata(ctx)
+		c.Assert(err, qt.IsNil)
+		// We should have just the one key now, and it should be the new one.
+		c.Assert(meta.Keys, qt.HasLen, 1)
+		c.Assert(meta.CurrentActiveKID, qt.Equals, expectedNewActiveKID)
+	})
 }

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/vault"
 )
 
 type controllerCredentials struct {
@@ -26,6 +27,7 @@ type InMemoryCredentialStore struct {
 	jwks                      jwk.Set
 	privateKey                []byte
 	expiry                    time.Time
+	keyMetadata               vault.KeyMetadata
 	oauthKey                  []byte
 	oauthSessionStoreSecret   []byte
 	controllerCredentials     map[string]controllerCredentials
@@ -188,5 +190,23 @@ func (s *InMemoryCredentialStore) PutJWKSExpiry(ctx context.Context, expiry time
 
 	s.expiry = expiry
 
+	return nil
+}
+
+// GetKeyMetadata retrieves the key metadata from the store.
+func (s *InMemoryCredentialStore) GetKeyMetadata(ctx context.Context) (vault.KeyMetadata, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return the stored metadata, or empty if not set
+	return s.keyMetadata, nil
+}
+
+// PutKeyMetadata stores the key metadata in the store.
+func (s *InMemoryCredentialStore) PutKeyMetadata(ctx context.Context, metadata vault.KeyMetadata) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.keyMetadata = metadata
 	return nil
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -32,8 +32,50 @@ const (
 	jwksKey        = "jwks"
 	jwksExpiryKey  = "jwks-expiry"
 	jwksPrivateKey = "jwks-private"
-	oAuthSecretKey = "oauth-secret"
 )
+
+// KeyInfo represents a single signing key and its lifecycle metadata.
+type KeyInfo struct {
+	// KID is the unique identifier for this key.
+	KID string `json:"kid"`
+
+	// PrivateKey is the private key material (PEM, PKCS8, etc.).
+	// Only populated for the active key; other keys have this empty to reduce exposure.
+	PrivateKey string `json:"private_key_pem,omitempty"`
+
+	// PublicJWK is the JSON Web Key representation of the public key.
+	// Used to publish to the JWKS endpoint so clients can verify tokens.
+	PublicJWK string `json:"public_jwk"`
+
+	// ActivatedAt is the timestamp when the key became active for signing.
+	// Pre-active keys have nil (not yet signing).
+	// All other state (retired, deleted) is derived from ActivatedAt, MaxTokenLifetime, and GracePeriod.
+	ActivatedAt *time.Time `json:"activated_at,omitempty"`
+}
+
+// KeyMetadata is the single Vault blob representing all keys and rotation policy.
+type KeyMetadata struct {
+	// Keys contains all signing keys in the system.
+	// New keys are appended; old keys are removed only after they're beyond MaxTokenLifetime + GracePeriod.
+	Keys []KeyInfo `json:"keys"`
+
+	// CurrentActiveKID points to the key currently used for signing tokens.
+	CurrentActiveKID string `json:"current_active_kid"`
+
+	// RotationInterval is the duration between consecutive key rotations.
+	// Rotation is triggered when: now >= activeKey.ActivatedAt + RotationInterval
+	RotationInterval time.Duration `json:"rotation_interval"`
+
+	// GracePeriod is the duration a pre-active key sits in JWKS before activation.
+	// Pre-active keys: ActivatedAt is in the future. Once ActivatedAt <= now, the key can be promoted to active.
+	// For a key to be publishable to JWKS: must be before its ActivatedAt + MaxTokenLifetime + GracePeriod deadline.
+	GracePeriod time.Duration `json:"grace_period"`
+
+	// MaxTokenLifetime is the maximum lifespan of any issued token.
+	// Retired keys must remain available for verification until MaxTokenLifetime has passed since ActivatedAt.
+	// Safe to delete once: now >= key.ActivatedAt + MaxTokenLifetime + GracePeriod
+	MaxTokenLifetime time.Duration `json:"max_token_lifetime"`
+}
 
 // A VaultStore stores cloud credential attributes and
 // controller credentials in vault.
@@ -411,6 +453,75 @@ func (s *VaultStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err e
 	return nil
 }
 
+// GetKeyMetadata retrieves the key metadata from the vault.
+func (s *VaultStore) GetKeyMetadata(ctx context.Context) (_ KeyMetadata, err error) {
+	const op = "vault.GetKeyMetadata"
+
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
+
+	client, err := s.client(ctx)
+	if err != nil {
+		return KeyMetadata{}, errors.E(err)
+	}
+
+	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getKeyMetadataPath())
+	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+		return KeyMetadata{}, errors.E(err)
+	}
+
+	// Return zero value if not found, caller should handle empty state
+	if secret == nil || secret.Data == nil {
+		return KeyMetadata{}, nil
+	}
+
+	// Vault KVv2 stores everything as map[string]interface{}
+	// We need to convert it back to our struct
+	metadataJSON, err := json.Marshal(secret.Data)
+	if err != nil {
+		return KeyMetadata{}, errors.E(err)
+	}
+
+	var metadata KeyMetadata
+	if err := json.Unmarshal(metadataJSON, &metadata); err != nil {
+		return KeyMetadata{}, errors.E(err)
+	}
+
+	return metadata, nil
+}
+
+// PutKeyMetadata stores the key metadata in the vault.
+func (s *VaultStore) PutKeyMetadata(ctx context.Context, metadata KeyMetadata) (err error) {
+	const op = "vault.PutKeyMetadata"
+
+	durationObserver := servermon.DurationObserver(servermon.VaultCallDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.VaultCallErrorCount, &err, op)
+
+	client, err := s.client(ctx)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	// Convert struct to map for vault storage
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return errors.E(err)
+	}
+
+	var dataMap map[string]interface{}
+	if err := json.Unmarshal(metadataJSON, &dataMap); err != nil {
+		return errors.E(err)
+	}
+
+	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getKeyMetadataPath(), dataMap); err != nil {
+		return errors.E(err)
+	}
+
+	return nil
+}
+
 // getWellKnownPath returns a hard coded path to the .well-known credentials.
 func (s *VaultStore) getWellKnownPath() string {
 	return path.Join("creds", ".well-known")
@@ -431,6 +542,11 @@ func (s *VaultStore) getJWKSPrivateKeyPath() string {
 // getJWKSPath returns the path to the jwks expiry secret.
 func (s *VaultStore) getJWKSExpiryPath() string {
 	return path.Join(s.getWellKnownPath(), "jwks-expiry")
+}
+
+// getKeyMetadataPath returns the path to the key metadata secret.
+func (s *VaultStore) getKeyMetadataPath() string {
+	return path.Join(s.getWellKnownPath(), "key-metadata")
 }
 
 // deleteControllerCredentials removes the credentials associated with the controller in

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -184,3 +184,122 @@ func TestGetAndPutJWKSPrivateKey(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(keyPem), qt.Contains, "-----BEGIN RSA PRIVATE KEY-----")
 }
+func TestGetKeyMetadataEmpty(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	store := newStore(c)
+
+	metadata, err := store.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+	// Should return zero value when not set
+	c.Assert(metadata.Keys, qt.HasLen, 0)
+	c.Assert(metadata.CurrentActiveKID, qt.Equals, "")
+}
+
+func TestPutAndGetKeyMetadata(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	store := newStore(c)
+
+	now := time.Now()
+	activeAt := now.Add(-1 * time.Hour)
+	preActiveAt := now.Add(30 * time.Minute)
+	oldAt := now.Add(-100 * time.Hour)
+
+	metadata := vault.KeyMetadata{
+		Keys: []vault.KeyInfo{
+			{
+				KID:         "key-1",
+				PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+				PublicJWK:   `{"kty":"RSA","kid":"key-1"}`,
+				ActivatedAt: &activeAt,
+			},
+			{
+				KID:         "key-2",
+				PrivateKey:  "",
+				PublicJWK:   `{"kty":"RSA","kid":"key-2"}`,
+				ActivatedAt: &preActiveAt,
+			},
+			{
+				KID:         "key-0",
+				PrivateKey:  "",
+				PublicJWK:   `{"kty":"RSA","kid":"key-0"}`,
+				ActivatedAt: &oldAt,
+			},
+		},
+		CurrentActiveKID: "key-1",
+		MaxTokenLifetime: 1 * time.Hour,
+		GracePeriod:      15 * time.Minute,
+		RotationInterval: 2160 * time.Hour, // 90 days
+	}
+
+	err := store.PutKeyMetadata(ctx, metadata)
+	c.Assert(err, qt.IsNil)
+
+	retrieved, err := store.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(retrieved.CurrentActiveKID, qt.Equals, "key-1")
+	c.Assert(retrieved.Keys, qt.HasLen, 3)
+	c.Assert(retrieved.Keys[0].KID, qt.Equals, "key-1")
+	c.Assert(retrieved.Keys[0].ActivatedAt, qt.IsNotNil)
+	c.Assert(retrieved.Keys[1].KID, qt.Equals, "key-2")
+	c.Assert(retrieved.Keys[2].KID, qt.Equals, "key-0")
+	c.Assert(retrieved.Keys[2].ActivatedAt, qt.IsNotNil)
+	c.Assert(retrieved.MaxTokenLifetime, qt.Equals, 1*time.Hour)
+	c.Assert(retrieved.GracePeriod, qt.Equals, 15*time.Minute)
+	c.Assert(retrieved.RotationInterval, qt.Equals, 2160*time.Hour)
+}
+
+func TestUpdateKeyMetadata(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	store := newStore(c)
+
+	now := time.Now()
+	activeAt := now
+	preActiveAt := now.Add(1 * time.Hour)
+
+	initial := vault.KeyMetadata{
+		Keys: []vault.KeyInfo{
+			{
+				KID:         "key-1",
+				PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+				PublicJWK:   `{"kty":"RSA","kid":"key-1"}`,
+				ActivatedAt: &activeAt,
+			},
+		},
+		CurrentActiveKID: "key-1",
+		MaxTokenLifetime: 1 * time.Hour,
+		GracePeriod:      15 * time.Minute,
+		RotationInterval: 2160 * time.Hour,
+	}
+
+	err := store.PutKeyMetadata(ctx, initial)
+	c.Assert(err, qt.IsNil)
+
+	// Retrieve and modify.
+	retrieved, err := store.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// Add newww key as preactive (ActivatedAt is in the future).
+	retrieved.Keys = append(retrieved.Keys, vault.KeyInfo{
+		KID:         "key-2",
+		PrivateKey:  "",
+		PublicJWK:   `{"kty":"RSA","kid":"key-2"}`,
+		ActivatedAt: &preActiveAt,
+	})
+
+	err = store.PutKeyMetadata(ctx, retrieved)
+	c.Assert(err, qt.IsNil)
+
+	// Verify changes persisted
+	final, err := store.GetKeyMetadata(ctx)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(final.Keys, qt.HasLen, 2)
+	c.Assert(final.Keys[0].KID, qt.Equals, "key-1")
+	c.Assert(final.Keys[1].KID, qt.Equals, "key-2")
+	c.Assert(final.Keys[1].ActivatedAt, qt.IsNotNil)
+	// key-2's ActivatedAt is in the future, so it's pre-active
+}


### PR DESCRIPTION
## Description
We have an issue in our current implementation where we immediately rotate the key, this is problematic as any controller's out there with the previous JWK cached will be unable to verify the authenticity of newer JWTs until the cache control TTL elapses. 

This is the first phase in a multiphase piece of work to rewrite our JWKS generation, rotation, and presentation. 
This PR is heavily inspired by the ideas explained [here](https://engineering.zalando.com/posts/2025/01/automated-json-web-key-rotation.html).

We now support rotating with a grace period between the N sets, dependent on the grace period configuration.

This PR specifically is purely the state machine and does not include the JWT generation not is it plugged it into JIMM yet.

I've additionally moved old rotate func up in the jwk file so that you can read only from the v2 for an easier review. (See my comment in jwks.go)

This implements:
- Implements V2 JWKS rotation state machine with metadata persistence and legacy migration.
- Ensures fresh installs create an active key immediately & & rotations use pre-active + grace overlap.
- Adds rotation tests using), with deterministic timing so we can be pretty sure this is sound (synctest)
- Crash tolerance (due to the metadata retrieval at each rotate)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


