### PR TITLE
fix: http proxy tracking body close

### DIFF
--- a/internal/rpc/multitransport.go
+++ b/internal/rpc/multitransport.go
@@ -33,6 +33,25 @@ type multiBackendTransport struct {
 	currentURLIndex int
 }
 
+// readTrackingNoOpCloserBody wraps an io.ReadCloser to track whether it has been read from
+// and provides a no-op Close method to allow the original request body to be closed separately.
+// This is similar to the stdlib's net/http/transport.go readTrackingBody but adds a no-op closer.
+type readTrackingNoOpCloserBody struct {
+	io.ReadCloser
+	didRead bool
+}
+
+// Read tracks that the body has been read from and delegates to the underlying ReadCloser.
+func (r *readTrackingNoOpCloserBody) Read(data []byte) (int, error) {
+	r.didRead = true
+	return r.ReadCloser.Read(data)
+}
+
+// Close is a no-op to allow the original request body to be closed separately.
+func (r *readTrackingNoOpCloserBody) Close() error {
+	return nil
+}
+
 // newMultiBackendTransport creates a new MultiBackendTransport with the given
 // base transport and URLs.
 func newMultiBackendTransport(baseTransport http.RoundTripper, urls []*url.URL) (*multiBackendTransport, error) {
@@ -50,6 +69,18 @@ func newMultiBackendTransport(baseTransport http.RoundTripper, urls []*url.URL) 
 func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var lastErr error
 
+	// Track the original request body to determine if we can safely retry on failure
+	trackedRequest := req
+	var trackedBody *readTrackingNoOpCloserBody
+	if req.Body != nil {
+		// We do not close the original request body, this is done
+		// by the HTTP server that accepts the request, see the godoc
+		// for the http.Request Body field.
+		trackedBody = &readTrackingNoOpCloserBody{ReadCloser: req.Body}
+		trackedRequest = req.Clone(req.Context())
+		trackedRequest.Body = trackedBody
+	}
+
 	// Try each URL in succession
 	for i := 0; i < len(m.urls); i++ {
 		// Calculate the URL index to try (round-robin starting from currentURLIndex)
@@ -57,7 +88,7 @@ func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, er
 		targetURL := m.urls[urlIndex]
 
 		// Clone the request to avoid modifying the original
-		clonedReq := req.Clone(req.Context())
+		clonedReq := trackedRequest.Clone(trackedRequest.Context())
 		clonedReq.URL.Scheme = targetURL.Scheme
 		clonedReq.URL.Host = targetURL.Host
 		newPath, err := url.JoinPath("/", targetURL.Path, clonedReq.URL.Path)
@@ -76,11 +107,9 @@ func (m *multiBackendTransport) RoundTrip(req *http.Request) (*http.Response, er
 			m.currentURLIndex = (urlIndex + 1) % len(m.urls)
 			return resp, nil
 		}
-		if errors.Is(err, io.EOF) {
-			// If we hit EOF, it likely means that we failed partway through
-			// the request and without the original body of the request
-			// stored, we cannot safely retry.
-			return nil, fmt.Errorf("backend failure during request: %w", err)
+		if trackedBody != nil && trackedBody.didRead {
+			// If we've read from the body we've lost some data and cannot retry, so return the error.
+			return nil, fmt.Errorf("non-retryable backend failure during request: %w", err)
 		}
 
 		// Log the failure and try the next URL

--- a/internal/rpc/multitransport_test.go
+++ b/internal/rpc/multitransport_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -16,9 +17,9 @@ import (
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
-// TestMultiBackendTransport tests the multiBackendTransport
-// implementation by simulating various server responses and ensuring
-// that the transport correctly handles them specifically for failover scenarios.
+// TestMultiBackendTransport exercises multiBackendTransport through a
+// reverse proxy by simulating various backend responses and checking the
+// resulting proxy behaviour for failover scenarios.
 func TestMultiBackendTransport(t *testing.T) {
 	c := qt.New(t)
 	expectedBody := "this is the request body"
@@ -56,7 +57,7 @@ func TestMultiBackendTransport(t *testing.T) {
 			http.Error(w, "unexpected number of bytes read from request body", http.StatusInternalServerError)
 			return
 		}
-		panic("foo")
+		panic("intentional panic after partial read")
 	}))
 	defer partialReadServer.Close()
 
@@ -118,22 +119,31 @@ func TestMultiBackendTransport(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.description, func(c *qt.C) {
-			body := strings.NewReader(expectedBody)
-			limitReader := io.LimitReader(body, int64(len(expectedBody))) // Ensure we can only read the data once.
-			req, err := http.NewRequest("POST", test.path, limitReader)
-			c.Assert(err, qt.IsNil)
-
 			transport, err := rpc.NewMultiBackendTransport(http.DefaultTransport, test.urls)
 			c.Assert(err, qt.IsNil)
 
-			resp, err := transport.RoundTrip(req)
+			proxyServer := httptest.NewServer(&httputil.ReverseProxy{
+				Rewrite:   func(pr *httputil.ProxyRequest) {},
+				Transport: transport,
+				ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+					http.Error(w, err.Error(), http.StatusBadGateway)
+				},
+			})
+			defer proxyServer.Close()
+
+			body := strings.NewReader(expectedBody)
+			req, err := http.NewRequest("POST", proxyServer.URL+test.path, body)
+			c.Assert(err, qt.IsNil)
+
+			resp, err := proxyServer.Client().Do(req)
+			c.Assert(err, qt.IsNil)
+			defer resp.Body.Close()
+
 			if test.shouldError {
-				c.Assert(err, qt.IsNotNil)
+				c.Assert(resp.StatusCode, qt.Equals, http.StatusBadGateway)
 				return
 			}
 
-			c.Assert(err, qt.IsNil)
-			defer resp.Body.Close()
 			c.Assert(resp.StatusCode, qt.Equals, test.statusExpected)
 		})
 	}


