### PR TITLE
test: fix tests with Juju 3.6.19

### DIFF
--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -136,7 +136,7 @@ func TestControllerVersion(t *testing.T) {
 	err := conn.APICall("Controller", 12, "", "ControllerVersion", nil, &result)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.DeepEquals, jujuparams.ControllerVersionResults{
-		Version:   "3.6.14",
+		Version:   "3.6.19",
 		GitCommit: jimmversion.VersionInfo.GitCommit,
 	})
 }

--- a/tests/upgrades/upgrade.sh
+++ b/tests/upgrades/upgrade.sh
@@ -13,7 +13,7 @@ source "local/jimm/detect-jaas.sh"
 # See: https://warthogs.atlassian.net/browse/JUJU-8938
 JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
 UPGRADE_CONTROLLER="upgrade-source-controller"
-SOURCE_CONTROLLER_VERSION="3.6.11"
+SOURCE_CONTROLLER_VERSION="3.6.19"
 # Generate a random 4-character suffix for the model name.
 RAND_SUFFIX=$(tr -dc 'a-z0-9' </dev/urandom | head -c 4 || true)
 UPGRADING_MODEL_NAME="upgrading-model-$RAND_SUFFIX"
@@ -75,13 +75,14 @@ max_attempts=60  # 60 attempts = 5 minutes / 5 seconds
 attempt=1
 while [ $attempt -le $max_attempts ]; do
     sleep 5
-    new_version="$(juju show-model "$UPGRADING_MODEL_NAME" | yq -r ".${UPGRADING_MODEL_NAME}.agent-version")"
-    if [ "$new_version" != "$current_model_version" ]; then
-        echo "Model upgrade completed to version $new_version."
+    controller_info="$($JAAS show-model "$model_uuid" --format json)"
+    current_controller="$(echo "$controller_info" | jq -r '."controller-name"')"
+    if [ "$current_controller" = "$target_controller" ]; then
+        echo "Model upgrade completed on controller $current_controller."
         break
     fi
     echo
-    echo "Upgrade still in progress (attempt $attempt/$max_attempts), current model version: $new_version"
+    echo "Upgrade still in progress (attempt $attempt/$max_attempts), current backing controller: $current_controller"
     attempt=$((attempt + 1))
 done
 if [ $attempt -gt $max_attempts ]; then


### PR DESCRIPTION
## Description
Fixes 2 test failures with Juju 3.6.19.
1. Expected controller version 3.6.14 -> 3.6.19
2. Our e2e test cannot bootstrap a 3.6.11 controller as 3.6.19 has fixed a Mongo vulnerability and cannot bootstrap older 3.6 versions anymore. Our `upgrade` test was verifying a model was migrated and upgraded away from 3.6.11. Since we now need to bootstrap a 3.6.19 controller/model and migrate it to another 3.6.19 controller the existing check needs to change. Now we check which controller is hosting the model to confirm the migrate+upgrade rather than checking the model version.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests
