### PR TITLE
Bump migrationtarget modelconfig appoffer facades for 4

### DIFF
--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -28,6 +28,7 @@ func init() {
 		findOffersMethod := rpc.Method(r.FindApplicationOffers)
 		applicationOffersMethod := rpc.Method(r.ApplicationOffers)
 
+		// Juju 3
 		r.AddMethod("ApplicationOffers", 5, "Offer", offerMethod)
 		r.AddMethod("ApplicationOffers", 5, "GetConsumeDetails", getConsumeDetailsMethod)
 		r.AddMethod("ApplicationOffers", 5, "ListApplicationOffers", listOffersMethod)
@@ -36,8 +37,22 @@ func init() {
 		r.AddMethod("ApplicationOffers", 5, "FindApplicationOffers", findOffersMethod)
 		r.AddMethod("ApplicationOffers", 5, "ApplicationOffers", applicationOffersMethod)
 
-		return []int{5}
+		// Juju 4
+		r.AddMethod("ApplicationOffers", 6, "Offer", offerMethod)
+		r.AddMethod("ApplicationOffers", 6, "GetConsumeDetails", getConsumeDetailsMethod)
+		r.AddMethod("ApplicationOffers", 6, "ListApplicationOffers", listOffersMethod)
+		r.AddMethod("ApplicationOffers", 6, "ModifyOfferAccess", modifyOfferAccessMethod)
+		r.AddMethod("ApplicationOffers", 6, "DestroyOffers", destroyOffersMethod)
+		r.AddMethod("ApplicationOffers", 6, "FindApplicationOffers", findOffersMethod)
+		r.AddMethod("ApplicationOffers", 6, "ApplicationOffers", applicationOffersMethod)
+
+		return []int{5, 6}
 	}
+}
+
+// Offer creates a new ApplicationOffer.
+func (r *controllerRoot) OfferV4(ctx context.Context, args jujuparams.AddApplicationOffers) (jujuparams.ErrorResults, error) {
+	return r.Offer(ctx, args)
 }
 
 // Offer creates a new ApplicationOffer.
@@ -73,6 +88,12 @@ func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicati
 		return errors.E(err)
 	}
 	return nil
+}
+
+// GetConsumeDetailsV4 implements the GetConsumeDetails procedure of the
+// ApplicationOffers facade.
+func (r *controllerRoot) GetConsumeDetailsV4(ctx context.Context, args jujuparams.ConsumeOfferDetailsArg) (jujuparams.ConsumeOfferDetailsResults, error) {
+	return r.GetConsumeDetails(ctx, args)
 }
 
 // GetConsumeDetails implements the GetConsumeDetails procedure of the
@@ -123,6 +144,11 @@ func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.Us
 	return details, nil
 }
 
+// ListApplicationOffersV4 returns all offers matching the specified filters.
+func (r *controllerRoot) ListApplicationOffersV4(ctx context.Context, args jujuparams.OfferFilters) (jujuparams.QueryApplicationOffersResultsV5, error) {
+	return r.ListApplicationOffers(ctx, args)
+}
+
 // ListApplicationOffers returns all offers matching the specified filters.
 func (r *controllerRoot) ListApplicationOffers(ctx context.Context, args jujuparams.OfferFilters) (jujuparams.QueryApplicationOffersResultsV5, error) {
 
@@ -136,6 +162,13 @@ func (r *controllerRoot) ListApplicationOffers(ctx context.Context, args jujupar
 	results.Results = offersToParams(offers)
 
 	return results, nil
+}
+
+// FindApplicationOffersV4 returns all offers matching the specified filters
+// as long as the user has read access to each offer. It also omits details
+// on users and connections.
+func (r *controllerRoot) FindApplicationOffersV4(ctx context.Context, args jujuparams.OfferFilters) (jujuparams.QueryApplicationOffersResultsV5, error) {
+	return r.FindApplicationOffers(ctx, args)
 }
 
 // FindApplicationOffers returns all offers matching the specified filters
@@ -153,6 +186,11 @@ func (r *controllerRoot) FindApplicationOffers(ctx context.Context, args jujupar
 	results.Results = offersToParams(offers)
 
 	return results, nil
+}
+
+// ModifyOfferAccessV4 modifies application offer access.
+func (r *controllerRoot) ModifyOfferAccessV4(ctx context.Context, args jujuparams.ModifyOfferAccessRequest) (jujuparams.ErrorResults, error) {
+	return r.ModifyOfferAccess(ctx, args)
 }
 
 // ModifyOfferAccess modifies application offer access.
@@ -189,6 +227,11 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 	}
 }
 
