### PR TITLE
refactor: replace redundant dial permissions with superuser

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -362,6 +362,6 @@ func NewDialerAdapter(dialer *jujuclient.Dialer) *DialerAdapter {
 // Dial implements the juju.Dialer interface for the DialerAdapter.
 // It uses the underlying jujuclient.Dialer to establish a connection
 // to the Juju controller and returns a juju.API connection.
-func (d *DialerAdapter) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (juju.API, error) {
-	return d.dialer.Dial(ctx, ctl, modelTag, user, withPermissions)
+func (d *DialerAdapter) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (juju.API, error) {
+	return d.dialer.Dial(ctx, ctl, modelTag, user)
 }

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -212,11 +212,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		ctx,
 		&offer.Model.Controller,
 		names.ModelTag{},
-		user,
-		permission{
-			resource: names.NewApplicationOfferTag(offer.UUID).String(),
-			relation: accessLevel,
-		},
+		nil,
 	)
 	if err != nil {
 		return errors.E(err)

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -30,7 +30,7 @@ type Dialer interface {
 	// dialing the controller the UUID, AgentVersion and HostPorts fields
 	// in the given controller should be updated to the values provided
 	// by the controller.
-	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (API, error)
+	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error)
 }
 
 // An API is the interface JIMM uses to access the API on a controller.

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -75,27 +75,15 @@ func NewJujuManager(
 	}, nil
 }
 
-type permission struct {
-	resource string
-	relation string
-}
-
 // dial dials the controller and model specified by the given Controller
 // and ModelTag. If no Dialer has been configured then an error with a
 // code of CodeConnectionFailed will be returned.
-func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, permissons ...permission) (API, error) {
+func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error) {
 	if j == nil || j.Dialer == nil {
 		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
 	}
-	var permissionMap map[string]string
-	if len(permissons) > 0 {
-		permissionMap = make(map[string]string, len(permissons))
-		for _, p := range permissons {
-			permissionMap[p.resource] = p.relation
-		}
-	}
 
-	return j.Dialer.Dial(ctx, ctl, modelTag, user, permissionMap)
+	return j.Dialer.Dial(ctx, ctl, modelTag, user, make(map[string]string, 0))
 }
 
 // ResourceTag returns JIMM's controller tag stating its UUID.

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -83,7 +83,7 @@ func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTa
 		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
 	}
 
-	return j.Dialer.Dial(ctx, ctl, modelTag, user, make(map[string]string, 0))
+	return j.Dialer.Dial(ctx, ctl, modelTag, user)
 }
 
 // ResourceTag returns JIMM's controller tag stating its UUID.

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"github.com/juju/juju/api/base"
-	jujupermission "github.com/juju/juju/core/permission"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil"
@@ -547,10 +546,6 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 		b.controller,
 		names.ModelTag{},
 		nil,
-		permission{
-			resource: b.cloud.ResourceTag().String(),
-			relation: string(jujupermission.AddModelAccess),
-		},
 	)
 	if err != nil {
 		b.err = errors.E(err)

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -106,7 +106,7 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 	currentControllerVersion := ctl.AgentVersion
 
 	// connect to the controller
-	api, err = w.Dialer.Dial(ctx, ctl, names.ModelTag{}, nil, nil)
+	api, err = w.Dialer.Dial(ctx, ctl, names.ModelTag{}, nil)
 	if err != nil {
 		ctl.UnavailableSince = db.Now()
 		updateController = true

--- a/internal/jimm/upgrade/mocks/dialer.go
+++ b/internal/jimm/upgrade/mocks/dialer.go
@@ -45,18 +45,18 @@ func (m *MockDialer) EXPECT() *MockDialerMockRecorder {
 }
 
 // Dial mocks base method.
-func (m *MockDialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (juju.API, error) {
+func (m *MockDialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (juju.API, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", ctx, ctl, modelTag, user, withPermissions)
+	ret := m.ctrl.Call(m, "Dial", ctx, ctl, modelTag, user)
 	ret0, _ := ret[0].(juju.API)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dial indicates an expected call of Dial.
-func (mr *MockDialerMockRecorder) Dial(ctx, ctl, modelTag, user, withPermissions any) *MockDialerDialCall {
+func (mr *MockDialerMockRecorder) Dial(ctx, ctl, modelTag, user any) *MockDialerDialCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockDialer)(nil).Dial), ctx, ctl, modelTag, user, withPermissions)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockDialer)(nil).Dial), ctx, ctl, modelTag, user)
 	return &MockDialerDialCall{Call: call}
 }
 
@@ -72,13 +72,13 @@ func (c *MockDialerDialCall) Return(arg0 juju.API, arg1 error) *MockDialerDialCa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDialerDialCall) Do(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User, map[string]string) (juju.API, error)) *MockDialerDialCall {
+func (c *MockDialerDialCall) Do(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User) (juju.API, error)) *MockDialerDialCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDialerDialCall) DoAndReturn(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User, map[string]string) (juju.API, error)) *MockDialerDialCall {
+func (c *MockDialerDialCall) DoAndReturn(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User) (juju.API, error)) *MockDialerDialCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -101,7 +101,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 		return errors.E(errors.CodeNotFound, err, "model not found")
 	}
 
