### PR TITLE
refactor: pass in user to dial

### DIFF
--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -40,7 +40,6 @@ type AddApplicationOfferParams struct {
 
 // Offer creates a new application offer.
 func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddApplicationOfferParams) error {
-
 	model := dbmodel.Model{
 		UUID: sql.NullString{
 			String: offer.ModelTag.Id(),
@@ -81,7 +80,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return errors.E(err)
 	}
 
-	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
+	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}
@@ -208,12 +207,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		return errors.E(errors.CodeNotFound)
 	}
 
-	api, err := j.dial(
-		ctx,
-		&offer.Model.Controller,
-		names.ModelTag{},
-		nil,
-	)
+	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}
@@ -371,12 +365,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// controller. The all-watcher events do not include enough
 	// information to reasonably keep the local database up-to-date,
 	// and it would be non-trivial to make it do so.
-	api, err := j.dial(
-		ctx,
-		&offer.Model.Controller,
-		names.ModelTag{},
-		nil,
-	)
+	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return nil, errors.E(err)
 	}
@@ -532,7 +521,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 			// Return early if a single controller has an error
 			// to avoid misleading clients about what exists which
 			// could cause unneeded reconciliation.
-			api, err := j.dial(ctx, ctl, names.ModelTag{}, nil)
+			api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
 			if err != nil {
 				return errors.E(err)
 			}
@@ -590,12 +579,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	// add offer admin claim
-	api, err := j.dial(
-		ctx,
-		&offer.Model.Controller,
-		names.ModelTag{},
-		nil,
-	)
+	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -292,7 +292,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	shuffleRegionControllers(region.Controllers)
 	controller := region.Controllers[0].Controller
 
-	ccloud, err := j.addControllerCloud(ctx, &controller, user.ResourceTag(), tag, cloud, force)
+	ccloud, err := j.addControllerCloud(ctx, &controller, user, tag, cloud, force)
 	if err != nil {
 		// TODO(mhilton) remove the added cloud if adding it to the controller failed.
 		return errors.E(err)
@@ -344,9 +344,8 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 // addControllerCloud returns the definition of the cloud retrieved from
 // the controller. No error will be returned if the cloud already exists on
 // the controller or the user already has access to the cloud.
-func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, ut names.UserTag, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
-
-	api, err := j.dial(ctx, ctl, names.ModelTag{}, nil)
+func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
+	api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
 	if err != nil {
 		return nil, errors.E(err)
 	}
@@ -403,7 +402,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		}
 		return errors.E(fmt.Sprintf("cloud administration not available for %s", ct.Id()))
 	}
-	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, nil)
+	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}
@@ -553,7 +552,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 		return errors.E("cloud not hosted by controller", errors.CodeNotFound)
 	}
 
-	api, err := j.dial(ctx, &controller, names.ModelTag{}, nil)
+	api, err := j.dial(ctx, &controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}
@@ -677,7 +676,7 @@ func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmode
 	dbCloud.FromJujuCloud(cloud)
 	dbCloud.Name = tag.Id()
 
-	ccloud, err := j.addControllerCloud(ctx, controller, user.ResourceTag(), tag, cloud, force)
+	ccloud, err := j.addControllerCloud(ctx, controller, user, tag, cloud, force)
 	if err != nil {
 		return dbCloud, errors.E(err)
 	}

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -204,7 +204,7 @@ func addControllerTx(ctx context.Context, j *JujuManager, jujuClouds []dbmodel.C
 // returned.
 func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, creds ControllerCreds) error {
 
-	api, err := j.dialController(ctx, ctl)
+	api, err := j.dialController(ctx, ctl, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial the controller: %v", err))
 	}
@@ -354,13 +354,13 @@ func newModelImporter(jimm *JujuManager, newOwner string) (modelImporter, error)
 	return modelImporter, nil
 }
 
-func (m *modelImporter) fetchModelInfo(ctx context.Context, controllerName string, modelTag names.ModelTag) error {
+func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag) error {
 	controller, err := m.jimm.getControllerByName(ctx, controllerName)
 	if err != nil {
 		return err
 	}
 
-	api, err := m.jimm.dialController(ctx, controller)
+	api, err := m.jimm.dialController(ctx, controller, user)
 	if err != nil {
 		return errors.E("failed to dial the controller", err)
 	}
@@ -535,7 +535,7 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 		return errors.E(err)
 	}
 