+// DestroyOffersV4 removes specified application offers.
+func (r *controllerRoot) DestroyOffersV4(ctx context.Context, args jujuparams.DestroyApplicationOffers) (jujuparams.ErrorResults, error) {
+	return r.DestroyOffers(ctx, args)
+}
+
 // DestroyOffers removes specified application offers.
 func (r *controllerRoot) DestroyOffers(ctx context.Context, args jujuparams.DestroyApplicationOffers) (jujuparams.ErrorResults, error) {
 	results := jujuparams.ErrorResults{
@@ -199,6 +242,11 @@ func (r *controllerRoot) DestroyOffers(ctx context.Context, args jujuparams.Dest
 		results.Results[i].Error = r.mapError(ctx, r.jimm.JujuManager().DestroyOffer(ctx, r.user, offerURL, args.Force))
 	}
 	return results, nil
+}
+
+// ApplicationOffersV4 returns details of the specified application offers.
+func (r *controllerRoot) ApplicationOffersV4(ctx context.Context, args jujuparams.OfferURLs) (jujuparams.ApplicationOffersResults, error) {
+	return r.ApplicationOffers(ctx, args)
 }
 
 func (r *controllerRoot) ApplicationOffers(ctx context.Context, args jujuparams.OfferURLs) (jujuparams.ApplicationOffersResults, error) {

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -41,6 +41,7 @@ func init() {
 		latestLogTime := rpc.Method(r.LatestLogTime)
 		abort := rpc.Method(r.Abort)
 
+		// Juju 3
 		r.AddMethod("MigrationTarget", 6, "Prechecks", preChecks)
 		r.AddMethod("MigrationTarget", 6, "CACert", caCert)
 		r.AddMethod("MigrationTarget", 6, "Activate", activate)
@@ -50,8 +51,35 @@ func init() {
 		r.AddMethod("MigrationTarget", 6, "Import", importMethod)
 		r.AddMethod("MigrationTarget", 6, "LatestLogTime", latestLogTime)
 
-		return []int{6}
+		// Juju 4
+		r.AddMethod("MigrationTarget", 7, "Prechecks", preChecks)
+		r.AddMethod("MigrationTarget", 7, "CACert", caCert)
+		r.AddMethod("MigrationTarget", 7, "Activate", activate)
+		r.AddMethod("MigrationTarget", 7, "AdoptResources", adoptResources)
+		r.AddMethod("MigrationTarget", 7, "Abort", abort)
+		r.AddMethod("MigrationTarget", 7, "CheckMachines", checkMachines)
+		r.AddMethod("MigrationTarget", 7, "Import", importMethod)
+		r.AddMethod("MigrationTarget", 7, "LatestLogTime", latestLogTime)
+
+		return []int{6, 7}
 	}
+}
+
+// CACert implements the CACert method of the MigrationTarget facade.
+// It is used by the source Juju controller to retrieve the CA cert of
+// the target controller during model migration, if the client did not
+// send a CA cert to the source controller (possible if the controller
+// uses a public CA rather than a self-signed cert).
+//
+// The above is nonsensical because if the source controller can reach
+// the target controller (and because Juju enforces WSS), it already has
+// everything it needs i.e. it either has the self-signed CA cert or it
+// was able to connect thanks to a public CA.
+//
+// However, because the source controller requires this call to be successful,
+// but doesn't actually require the result to have len() > 0, we can return an empty result.
+func (r *controllerRoot) CACertV4() (jujuparams.BytesResult, error) {
+	return r.CACert()
 }
 
 // CACert implements the CACert method of the MigrationTarget facade.
@@ -69,6 +97,10 @@ func init() {
 // but doesn't actually require the result to have len() > 0, we can return an empty result.
 func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 	return jujuparams.BytesResult{}, nil
+}
+
+func (r *controllerRoot) CheckMachinesV4(ctx context.Context, args jujuparams.ModelArgs) (jujuparams.ErrorResults, error) {
+	return r.CheckMachines(ctx, args)
 }
 
 func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.ModelArgs) (jujuparams.ErrorResults, error) {
@@ -98,6 +130,12 @@ func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.Mode
 
 // Abort implements the Abort method of the MigrationTarget facade.
 // It is used by the source Juju controller to abort a model migration.
+func (r *controllerRoot) AbortV4(ctx context.Context, args jujuparams.ModelArgs) error {
+	return r.Abort(ctx, args)
+}
+
+// Abort implements the Abort method of the MigrationTarget facade.
+// It is used by the source Juju controller to abort a model migration.
 func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) error {
 	if !r.user.JimmAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -108,6 +146,15 @@ func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) e
 		return errors.E(err)
 	}
 	return r.jimm.JujuManager().AbortMigration(ctx, r.user, modelTag.Id())
