### PR TITLE
fix: handle scenarios with nil machine info

### DIFF
--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -271,13 +271,9 @@ func toModelInfo(modelInfo base.ModelInfo) jujuparams.ModelInfo {
 		})
 	}
 	for _, machine := range modelInfo.Machines {
-		mi.Machines = append(mi.Machines, jujuparams.ModelMachineInfo{
-			Id:          machine.Id,
-			InstanceId:  machine.InstanceId,
-			DisplayName: machine.DisplayName,
-			Status:      machine.Status,
-			Message:     machine.Message,
-			Hardware: &jujuparams.MachineHardware{
+		hardwareInfo := &jujuparams.MachineHardware{}
+		if machine.Hardware != nil {
+			hardwareInfo = &jujuparams.MachineHardware{
 				Arch:             machine.Hardware.Arch,
 				Cores:            machine.Hardware.CpuCores,
 				Mem:              machine.Hardware.Mem,
@@ -286,10 +282,18 @@ func toModelInfo(modelInfo base.ModelInfo) jujuparams.ModelInfo {
 				Tags:             machine.Hardware.Tags,
 				AvailabilityZone: machine.Hardware.AvailabilityZone,
 				VirtType:         machine.Hardware.VirtType,
-			},
-			HAPrimary: machine.HAPrimary,
-			HasVote:   machine.HasVote,
-			WantsVote: machine.WantsVote,
+			}
+		}
+		mi.Machines = append(mi.Machines, jujuparams.ModelMachineInfo{
+			Id:          machine.Id,
+			InstanceId:  machine.InstanceId,
+			DisplayName: machine.DisplayName,
+			Status:      machine.Status,
+			Message:     machine.Message,
+			Hardware:    hardwareInfo,
+			HAPrimary:   machine.HAPrimary,
+			HasVote:     machine.HasVote,
+			WantsVote:   machine.WantsVote,
 		})
 	}
 	return mi

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -4,13 +4,20 @@ package jujuapi
 
 import (
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/life"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jujuclient"
 )
 
 func TestModelCreateArgs(t *testing.T) {
@@ -116,4 +123,243 @@ func TestModelCreateArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToModelInfo(t *testing.T) {
+	c := qt.New(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	lastConnection := now.Add(-5 * time.Minute)
+	arch := "amd64"
+	cores := uint64(8)
+	mem := uint64(16384)
+	rootDisk := uint64(512000)
+	cpuPower := uint64(4000)
+	availabilityZone := "eu-west-1a"
+	virtType := "kvm"
+	tags := []string{"tag1", "tag2"}
+	haPrimary := true
+	hasVote := true
+	wantsVote := true
+	agentVersion := version.MustParse("3.6.0")
+
+	modelInfo := base.ModelInfo{
+		Name:            "test-model",
+		UUID:            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		ControllerUUID:  "11111111-2222-3333-4444-555555555555",
+		IsController:    false,
+		Type:            "iaas",
+		DefaultSeries:   "jammy",
+		Cloud:           "aws",
+		CloudRegion:     "eu-west-1",
+		CloudCredential: "aws/alice@canonical.com/main-cred",
+		Owner:           "alice@canonical.com",
+		Life:            life.Value("alive"),
+		ProviderType:    "ec2",
+		AgentVersion:    &agentVersion,
+		Status: base.Status{
+			Status: "available",
+			Info:   "ready",
+			Data: map[string]any{
+				"k": "v",
+			},
+			Since: &now,
+		},
+		Users: []base.UserInfo{{
+			UserName:       "alice@canonical.com",
+			DisplayName:    "Alice",
+			Access:         "admin",
+			LastConnection: &lastConnection,
+		}},
+		Machines: []base.Machine{{
+			Id:          "0",
+			InstanceId:  "i-000001",
+			DisplayName: "machine-0",
+			Status:      "running",
+			Message:     "ok",
+			HAPrimary:   &haPrimary,
+			HasVote:     hasVote,
+			WantsVote:   wantsVote,
+			Hardware: &instance.HardwareCharacteristics{
+				Arch:             &arch,
+				CpuCores:         &cores,
+				Mem:              &mem,
+				RootDisk:         &rootDisk,
+				CpuPower:         &cpuPower,
+				Tags:             &tags,
+				AvailabilityZone: &availabilityZone,
+				VirtType:         &virtType,
+			},
+		}, {
+			Id:          "1",
+			InstanceId:  "i-000002",
+			DisplayName: "machine-1",
+			Status:      "pending",
+			Message:     "provisioning",
+		}},
+	}
+
+	got := toModelInfo(modelInfo)
+
+	c.Assert(got.Name, qt.Equals, modelInfo.Name)
+	c.Assert(got.UUID, qt.Equals, modelInfo.UUID)
+	c.Assert(got.ControllerUUID, qt.Equals, modelInfo.ControllerUUID)
+	c.Assert(got.IsController, qt.Equals, modelInfo.IsController)
+	c.Assert(got.Type, qt.Equals, modelInfo.Type.String())
+	c.Assert(got.DefaultSeries, qt.Equals, modelInfo.DefaultSeries)
+	c.Assert(got.DefaultBase, qt.Equals, modelInfo.DefaultSeries)
+	c.Assert(got.CloudTag, qt.Equals, names.NewCloudTag(modelInfo.Cloud).String())
+	c.Assert(got.CloudRegion, qt.Equals, modelInfo.CloudRegion)
+	c.Assert(got.CloudCredentialTag, qt.Equals, names.NewCloudCredentialTag(modelInfo.CloudCredential).String())
+	c.Assert(got.OwnerTag, qt.Equals, names.NewUserTag(modelInfo.Owner).String())
+	c.Assert(got.Life, qt.Equals, modelInfo.Life)
+	c.Assert(got.ProviderType, qt.Equals, modelInfo.ProviderType)
+	c.Assert(got.AgentVersion, qt.Equals, modelInfo.AgentVersion)
+	c.Assert(got.Status, qt.DeepEquals, jujuparams.EntityStatus{
+		Status: modelInfo.Status.Status,
+		Info:   modelInfo.Status.Info,
+		Data:   modelInfo.Status.Data,
+		Since:  modelInfo.Status.Since,
+	})
+
+	c.Assert(got.Users, qt.DeepEquals, []jujuparams.ModelUserInfo{{
+		UserName:       "alice@canonical.com",
+		DisplayName:    "Alice",
+		LastConnection: &lastConnection,
+		Access:         jujuparams.UserAccessPermission("admin"),
+	}})
+
+	c.Assert(got.Machines, qt.HasLen, 2)
+	c.Assert(got.Machines[0], qt.DeepEquals, jujuparams.ModelMachineInfo{
+		Id:          "0",
+		InstanceId:  "i-000001",
+		DisplayName: "machine-0",
+		Status:      "running",
+		Message:     "ok",
+		Hardware: &jujuparams.MachineHardware{
+			Arch:             &arch,
+			Cores:            &cores,
+			Mem:              &mem,
+			RootDisk:         &rootDisk,
+			CpuPower:         &cpuPower,
+			Tags:             &tags,
+			AvailabilityZone: &availabilityZone,
+			VirtType:         &virtType,
+		},
+		HAPrimary: &haPrimary,
+		HasVote:   hasVote,
+		WantsVote: wantsVote,
+	})
+	c.Assert(got.Machines[1], qt.DeepEquals, jujuparams.ModelMachineInfo{
+		Id:          "1",
+		InstanceId:  "i-000002",
+		DisplayName: "machine-1",
+		Status:      "pending",
+		Message:     "provisioning",
+		Hardware:    &jujuparams.MachineHardware{},
+	})
+}
+
+func TestToModelInfoNilMachineInfo(t *testing.T) {
+	c := qt.New(t)
+
+	modelInfo := base.ModelInfo{
+		Name:            "test-model",
+		Cloud:           "aws",
+		CloudCredential: "aws/alice@canonical.com/main-cred",
+		Owner:           "alice@canonical.com",
+	}
+
+	got := toModelInfo(modelInfo)
+
+	c.Assert(got.Name, qt.Equals, "test-model")
+	c.Assert(got.Machines, qt.IsNil)
+}
+
+func TestToFullModelInfo(t *testing.T) {
+	c := qt.New(t)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	end := start.Add(15 * time.Minute)
+	rotateInterval := 30 * time.Minute
+	validity := true
+	agentVersion := version.MustParse("3.6.0")
+
+	modelInfo := jujuclient.ModelInfo{
+		ModelInfo: base.ModelInfo{
+			Name:            "test-model",
+			UUID:            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			ControllerUUID:  "11111111-2222-3333-4444-555555555555",
+			IsController:    false,
+			Type:            "iaas",
+			DefaultSeries:   "jammy",
+			Cloud:           "aws",
+			CloudRegion:     "eu-west-1",
+			CloudCredential: "aws/alice@canonical.com/main-cred",
+			Owner:           "alice@canonical.com",
+			Life:            life.Value("alive"),
+			ProviderType:    "ec2",
+			AgentVersion:    &agentVersion,
+		},
+		MigrationStatus: &jujuclient.ModelMigrationStatus{
+			Status: "running",
+			Start:  &start,
+			End:    &end,
+		},
+		CloudCredentialValidity: &validity,
+		SupportedFeatures: []jujuclient.SupportedFeature{{
+			Name:        "feature-a",
+			Description: "test feature",
+			Version:     "v1",
+		}},
+		SecretBackends: []jujuclient.SecretBackendResult{{
+			Result: jujuclient.SecretBackend{
+				Name:                "vault",
+				BackendType:         "vault",
+				TokenRotateInterval: &rotateInterval,
+				Config: map[string]interface{}{
+					"endpoint": "https://vault.example.com",
+				},
+			},
+			ID:         "backend-1",
+			NumSecrets: 7,
+			Status:     "available",
+			Message:    "ready",
+			Error:      errors.E("backend warning", errors.CodeBadRequest),
+		}},
+	}
+
+	got := toFullModelInfo(modelInfo)
+
+	c.Assert(got.Name, qt.Equals, modelInfo.Name)
+	c.Assert(got.CloudCredentialValidity, qt.DeepEquals, &validity)
+	c.Assert(got.Migration, qt.DeepEquals, &jujuparams.ModelMigrationStatus{
+		Status: "running",
+		Start:  &start,
+		End:    &end,
+	})
+	c.Assert(got.SupportedFeatures, qt.DeepEquals, []jujuparams.SupportedFeature{{
+		Name:        "feature-a",
+		Description: "test feature",
+		Version:     "v1",
+	}})
+	c.Assert(got.SecretBackends, qt.DeepEquals, []jujuparams.SecretBackendResult{{
+		Result: jujuparams.SecretBackend{
+			Name:                "vault",
+			BackendType:         "vault",
+			TokenRotateInterval: &rotateInterval,
+			Config: map[string]interface{}{
+				"endpoint": "https://vault.example.com",
+			},
+		},
+		ID:         "backend-1",
+		NumSecrets: 7,
+		Status:     "available",
+		Message:    "ready",
+		Error: &jujuparams.Error{
+			Message: "backend warning",
+			Code:    string(errors.CodeBadRequest),
+			Info:    nil,
+		},
+	}})
 }

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -361,13 +361,22 @@ func TestAddControllerCustomTLSHostname(t *testing.T) {
 func TestRemoveController(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	model := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
 	name, conf := s.GetOneControllerConfig(c)
+
+	// Create a model on the controller we are going to remove
+	model := s.CreateModel(c, jimmtest.AddModelArgs{
+		Name:                 petname.Generate(2, "-"),
+		Owner:                names.NewUserTag("bob@canonical.com"),
+		Cloud:                names.NewCloudTag(jimmtest.TestE2ECloudName),
+		Region:               jimmtest.TestE2ECloudRegionName,
+		Cred:                 s.BobCredential.ResourceTag(),
+		TargetControllerName: name,
+	})
 
 	_, err := client.RemoveController(&apiparams.RemoveControllerRequest{
 		Name: name,


### PR DESCRIPTION
## Description
Fixes a panic in the `toModelInfo` function when Juju returns nil for machine info. I previously didn't add unit tests for this mapping function because it's tested in our integration tests but running the Terraform provider tests against the latest JIMM, I saw we were encountering a panic when destroying a model/application. During destruction there seems to be times when the Juju controller reports a `nil` value for machine info, and we were not correctly handling that.

I've now added some unit tests for this case and the successful case.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