-	if err := importer.fetchModelInfo(ctx, controllerName, modelTag); err != nil {
+	if err := importer.fetchModelInfo(ctx, user, controllerName, modelTag); err != nil {
 		return errors.E(err)
 	}
 
@@ -726,14 +726,14 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 }
 
 // ControllerConfig returns the controller config for the specified controller.
-func (j *JujuManager) ControllerConfig(ctx context.Context, controllerName string) (jujucontroller.Config, error) {
+func (j *JujuManager) ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error) {
 
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
 		return jujucontroller.Config{}, errors.E(err)
 	}
 
-	api, err := j.dialController(ctx, controller)
+	api, err := j.dialController(ctx, controller, user)
 	if err != nil {
 		return jujucontroller.Config{}, errors.E(err)
 	}

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -427,12 +427,21 @@ func TestControllerConfig(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testControllerConfigEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	config, err := j.ControllerConfig(ctx, env.Controllers[0].Name)
+	u, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	alice := openfga.NewUser(u, j.OpenFGAClient)
+	alice.JimmAdmin = true
+
+	err = alice.SetControllerAccess(context.Background(), j.ResourceTag(), ofganames.AdministratorRelation)
+	c.Assert(err, qt.IsNil)
+
+	config, err := j.ControllerConfig(ctx, alice, env.Controllers[0].Name)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(config, qt.Not(qt.IsNil))
 	c.Assert(config.SSHServerPort(), qt.Equals, 17022)
 
-	_, err = j.ControllerConfig(ctx, "not-found")
+	_, err = j.ControllerConfig(ctx, alice, "not-found")
 	c.Assert(err, qt.ErrorMatches, "controller not found")
 }
 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -47,7 +47,7 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 		return errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController)
+	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -100,7 +100,7 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 		return nil, errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController)
+	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
 		return nil, errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -198,7 +198,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 		return errors.E(err)
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController)
+	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -276,7 +276,7 @@ func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, mo
 		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
 	}
 