-	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil, nil)
+	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial target controller: %w", err))
 	}

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -428,7 +428,7 @@ func TestUpgradeModel_AlreadyAtTargetDoesNotCallUpgrade(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	s.api.EXPECT().ModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, mt names.ModelTag) (jujuclient.ModelInfo, error) {
@@ -469,7 +469,7 @@ func TestUpgradeModel_RetriesUntilModelReportsTargetVersion(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	modelInfoCalls := 0
@@ -524,7 +524,7 @@ func TestUpgradeModel_AlreadyUpgraded(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	s.api.EXPECT().ModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, mt names.ModelTag) (jujuclient.ModelInfo, error) {

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -103,7 +103,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil, nil)
+	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -98,7 +98,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, model.ResourceTag(), nil, nil)
+	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, model.ResourceTag(), nil)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -31,7 +31,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
 	"github.com/canonical/jimm/v3/internal/openfga"
-	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/rpc"
 	"github.com/canonical/jimm/v3/internal/servermon"
 	jimmversion "github.com/canonical/jimm/v3/version"
@@ -55,13 +54,20 @@ type Dialer struct {
 	JWTService                 *jimmjwx.JWTService
 }
 
-func (d *Dialer) createLoginRequest1(ctx context.Context, controllerTag names.ControllerTag, userTag names.UserTag, permissions map[string]string) (*jujuparams.LoginRequest, error) {
-	if len(permissions) == 0 {
-		return nil, errors.E("")
+func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*jujuparams.LoginRequest, error) {
+	// Always request superuser permissions, even when representing a non-admin user
+	// This is only safe because we have already checked the user's openfga permissions in a layer above.
+	permissions := make(map[string]string)
+	permissions[ctl.ResourceTag().String()] = "superuser"
+	if modelTag.Id() != "" {
+		permissions[modelTag.String()] = string(jujuparams.ModelAdminAccess)
 	}
+
+	userTag := user.ResourceTag().String()
+
 	jwt, err := d.JWTService.NewJWT(ctx, jimmjwx.JWTParams{
-		Controller: controllerTag.Id(),
-		User:       userTag.String(),
+		Controller: ctl.ResourceTag().Id(),
+		User:       userTag,
 		Access:     permissions,
 	})
 	if err != nil {
@@ -70,44 +76,10 @@ func (d *Dialer) createLoginRequest1(ctx context.Context, controllerTag names.Co
 	jwtString := base64.StdEncoding.EncodeToString(jwt)
 
 	return &jujuparams.LoginRequest{
-		AuthTag:       userTag.String(),
+		AuthTag:       userTag,
 		ClientVersion: jimmversion.ControllerVersion,
 		Token:         jwtString,
 	}, nil
-}
-
-func (d *Dialer) createAdminLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (*jujuparams.LoginRequest, error) {
-	permissions := make(map[string]string)
-	permissions[ctl.ResourceTag().String()] = "superuser"
-	if modelTag.Id() != "" {
-		permissions[modelTag.String()] = string(jujuparams.ModelAdminAccess)
-	}
-	return d.createLoginRequest1(ctx, ctl.ResourceTag(), names.NewUserTag(adminUser), permissions)
-}
-
-func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*jujuparams.LoginRequest, error) {
-	permissions := make(map[string]string)
-	permissions[ctl.ResourceTag().String()] = "superuser"
-	modelRelation := user.GetModelAccess(ctx, modelTag)
-	if modelRelation != ofganames.NoRelation {
-		permissions[modelTag.String()] = toModelAccessString(modelRelation)
-	}
-
-	return d.createLoginRequest1(ctx, ctl.ResourceTag(), user.ResourceTag(), permissions)
-}
-
-// toModelAccessString maps relation to a model access string.
-func toModelAccessString(relation openfga.Relation) string {
-	switch relation {
-	case ofganames.AdministratorRelation:
-		return "admin"
-	case ofganames.WriterRelation:
-		return "write"
-	case ofganames.ReaderRelation:
-		return "read"
-	default:
-		return ""
-	}
 }
 
 // Dial implements jimm.Dialer.
@@ -123,21 +95,13 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	client := rpc.NewClient(conn)
 
 	if user == nil {
-		user = &openfga.User{Identity: &dbmodel.Identity{Name: "admin"}}
+		user = &openfga.User{Identity: &dbmodel.Identity{Name: adminUser}}
 	}
 
 	var loginRequest *jujuparams.LoginRequest
-	if user.Name == adminUser {
-		loginRequest, err = d.createAdminLoginRequest(ctx, ctl, modelTag)
-		if err != nil {
-			return nil, errors.E(err)
-		}
-
-	} else {
-		loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user)
-		if err != nil {
-			return nil, errors.E(err)
-		}
+	loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user)
+	if err != nil {
+		return nil, errors.E(err)
 	}
 
 	var res jujuparams.LoginResult

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -76,35 +76,24 @@ func (d *Dialer) createLoginRequest1(ctx context.Context, controllerTag names.Co
 	}, nil
 }
 