+}
+
+// AdoptResources implements the AdoptResources method of the MigrationTarget facade.
+// It is used by the source Juju controller to update the tags of the
+// resources of a model that has been migrated to a new controller.
+// This prevents the resources from being destroyed if the source controller
+// is destroyed after the model is migrated away.
+func (r *controllerRoot) AdoptResourcesV4(ctx context.Context, args jujuparams.AdoptResourcesArgs) error {
+	return r.AdoptResources(ctx, args)
 }
 
 // AdoptResources implements the AdoptResources method of the MigrationTarget facade.
@@ -130,6 +177,13 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.Ado
 // LatestLogTime implements the LatestLogTime method of the MigrationTarget facade.
 // It is used by the source Juju controller to retrieve the time of the
 // latest log record it has seen.
+func (r *controllerRoot) LatestLogTimeV4(ctx context.Context, args jujuparams.ModelArgs) (time.Time, error) {
+	return r.LatestLogTime(ctx, args)
+}
+
+// LatestLogTime implements the LatestLogTime method of the MigrationTarget facade.
+// It is used by the source Juju controller to retrieve the time of the
+// latest log record it has seen.
 func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.ModelArgs) (time.Time, error) {
 	if !r.user.JimmAdmin {
 		return time.Time{}, errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -145,6 +199,11 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 		return time.Time{}, errors.E(err)
 	}
 	return t, nil
+}
+
+// Prechecks implements the Prechecks method of the MigrationTarget facade.
+func (r *controllerRoot) PrechecksV4(ctx context.Context, args jujuparams.MigrationModelInfo) error {
+	return r.Prechecks(ctx, args)
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.
@@ -172,6 +231,11 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 		return errors.E(err)
 	}
 	return nil
+}
+
+// Activate is the implementation of the Activate method of the MigrationTarget facade.
+func (r *controllerRoot) ActivateV4(ctx context.Context, args jujuparams.ActivateModelArgs) error {
+	return r.Activate(ctx, args)
 }
 
 // Activate is the implementation of the Activate method of the MigrationTarget facade.
@@ -208,6 +272,12 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 		return err
 	}
 	return nil
+}
+
+// Import implements the Import method of the MigrationTarget facade.
+// It imports resources into JIMM and proxies the import request to the target Juju controller.
+func (r *controllerRoot) ImportV4(ctx context.Context, serialized jujuparams.SerializedModel) error {
+	return r.Import(ctx, serialized)
 }
 
 // Import implements the Import method of the MigrationTarget facade.

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -20,7 +20,7 @@ func init() {
 
 		// Juju 4
 		r.AddMethod("ModelConfig", 4, "ModelGet", modelGetMethod)
-		return []int{3}
+		return []int{3, 4}
 	}
 }
 

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -15,9 +15,18 @@ func init() {
 	facadeInit["ModelConfig"] = func(r *controllerRoot) []int {
 		modelGetMethod := rpc.Method(r.ModelGet)
 
+		// Juju 3
 		r.AddMethod("ModelConfig", 3, "ModelGet", modelGetMethod)
+
+		// Juju 4
+		r.AddMethod("ModelConfig", 4, "ModelGet", modelGetMethod)
 		return []int{3}
 	}
+}
+
+// ModelGetV4 returns the model configuration.
+func (r *controllerRoot) ModelGetV4(ctx context.Context) (params.ModelConfigResults, error) {
+	return r.ModelGet(ctx)
 }
 
 // ModelGet returns the model configuration in JIMM's case, this is used to return the "controller" model config.


### PR DESCRIPTION
## Description
Whilst investigating all facade methods in JIMM and checking what is missing in Juju 4. I realised the parameters on these specific methods have not changed. 

We still require ModelManager and Controller to be bumped, but I thougtht we may as well put the work in for these one now as they seem sensible to do.

I've simply just made a "v4" variant of each method, just in case there's ever an implementation change. For now it appears there isn't. 

Facades bumped and why:
- ApplicationOffers (6): [Bumped here](https://github.com/juju/juju/pull/19955) to introduce model qualifiers. Wire wise, we appear OK.
- MigrationTarget (7): [Bumped here](https://github.com/juju/juju/pull/20240/changes#diff-315db6f39093f9f3b2dbe2b788bff266a7ee8f674faabeb889c7a9bee3ae5631), Migration Target 6 was done by @kian99 to handle redirects. However I'm not actually sure why it was bumped to 7 in this case as the reference PRs in the merge forward from 3.6 don't include the migration target to 7. The doc on this PR does state it is to handle model qualifiers though (cosmetic apparently?)
- ModelConfig (4): [Bumped here](https://github.com/juju/juju/pull/18754) Appears to be just when plugging in service & conn to DQLite (possibly migration target (7) is the same ordeal?)