-	api, err := j.dialController(ctx, &model.Controller)
+	api, err := j.dialController(ctx, &model.Controller, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -367,7 +367,7 @@ func modifyModelDescription(modelDescription description.Model, userMapping dbmo
 
 // LatestLogTime asks the target controller for the time of the latest
 // log record it has seen.
-func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error) {
+func (j *JujuManager) LatestLogTime(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error) {
 
 	model := dbmodel.Model{
 		UUID: sql.NullString{
@@ -380,7 +380,7 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time
 		return time.Time{}, errors.E(fmt.Errorf("failed to get model %q: %w", modelUUID, err))
 	}
 
-	api, err := j.dialController(ctx, &model.Controller)
+	api, err := j.dialController(ctx, &model.Controller, user)
 	if err != nil {
 		return time.Time{}, errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -395,7 +395,7 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, modelUUID string) (time
 
 // Activate gets the model migration, proxies the Activate call to the target controller,
 // and then deletes the model migration from the database.
-func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error {
+func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error {
 
 	modelMigration := dbmodel.IncomingModelMigration{
 		ModelUUID: sql.NullString{
@@ -407,7 +407,7 @@ func (j *JujuManager) Activate(ctx context.Context, modelTag names.ModelTag, mig
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err))
 	}
-	api, err := j.dialController(ctx, &modelMigration.TargetController)
+	api, err := j.dialController(ctx, &modelMigration.TargetController, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}
@@ -541,7 +541,7 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	}
 
 	// Call the import method on the target controller to import the model.
-	api, err := j.dialController(ctx, &incomingMigration.TargetController)
+	api, err := j.dialController(ctx, &incomingMigration.TargetController, user)
 	if err != nil {
 		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
 	}

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -792,7 +792,10 @@ func TestActivate_Success(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(incomingModelMigration.UserMapping["jane"], qt.Equals, "")
 
-	err = j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+
+	err = j.Activate(ctx, user, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.IsNil)
 
 	modelMigration := dbmodel.IncomingModelMigration{
@@ -853,7 +856,10 @@ func TestActivate_APIFailure(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testEnvWithIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	err := j.Activate(ctx, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+
+	err := j.Activate(ctx, user, names.NewModelTag(migratingModelUUID), sourceInfo, relatedModels)
 	c.Assert(err, qt.ErrorMatches, `.*API failure`)
 
 	modelMigration := dbmodel.IncomingModelMigration{
@@ -876,7 +882,10 @@ func TestActivate_NoIncomingModelMigration(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, testEnvNoIncomingMigration)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	err := j.Activate(ctx, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+
+	err := j.Activate(ctx, user, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
 	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
@@ -978,12 +987,15 @@ func TestLatestLogTime_Success(t *testing.T) {
 	env := jimmtest.ParseEnvironment(c, migratedModelEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
+	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+
 	// Test a model UUID that does not exist
-	_, err := j.LatestLogTime(ctx, "does-not-exist")
+	_, err := j.LatestLogTime(ctx, user, "does-not-exist")
 	c.Assert(err, qt.IsNotNil)
 
 	// Test a model UUID that exists
-	logTime, err := j.LatestLogTime(ctx, modelUUID)
+	logTime, err := j.LatestLogTime(ctx, user, modelUUID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(logTime, qt.Not(qt.IsNil))
 	c.Assert(latestLogTimeCalled, qt.IsTrue)

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -214,13 +214,13 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 		return jujuclient.ModelInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, nil)
+	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return jujuclient.ModelInfo{}, errors.E(err)
 	}
 	defer api.Close()
 
-	modelInfo, err := j.modelInfo(ctx, &m, api)
+	modelInfo, err := j.modelInfo(ctx, user, &m, api)
 	if err != nil {
 		return jujuclient.ModelInfo{}, errors.E(err)
 	}
@@ -230,17 +230,17 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 
 // modelInfo retrieves the model information from the controller and reacts
 // to the error to update JIMM's state.
-func (j *JujuManager) modelInfo(ctx context.Context, model *dbmodel.Model, api API) (jujuclient.ModelInfo, error) {
+func (j *JujuManager) modelInfo(ctx context.Context, user *openfga.User, model *dbmodel.Model, api API) (jujuclient.ModelInfo, error) {
 	modelInfo, errFromAPI := api.ModelInfo(ctx, model.ResourceTag())
 
 	if errFromAPI == nil {
 		return j.reactToModelInfoSuccess(ctx, model, modelInfo)
 	} else {
-		return j.reactToModelInfoError(ctx, errFromAPI, model)
+		return j.reactToModelInfoError(ctx, user, errFromAPI, model)
 	}
 }
 
-func (j *JujuManager) reactToModelInfoError(ctx context.Context, errFromAPI error, model *dbmodel.Model) (jujuclient.ModelInfo, error) {
+func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.User, errFromAPI error, model *dbmodel.Model) (jujuclient.ModelInfo, error) {
 	switch model.MigrationMode {
 	case dbmodel.MigrationModeNone:
 		err := j.maybeCleanupModel(ctx, errFromAPI, model)
@@ -261,7 +261,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, errFromAPI erro
 		if err := j.Database.GetModel(ctx, model); err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
-		api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
+		api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
 		if err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
@@ -670,7 +670,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, nil)
+	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
 	if err != nil {
 		return errors.E(err)
 	}

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -42,7 +42,7 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 		if len(models) == 0 {
 			continue
 		}
-		api, err := j.dialController(ctx, &models[0].Controller)
+		api, err := j.dialController(ctx, &models[0].Controller, nil)
 		if err != nil {
 			zapctx.Error(ctx, "cannot dial controller", zap.String("controller", controllerUUID), zap.Error(err))
 			continue
@@ -58,7 +58,7 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 				zap.String("migration-mode", string(m.MigrationMode)),
 			)
 
-			_, err := j.modelInfo(ctx, m, api)
+			_, err := j.modelInfo(ctx, nil, m, api)
 			if err != nil {
 				zapctx.Error(ctx, "error getting model info", zap.Error(err))
 			}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -541,12 +541,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 		return b
 	}
 
-	api, err := b.jujuManager.dial(
-		b.ctx,
-		b.controller,
-		names.ModelTag{},
-		nil,
-	)
+	api, err := b.jujuManager.dial(b.ctx, b.controller, names.ModelTag{}, b.ofgaUser)
 	if err != nil {
 		b.err = errors.E(err)
 		return b

--- a/internal/jimm/juju/utils.go
+++ b/internal/jimm/juju/utils.go
@@ -61,8 +61,8 @@ func (j *JujuManager) getControllerByName(ctx context.Context, controllerName st
 }
 
 // dialController dials a controller.
-func (j *JujuManager) dialController(ctx context.Context, ctl *dbmodel.Controller) (API, error) {
-	api, err := j.dial(ctx, ctl, names.ModelTag{}, nil)
+func (j *JujuManager) dialController(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User) (API, error) {
+	api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial the controller", zaputil.Error(err))
 		return nil, err

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -43,7 +43,7 @@ type IdentityManager interface {
 // JujuManager provides a means to fetch a model from the model service.
 type JujuManager interface {
 	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
-	ControllerConfig(ctx context.Context, controllerName string) (jujucontroller.Config, error)
+	ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error)
 }
 
 // SSHKeyManager provides a means to manage ssh keys within JIMM.
@@ -142,7 +142,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 		return DialInfo{}, fmt.Errorf("cannot find model: %v", err)
 	}
 
-	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, model.Controller.Name)
+	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, user, model.Controller.Name)
 	if err != nil {
 		return DialInfo{}, errors.E(err, "cannot get controller config")
 	}

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -117,7 +117,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 	cfg, err := jujucontroller.NewConfig(uuid, jujutesting.CACert, attrs)
 	c.Assert(err, qt.IsNil)
 	controllerService := mocks.ControllerService{
-		ControllerConfig_: func(ctx context.Context, controllerName string) (jujucontroller.Config, error) {
+		ControllerConfig_: func(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error) {
 			return cfg, nil
 		},
 	}

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -229,7 +229,7 @@ type JujuManager interface {
 	ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
 	RemoveController(ctx context.Context, user *openfga.User, controllerName string, force bool) error
 	SetControllerDeprecated(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error
-	ControllerConfig(ctx context.Context, controllerName string) (jujucontroller.Config, error)
+	ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error)
 
 	// Model related methods
 
@@ -268,9 +268,9 @@ type JujuManager interface {
 	Prechecks(ctx context.Context, user *openfga.User, model juju.MigratingModelInfo) error
 	CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 	Import(ctx context.Context, user *openfga.User, serialized jujuparams.SerializedModel) error
-	Activate(ctx context.Context, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error
+	Activate(ctx context.Context, user *openfga.User, modelTag names.ModelTag, migrationInfo coremigration.SourceControllerInfo, relatedModels []string) error
 	AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
-	LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error)
+	LatestLogTime(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error)
 	AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error
 	CleanupPartialModelMigrations(ctx context.Context) error
 	ListMigrationTargets(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error)

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -140,7 +140,7 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 		return time.Time{}, errors.E(err)
 	}
 
-	t, err := r.jimm.JujuManager().LatestLogTime(ctx, modelTag.Id())
+	t, err := r.jimm.JujuManager().LatestLogTime(ctx, r.user, modelTag.Id())
 	if err != nil {
 		return time.Time{}, errors.E(err)
 	}
@@ -197,6 +197,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 
 	err = r.jimm.JujuManager().Activate(
 		ctx,
+		r.user,
 		modelTag, migration.SourceControllerInfo{
 			ControllerTag:   controllerTag,
 			ControllerAlias: args.ControllerAlias,

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -270,7 +270,7 @@ func TestActivateValid(t *testing.T) {
 	activateCalled := false
 	jujuManager := mocks.JujuManager{
 		MigrationMocks: mocks.MigrationMocks{
-			Activate_: func(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+			Activate_: func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
 				activateCalled = true
 				c.Assert(modelTag.Id(), qt.Equals, "00000001-0000-0000-0000-000000000001")
 				c.Assert(sourceControllerInfo.ControllerAlias, qt.Equals, "controller-1")
@@ -373,7 +373,7 @@ func TestActivateMissingControllerTag(t *testing.T) {
 
 	jujuManager := mocks.JujuManager{
 		MigrationMocks: mocks.MigrationMocks{
-			Activate_: func(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+			Activate_: func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
 				// This function should not be called
 				return nil
 			},
@@ -410,7 +410,7 @@ func TestLatestLogTime(t *testing.T) {
 	latestLogTimeCalled := false
 	jujuManager := mocks.JujuManager{
 		MigrationMocks: mocks.MigrationMocks{
-			LatestLogTime_: func(ctx context.Context, modelUUID string) (time.Time, error) {
+			LatestLogTime_: func(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error) {
 				latestLogTimeCalled = true
 				c.Check(modelUUID, qt.Equals, "00000001-0000-0000-0000-000000000001")
 				return time.Now(), nil

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -103,7 +103,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
+	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, user)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -98,7 +98,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, model.ResourceTag(), nil)
+	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, model.ResourceTag(), user)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -99,9 +99,8 @@ func (c Connection) ModelInfo(ctx context.Context, model names.ModelTag) (ModelI
 // GrantJIMMModelAdmin uses the ModifyModelAccess procedure on the
 // ModelManager facade.
 func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
-	userID := c.user.ResourceTag().Id()
 	access := string(jujuparams.ModelAdminAccess)
-	return modelmanager.NewClient(&c).GrantModel(userID, access, tag.Id())
+	return modelmanager.NewClient(&c).GrantModel(adminUser, access, tag.Id())
 }
 
 // DumpModel dumps debugging details for the given model. If the simplied

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -101,9 +101,9 @@ func (w apiWrapper) Close() error {
 type ModelDialerMap map[string]juju.Dialer
 
 // Dial implements juju.Dialer.
-func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User) (juju.API, error) {
+func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, u *openfga.User) (juju.API, error) {
 	if d, ok := m[mt.Id()]; ok {
-		return d.Dial(ctx, ctl, mt, nil)
+		return d.Dial(ctx, ctl, mt, u)
 	}
 	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }
@@ -113,9 +113,9 @@ func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt na
 type DialerMap map[string]juju.Dialer
 
 // Dial implements juju.Dialer.
-func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, _ *openfga.User) (juju.API, error) {
+func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, u *openfga.User) (juju.API, error) {
 	if d, ok := m[ctl.Name]; ok {
-		return d.Dial(ctx, ctl, mt, nil)
+		return d.Dial(ctx, ctl, mt, u)
 	}
 	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -24,7 +24,7 @@ type ControllerService struct {
 	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
 	RemoveController_                  func(ctx context.Context, user *openfga.User, controllerName string, force bool) error
 	SetControllerDeprecated_           func(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error
-	ControllerConfig_                  func(ctx context.Context, controllerName string) (jujucontroller.Config, error)
+	ControllerConfig_                  func(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error)
 }
 
 func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error {
@@ -83,9 +83,9 @@ func (j *ControllerService) SetControllerDeprecated(ctx context.Context, user *o
 	return j.SetControllerDeprecated_(ctx, user, controllerName, deprecated)
 }
 
-func (j *ControllerService) ControllerConfig(ctx context.Context, controllerName string) (jujucontroller.Config, error) {
+func (j *ControllerService) ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error) {
 	if j.ControllerConfig_ == nil {
 		return jujucontroller.Config{}, errors.E(errors.CodeNotImplemented)
 	}
-	return j.ControllerConfig_(ctx, controllerName)
+	return j.ControllerConfig_(ctx, user, controllerName)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -19,11 +19,11 @@ import (
 type MigrationMocks struct {
 	Prechecks_            func(ctx context.Context, user *openfga.User, model juju.MigratingModelInfo) error
 	AdoptResources_       func(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error
-	Activate_             func(ctx context.Context, modelUUID names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error
+	Activate_             func(ctx context.Context, user *openfga.User, modelUUID names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error
 	AbortMigration_       func(ctx context.Context, user *openfga.User, modelUUID string) error
 	CheckMachines_        func(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error)
 	Import_               func(ctx context.Context, user *openfga.User, serialized jujuparams.SerializedModel) error
-	LatestLogTime_        func(ctx context.Context, modelUUID string) (time.Time, error)
+	LatestLogTime_        func(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error)
 	ListMigrationTargets_ func(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error)
 }
 
@@ -48,11 +48,11 @@ func (j *MigrationMocks) AdoptResources(ctx context.Context, user *openfga.User,
 	return j.AdoptResources_(ctx, user, modelUUID, sourceControllerVersion)
 }
 
-func (j *MigrationMocks) Activate(ctx context.Context, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
+func (j *MigrationMocks) Activate(ctx context.Context, user *openfga.User, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
 	if j.Activate_ == nil {
 		return errors.E(errors.CodeNotImplemented)
 	}
-	return j.Activate_(ctx, modelTag, sourceControllerInfo, relatedModels)
+	return j.Activate_(ctx, user, modelTag, sourceControllerInfo, relatedModels)
 }
 
 func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
@@ -62,11 +62,11 @@ func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, 
 	return j.CheckMachines_(ctx, user, modelUUID)
 }
 
-func (j *MigrationMocks) LatestLogTime(ctx context.Context, modelUUID string) (time.Time, error) {
+func (j *MigrationMocks) LatestLogTime(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error) {
 	if j.LatestLogTime_ == nil {
 		return time.Time{}, errors.E(errors.CodeNotImplemented)
 	}
-	return j.LatestLogTime_(ctx, modelUUID)
+	return j.LatestLogTime_(ctx, user, modelUUID)
 }
 
 func (j *MigrationMocks) Import(ctx context.Context, user *openfga.User, serialized jujuparams.SerializedModel) error {


### PR DESCRIPTION
## Description
Explicitly pass in the user tag when dialling the underlying Juju controller, in all cases where we're directly acting on behalf of the user.

Some cases remain where we dial as `admin`, like the watcher.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
