### PR TITLE
refactor: improve error handling/debugging for http proxy

### DIFF
--- a/internal/rpc/httpproxy.go
+++ b/internal/rpc/httpproxy.go
@@ -104,6 +104,11 @@ func ProxyHTTP(ctx context.Context, ctl ConnectionDetails, w http.ResponseWriter
 		},
 		Transport: multiBackendTransport,
 		ErrorLog:  log.New(&proxyErrorLogger{}, "", 0), // flag=0 to avoid printing extra info that zap already gives us
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			zapctx.Error(ctx, "HTTP proxy error", zap.Error(err))
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprintf(w, "proxy error: %v", err)
+		},
 	}
 	proxy.ServeHTTP(w, req)
 }

--- a/internal/rpc/multitransport.go
+++ b/internal/rpc/multitransport.go
@@ -76,15 +76,15 @@ func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, er
 			m.currentURLIndex = (urlIndex + 1) % len(m.urls)
 			return resp, nil
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// If we hit EOF, it likely means that we failed partway through
 			// the request and without the original body of the request
 			// stored, we cannot safely retry.
-			return nil, errors.New("backend failure during request")
+			return nil, fmt.Errorf("backend failure during request: %w", err)
 		}
 
 		// Log the failure and try the next URL
-		zapctx.Debug(context.Background(), "request to backend failed, trying next",
+		zapctx.Error(context.Background(), "request to backend failed, trying next",
 			zap.String("backend", targetURL.String()),
 			zap.Error(err),
 			zap.Int("attempt", i+1),


### PR DESCRIPTION
## Description
This change improves our error handling for our HTTP proxy. Now we set an explicit error handler to return the error to the client. The error reflects the last failure connecting to the backing Juju controller. To improve our ability to debug these situations, I've increased the level of one log line from debug -> error.
