### PR TITLE
feat: add API and domain methods for controller profiles

### DIFF
--- a/internal/db/controllerprofile.go
+++ b/internal/db/controllerprofile.go
@@ -114,8 +114,9 @@ func (d *Database) GetControllerProfile(ctx context.Context, profile *dbmodel.Co
 }
 
 // ListControllerProfiles retrieves all saved controller profiles ordered by
-// name.
-func (d *Database) ListControllerProfiles(ctx context.Context) (_ []dbmodel.ControllerProfile, err error) {
+// name. When jujuVersion is provided, only profiles whose saved juju-version
+// is a prefix of the requested version are returned.
+func (d *Database) ListControllerProfiles(ctx context.Context, jujuVersion string) (_ []dbmodel.ControllerProfile, err error) {
 	const op = "db.ListControllerProfiles"
 	if err := d.ready(); err != nil {
 		return nil, errors.E(err)
@@ -126,7 +127,11 @@ func (d *Database) ListControllerProfiles(ctx context.Context) (_ []dbmodel.Cont
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	var profiles []dbmodel.ControllerProfile
-	if err := d.DB.WithContext(ctx).Order("name asc").Find(&profiles).Error; err != nil {
+	query := d.DB.WithContext(ctx).Order("name asc")
+	if jujuVersion != "" {
+		query = query.Where("juju_version IN ?", dbmodel.PartialJujuVersionPrefixes(jujuVersion))
+	}
+	if err := query.Find(&profiles).Error; err != nil {
 		return nil, errors.E(dbError(err))
 	}
 	return profiles, nil

--- a/internal/db/controllerprofile_test.go
+++ b/internal/db/controllerprofile_test.go
@@ -16,6 +16,7 @@ func testControllerProfile() dbmodel.ControllerProfile {
 	return dbmodel.ControllerProfile{
 		Name:        "openstack-production",
 		Description: "Reusable bootstrap settings for OpenStack production controllers",
+		JujuVersion: "3.6",
 		Cloud: dbmodel.ControllerProfileCloud{
 			Name:            "my-private-cloud",
 			Type:            "openstack",
@@ -75,7 +76,7 @@ func (s *dbSuite) TestControllerProfileCRUD(c *qt.C) {
 	c.Assert(s.Database.GetControllerProfile(ctx, &lookup), qt.IsNil)
 	c.Check(lookup, controllerProfileEquals, profile)
 
-	profiles, err := s.Database.ListControllerProfiles(ctx)
+	profiles, err := s.Database.ListControllerProfiles(ctx, "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(profiles, qt.HasLen, 1)
 	c.Check(profiles[0], controllerProfileEquals, profile)
@@ -110,6 +111,39 @@ func (s *dbSuite) TestCreateOrReplaceControllerProfileRequiresCurrentVersion(c *
 	c.Assert(s.Database.GetControllerProfile(ctx, &lookup), qt.IsNil)
 	c.Check(lookup.Description, qt.Equals, "fresh update")
 	c.Check(lookup.Version, qt.Equals, uint(2))
+}
+
+func (s *dbSuite) TestListControllerProfilesFiltersByJujuVersion(c *qt.C) {
+	ctx := context.Background()
+	c.Assert(s.Database.Migrate(ctx), qt.IsNil)
+
+	for _, tc := range []struct {
+		name        string
+		jujuVersion string
+	}{
+		{name: "profile-3", jujuVersion: "3"},
+		{name: "profile-3-6", jujuVersion: "3.6"},
+		{name: "profile-3-6-4", jujuVersion: "3.6.4"},
+		{name: "profile-4", jujuVersion: "4"},
+	} {
+		profile := testControllerProfile()
+		profile.Name = tc.name
+		profile.JujuVersion = tc.jujuVersion
+		c.Assert(s.Database.CreateOrReplaceControllerProfile(ctx, &profile), qt.IsNil)
+	}
+
+	profiles, err := s.Database.ListControllerProfiles(ctx, "3.6.4")
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 3)
+	c.Check(profiles[0].Name, qt.Equals, "profile-3")
+	c.Check(profiles[1].Name, qt.Equals, "profile-3-6")
+	c.Check(profiles[2].Name, qt.Equals, "profile-3-6-4")
+
+	profiles, err = s.Database.ListControllerProfiles(ctx, "3.6")
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 2)
+	c.Check(profiles[0].Name, qt.Equals, "profile-3")
+	c.Check(profiles[1].Name, qt.Equals, "profile-3-6")
 }
 
 func (s *dbSuite) TestControllerProfileNameMustBeUnique(c *qt.C) {

--- a/internal/dbmodel/controllerprofile.go
+++ b/internal/dbmodel/controllerprofile.go
@@ -2,7 +2,10 @@
 
 package dbmodel
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ControllerProfile stores reusable, non-secret controller bootstrap settings.
 //
@@ -16,10 +19,26 @@ type ControllerProfile struct {
 
 	Name        string `gorm:"not null;uniqueIndex"`
 	Description string
-	Version     uint `gorm:"not null"`
+	JujuVersion string `gorm:"column:juju_version;not null"`
+	Version     uint   `gorm:"not null"`
 
 	Cloud            ControllerProfileCloud            `gorm:"embedded"`
 	BootstrapOptions ControllerProfileBootstrapOptions `gorm:"embedded"`
+}
+
+// PartialJujuVersionPrefixes returns the progressive prefixes of a Juju
+// version string. Callers are expected to validate the version before use if
+// needed.
+func PartialJujuVersionPrefixes(version string) []string {
+	if version == "" {
+		return nil
+	}
+	parts := strings.Split(version, ".")
+	prefixes := make([]string, 0, len(parts))
+	for i := 1; i <= len(parts); i++ {
+		prefixes = append(prefixes, strings.Join(parts[:i], "."))
+	}
+	return prefixes
 }
 
 // ControllerProfileCloud stores the cloud definition persisted in a controller

--- a/internal/dbmodel/controllerprofile_test.go
+++ b/internal/dbmodel/controllerprofile_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Canonical.
+
+package dbmodel_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+)
+
+func TestPartialJujuVersionPrefixes(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range []struct {
+		about   string
+		version string
+		want    []string
+	}{
+		{
+			about:   "empty version",
+			version: "",
+			want:    nil,
+		},
+		{
+			about:   "major only",
+			version: "3",
+			want:    []string{"3"},
+		},
+		{
+			about:   "major minor",
+			version: "3.6",
+			want:    []string{"3", "3.6"},
+		},
+		{
+			about:   "major minor patch",
+			version: "3.6.4",
+			want:    []string{"3", "3.6", "3.6.4"},
+		},
+	} {
+		c.Run(tc.about, func(c *qt.C) {
+			c.Assert(dbmodel.PartialJujuVersionPrefixes(tc.version), qt.DeepEquals, tc.want)
+		})
+	}
+}

--- a/internal/dbmodel/sql/postgres/036_add_controller_profiles.up.sql
+++ b/internal/dbmodel/sql/postgres/036_add_controller_profiles.up.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS controller_profiles (
     updated_at TIMESTAMP WITH TIME ZONE,
     name VARCHAR(255) NOT NULL UNIQUE,
     description TEXT,
+    juju_version VARCHAR(20) NOT NULL,
     version BIGINT NOT NULL CHECK (version > 0),
     cloud_name VARCHAR(255) NOT NULL,
     cloud_type VARCHAR(255),

--- a/internal/jimm/controllerprofile/controllerprofile.go
+++ b/internal/jimm/controllerprofile/controllerprofile.go
@@ -28,7 +28,7 @@ func NewControllerProfileManager(store *db.Database) (*ControllerProfileManager,
 // SaveControllerProfile creates or replaces a saved controller profile.
 func (m *ControllerProfileManager) SaveControllerProfile(ctx context.Context, profile *dbmodel.ControllerProfile) error {
 	if err := m.store.CreateOrReplaceControllerProfile(ctx, profile); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -37,7 +37,7 @@ func (m *ControllerProfileManager) SaveControllerProfile(ctx context.Context, pr
 func (m *ControllerProfileManager) GetControllerProfile(ctx context.Context, name string) (*dbmodel.ControllerProfile, error) {
 	profile := &dbmodel.ControllerProfile{Name: name}
 	if err := m.store.GetControllerProfile(ctx, profile); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return profile, nil
 }
@@ -47,7 +47,7 @@ func (m *ControllerProfileManager) GetControllerProfile(ctx context.Context, nam
 func (m *ControllerProfileManager) ListControllerProfiles(ctx context.Context, jujuVersion string) ([]dbmodel.ControllerProfile, error) {
 	profiles, err := m.store.ListControllerProfiles(ctx, jujuVersion)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return profiles, nil
 }
@@ -55,7 +55,7 @@ func (m *ControllerProfileManager) ListControllerProfiles(ctx context.Context, j
 // RemoveControllerProfile removes a saved controller profile by name.
 func (m *ControllerProfileManager) RemoveControllerProfile(ctx context.Context, name string) error {
 	if err := m.store.RemoveControllerProfile(ctx, name); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jimm/controllerprofile/controllerprofile.go
+++ b/internal/jimm/controllerprofile/controllerprofile.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Canonical.
+
+package controllerprofile
+
+import (
+	"context"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+// ControllerProfileManager provides a means to manage controller profiles within JIMM.
+type ControllerProfileManager struct {
+	store *db.Database
+}
+
+// NewControllerProfileManager returns a new controller profile manager backed by the provided store.
+func NewControllerProfileManager(store *db.Database) (*ControllerProfileManager, error) {
+	if store == nil {
+		return nil, errors.E("controller profile store cannot be nil")
+	}
+	return &ControllerProfileManager{store: store}, nil
+}
+
+// SaveControllerProfile creates or replaces a saved controller profile.
+func (m *ControllerProfileManager) SaveControllerProfile(ctx context.Context, profile *dbmodel.ControllerProfile) error {
+	if err := m.store.CreateOrReplaceControllerProfile(ctx, profile); err != nil {
+		return errors.E(err)
+	}
+	return nil
+}
+
+// GetControllerProfile retrieves a saved controller profile by name.
+func (m *ControllerProfileManager) GetControllerProfile(ctx context.Context, name string) (*dbmodel.ControllerProfile, error) {
+	profile := &dbmodel.ControllerProfile{Name: name}
+	if err := m.store.GetControllerProfile(ctx, profile); err != nil {
+		return nil, errors.E(err)
+	}
+	return profile, nil
+}
+
+// ListControllerProfiles lists all saved controller profiles.
+func (m *ControllerProfileManager) ListControllerProfiles(ctx context.Context) ([]dbmodel.ControllerProfile, error) {
+	profiles, err := m.store.ListControllerProfiles(ctx)
+	if err != nil {
+		return nil, errors.E(err)
+	}
+	return profiles, nil
+}
+
+// RemoveControllerProfile removes a saved controller profile by name.
+func (m *ControllerProfileManager) RemoveControllerProfile(ctx context.Context, name string) error {
+	if err := m.store.RemoveControllerProfile(ctx, name); err != nil {
+		return errors.E(err)
+	}
+	return nil
+}

--- a/internal/jimm/controllerprofile/controllerprofile.go
+++ b/internal/jimm/controllerprofile/controllerprofile.go
@@ -1,5 +1,7 @@
 // Copyright 2026 Canonical.
 
+// Package controllerprofile provides an implementation
+// for managing controller profiles within JIMM.
 package controllerprofile
 
 import (
@@ -40,9 +42,10 @@ func (m *ControllerProfileManager) GetControllerProfile(ctx context.Context, nam
 	return profile, nil
 }
 
-// ListControllerProfiles lists all saved controller profiles.
-func (m *ControllerProfileManager) ListControllerProfiles(ctx context.Context) ([]dbmodel.ControllerProfile, error) {
-	profiles, err := m.store.ListControllerProfiles(ctx)
+// ListControllerProfiles lists saved controller profiles, optionally filtered
+// by Juju version.
+func (m *ControllerProfileManager) ListControllerProfiles(ctx context.Context, jujuVersion string) ([]dbmodel.ControllerProfile, error) {
+	profiles, err := m.store.ListControllerProfiles(ctx, jujuVersion)
 	if err != nil {
 		return nil, errors.E(err)
 	}

--- a/internal/jimm/controllerprofile/controllerprofile_test.go
+++ b/internal/jimm/controllerprofile/controllerprofile_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Canonical.
+
+package controllerprofile_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/controllerprofile"
+	"github.com/canonical/jimm/v3/internal/testutils/testdb"
+)
+
+type controllerProfileTestEnv struct {
+	manager *controllerprofile.ControllerProfileManager
+	db      *db.Database
+}
+
+func testControllerProfile(name string) dbmodel.ControllerProfile {
+	return dbmodel.ControllerProfile{
+		Name:        name,
+		Description: "Reusable profile",
+		Cloud: dbmodel.ControllerProfileCloud{
+			Name:           "aws",
+			Type:           "ec2",
+			AuthTypes:      dbmodel.Strings{"access-key"},
+			CACertificates: dbmodel.Strings{"ca-cert"},
+			Config:         dbmodel.Map{"default-base": "ubuntu@24.04"},
+			Endpoint:       "https://aws.example.com",
+			Region: dbmodel.ControllerProfileCloudRegion{
+				Name:             "eu-west-1",
+				Endpoint:         "https://region.example.com",
+				IdentityEndpoint: "https://identity.example.com",
+				StorageEndpoint:  "https://storage.example.com",
+			},
+		},
+		BootstrapOptions: dbmodel.ControllerProfileBootstrapOptions{
+			BootstrapBase:         "ubuntu@24.04",
+			BootstrapConstraints:  dbmodel.StringMap{"mem": "8G"},
+			ModelConstraints:      dbmodel.StringMap{"arch": "amd64"},
+			ModelDefault:          dbmodel.StringMap{"logging-config": "<root>=INFO"},
+			BootstrapConfig:       dbmodel.StringMap{"bootstrap-timeout": "20m"},
+			ControllerConfig:      dbmodel.StringMap{"audit-log-enabled": "true"},
+			ControllerModelConfig: dbmodel.StringMap{"logging-config": "<root>=INFO"},
+			StoragePool: dbmodel.ControllerProfileStoragePool{
+				Name:       "controller-pool",
+				Type:       "ebs",
+				Attributes: dbmodel.StringMap{"volume-type": "gp3"},
+			},
+		},
+	}
+}
+
+func setupControllerProfileTestEnv(c *qt.C) *controllerProfileTestEnv {
+	database := &db.Database{DB: testdb.PostgresDB(c, time.Now)}
+	err := database.Migrate(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	manager, err := controllerprofile.NewControllerProfileManager(database)
+	c.Assert(err, qt.IsNil)
+
+	return &controllerProfileTestEnv{
+		manager: manager,
+		db:      database,
+	}
+}
+
+func TestSaveControllerProfile(t *testing.T) {
+	c := qt.New(t)
+	t.Parallel()
+	env := setupControllerProfileTestEnv(c)
+	ctx := context.Background()
+
+	profile := testControllerProfile("profile-a")
+	err := env.manager.SaveControllerProfile(ctx, &profile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(profile.Version, qt.Equals, uint(1))
+
+	lookup := dbmodel.ControllerProfile{Name: profile.Name}
+	err = env.db.GetControllerProfile(ctx, &lookup)
+	c.Assert(err, qt.IsNil)
+	c.Assert(lookup.Name, qt.Equals, profile.Name)
+	c.Assert(lookup.Version, qt.Equals, uint(1))
+	c.Assert(lookup.Cloud.Name, qt.Equals, "aws")
+}
+
+func TestGetControllerProfile(t *testing.T) {
+	c := qt.New(t)
+	t.Parallel()
+	env := setupControllerProfileTestEnv(c)
+	ctx := context.Background()
+
+	profile := testControllerProfile("profile-b")
+	err := env.db.CreateOrReplaceControllerProfile(ctx, &profile)
+	c.Assert(err, qt.IsNil)
+
+	loaded, err := env.manager.GetControllerProfile(ctx, profile.Name)
+	c.Assert(err, qt.IsNil)
+	c.Assert(loaded.Name, qt.Equals, profile.Name)
+	c.Assert(loaded.Description, qt.Equals, profile.Description)
+	c.Assert(loaded.BootstrapOptions.BootstrapBase, qt.Equals, profile.BootstrapOptions.BootstrapBase)
+}
+
+func TestListControllerProfiles(t *testing.T) {
+	c := qt.New(t)
+	t.Parallel()
+	env := setupControllerProfileTestEnv(c)
+	ctx := context.Background()
+
+	for _, name := range []string{"profile-a", "profile-b"} {
+		profile := testControllerProfile(name)
+		err := env.db.CreateOrReplaceControllerProfile(ctx, &profile)
+		c.Assert(err, qt.IsNil)
+	}
+
+	profiles, err := env.manager.ListControllerProfiles(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 2)
+	c.Assert(profiles[0].Name, qt.Equals, "profile-a")
+	c.Assert(profiles[1].Name, qt.Equals, "profile-b")
+}
+
+func TestRemoveControllerProfile(t *testing.T) {
+	c := qt.New(t)
+	t.Parallel()
+	env := setupControllerProfileTestEnv(c)
+	ctx := context.Background()
+
+	profile := testControllerProfile("profile-c")
+	err := env.db.CreateOrReplaceControllerProfile(ctx, &profile)
+	c.Assert(err, qt.IsNil)
+
+	err = env.manager.RemoveControllerProfile(ctx, profile.Name)
+	c.Assert(err, qt.IsNil)
+
+	err = env.db.GetControllerProfile(ctx, &dbmodel.ControllerProfile{Name: profile.Name})
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}

--- a/internal/jimm/controllerprofile/controllerprofile_test.go
+++ b/internal/jimm/controllerprofile/controllerprofile_test.go
@@ -25,6 +25,7 @@ func testControllerProfile(name string) dbmodel.ControllerProfile {
 	return dbmodel.ControllerProfile{
 		Name:        name,
 		Description: "Reusable profile",
+		JujuVersion: "3.6",
 		Cloud: dbmodel.ControllerProfileCloud{
 			Name:           "aws",
 			Type:           "ec2",
@@ -118,11 +119,38 @@ func TestListControllerProfiles(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 	}
 
-	profiles, err := env.manager.ListControllerProfiles(ctx)
+	profiles, err := env.manager.ListControllerProfiles(ctx, "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(profiles, qt.HasLen, 2)
 	c.Assert(profiles[0].Name, qt.Equals, "profile-a")
 	c.Assert(profiles[1].Name, qt.Equals, "profile-b")
+}
+
+func TestListControllerProfilesFiltersByJujuVersion(t *testing.T) {
+	c := qt.New(t)
+	t.Parallel()
+	env := setupControllerProfileTestEnv(c)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name        string
+		jujuVersion string
+	}{
+		{name: "profile-3", jujuVersion: "3"},
+		{name: "profile-3-6", jujuVersion: "3.6"},
+		{name: "profile-4", jujuVersion: "4"},
+	} {
+		profile := testControllerProfile(tc.name)
+		profile.JujuVersion = tc.jujuVersion
+		err := env.db.CreateOrReplaceControllerProfile(ctx, &profile)
+		c.Assert(err, qt.IsNil)
+	}
+
+	profiles, err := env.manager.ListControllerProfiles(ctx, "3.6.4")
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 2)
+	c.Assert(profiles[0].Name, qt.Equals, "profile-3")
+	c.Assert(profiles[1].Name, qt.Equals, "profile-3-6")
 }
 
 func TestRemoveControllerProfile(t *testing.T) {

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/jimm/auditlog"
 	"github.com/canonical/jimm/v3/internal/jimm/bootstrap"
 	"github.com/canonical/jimm/v3/internal/jimm/config"
+	"github.com/canonical/jimm/v3/internal/jimm/controllerprofile"
 	"github.com/canonical/jimm/v3/internal/jimm/credentials"
 	"github.com/canonical/jimm/v3/internal/jimm/group"
 	"github.com/canonical/jimm/v3/internal/jimm/identity"
@@ -265,6 +266,13 @@ func New(p Parameters) (*JIMM, error) {
 
 	j.BootstrapManager = bootstrapManager
 
+	controllerProfileManager, err := controllerprofile.NewControllerProfileManager(j.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	j.ControllerProfileManager = controllerProfileManager
+
 	upgradeManager, err := upgrade.NewUpgradeManager(j.JujuManager, j.Database, j.Dialer, j.RiverClient)
 	if err != nil {
 		return nil, err
@@ -325,6 +333,9 @@ type JIMM struct {
 
 	// BootstrapManager provides a means to manage bootstrap jobs.
 	BootstrapManager *bootstrap.BootstrapManager
+
+	// ControllerProfileManager provides a means to manage saved controller profiles.
+	ControllerProfileManager *controllerprofile.ControllerProfileManager
 
 	// UpgradeManager provides a means to manage controller cloning and model automated upgrades.
 	UpgradeManager *upgrade.UpgradeManager

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -6,12 +6,17 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
+
+	jujuversion "github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
+
+const partialJujuVersionFormatMessage = "must be a partial/full version string with one, two, or three dot-separated numeric components"
 
 // SaveControllerProfile creates or replaces a saved controller profile.
 func (r *controllerRoot) SaveControllerProfile(ctx context.Context, req apiparams.SaveControllerProfileRequest) (apiparams.SaveControllerProfileResponse, error) {
@@ -43,12 +48,16 @@ func (r *controllerRoot) GetControllerProfile(ctx context.Context, req apiparams
 	return apiparams.GetControllerProfileResponse{ControllerProfile: controllerProfileToParams(*profile)}, nil
 }
 
-// ListControllerProfiles lists all saved controller profiles.
-func (r *controllerRoot) ListControllerProfiles(ctx context.Context, _ apiparams.ListControllerProfilesRequest) (apiparams.ListControllerProfilesResponse, error) {
+// ListControllerProfiles lists saved controller profiles, optionally filtered
+// by Juju version.
+func (r *controllerRoot) ListControllerProfiles(ctx context.Context, req apiparams.ListControllerProfilesRequest) (apiparams.ListControllerProfilesResponse, error) {
 	if !r.user.JimmAdmin {
 		return apiparams.ListControllerProfilesResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
-	profiles, err := r.jimm.ControllerProfileManager().ListControllerProfiles(ctx)
+	if err := validateListControllerProfilesRequest(req); err != nil {
+		return apiparams.ListControllerProfilesResponse{}, errors.E(err)
+	}
+	profiles, err := r.jimm.ControllerProfileManager().ListControllerProfiles(ctx, req.JujuVersion)
 	if err != nil {
 		return apiparams.ListControllerProfilesResponse{}, errors.E(fmt.Errorf("failed to list controller profiles: %w", err))
 	}
@@ -72,6 +81,9 @@ func (r *controllerRoot) RemoveControllerProfile(ctx context.Context, req apipar
 }
 
 func validateSaveControllerProfileRequest(req apiparams.SaveControllerProfileRequest) error {
+	if err := validatePartialJujuVersion(req.JujuVersion, "controller profile juju version", false); err != nil {
+		return err
+	}
 	if slices.Contains(builtInClouds, req.Cloud.Name) {
 		return errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("controller profiles do not support built-in clouds like %q", req.Cloud.Name))
 	}
@@ -82,10 +94,31 @@ func validateSaveControllerProfileRequest(req apiparams.SaveControllerProfileReq
 	return nil
 }
 
+func validateListControllerProfilesRequest(req apiparams.ListControllerProfilesRequest) error {
+	return validatePartialJujuVersion(req.JujuVersion, "controller profile juju version filter", true)
+}
+
+func validatePartialJujuVersion(versionString, fieldName string, allowEmpty bool) error {
+	if versionString == "" {
+		if allowEmpty {
+			return nil
+		}
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("%s must be provided", fieldName))
+	}
+	if _, err := jujuversion.ParseNonStrict(versionString); err != nil {
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("%s %s", fieldName, partialJujuVersionFormatMessage))
+	}
+	if strings.Contains(versionString, "-") || len(strings.Split(versionString, ".")) > 3 {
+		return errors.E(errors.CodeBadRequest, fmt.Sprintf("%s %s", fieldName, partialJujuVersionFormatMessage))
+	}
+	return nil
+}
+
 func controllerProfileFromParams(profile apiparams.ControllerProfile) dbmodel.ControllerProfile {
 	return dbmodel.ControllerProfile{
 		Name:        profile.Name,
 		Description: profile.Description,
+		JujuVersion: profile.JujuVersion,
 		Version:     profile.Version,
 		Cloud: dbmodel.ControllerProfileCloud{
 			Name:            profile.Cloud.Name,
@@ -130,6 +163,7 @@ func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.Cont
 	return apiparams.ControllerProfile{
 		Name:        profile.Name,
 		Description: profile.Description,
+		JujuVersion: profile.JujuVersion,
 		Version:     profile.Version,
 		CreatedAt:   profile.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:   profile.UpdatedAt.Format(time.RFC3339),

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -24,12 +24,12 @@ func (r *controllerRoot) SaveControllerProfile(ctx context.Context, req apiparam
 		return apiparams.SaveControllerProfileResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := validateSaveControllerProfileRequest(req); err != nil {
-		return apiparams.SaveControllerProfileResponse{}, errors.E(err)
+		return apiparams.SaveControllerProfileResponse{}, err
 	}
 
 	profile := controllerProfileFromParams(req.ControllerProfile)
 	if err := r.jimm.ControllerProfileManager().SaveControllerProfile(ctx, &profile); err != nil {
-		return apiparams.SaveControllerProfileResponse{}, errors.E(fmt.Errorf("failed to save controller profile: %w", err))
+		return apiparams.SaveControllerProfileResponse{}, fmt.Errorf("failed to save controller profile: %w", err)
 	}
 
 	return apiparams.SaveControllerProfileResponse{ControllerProfile: controllerProfileToParams(profile)}, nil
@@ -42,7 +42,7 @@ func (r *controllerRoot) GetControllerProfile(ctx context.Context, req apiparams
 	}
 	profile, err := r.jimm.ControllerProfileManager().GetControllerProfile(ctx, req.Name)
 	if err != nil {
-		return apiparams.GetControllerProfileResponse{}, errors.E(fmt.Errorf("failed to get controller profile: %w", err))
+		return apiparams.GetControllerProfileResponse{}, fmt.Errorf("failed to get controller profile: %w", err)
 	}
 
 	return apiparams.GetControllerProfileResponse{ControllerProfile: controllerProfileToParams(*profile)}, nil
@@ -55,11 +55,11 @@ func (r *controllerRoot) ListControllerProfiles(ctx context.Context, req apipara
 		return apiparams.ListControllerProfilesResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := validateListControllerProfilesRequest(req); err != nil {
-		return apiparams.ListControllerProfilesResponse{}, errors.E(err)
+		return apiparams.ListControllerProfilesResponse{}, err
 	}
 	profiles, err := r.jimm.ControllerProfileManager().ListControllerProfiles(ctx, req.JujuVersion)
 	if err != nil {
-		return apiparams.ListControllerProfilesResponse{}, errors.E(fmt.Errorf("failed to list controller profiles: %w", err))
+		return apiparams.ListControllerProfilesResponse{}, fmt.Errorf("failed to list controller profiles: %w", err)
 	}
 
 	resp := apiparams.ListControllerProfilesResponse{Profiles: make([]apiparams.ControllerProfileSummary, len(profiles))}
@@ -75,7 +75,7 @@ func (r *controllerRoot) RemoveControllerProfile(ctx context.Context, req apipar
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := r.jimm.ControllerProfileManager().RemoveControllerProfile(ctx, req.Name); err != nil {
-		return errors.E(fmt.Errorf("failed to remove controller profile: %w", err))
+		return fmt.Errorf("failed to remove controller profile: %w", err)
 	}
 	return nil
 }

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Canonical.
+
+package jujuapi
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+// SaveControllerProfile creates or replaces a saved controller profile.
+func (r *controllerRoot) SaveControllerProfile(ctx context.Context, req apiparams.SaveControllerProfileRequest) (apiparams.SaveControllerProfileResponse, error) {
+	if !r.user.JimmAdmin {
+		return apiparams.SaveControllerProfileResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+	if err := validateSaveControllerProfileRequest(req); err != nil {
+		return apiparams.SaveControllerProfileResponse{}, errors.E(err)
+	}
+
+	profile := controllerProfileFromParams(req.ControllerProfile)
+	if err := r.jimm.ControllerProfileManager().SaveControllerProfile(ctx, &profile); err != nil {
+		return apiparams.SaveControllerProfileResponse{}, errors.E(fmt.Errorf("failed to save controller profile: %w", err))
+	}
+
+	return apiparams.SaveControllerProfileResponse{ControllerProfile: controllerProfileToParams(profile)}, nil
+}
+
+// GetControllerProfile retrieves a saved controller profile by name.
+func (r *controllerRoot) GetControllerProfile(ctx context.Context, req apiparams.GetControllerProfileRequest) (apiparams.GetControllerProfileResponse, error) {
+	if !r.user.JimmAdmin {
+		return apiparams.GetControllerProfileResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+	profile, err := r.jimm.ControllerProfileManager().GetControllerProfile(ctx, req.Name)
+	if err != nil {
+		return apiparams.GetControllerProfileResponse{}, errors.E(fmt.Errorf("failed to get controller profile: %w", err))
+	}
+
+	return apiparams.GetControllerProfileResponse{ControllerProfile: controllerProfileToParams(*profile)}, nil
+}
+
+// ListControllerProfiles lists all saved controller profiles.
+func (r *controllerRoot) ListControllerProfiles(ctx context.Context, _ apiparams.ListControllerProfilesRequest) (apiparams.ListControllerProfilesResponse, error) {
+	if !r.user.JimmAdmin {
+		return apiparams.ListControllerProfilesResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+	profiles, err := r.jimm.ControllerProfileManager().ListControllerProfiles(ctx)
+	if err != nil {
+		return apiparams.ListControllerProfilesResponse{}, errors.E(fmt.Errorf("failed to list controller profiles: %w", err))
+	}
+
+	resp := apiparams.ListControllerProfilesResponse{Profiles: make([]apiparams.ControllerProfileSummary, len(profiles))}
+	for i, profile := range profiles {
+		resp.Profiles[i] = controllerProfileSummaryToParams(profile)
+	}
+	return resp, nil
+}
+
+// RemoveControllerProfile removes a saved controller profile by name.
+func (r *controllerRoot) RemoveControllerProfile(ctx context.Context, req apiparams.RemoveControllerProfileRequest) error {
+	if !r.user.JimmAdmin {
+		return errors.E(errors.CodeUnauthorized, "unauthorized")
+	}
+	if err := r.jimm.ControllerProfileManager().RemoveControllerProfile(ctx, req.Name); err != nil {
+		return errors.E(fmt.Errorf("failed to remove controller profile: %w", err))
+	}
+	return nil
+}
+
+func validateSaveControllerProfileRequest(req apiparams.SaveControllerProfileRequest) error {
+	if slices.Contains(builtInClouds, req.Cloud.Name) {
+		return errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("controller profiles do not support built-in clouds like %q", req.Cloud.Name))
+	}
+	storagePool := req.BootstrapOptions.StoragePool
+	if storagePool != nil && (storagePool.Name == "") != (storagePool.Type == "") {
+		return errors.E(errors.CodeBadRequest, "controller profile storage pool requires both name and type")
+	}
+	return nil
+}
+
+func controllerProfileFromParams(profile apiparams.ControllerProfile) dbmodel.ControllerProfile {
+	return dbmodel.ControllerProfile{
+		Name:        profile.Name,
+		Description: profile.Description,
+		Version:     profile.Version,
+		Cloud: dbmodel.ControllerProfileCloud{
+			Name:            profile.Cloud.Name,
+			Type:            profile.Cloud.Type,
+			AuthTypes:       dbmodel.Strings(profile.Cloud.AuthTypes),
+			CACertificates:  dbmodel.Strings(profile.Cloud.CACertificates),
+			Config:          dbmodel.Map(profile.Cloud.Config),
+			Endpoint:        profile.Cloud.Endpoint,
+			HostCloudRegion: profile.Cloud.HostCloudRegion,
+			Region: dbmodel.ControllerProfileCloudRegion{
+				Name:             profile.Cloud.Region.Name,
+				Endpoint:         profile.Cloud.Region.Endpoint,
+				IdentityEndpoint: profile.Cloud.Region.IdentityEndpoint,
+				StorageEndpoint:  profile.Cloud.Region.StorageEndpoint,
+			},
+		},
+		BootstrapOptions: dbmodel.ControllerProfileBootstrapOptions{
+			BootstrapBase:         profile.BootstrapOptions.BootstrapBase,
+			BootstrapConstraints:  dbmodel.StringMap(profile.BootstrapOptions.BootstrapConstraints),
+			ModelConstraints:      dbmodel.StringMap(profile.BootstrapOptions.ModelConstraints),
+			ModelDefault:          dbmodel.StringMap(profile.BootstrapOptions.ModelDefault),
+			StoragePool:           storagePoolFromParams(profile.BootstrapOptions.StoragePool),
+			BootstrapConfig:       dbmodel.StringMap(profile.BootstrapOptions.BootstrapConfig),
+			ControllerConfig:      dbmodel.StringMap(profile.BootstrapOptions.ControllerConfig),
+			ControllerModelConfig: dbmodel.StringMap(profile.BootstrapOptions.ControllerModelConfig),
+		},
+	}
+}
+
+func storagePoolFromParams(pool *apiparams.ControllerProfileStoragePool) dbmodel.ControllerProfileStoragePool {
+	if pool == nil {
+		return dbmodel.ControllerProfileStoragePool{}
+	}
+	return dbmodel.ControllerProfileStoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: dbmodel.StringMap(pool.Attributes),
+	}
+}
+
+func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.ControllerProfile {
+	return apiparams.ControllerProfile{
+		Name:        profile.Name,
+		Description: profile.Description,
+		Version:     profile.Version,
+		CreatedAt:   profile.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:   profile.UpdatedAt.Format(time.RFC3339),
+		Cloud: apiparams.ControllerProfileCloud{
+			Name:            profile.Cloud.Name,
+			Type:            profile.Cloud.Type,
+			AuthTypes:       []string(profile.Cloud.AuthTypes),
+			CACertificates:  []string(profile.Cloud.CACertificates),
+			Config:          map[string]interface{}(profile.Cloud.Config),
+			Endpoint:        profile.Cloud.Endpoint,
+			HostCloudRegion: profile.Cloud.HostCloudRegion,
+			Region: apiparams.ControllerProfileCloudRegion{
+				Name:             profile.Cloud.Region.Name,
+				Endpoint:         profile.Cloud.Region.Endpoint,
+				IdentityEndpoint: profile.Cloud.Region.IdentityEndpoint,
+				StorageEndpoint:  profile.Cloud.Region.StorageEndpoint,
+			},
+		},
+		BootstrapOptions: apiparams.ControllerProfileBootstrapOptions{
+			BootstrapBase:         profile.BootstrapOptions.BootstrapBase,
+			BootstrapConstraints:  map[string]string(profile.BootstrapOptions.BootstrapConstraints),
+			ModelConstraints:      map[string]string(profile.BootstrapOptions.ModelConstraints),
+			ModelDefault:          map[string]string(profile.BootstrapOptions.ModelDefault),
+			StoragePool:           storagePoolToParams(profile.BootstrapOptions.StoragePool),
+			BootstrapConfig:       map[string]string(profile.BootstrapOptions.BootstrapConfig),
+			ControllerConfig:      map[string]string(profile.BootstrapOptions.ControllerConfig),
+			ControllerModelConfig: map[string]string(profile.BootstrapOptions.ControllerModelConfig),
+		},
+	}
+}
+
+func controllerProfileSummaryToParams(profile dbmodel.ControllerProfile) apiparams.ControllerProfileSummary {
+	return apiparams.ControllerProfileSummary{
+		Name:        profile.Name,
+		Description: profile.Description,
+		CreatedAt:   profile.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:   profile.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+func storagePoolToParams(pool dbmodel.ControllerProfileStoragePool) *apiparams.ControllerProfileStoragePool {
+	if pool.Name == "" && pool.Type == "" && len(pool.Attributes) == 0 {
+		return nil
+	}
+	return &apiparams.ControllerProfileStoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: map[string]string(pool.Attributes),
+	}
+}

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -329,7 +329,7 @@ type BootstrapManager interface {
 type ControllerProfileManager interface {
 	SaveControllerProfile(ctx context.Context, profile *dbmodel.ControllerProfile) error
 	GetControllerProfile(ctx context.Context, name string) (*dbmodel.ControllerProfile, error)
-	ListControllerProfiles(ctx context.Context) ([]dbmodel.ControllerProfile, error)
+	ListControllerProfiles(ctx context.Context, jujuVersion string) ([]dbmodel.ControllerProfile, error)
 	RemoveControllerProfile(ctx context.Context, name string) error
 }
 

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -46,6 +46,7 @@ type JIMM interface {
 	JujuManager() JujuManager
 	ConfigManager() ConfigManager
 	BootstrapManager() BootstrapManager
+	ControllerProfileManager() ControllerProfileManager
 	UpgradeManager() UpgradeManager
 	JobManager() JobManager
 
@@ -322,6 +323,14 @@ type BootstrapManager interface {
 	BootstrapController(ctx context.Context, p bootstrap.RunBootstrapArgs, cmdFactory bootstrap.CommandFactory, user *openfga.User) error
 	// DestroyController destroys a Juju controller.
 	DestroyController(ctx context.Context, p bootstrap.RunDestroyControllerArgs, cmdFactory bootstrap.CommandFactory, user *openfga.User) error
+}
+
+// ControllerProfileManager provides methods to manage saved controller profiles.
+type ControllerProfileManager interface {
+	SaveControllerProfile(ctx context.Context, profile *dbmodel.ControllerProfile) error
+	GetControllerProfile(ctx context.Context, name string) (*dbmodel.ControllerProfile, error)
+	ListControllerProfiles(ctx context.Context) ([]dbmodel.ControllerProfile, error)
+	RemoveControllerProfile(ctx context.Context, name string) error
 }
 
 // UpgradeManager provides methods to manage controller cloning and model automated upgrades.

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -70,6 +70,10 @@ func init() {
 		stopBootstrap := rpc.Method(r.StopBootstrap)
 		startBootstrap := rpc.Method(r.StartBootstrap)
 		startDestroyController := rpc.Method(r.StartDestroyController)
+		saveControllerProfile := rpc.Method(r.SaveControllerProfile)
+		getControllerProfile := rpc.Method(r.GetControllerProfile)
+		listControllerProfiles := rpc.Method(r.ListControllerProfiles)
+		removeControllerProfile := rpc.Method(r.RemoveControllerProfile)
 		upgradeToMethod := rpc.Method(r.UpgradeTo)
 		listUserCloudsMethod := rpc.Method(r.ListUserClouds)
 		modelControllerInfoMethod := rpc.Method(r.ModelControllerInfo)
@@ -128,6 +132,11 @@ func init() {
 		// Job management
 		r.AddMethod("JIMM", 4, "JobInfo", jobInfoMethod)
 		r.AddMethod("JIMM", 4, "ListJobs", listJobsMethod)
+		// JIMM Controller Profiles
+		r.AddMethod("JIMM", 4, "GetControllerProfile", getControllerProfile)
+		r.AddMethod("JIMM", 4, "ListControllerProfiles", listControllerProfiles)
+		r.AddMethod("JIMM", 4, "RemoveControllerProfile", removeControllerProfile)
+		r.AddMethod("JIMM", 4, "SaveControllerProfile", saveControllerProfile)
 
 		return []int{4}
 	}

--- a/internal/jujuapi/jimm_adapter.go
+++ b/internal/jujuapi/jimm_adapter.go
@@ -19,58 +19,72 @@ func NewJIMMAdapter(j *jimm.JIMM) JIMM {
 	return &JIMMAdapter{j: j}
 }
 
+// RoleManager returns the role manager from the underlying JIMM instance.
 func (j *JIMMAdapter) RoleManager() RoleManager {
 	return j.j.RoleManager
 }
 
+// GroupManager returns the group manager from the underlying JIMM instance.
 func (j *JIMMAdapter) GroupManager() GroupManager {
 	return j.j.GroupManager
 }
 
+// IdentityManager returns the identity manager from the underlying JIMM instance.
 func (j *JIMMAdapter) IdentityManager() IdentityManager {
 	return j.j.IdentityManager
 }
 
+// LoginManager returns the login manager from the underlying JIMM instance.
 func (j *JIMMAdapter) LoginManager() LoginManager {
 	return j.j.LoginManager
 }
 
+// PermissionManager returns the permission manager from the underlying JIMM instance.
 func (j *JIMMAdapter) PermissionManager() PermissionManager {
 	return j.j.PermissionManager
 }
 
+// AuditLogManager returns the audit log manager from the underlying JIMM instance.
 func (j *JIMMAdapter) AuditLogManager() AuditLogManager {
 	return j.j.AuditLogManager
 }
 
+// JujuManager returns the Juju manager from the underlying JIMM instance.
 func (j *JIMMAdapter) JujuManager() JujuManager {
 	return j.j.JujuManager
 }
 
+// ConfigManager returns the config manager from the underlying JIMM instance.
 func (j *JIMMAdapter) ConfigManager() ConfigManager {
 	return j.j.ConfigManager
 }
 
+// BootstrapManager returns the bootstrap manager from the underlying JIMM instance.
 func (j *JIMMAdapter) BootstrapManager() BootstrapManager {
 	return j.j.BootstrapManager
 }
 
+// ControllerProfileManager returns the controller profile manager from the underlying JIMM instance.
 func (j *JIMMAdapter) ControllerProfileManager() ControllerProfileManager {
 	return j.j.ControllerProfileManager
 }
 
+// UpgradeManager returns the upgrade manager from the underlying JIMM instance.
 func (j *JIMMAdapter) UpgradeManager() UpgradeManager {
 	return j.j.UpgradeManager
 }
 
+// JobManager returns the job manager from the underlying JIMM instance.
 func (j *JIMMAdapter) JobManager() JobManager {
 	return j.j.JobManager
 }
 
+// ResourceTag returns JIMM's controller tag.
 func (j *JIMMAdapter) ResourceTag() names.ControllerTag {
 	return j.j.ResourceTag()
 }
 
+// PubSubHub returns the pub/sub hub from the underlying JIMM instance.
 func (j *JIMMAdapter) PubSubHub() *pubsub.Hub {
 	return j.j.Pubsub
 }

--- a/internal/jujuapi/jimm_adapter.go
+++ b/internal/jujuapi/jimm_adapter.go
@@ -55,6 +55,10 @@ func (j *JIMMAdapter) BootstrapManager() BootstrapManager {
 	return j.j.BootstrapManager
 }
 
+func (j *JIMMAdapter) ControllerProfileManager() ControllerProfileManager {
+	return j.j.ControllerProfileManager
+}
+
 func (j *JIMMAdapter) UpgradeManager() UpgradeManager {
 	return j.j.UpgradeManager
 }

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -15,20 +15,21 @@ import (
 // will delegate to the requested funcion or if the funcion is nil return
 // a NotImplemented error.
 type JIMM struct {
-	AuditLogManager_   func() jujuapi.AuditLogManager
-	GroupManager_      func() jujuapi.GroupManager
-	IdentityManager_   func() jujuapi.IdentityManager
-	LoginManager_      func() jujuapi.LoginManager
-	RoleManager_       func() jujuapi.RoleManager
-	PermissionManager_ func() jujuapi.PermissionManager
-	JujuManager_       func() jujuapi.JujuManager
-	PubSubHub_         func() *pubsub.Hub
-	ResourceTag_       func() names.ControllerTag
-	ConfigManager_     func() jujuapi.ConfigManager
-	OfferAuthorizer_   func() jujuapi.OfferAuthorizer
-	BootstapManager_   func() jujuapi.BootstrapManager
-	UpgradeManager_    func() jujuapi.UpgradeManager
-	JobManager_        func() jujuapi.JobManager
+	AuditLogManager_          func() jujuapi.AuditLogManager
+	GroupManager_             func() jujuapi.GroupManager
+	IdentityManager_          func() jujuapi.IdentityManager
+	LoginManager_             func() jujuapi.LoginManager
+	RoleManager_              func() jujuapi.RoleManager
+	PermissionManager_        func() jujuapi.PermissionManager
+	JujuManager_              func() jujuapi.JujuManager
+	PubSubHub_                func() *pubsub.Hub
+	ResourceTag_              func() names.ControllerTag
+	ConfigManager_            func() jujuapi.ConfigManager
+	OfferAuthorizer_          func() jujuapi.OfferAuthorizer
+	BootstapManager_          func() jujuapi.BootstrapManager
+	ControllerProfileManager_ func() jujuapi.ControllerProfileManager
+	UpgradeManager_           func() jujuapi.UpgradeManager
+	JobManager_               func() jujuapi.JobManager
 }
 
 func (j *JIMM) RoleManager() jujuapi.RoleManager {
@@ -113,6 +114,13 @@ func (j *JIMM) BootstrapManager() jujuapi.BootstrapManager {
 		return nil
 	}
 	return j.BootstapManager_()
+}
+
+func (j *JIMM) ControllerProfileManager() jujuapi.ControllerProfileManager {
+	if j.ControllerProfileManager_ == nil {
+		return nil
+	}
+	return j.ControllerProfileManager_()
 }
 
 func (j *JIMM) UpgradeManager() jujuapi.UpgradeManager {

--- a/internal/testutils/jimmtest/jimm_mock.go
+++ b/internal/testutils/jimmtest/jimm_mock.go
@@ -11,8 +11,8 @@ import (
 )
 
 // JIMM is a default implementation of the jujuapi.JIMM interface. Every method
-// has a corresponding funcion field. Whenever the method is called it
-// will delegate to the requested funcion or if the funcion is nil return
+// has a corresponding function field. Whenever the method is called it
+// will delegate to the requested function or if the function is nil return
 // a NotImplemented error.
 type JIMM struct {
 	AuditLogManager_          func() jujuapi.AuditLogManager

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -124,7 +124,8 @@ func (c *Client) GetControllerProfile(req *params.GetControllerProfileRequest) (
 	return response, err
 }
 
-// ListControllerProfiles lists all saved controller profiles.
+// ListControllerProfiles lists saved controller profiles, optionally filtered
+// by Juju version.
 func (c *Client) ListControllerProfiles(req *params.ListControllerProfilesRequest) ([]params.ControllerProfileSummary, error) {
 	var response params.ListControllerProfilesResponse
 	err := c.caller.APICall("JIMM", 4, "", "ListControllerProfiles", req, &response)

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -110,6 +110,32 @@ func (c *Client) SetControllerDeprecated(req *params.SetControllerDeprecatedRequ
 	return info, err
 }
 
+// SaveControllerProfile creates or replaces a saved controller profile.
+func (c *Client) SaveControllerProfile(req *params.SaveControllerProfileRequest) (params.SaveControllerProfileResponse, error) {
+	var response params.SaveControllerProfileResponse
+	err := c.caller.APICall("JIMM", 4, "", "SaveControllerProfile", req, &response)
+	return response, err
+}
+
+// GetControllerProfile retrieves a saved controller profile by name.
+func (c *Client) GetControllerProfile(req *params.GetControllerProfileRequest) (params.GetControllerProfileResponse, error) {
+	var response params.GetControllerProfileResponse
+	err := c.caller.APICall("JIMM", 4, "", "GetControllerProfile", req, &response)
+	return response, err
+}
+
+// ListControllerProfiles lists all saved controller profiles.
+func (c *Client) ListControllerProfiles(req *params.ListControllerProfilesRequest) ([]params.ControllerProfileSummary, error) {
+	var response params.ListControllerProfilesResponse
+	err := c.caller.APICall("JIMM", 4, "", "ListControllerProfiles", req, &response)
+	return response.Profiles, err
+}
+
+// RemoveControllerProfile removes a saved controller profile by name.
+func (c *Client) RemoveControllerProfile(req *params.RemoveControllerProfileRequest) error {
+	return c.caller.APICall("JIMM", 4, "", "RemoveControllerProfile", req, nil)
+}
+
 // UpgradeTo initiates a controller upgrade to the specified version.
 func (c *Client) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
 	var resp params.UpgradeToResponse

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -246,6 +246,131 @@ type SetControllerDeprecatedRequest struct {
 	Deprecated bool `json:"deprecated"`
 }
 
+// ControllerProfile stores reusable, non-secret controller bootstrap settings.
+type ControllerProfile struct {
+	// Name is the profile's name and must be unique across all profiles.
+	Name string `json:"name" yaml:"name"`
+	// Description is an optional human-readable summary of the profile.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Version must be provided when updating an existing profile.
+	Version uint `json:"version" yaml:"version"`
+	// CreatedAt is the time the profile was first created.
+	CreatedAt string `json:"created-at,omitempty" yaml:"created-at,omitempty"`
+	// UpdatedAt is the time the profile was last updated.
+	UpdatedAt string `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+	// Cloud stores the cloud definition for the profile.
+	Cloud ControllerProfileCloud `json:"cloud" yaml:"cloud"`
+	// BootstrapOptions holds the reusable bootstrap settings saved in the profile.
+	BootstrapOptions ControllerProfileBootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
+}
+
+// ControllerProfileSummary contains the fields returned when listing controller profiles.
+type ControllerProfileSummary struct {
+	// Name is the profile's name and must be unique across all profiles.
+	Name string `json:"name" yaml:"name"`
+	// Description is an optional human-readable summary of the profile.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// CreatedAt is the time the profile was first created.
+	CreatedAt string `json:"created-at,omitempty" yaml:"created-at,omitempty"`
+	// UpdatedAt is the time the profile was last updated.
+	UpdatedAt string `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
+}
+
+// ControllerProfileCloud stores the cloud definition persisted in a controller profile.
+type ControllerProfileCloud struct {
+	// Name is the cloud's name, e.g. "aws", "azure", "gcp", "localhost", etc.
+	Name string `json:"name" yaml:"name"`
+	// Type is the cloud's type, e.g. "ec2", "azure", "openstack", etc.
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	// AuthTypes contains the supported cloud auth types.
+	AuthTypes []string `json:"auth-types,omitempty" yaml:"auth-types,omitempty"`
+	// CACertificates contains the cloud CA certificates.
+	CACertificates []string `json:"ca-certificates,omitempty" yaml:"ca-certificates,omitempty"`
+	// Config contains cloud-specific configuration.
+	Config map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
+	// Endpoint contains the cloud API endpoint, if needed.
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	// HostCloudRegion contains the host cloud region for the cloud, if any.
+	HostCloudRegion string `json:"host-cloud-region,omitempty" yaml:"host-cloud-region,omitempty"`
+	// Region contains the cloud region definition for the profile's bootstrap region.
+	Region ControllerProfileCloudRegion `json:"region" yaml:"region"`
+}
+
+// ControllerProfileCloudRegion stores the single bootstrap region definition for a profile.
+type ControllerProfileCloudRegion struct {
+	// Name is the region's name, e.g. "us-east-1".
+	Name string `json:"name" yaml:"name"`
+	// Endpoint contains the region-specific cloud API endpoint, if needed.
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	// IdentityEndpoint contains the region-specific cloud identity API endpoint, if needed.
+	IdentityEndpoint string `json:"identity-endpoint,omitempty" yaml:"identity-endpoint,omitempty"`
+	// StorageEndpoint contains the region-specific cloud storage API endpoint, if needed.
+	StorageEndpoint string `json:"storage-endpoint,omitempty" yaml:"storage-endpoint,omitempty"`
+}
+
+// ControllerProfileBootstrapOptions stores the reusable bootstrap settings supported by a profile.
+type ControllerProfileBootstrapOptions struct {
+	// BootstrapBase specifies the base of the bootstrap machine, e.g. "ubuntu@24.04".
+	BootstrapBase string `json:"bootstrap-base,omitempty" yaml:"bootstrap-base,omitempty"`
+	// BootstrapConstraints specifies bootstrap machine constraints.
+	BootstrapConstraints map[string]string `json:"bootstrap-constraints,omitempty" yaml:"bootstrap-constraints,omitempty"`
+	// ModelConstraints sets the default constraints for workload machines in the controller model.
+	ModelConstraints map[string]string `json:"model-constraints,omitempty" yaml:"model-constraints,omitempty"`
+	// ModelDefault specifies default model configuration values.
+	ModelDefault map[string]string `json:"model-default,omitempty" yaml:"model-default,omitempty"`
+	// StoragePool holds the options for an initial storage pool created in the controller model.
+	StoragePool *ControllerProfileStoragePool `json:"storage-pool,omitempty" yaml:"storage-pool,omitempty"`
+	// BootstrapConfig holds bootstrap configuration values.
+	BootstrapConfig map[string]string `json:"bootstrap-config,omitempty" yaml:"bootstrap-config,omitempty"`
+	// ControllerConfig holds controller configuration.
+	ControllerConfig map[string]string `json:"controller-config,omitempty" yaml:"controller-config,omitempty"`
+	// ControllerModelConfig holds model configuration values that apply only to the controller model.
+	ControllerModelConfig map[string]string `json:"controller-model-config,omitempty" yaml:"controller-model-config,omitempty"`
+}
+
+// ControllerProfileStoragePool stores the optional storage pool configuration for a profile.
+type ControllerProfileStoragePool struct {
+	// Name is the storage pool name and is required.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Type is the storage pool type and is required.
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	// Attributes holds additional storage pool attributes.
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
+}
+
+// SaveControllerProfileRequest saves or replaces a named controller profile.
+type SaveControllerProfileRequest struct {
+	ControllerProfile
+}
+
+// SaveControllerProfileResponse contains the saved controller profile.
+type SaveControllerProfileResponse struct {
+	ControllerProfile
+}
+
+// GetControllerProfileRequest retrieves a controller profile by name.
+type GetControllerProfileRequest struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// GetControllerProfileResponse contains a single controller profile.
+type GetControllerProfileResponse struct {
+	ControllerProfile
+}
+
+// ListControllerProfilesRequest lists all saved controller profiles.
+type ListControllerProfilesRequest struct{}
+
+// ListControllerProfilesResponse contains the summary fields for all saved controller profiles.
+type ListControllerProfilesResponse struct {
+	Profiles []ControllerProfileSummary `json:"profiles" yaml:"profiles"`
+}
+
+// RemoveControllerProfileRequest removes a controller profile by name.
+type RemoveControllerProfileRequest struct {
+	Name string `json:"name" yaml:"name"`
+}
+
 // UpgradeToRequest holds the parameters for phase 1 for automated upgrades.
 type UpgradeToRequest struct {
 	// ModelTag is the tag of the model to upgrade.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -252,6 +252,8 @@ type ControllerProfile struct {
 	Name string `json:"name" yaml:"name"`
 	// Description is an optional human-readable summary of the profile.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// JujuVersion is the Juju version(s) this profile is intended for e.g. 3, 3.6, 3.6.1.
+	JujuVersion string `json:"juju-version" yaml:"juju-version"`
 	// Version must be provided when updating an existing profile.
 	Version uint `json:"version" yaml:"version"`
 	// CreatedAt is the time the profile was first created.
@@ -358,8 +360,16 @@ type GetControllerProfileResponse struct {
 	ControllerProfile
 }
 
-// ListControllerProfilesRequest lists all saved controller profiles.
-type ListControllerProfilesRequest struct{}
+// ListControllerProfilesRequest lists saved controller profiles and can filter
+// them by Juju version.
+type ListControllerProfilesRequest struct {
+	// JujuVersion allows clients to filter profiles to those appropriate for the
+	// Juju version(s) they are intending to use. The filter matches profiles that
+	// specify a Juju version that is a prefix of the provided version. For example,
+	// a filter value of "3.6.7" will show profiles with juju-version set to "3",
+	// "3.6", and "3.6.7" but not "3.6.5", or "3.7", or "4".
+	JujuVersion string `json:"juju-version,omitempty" yaml:"juju-version,omitempty"`
+}
 
 // ListControllerProfilesResponse contains the summary fields for all saved controller profiles.
 type ListControllerProfilesResponse struct {

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -17,6 +17,7 @@ func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRe
 		ControllerProfile: apiparams.ControllerProfile{
 			Name:        name,
 			Description: "Reusable bootstrap settings",
+			JujuVersion: "3.6",
 			Cloud: apiparams.ControllerProfileCloud{
 				Name:           "aws",
 				Type:           "ec2",
@@ -109,6 +110,67 @@ func TestControllerProfileValidation(t *testing.T) {
 	malformedPool.BootstrapOptions.StoragePool = &apiparams.ControllerProfileStoragePool{Name: "controller-pool"}
 	_, err = client.SaveControllerProfile(&malformedPool)
 	c.Assert(err, qt.ErrorMatches, ".*storage pool requires both name and type.*")
+
+	missingVersion := testControllerProfileRequest("missing-version")
+	missingVersion.JujuVersion = ""
+	_, err = client.SaveControllerProfile(&missingVersion)
+	c.Assert(err, qt.ErrorMatches, ".*juju version must be provided.*")
+
+	invalidVersion := testControllerProfileRequest("invalid-version")
+	invalidVersion.JujuVersion = "3.6.x"
+	_, err = client.SaveControllerProfile(&invalidVersion)
+	c.Assert(err, qt.ErrorMatches, ".*partial/full version string with one, two, or three dot-separated numeric components.*")
+
+	buildVersion := testControllerProfileRequest("build-version")
+	buildVersion.JujuVersion = "3.6.4.1"
+	_, err = client.SaveControllerProfile(&buildVersion)
+	c.Assert(err, qt.ErrorMatches, ".*partial/full version string with one, two, or three dot-separated numeric components.*")
+
+	taggedVersion := testControllerProfileRequest("tagged-version")
+	taggedVersion.JujuVersion = "3.6-beta1"
+	_, err = client.SaveControllerProfile(&taggedVersion)
+	c.Assert(err, qt.ErrorMatches, ".*partial/full version string with one, two, or three dot-separated numeric components.*")
+
+	_, err = client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{JujuVersion: "3.6.x"})
+	c.Assert(err, qt.ErrorMatches, ".*juju version filter must be a partial/full version string with one, two, or three dot-separated numeric components.*")
+
+	_, err = client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{JujuVersion: "3.6.4.1"})
+	c.Assert(err, qt.ErrorMatches, ".*juju version filter must be a partial/full version string with one, two, or three dot-separated numeric components.*")
+
+	_, err = client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{JujuVersion: "3.6-beta1"})
+	c.Assert(err, qt.ErrorMatches, ".*juju version filter must be a partial/full version string with one, two, or three dot-separated numeric components.*")
+}
+
+func TestControllerProfileListFiltering(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	conn := s.Open(c, nil, "alice", nil)
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+
+	for _, tc := range []struct {
+		name        string
+		jujuVersion string
+	}{
+		{name: "profile-3", jujuVersion: "3"},
+		{name: "profile-3-6", jujuVersion: "3.6"},
+		{name: "profile-3-6-4", jujuVersion: "3.6.4"},
+		{name: "profile-4", jujuVersion: "4"},
+	} {
+		req := testControllerProfileRequest(tc.name)
+		req.JujuVersion = tc.jujuVersion
+		_, err := client.SaveControllerProfile(&req)
+		c.Assert(err, qt.IsNil)
+	}
+
+	profiles, err := client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{JujuVersion: "3.6.4"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 3)
+	c.Assert(profiles[0].Name, qt.Equals, "profile-3")
+	c.Assert(profiles[1].Name, qt.Equals, "profile-3-6")
+	c.Assert(profiles[2].Name, qt.Equals, "profile-3-6-4")
 }
 
 func TestControllerProfileUnauthorized(t *testing.T) {

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRequest {
+	return apiparams.SaveControllerProfileRequest{
+		ControllerProfile: apiparams.ControllerProfile{
+			Name:        name,
+			Description: "Reusable bootstrap settings",
+			Cloud: apiparams.ControllerProfileCloud{
+				Name:           "aws",
+				Type:           "ec2",
+				AuthTypes:      []string{"access-key"},
+				CACertificates: []string{"ca-cert"},
+				Config:         map[string]interface{}{"default-base": "ubuntu@24.04"},
+				Endpoint:       "https://aws.example.com",
+				Region: apiparams.ControllerProfileCloudRegion{
+					Name:             "eu-west-1",
+					Endpoint:         "https://region.example.com",
+					IdentityEndpoint: "https://identity.example.com",
+					StorageEndpoint:  "https://storage.example.com",
+				},
+			},
+			BootstrapOptions: apiparams.ControllerProfileBootstrapOptions{
+				BootstrapBase:         "ubuntu@24.04",
+				BootstrapConstraints:  map[string]string{"mem": "8G", "cores": "2"},
+				ModelConstraints:      map[string]string{"arch": "amd64"},
+				ModelDefault:          map[string]string{"logging-config": "<root>=INFO"},
+				BootstrapConfig:       map[string]string{"bootstrap-timeout": "20m"},
+				ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
+				ControllerModelConfig: map[string]string{"logging-config": "<root>=INFO"},
+				StoragePool: &apiparams.ControllerProfileStoragePool{
+					Name:       "controller-pool",
+					Type:       "ebs",
+					Attributes: map[string]string{"volume-type": "gp3"},
+				},
+			},
+		},
+	}
+}
+
+func TestControllerProfileCRUD(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	conn := s.Open(c, nil, "alice", nil)
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+
+	req := testControllerProfileRequest("aws-production")
+	saved, err := client.SaveControllerProfile(&req)
+	c.Assert(err, qt.IsNil)
+	c.Assert(saved.Name, qt.Equals, req.Name)
+	c.Assert(saved.Version, qt.Equals, uint(1))
+	c.Assert(saved.CreatedAt, qt.Not(qt.Equals), "")
+	c.Assert(saved.UpdatedAt, qt.Not(qt.Equals), "")
+
+	got, err := client.GetControllerProfile(&apiparams.GetControllerProfileRequest{Name: req.Name})
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.ControllerProfile, qt.DeepEquals, saved.ControllerProfile)
+
+	saved.Description = "Updated reusable bootstrap settings"
+	updated, err := client.SaveControllerProfile(&apiparams.SaveControllerProfileRequest{ControllerProfile: saved.ControllerProfile})
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated.Version, qt.Equals, uint(2))
+	c.Assert(updated.Description, qt.Equals, "Updated reusable bootstrap settings")
+
+	profiles, err := client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(profiles, qt.HasLen, 1)
+	c.Assert(profiles[0].Name, qt.Equals, req.Name)
+	c.Assert(profiles[0].Description, qt.Equals, updated.Description)
+	c.Assert(profiles[0].CreatedAt, qt.Not(qt.Equals), "")
+	c.Assert(profiles[0].UpdatedAt, qt.Not(qt.Equals), "")
+
+	err = client.RemoveControllerProfile(&apiparams.RemoveControllerProfileRequest{Name: req.Name})
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.GetControllerProfile(&apiparams.GetControllerProfileRequest{Name: req.Name})
+	c.Assert(err, qt.ErrorMatches, ".*not found.*")
+}
+
+func TestControllerProfileValidation(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	conn := s.Open(c, nil, "alice", nil)
+	defer conn.Close()
+
+	client := api.NewClient(conn)
+
+	builtIn := testControllerProfileRequest("local-profile")
+	builtIn.Cloud.Name = "localhost"
+	_, err := client.SaveControllerProfile(&builtIn)
+	c.Assert(err, qt.ErrorMatches, ".*built-in clouds like \"localhost\".*")
+
+	malformedPool := testControllerProfileRequest("bad-storage-pool")
+	malformedPool.BootstrapOptions.StoragePool = &apiparams.ControllerProfileStoragePool{Name: "controller-pool"}
+	_, err = client.SaveControllerProfile(&malformedPool)
+	c.Assert(err, qt.ErrorMatches, ".*storage pool requires both name and type.*")
+}
+
+func TestControllerProfileUnauthorized(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	adminConn := s.Open(c, nil, "alice", nil)
+	defer adminConn.Close()
+	adminClient := api.NewClient(adminConn)
+
+	req := testControllerProfileRequest("shared-profile")
+	_, err := adminClient.SaveControllerProfile(&req)
+	c.Assert(err, qt.IsNil)
+
+	conn := s.Open(c, nil, "not-authorized-user", nil)
+	defer conn.Close()
+	client := api.NewClient(conn)
+
+	unauthorizedReq := testControllerProfileRequest("unauthorized-profile")
+	_, err = client.SaveControllerProfile(&unauthorizedReq)
+	c.Assert(err, qt.ErrorMatches, ".*unauthorized.*")
+
+	_, err = client.GetControllerProfile(&apiparams.GetControllerProfileRequest{Name: req.Name})
+	c.Assert(err, qt.ErrorMatches, ".*unauthorized.*")
+
+	_, err = client.ListControllerProfiles(&apiparams.ListControllerProfilesRequest{})
+	c.Assert(err, qt.ErrorMatches, ".*unauthorized.*")
+
+	err = client.RemoveControllerProfile(&apiparams.RemoveControllerProfileRequest{Name: req.Name})
+	c.Assert(err, qt.ErrorMatches, ".*unauthorized.*")
+}


### PR DESCRIPTION
## Description
This PR builds on https://github.com/canonical/jimm/pull/1904.

It implements the CRUD api methods and domain methods for the controller profiles feature and introduces the client methods for using the new api methods.

This PR also adds a new field `juju-version` to the controller profile that must be specified when creating a profile. It is a string value representing a full/partial version e.g. `3` or `3.6` or `3.6.7` and can be used when listing profiles as a filter.

Some things worth noting:
1. We convert from the dbmodel type to the api type in the api layer. There is no domain specific representation at the moment. This was mostly done with the thinking that we can add domain types in the future if needed.
2. In the api layer, I've put the new methods in `internal/jujuapi/controllerprofile.go`. Currently all the methods on the JIMM facade are inside of `internal/jujuapi/jimm.go` but this file is getting quite big (nearing 900 lines), so I think it makes sense to split it out.

Resolves [JUJU-9425](https://warthogs.atlassian.net/browse/JUJU-9425)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


[JUJU-9425]: https://warthogs.atlassian.net/browse/JUJU-9425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