### PR DESCRIPTION
## Description

This PR aims to fix an issue we've seen in production where the HTTP proxy returns a `invalid Read on closed Body` error when proxying an HTTP request to a controller with multiple addresses. It turns out the tests were not correct, and although we had a test scenario where the 1st address was invalid and the second was working, this didn't reflect the real world. That has now been addressed and the implementation fixed. A full explanation is below.

### The misleading test:
One of the test cases in `TestMultiBackendTransport` tests connecting to an unreachable server, then connecting to a reachable server. This didn't align with production because we were testing the multi-transport method without the context of an HTTP server. We were only calling the multi-transport's `RoundTrip()` method. If you look at the test closely before the changes you'll see the function under test is `transport.RoundTrip(req)`. In `net/http/transport.go`, if the roundtripper fails to connect to the destination it closes the request body,
```go
	pconn, err := t.getConn(treq, cm)
	if err != nil {
		req.closeBody()
		return nil, err
	}
```
Before the changes, this `req` object was the client side request. Below is a snippet from `NewRequestWithContext`,
```go
func NewRequestWithContext(ctx context.Context, method, url string, body io.Reader) (*Request, error) {
	<excluded>
	rc, ok := body.(io.ReadCloser)
	if !ok && body != nil {
		rc = io.NopCloser(body)
	}
```
And here you can see that on the client side, a request is just an io.Reader it is wrapped with a no-op closer. So effectively we would never run into the problem of closing the request's body because with the test setup, `Close()` was a no-op.

While I believe I could have wrapped the `strings.NewReader(expectedBody)` with a closer, I added a real server that runs the `httputil.NewProxy{}` handler. Now we have a realistic scenario with a request from a client -> proxy-server -> backend. And with this setup the test begins to fail with the same error observed in production - "invalid Read on closed Body".

### The fix:

To address the issue we can track whether the body has been read and if it has, respond with the failure. If we haven't read the body yet, we can continue trying other backends.

After making this change, the failing test started working.

Fixes https://github.com/canonical/jimm/issues/1885 and [JUJU-9266](https://warthogs.atlassian.net/browse/JUJU-9266)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9266]: https://warthogs.atlassian.net/browse/JUJU-9266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