-func (d *Dialer) createAdminLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, additionalPermissions map[string]string) (*jujuparams.LoginRequest, error) {
+func (d *Dialer) createAdminLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (*jujuparams.LoginRequest, error) {
 	permissions := make(map[string]string)
 	permissions[ctl.ResourceTag().String()] = "superuser"
 	if modelTag.Id() != "" {
 		permissions[modelTag.String()] = string(jujuparams.ModelAdminAccess)
 	}
-	for k, v := range additionalPermissions {
-		permissions[k] = v
-	}
 	return d.createLoginRequest1(ctx, ctl.ResourceTag(), names.NewUserTag(adminUser), permissions)
 }
 
-func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, additionalPermissions map[string]string) (*jujuparams.LoginRequest, error) {
-	p := make(map[string]string)
-	ctlRelation := user.GetControllerAccess(ctx, ctl.ResourceTag())
-	if ctlRelation == ofganames.AdministratorRelation {
-		p[ctl.ResourceTag().String()] = "superuser"
-	} else {
-		p[ctl.ResourceTag().String()] = "login"
-	}
+func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*jujuparams.LoginRequest, error) {
+	permissions := make(map[string]string)
+	permissions[ctl.ResourceTag().String()] = "superuser"
 	modelRelation := user.GetModelAccess(ctx, modelTag)
 	if modelRelation != ofganames.NoRelation {
-		p[modelTag.String()] = toModelAccessString(modelRelation)
+		permissions[modelTag.String()] = toModelAccessString(modelRelation)
 	}
 
-	for k, v := range additionalPermissions {
-		p[k] = v
-	}
-	return d.createLoginRequest1(ctx, ctl.ResourceTag(), user.ResourceTag(), p)
+	return d.createLoginRequest1(ctx, ctl.ResourceTag(), user.ResourceTag(), permissions)
 }
 
 // toModelAccessString maps relation to a model access string.
@@ -122,7 +111,7 @@ func toModelAccessString(relation openfga.Relation) string {
 }
 
 // Dial implements jimm.Dialer.
-func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User, withPermissions map[string]string) (*Connection, error) {
+func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*Connection, error) {
 
 	conn, err := rpc.Dial(ctx, ctl, modelTag, "", nil, nil)
 	if err != nil {
@@ -139,13 +128,13 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 
 	var loginRequest *jujuparams.LoginRequest
 	if user.Name == adminUser {
-		loginRequest, err = d.createAdminLoginRequest(ctx, ctl, modelTag, withPermissions)
+		loginRequest, err = d.createAdminLoginRequest(ctx, ctl, modelTag)
 		if err != nil {
 			return nil, errors.E(err)
 		}
 
 	} else {
-		loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user, withPermissions)
+		loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user)
 		if err != nil {
 			return nil, errors.E(err)
 		}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -56,7 +56,7 @@ type Dialer struct {
 }
 
 // Dialer implements juju.Dialer.
-func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelTag, _ *openfga.User, _ map[string]string) (juju.API, error) {
+func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelTag, _ *openfga.User) (juju.API, error) {
 	if d.Err != nil {
 		return nil, d.Err
 	}
@@ -101,9 +101,9 @@ func (w apiWrapper) Close() error {
 type ModelDialerMap map[string]juju.Dialer
 
 // Dial implements juju.Dialer.
-func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User, _ map[string]string) (juju.API, error) {
+func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User) (juju.API, error) {
 	if d, ok := m[mt.Id()]; ok {
-		return d.Dial(ctx, ctl, mt, nil, nil)
+		return d.Dial(ctx, ctl, mt, nil)
 	}
 	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }
@@ -113,9 +113,9 @@ func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt na
 type DialerMap map[string]juju.Dialer
 
 // Dial implements juju.Dialer.
-func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User, _ map[string]string) (juju.API, error) {
+func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User) (juju.API, error) {
 	if d, ok := m[ctl.Name]; ok {
-		return d.Dial(ctx, ctl, mt, nil, nil)
+		return d.Dial(ctx, ctl, mt, nil)
 	}
 	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }

--- a/testing/dial_test.go
+++ b/testing/dial_test.go
@@ -31,7 +31,7 @@ func TestDial(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil, nil)
+	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -68,7 +68,7 @@ func TestDialWithJWT(t *testing.T) {
 	}
 
 	// Check dial is OK
-	api, err := dialer.Dial(ctx, &ctl, names.ModelTag{}, nil, nil)
+	api, err := dialer.Dial(ctx, &ctl, names.ModelTag{}, nil)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -97,7 +97,7 @@ func TestDialModelStatusMissingModel(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil, nil)
+	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -124,7 +124,7 @@ func TestConnectStreams(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, model.ResourceTag(), nil, nil)
+	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, model.ResourceTag(), nil)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 


### PR DESCRIPTION
## Description

Remove the ability to explicitly pass permissions when dialling a controller, since in the vast majority of cases it wasn't used. The couple cases that did use it didn't need it.

Always set `superuser` permissions when dialling, whether as an `admin` user or as an openfga user.

Since the user wasn't passed in the vast majority of cases anyway, the net effect of these changes on the dialling login request is zero.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
