### PR TITLE
feat: expand bootstrap options for jaas bootstrap

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -223,7 +223,9 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 			Attributes: bootstrapCred.Attributes(),
 			AuthType:   string(bootstrapCred.AuthType()),
 		},
-		Config: stringConfigValues,
+		BootstrapOptions: apiparams.BootstrapOptions{
+			BootstrapConfig: stringConfigValues,
+		},
 	}
 
 	client, err := c.getJIMMAPI()

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -161,9 +161,11 @@ func TestBootstrapApiParams(t *testing.T) {
 				AuthType:   string(jujucloud.UserPassAuthType),
 				Attributes: map[string]string{},
 			},
-			Config: map[string]string{
-				"bootstrap-timeout": "60",
-				"string-option":     "value",
+			BootstrapOptions: params.BootstrapOptions{
+				BootstrapConfig: map[string]string{
+					"bootstrap-timeout": "60",
+					"string-option":     "value",
+				},
 			},
 			ControllerVersion: "controller-version",
 		}
@@ -172,7 +174,7 @@ func TestBootstrapApiParams(t *testing.T) {
 		c.Check(bsp.RegionName, qt.Equals, expected.RegionName)
 		c.Check(bsp.Cloud, qt.DeepEquals, expected.Cloud)
 		c.Check(bsp.Credential, qt.DeepEquals, expected.Credential)
-		c.Check(bsp.Config, qt.DeepEquals, expected.Config)
+		c.Check(bsp.BootstrapOptions, qt.DeepEquals, expected.BootstrapOptions)
 		c.Check(bsp.ControllerVersion, qt.Equals, expected.ControllerVersion)
 
 		return &params.StartBootstrapResponse{

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -252,7 +252,8 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 	bootstrapArgs := rivertypes.BootstrapArgs{
 		Username: user.Name,
 		// Binary args.
-		CLIVersion: params.CLIVersion,
+		CLIVersion:   params.CLIVersion,
+		AgentVersion: params.CLIVersion,
 		// User defined command arguments
 		CloudNameAndRegion: params.CloudNameAndRegion,
 		ControllerName:     params.ControllerName,
@@ -260,8 +261,17 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		Cloud:              params.Cloud,
 		// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 		LoginTokenRefreshURL: b.jimmWellknownJWKSEndpoint,
-		// User defined config
-		UserConfig: params.UserConfig,
+		// Supported bootstrap options.
+		BootstrapOptions: rivertypes.BootstrapOptions{
+			BootstrapBase:         params.BootstrapOptions.BootstrapBase,
+			BootstrapConstraints:  params.BootstrapOptions.BootstrapConstraints,
+			ModelConstraints:      params.BootstrapOptions.ModelConstraints,
+			ModelDefault:          params.BootstrapOptions.ModelDefault,
+			StoragePool:           riverStoragePool(params.BootstrapOptions.StoragePool),
+			BootstrapConfig:       params.BootstrapOptions.BootstrapConfig,
+			ControllerConfig:      params.BootstrapOptions.ControllerConfig,
+			ControllerModelConfig: params.BootstrapOptions.ControllerModelConfig,
+		},
 	}
 	job, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs)
 	if err != nil {
@@ -397,7 +407,16 @@ func (b *BootstrapManager) runBootstrap(
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions: jujucommands.BootstrapOptions{
+				BootstrapBase:         p.BootstrapOptions.BootstrapBase,
+				BootstrapConstraints:  p.BootstrapOptions.BootstrapConstraints,
+				ModelConstraints:      p.BootstrapOptions.ModelConstraints,
+				ModelDefault:          p.BootstrapOptions.ModelDefault,
+				StoragePool:           commandStoragePool(p.BootstrapOptions.StoragePool),
+				BootstrapConfig:       p.BootstrapOptions.BootstrapConfig,
+				ControllerConfig:      p.BootstrapOptions.ControllerConfig,
+				ControllerModelConfig: p.BootstrapOptions.ControllerModelConfig,
+			},
 		},
 	)
 	if err != nil {
@@ -488,6 +507,28 @@ func (b *BootstrapManager) runBootstrap(
 	}
 
 	return nil
+}
+
+func riverStoragePool(pool *StoragePool) *rivertypes.BootstrapStoragePool {
+	if pool == nil {
+		return nil
+	}
+	return &rivertypes.BootstrapStoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: pool.Attributes,
+	}
+}
+
+func commandStoragePool(pool *rivertypes.BootstrapStoragePool) *jujucommands.StoragePool {
+	if pool == nil {
+		return nil
+	}
+	return &jujucommands.StoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: pool.Attributes,
+	}
 }
 
 func (b *BootstrapManager) tryCleanupController(ctx context.Context, jujuCmd JujuCommands, jobID int64, controllerName string) error {

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -56,8 +56,63 @@ func defaultBootstrapArgs() bootstrap.RunBootstrapArgs {
 			CloudCred:            jujucloud.Credential{},
 			Cloud:                jujucloud.Cloud{},
 			LoginTokenRefreshURL: loginTokenRefreshURLParam,
-			UserConfig:           map[string]string{},
+			BootstrapOptions:     defaultRiverBootstrapOptions(),
 		},
+	}
+}
+
+func defaultBootstrapOptions() bootstrap.BootstrapOptions {
+	return bootstrap.BootstrapOptions{
+		BootstrapBase:        "ubuntu@24.04",
+		BootstrapConstraints: map[string]string{"mem": "8G"},
+		ModelConstraints:     map[string]string{"arch": "amd64"},
+		ModelDefault:         map[string]string{"logging-config": "<root>=INFO"},
+		StoragePool: &bootstrap.StoragePool{
+			Name:       "controller-pool",
+			Type:       "ebs",
+			Attributes: map[string]string{"volume-type": "gp3"},
+		},
+		BootstrapConfig:       map[string]string{"foo": "bar"},
+		ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
+		ControllerModelConfig: map[string]string{"image-stream": "released"},
+	}
+}
+
+func defaultRiverBootstrapOptions() rivertypes.BootstrapOptions {
+	return expectedRiverBootstrapOptions(defaultBootstrapOptions())
+}
+
+func expectedRiverBootstrapOptions(options bootstrap.BootstrapOptions) rivertypes.BootstrapOptions {
+	return rivertypes.BootstrapOptions{
+		BootstrapBase:        options.BootstrapBase,
+		BootstrapConstraints: options.BootstrapConstraints,
+		ModelConstraints:     options.ModelConstraints,
+		ModelDefault:         options.ModelDefault,
+		StoragePool: &rivertypes.BootstrapStoragePool{
+			Name:       options.StoragePool.Name,
+			Type:       options.StoragePool.Type,
+			Attributes: options.StoragePool.Attributes,
+		},
+		BootstrapConfig:       options.BootstrapConfig,
+		ControllerConfig:      options.ControllerConfig,
+		ControllerModelConfig: options.ControllerModelConfig,
+	}
+}
+
+func expectedCommandBootstrapOptions(args bootstrap.RunBootstrapArgs) jujucommands.BootstrapOptions {
+	return jujucommands.BootstrapOptions{
+		BootstrapBase:        args.BootstrapOptions.BootstrapBase,
+		BootstrapConstraints: args.BootstrapOptions.BootstrapConstraints,
+		ModelConstraints:     args.BootstrapOptions.ModelConstraints,
+		ModelDefault:         args.BootstrapOptions.ModelDefault,
+		StoragePool: &jujucommands.StoragePool{
+			Name:       args.BootstrapOptions.StoragePool.Name,
+			Type:       args.BootstrapOptions.StoragePool.Type,
+			Attributes: args.BootstrapOptions.StoragePool.Attributes,
+		},
+		BootstrapConfig:       args.BootstrapOptions.BootstrapConfig,
+		ControllerConfig:      args.BootstrapOptions.ControllerConfig,
+		ControllerModelConfig: args.BootstrapOptions.ControllerModelConfig,
 	}
 }
 
@@ -141,18 +196,19 @@ func (s *bootstrapManagerSuite) TestStartBootstrapJob_EnqueuesJob(c *qt.C) {
 		ControllerName:     "a",
 		CloudCred:          jujucloud.Credential{},
 		Cloud:              jujucloud.Cloud{},
-		UserConfig:         map[string]string{"foo": "bar"},
+		BootstrapOptions:   defaultBootstrapOptions(),
 	}
 
 	mocks.jobQueue.EXPECT().EnqueueBootstrap(gomock.Any(), rivertypes.BootstrapArgs{
 		Username:             "bob@canonical.com",
 		CLIVersion:           requested.CLIVersion,
+		AgentVersion:         requested.CLIVersion,
 		CloudNameAndRegion:   requested.CloudNameAndRegion,
 		ControllerName:       requested.ControllerName,
 		CloudCred:            requested.CloudCred,
 		Cloud:                requested.Cloud,
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,
-		UserConfig:           requested.UserConfig,
+		BootstrapOptions:     expectedRiverBootstrapOptions(requested.BootstrapOptions),
 	}).Return(&rivertype.JobInsertResult{
 		Job: &rivertype.JobRow{
 			ID: 99,
@@ -372,7 +428,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -561,7 +617,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -623,7 +679,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -690,7 +746,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -793,7 +849,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -896,7 +952,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -1024,7 +1080,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).Return(
 		func() chan jujucommands.OutputLine {
@@ -1125,7 +1181,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 			DefaultLoginTokenURL: p.LoginTokenRefreshURL,
 			Cloud:                p.Cloud,
 			CloudCred:            p.CloudCred,
-			UserConfig:           p.UserConfig,
+			BootstrapOptions:     expectedCommandBootstrapOptions(p),
 		},
 	).DoAndReturn(func(ctx context.Context, _ jujucommands.BootstrapCmdParams) (<-chan jujucommands.OutputLine, jujuclient.ClientStore, func(), error) {
 		cancel()

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -23,7 +23,27 @@ type BootstrapParams struct {
 	CloudCred jujucloud.Credential
 	Cloud     jujucloud.Cloud
 
-	UserConfig map[string]string
+	BootstrapOptions BootstrapOptions
+}
+
+// BootstrapOptions defines the supported bootstrap settings carried through the
+// bootstrap manager and worker payload.
+type BootstrapOptions struct {
+	BootstrapBase         string
+	BootstrapConstraints  map[string]string
+	ModelConstraints      map[string]string
+	ModelDefault          map[string]string
+	StoragePool           *StoragePool
+	BootstrapConfig       map[string]string
+	ControllerConfig      map[string]string
+	ControllerModelConfig map[string]string
+}
+
+// StoragePool defines the optional bootstrap storage pool.
+type StoragePool struct {
+	Name       string
+	Type       string
+	Attributes map[string]string
 }
 
 // RunnerArgs defines the parameters required for running a bootstrap or destroy-controller job.
@@ -63,6 +83,9 @@ func (p BootstrapParams) validate() error {
 	}
 	if p.ControllerName == "" {
 		msgs = append(msgs, "controller name cannot be empty")
+	}
+	if pool := p.BootstrapOptions.StoragePool; pool != nil && (pool.Name == "" || pool.Type == "") {
+		msgs = append(msgs, "storage pool requires both name and type")
 	}
 
 	// Don't validate cloud or cloud cred. Juju knows better how to validate those.

--- a/internal/jimm/bootstrap/types_test.go
+++ b/internal/jimm/bootstrap/types_test.go
@@ -66,6 +66,20 @@ func TestValidateBootstrapParams_EmptyFields(t *testing.T) {
 				"controller name cannot be empty",
 			},
 		},
+		{
+			name: "storage pool missing type",
+			params: BootstrapParams{
+				CLIVersion:         "1.0.0",
+				CloudNameAndRegion: "cloud/region",
+				ControllerName:     "my-controller",
+				BootstrapOptions: BootstrapOptions{
+					StoragePool: &StoragePool{Name: "pool-only-name"},
+				},
+			},
+			want: []string{
+				"storage pool requires both name and type",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -148,7 +148,7 @@ func controllerProfileFromParams(profile apiparams.ControllerProfile) dbmodel.Co
 	}
 }
 
-func storagePoolFromParams(pool *apiparams.ControllerProfileStoragePool) dbmodel.ControllerProfileStoragePool {
+func storagePoolFromParams(pool *apiparams.BootstrapStoragePool) dbmodel.ControllerProfileStoragePool {
 	if pool == nil {
 		return dbmodel.ControllerProfileStoragePool{}
 	}
@@ -182,7 +182,7 @@ func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.Cont
 				StorageEndpoint:  profile.Cloud.Region.StorageEndpoint,
 			},
 		},
-		BootstrapOptions: apiparams.ControllerProfileBootstrapOptions{
+		BootstrapOptions: apiparams.BootstrapOptions{
 			BootstrapBase:         profile.BootstrapOptions.BootstrapBase,
 			BootstrapConstraints:  map[string]string(profile.BootstrapOptions.BootstrapConstraints),
 			ModelConstraints:      map[string]string(profile.BootstrapOptions.ModelConstraints),
@@ -204,11 +204,11 @@ func controllerProfileSummaryToParams(profile dbmodel.ControllerProfile) apipara
 	}
 }
 
-func storagePoolToParams(pool dbmodel.ControllerProfileStoragePool) *apiparams.ControllerProfileStoragePool {
+func storagePoolToParams(pool dbmodel.ControllerProfileStoragePool) *apiparams.BootstrapStoragePool {
 	if pool.Name == "" && pool.Type == "" && len(pool.Attributes) == 0 {
 		return nil
 	}
-	return &apiparams.ControllerProfileStoragePool{
+	return &apiparams.BootstrapStoragePool{
 		Name:       pool.Name,
 		Type:       pool.Type,
 		Attributes: map[string]string(pool.Attributes),

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -692,7 +692,16 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 			false,
 		),
 
-		UserConfig: req.Config,
+		BootstrapOptions: bootstrap.BootstrapOptions{
+			BootstrapBase:         req.BootstrapOptions.BootstrapBase,
+			BootstrapConstraints:  req.BootstrapOptions.BootstrapConstraints,
+			ModelConstraints:      req.BootstrapOptions.ModelConstraints,
+			ModelDefault:          req.BootstrapOptions.ModelDefault,
+			StoragePool:           bootstrapStoragePoolFromParams(req.BootstrapOptions.StoragePool),
+			BootstrapConfig:       req.BootstrapOptions.BootstrapConfig,
+			ControllerConfig:      req.BootstrapOptions.ControllerConfig,
+			ControllerModelConfig: req.BootstrapOptions.ControllerModelConfig,
+		},
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrapJob(ctx, r.user, params)
@@ -702,6 +711,17 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 	return apiparams.StartBootstrapResponse{
 		JobID: strconv.FormatInt(jobID, 10),
 	}, nil
+}
+
+func bootstrapStoragePoolFromParams(pool *apiparams.BootstrapStoragePool) *bootstrap.StoragePool {
+	if pool == nil {
+		return nil
+	}
+	return &bootstrap.StoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: pool.Attributes,
+	}
 }
 
 // StartDestroyController starts a destroy-controller job.

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -353,11 +353,13 @@ func TestBootstrapStart(t *testing.T) {
 
 	ctx := c.Context()
 	var startBootstrapErr error
+	var gotParams bootstrap.BootstrapParams
 
 	jimm := &jimmtest.JIMM{
 		BootstapManager_: func() jujuapi.BootstrapManager {
 			return &mocks.BootstapManager{
 				StartBootstrapJob_: func(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (int64, error) {
+					gotParams = params
 					if startBootstrapErr != nil {
 						return 0, startBootstrapErr
 					}
@@ -369,10 +371,23 @@ func TestBootstrapStart(t *testing.T) {
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
 
 	params := apiparams.BootstrapParams{
-		ControllerName:    "controller",
-		CloudName:         "cloud",
-		RegionName:        "region",
-		Config:            map[string]string{},
+		ControllerName: "controller",
+		CloudName:      "cloud",
+		RegionName:     "region",
+		BootstrapOptions: apiparams.BootstrapOptions{
+			BootstrapBase:        "ubuntu@24.04",
+			BootstrapConstraints: map[string]string{"mem": "8G"},
+			ModelConstraints:     map[string]string{"arch": "amd64"},
+			ModelDefault:         map[string]string{"logging-config": "<root>=INFO"},
+			StoragePool: &apiparams.BootstrapStoragePool{
+				Name:       "controller-pool",
+				Type:       "ebs",
+				Attributes: map[string]string{"volume-type": "gp3"},
+			},
+			BootstrapConfig:       map[string]string{"bootstrap-timeout": "20m"},
+			ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
+			ControllerModelConfig: map[string]string{"image-stream": "released"},
+		},
 		Cloud:             jujuparams.Cloud{},
 		Credential:        jujuparams.CloudCredential{},
 		ControllerVersion: "3.6.9",
@@ -381,6 +396,21 @@ func TestBootstrapStart(t *testing.T) {
 	response, err := root.StartBootstrap(ctx, params)
 	c.Assert(err, qt.IsNil)
 	c.Assert(response.JobID, qt.Not(qt.Equals), "")
+	c.Assert(gotParams.CLIVersion, qt.Equals, params.ControllerVersion)
+	c.Assert(gotParams.CloudNameAndRegion, qt.Equals, "cloud/region")
+	c.Assert(gotParams.ControllerName, qt.Equals, params.ControllerName)
+	c.Assert(gotParams.BootstrapOptions.BootstrapBase, qt.Equals, params.BootstrapOptions.BootstrapBase)
+	c.Assert(gotParams.BootstrapOptions.BootstrapConstraints, qt.DeepEquals, params.BootstrapOptions.BootstrapConstraints)
+	c.Assert(gotParams.BootstrapOptions.ModelConstraints, qt.DeepEquals, params.BootstrapOptions.ModelConstraints)
+	c.Assert(gotParams.BootstrapOptions.ModelDefault, qt.DeepEquals, params.BootstrapOptions.ModelDefault)
+	c.Assert(gotParams.BootstrapOptions.BootstrapConfig, qt.DeepEquals, params.BootstrapOptions.BootstrapConfig)
+	c.Assert(gotParams.BootstrapOptions.ControllerConfig, qt.DeepEquals, params.BootstrapOptions.ControllerConfig)
+	c.Assert(gotParams.BootstrapOptions.ControllerModelConfig, qt.DeepEquals, params.BootstrapOptions.ControllerModelConfig)
+	c.Assert(gotParams.BootstrapOptions.StoragePool, qt.DeepEquals, &bootstrap.StoragePool{
+		Name:       "controller-pool",
+		Type:       "ebs",
+		Attributes: map[string]string{"volume-type": "gp3"},
+	})
 
 	// Test start bootstrap fails
 	startBootstrapErr = errors.E("foo")

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 
 	jujucloud "github.com/juju/juju/cloud"
@@ -38,8 +40,27 @@ type BootstrapCmdParams struct {
 	// The credential to use for the cloud.
 	CloudCred jujucloud.Credential
 
-	// UserConfig holds user defined config for bootstrap.
-	UserConfig map[string]string
+	// BootstrapOptions holds the supported bootstrap settings.
+	BootstrapOptions BootstrapOptions
+}
+
+// BootstrapOptions holds the supported bootstrap settings rendered into Juju CLI flags.
+type BootstrapOptions struct {
+	BootstrapBase         string
+	BootstrapConstraints  map[string]string
+	ModelConstraints      map[string]string
+	ModelDefault          map[string]string
+	StoragePool           *StoragePool
+	BootstrapConfig       map[string]string
+	ControllerConfig      map[string]string
+	ControllerModelConfig map[string]string
+}
+
+// StoragePool describes an initial controller-model storage pool.
+type StoragePool struct {
+	Name       string
+	Type       string
+	Attributes map[string]string
 }
 
 // Validate validates the BootstrapCmdParams.
@@ -64,6 +85,14 @@ func (b BootstrapCmdParams) Validate() error {
 		return errors.New("missing login token refresh URL, this value should be automatically set by JIMM")
 	}
 
+	if pool := b.BootstrapOptions.StoragePool; pool != nil && (pool.Name == "" || pool.Type == "") {
+		return errors.New("storage pool requires both name and type")
+	}
+
+	if arch, ok := b.BootstrapOptions.BootstrapConstraints["arch"]; ok && arch != runtime.GOARCH {
+		return fmt.Errorf("bootstrap constraint arch must be %q", runtime.GOARCH)
+	}
+
 	return nil
 }
 
@@ -72,36 +101,95 @@ func (b BootstrapCmdParams) BuildBootstrapCmdArgs() []string {
 	var args []string
 	args = append(args, "bootstrap")
 
-	args = append(args, "--config")
-
-	// Allow the user to override the login token refresh URL.
-	// Skip adding it later to avoid duplication.
-	loginTokenRefreshURL := b.DefaultLoginTokenURL
-	if v, ok := b.UserConfig[loginTokenRefreshURLKey]; ok {
-		loginTokenRefreshURL = v
-	}
-	args = append(args, fmt.Sprintf("login-token-refresh-url=%s", loginTokenRefreshURL))
-
 	// Conditionally add --agent-version if set
 	if b.AgentVersion != "" {
 		args = append(args, fmt.Sprintf("--agent-version=%s", b.AgentVersion))
 	}
 
-	for k, v := range b.UserConfig {
-		if k == loginTokenRefreshURLKey {
-			continue
-		}
-		args = append(args, "--config")
-		args = append(args, fmt.Sprintf("%s=%s", k, fmt.Sprint(v)))
+	if b.BootstrapOptions.BootstrapBase != "" {
+		args = append(args, fmt.Sprintf("--bootstrap-base=%s", b.BootstrapOptions.BootstrapBase))
 	}
+
+	args = appendKeyValueFlags(args, "bootstrap-constraints", withBootstrapArch(b.BootstrapOptions.BootstrapConstraints))
+	args = appendKeyValueFlags(args, "constraints", b.BootstrapOptions.ModelConstraints)
+	args = appendKeyValueFlags(args, "model-default", b.BootstrapOptions.ModelDefault)
+	args = appendStoragePoolFlags(args, b.BootstrapOptions.StoragePool)
+	args = appendConfigFlags(args, mergedBootstrapConfig(b.DefaultLoginTokenURL, b.BootstrapOptions))
 
 	// Always add controller name & cloud at the end
 	args = append(args, b.CloudNameAndRegion, b.ControllerName)
 
+	return args
+}
+
+func withBootstrapArch(constraints map[string]string) map[string]string {
+	merged := maps.Clone(constraints)
+	if merged == nil {
+		merged = make(map[string]string, 1)
+	}
 	// Add architecture constraint to ensure juju bootstraps with the correct arch.
 	// Without this, the controller application that is deployed can be deployed with the wrong architecture.
-	args = append(args, fmt.Sprintf("--bootstrap-constraints=%s", fmt.Sprintf("arch=%s", runtime.GOARCH)))
+	merged["arch"] = runtime.GOARCH
+	return merged
+}
 
+func mergedBootstrapConfig(defaultLoginTokenURL string, options BootstrapOptions) map[string]string {
+	merged := make(map[string]string)
+	for _, configMap := range []map[string]string{options.ControllerConfig, options.ControllerModelConfig, options.BootstrapConfig} {
+		for key, value := range configMap {
+			merged[key] = value
+		}
+	}
+	if _, ok := merged[loginTokenRefreshURLKey]; !ok {
+		merged[loginTokenRefreshURLKey] = defaultLoginTokenURL
+	}
+	return merged
+}
+
+func appendConfigFlags(args []string, config map[string]string) []string {
+	if len(config) == 0 {
+		return args
+	}
+	if value, ok := config[loginTokenRefreshURLKey]; ok {
+		args = append(args, "--config", fmt.Sprintf("%s=%s", loginTokenRefreshURLKey, value))
+	}
+	remaining := maps.Clone(config)
+	delete(remaining, loginTokenRefreshURLKey)
+	return appendKeyValueFlags(args, "config", remaining)
+}
+
+func appendKeyValueFlags(args []string, flagName string, values map[string]string) []string {
+	if len(values) == 0 {
+		return args
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, fmt.Sprintf("--%s", flagName), fmt.Sprintf("%s=%s", key, values[key]))
+	}
+	return args
+}
+
+func appendStoragePoolFlags(args []string, pool *StoragePool) []string {
+	if pool == nil {
+		return args
+	}
+	args = append(args, "--storage-pool", fmt.Sprintf("name=%s", pool.Name))
+	args = append(args, "--storage-pool", fmt.Sprintf("type=%s", pool.Type))
+	if len(pool.Attributes) == 0 {
+		return args
+	}
+	keys := make([]string, 0, len(pool.Attributes))
+	for key := range pool.Attributes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, "--storage-pool", fmt.Sprintf("%s=%s", key, pool.Attributes[key]))
+	}
 	return args
 }
 

--- a/internal/jujucommands/bootstrap_test.go
+++ b/internal/jujucommands/bootstrap_test.go
@@ -35,29 +35,35 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_Validate(c *qt.C) {
 
 	p.AgentVersion = "1.1.1"
 	c.Assert(p.Validate(), qt.IsNil)
+
+	p.BootstrapOptions.StoragePool = &jujucommands.StoragePool{Name: "pool-only-name"}
+	c.Assert(p.Validate(), qt.ErrorMatches, "storage pool requires both name and type")
 }
 
-func (s *jujucommandsSuite) TestBootstrapCmdParams_LoginTokenRefreshURLOverrideFromUserConfig(c *qt.C) {
+func (s *jujucommandsSuite) TestBootstrapCmdParams_LoginTokenRefreshURLOverrideFromBootstrapConfig(c *qt.C) {
 	p := jujucommands.BootstrapCmdParams{
 		CloudNameAndRegion:   "testregion/testcloud",
 		ControllerName:       "my-controller",
 		DefaultLoginTokenURL: "https://default.example/.well-known/jwks.json",
-		UserConfig: map[string]string{
-			"bootstrap-timeout":       "1000",
-			"login-token-refresh-url": "https://override.example/.well-known/jwks.json",
+		BootstrapOptions: jujucommands.BootstrapOptions{
+			BootstrapConfig: map[string]string{
+				"bootstrap-timeout":       "1000",
+				"login-token-refresh-url": "https://override.example/.well-known/jwks.json",
+			},
 		},
 	}
 
 	args := p.BuildBootstrapCmdArgs()
 	c.Assert(args, qt.DeepEquals, []string{
 		"bootstrap",
+		"--bootstrap-constraints",
+		fmt.Sprintf("arch=%s", runtime.GOARCH),
 		"--config",
 		"login-token-refresh-url=https://override.example/.well-known/jwks.json",
 		"--config",
 		"bootstrap-timeout=1000",
 		"testregion/testcloud",
 		"my-controller",
-		fmt.Sprintf("--bootstrap-constraints=arch=%s", runtime.GOARCH),
 	})
 }
 
@@ -74,20 +80,49 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_BuildBootstrapCmdArgs(c *qt.C
 				ControllerName:       "my-controller",
 				AgentVersion:         "1.1.1",
 				DefaultLoginTokenURL: "myurl.com",
-				UserConfig: map[string]string{
-					"bootstrap-timeout": "1000",
+				BootstrapOptions: jujucommands.BootstrapOptions{
+					BootstrapBase:        "ubuntu@24.04",
+					BootstrapConstraints: map[string]string{"mem": "8G"},
+					ModelConstraints:     map[string]string{"arch": "amd64"},
+					ModelDefault:         map[string]string{"logging-config": "<root>=INFO"},
+					StoragePool: &jujucommands.StoragePool{
+						Name:       "controller-pool",
+						Type:       "ebs",
+						Attributes: map[string]string{"volume-type": "gp3"},
+					},
+					BootstrapConfig:       map[string]string{"bootstrap-timeout": "1000"},
+					ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
+					ControllerModelConfig: map[string]string{"image-stream": "released"},
 				},
 			},
 			expect: []string{
 				"bootstrap",
+				"--agent-version=1.1.1",
+				"--bootstrap-base=ubuntu@24.04",
+				"--bootstrap-constraints",
+				fmt.Sprintf("arch=%s", runtime.GOARCH),
+				"--bootstrap-constraints",
+				"mem=8G",
+				"--constraints",
+				"arch=amd64",
+				"--model-default",
+				"logging-config=<root>=INFO",
+				"--storage-pool",
+				"name=controller-pool",
+				"--storage-pool",
+				"type=ebs",
+				"--storage-pool",
+				"volume-type=gp3",
 				"--config",
 				"login-token-refresh-url=myurl.com",
-				"--agent-version=1.1.1",
+				"--config",
+				"audit-log-enabled=true",
 				"--config",
 				"bootstrap-timeout=1000",
+				"--config",
+				"image-stream=released",
 				"testregion/testcloud",
 				"my-controller",
-				fmt.Sprintf("--bootstrap-constraints=arch=%s", runtime.GOARCH),
 			},
 		},
 		{
@@ -97,19 +132,22 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_BuildBootstrapCmdArgs(c *qt.C
 				ControllerName:       "my-controller",
 				AgentVersion:         "",
 				DefaultLoginTokenURL: "myurl.com",
-				UserConfig: map[string]string{
-					"bootstrap-timeout": "1000",
+				BootstrapOptions: jujucommands.BootstrapOptions{
+					BootstrapConfig: map[string]string{
+						"bootstrap-timeout": "1000",
+					},
 				},
 			},
 			expect: []string{
 				"bootstrap",
+				"--bootstrap-constraints",
+				fmt.Sprintf("arch=%s", runtime.GOARCH),
 				"--config",
 				"login-token-refresh-url=myurl.com",
 				"--config",
 				"bootstrap-timeout=1000",
 				"testregion/testcloud",
 				"my-controller",
-				fmt.Sprintf("--bootstrap-constraints=arch=%s", runtime.GOARCH),
 			},
 		},
 		{
@@ -122,11 +160,12 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_BuildBootstrapCmdArgs(c *qt.C
 			},
 			expect: []string{
 				"bootstrap",
+				"--bootstrap-constraints",
+				fmt.Sprintf("arch=%s", runtime.GOARCH),
 				"--config",
 				"login-token-refresh-url=myurl.com",
 				"testregion/testcloud",
 				"my-controller",
-				fmt.Sprintf("--bootstrap-constraints=arch=%s", runtime.GOARCH),
 			},
 		},
 	}

--- a/internal/jujucommands/jujucommands.go
+++ b/internal/jujucommands/jujucommands.go
@@ -21,6 +21,17 @@ const (
 	CommandKillDelay = time.Minute * 40
 )
 
+var proxyEnvKeys = []string{
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"ALL_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"all_proxy",
+}
+
 // OutputLine represents a line of output from a juju command.
 type OutputLine struct {
 	Line string
@@ -64,7 +75,7 @@ func (b *CommandRunner) RunJujuCmd(ctx context.Context, args []string) (<-chan O
 	// will kick in and kill the process. We set it to the same
 	// as our bootstrap lock.
 	cmd.WaitDelay = CommandKillDelay
-	cmd.Env = append(cmd.Env, "JUJU_DATA="+b.jujuDataDir)
+	cmd.Env = buildCommandEnv(b.jujuDataDir)
 	cmd.Cancel = func() error {
 		err := cmd.Process.Signal(os.Interrupt)
 		if err != nil {
@@ -117,4 +128,18 @@ func (b *CommandRunner) RunJujuCmd(ctx context.Context, args []string) (<-chan O
 	}()
 
 	return outputCh, nil
+}
+
+// buildCommandEnv builds the environment variables for the juju command,
+// including proxy settings and JUJU_DATA directory. We intentionally
+// avoid passing all environment variables from the parent process to
+// the Juju command to avoid leaking sensitive values.
+func buildCommandEnv(jujuDataDir string) []string {
+	env := make([]string, 0, len(proxyEnvKeys)+1)
+	for _, key := range proxyEnvKeys {
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return append(env, "JUJU_DATA="+jujuDataDir)
 }

--- a/internal/jujucommands/jujucommands_test.go
+++ b/internal/jujucommands/jujucommands_test.go
@@ -4,6 +4,7 @@ package jujucommands_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -80,6 +81,32 @@ func (s *jujucommandsSuite) TestRunCmdWithOutputRetriever_Error(c *qt.C) {
 
 func (s *jujucommandsSuite) TestEnvironmentIsCorrectlySet(c *qt.C) {
 	testCtx := c.Context()
+	oldProxyEnv := make(map[string]string, 8)
+	proxyKeys := []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "no_proxy", "all_proxy"}
+	for _, key := range proxyKeys {
+		oldProxyEnv[key] = os.Getenv(key)
+	}
+	oldAppEnv := os.Getenv("APP_ENV")
+	c.Cleanup(func() {
+		for _, key := range proxyKeys {
+			if oldProxyEnv[key] == "" {
+				_ = os.Unsetenv(key)
+			} else {
+				_ = os.Setenv(key, oldProxyEnv[key])
+			}
+		}
+		if oldAppEnv == "" {
+			_ = os.Unsetenv("APP_ENV")
+		} else {
+			_ = os.Setenv("APP_ENV", oldAppEnv)
+		}
+	})
+	for _, key := range proxyKeys {
+		_ = os.Unsetenv(key)
+	}
+	c.Assert(os.Setenv("HTTP_PROXY", "http://proxy.example:3128"), qt.IsNil)
+	c.Assert(os.Setenv("HTTPS_PROXY", "https://proxy.example:4443"), qt.IsNil)
+	c.Assert(os.Setenv("APP_ENV", "secret-value"), qt.IsNil)
 
 	runner := jujucommands.NewCommandRunner("env", "testing-data-is-set")
 	outputCh, err := runner.RunJujuCmd(testCtx, []string{})
@@ -93,7 +120,13 @@ func (s *jujucommandsSuite) TestEnvironmentIsCorrectlySet(c *qt.C) {
 		b.WriteString(out.Line + "\n")
 	}
 
-	c.Assert(b.String(), qt.Equals, "JUJU_DATA=testing-data-is-set\n")
+	envOutput := b.String()
+	c.Assert(envOutput, qt.Equals, strings.Join([]string{
+		"HTTP_PROXY=http://proxy.example:3128",
+		"HTTPS_PROXY=https://proxy.example:4443",
+		"JUJU_DATA=testing-data-is-set",
+		"",
+	}, "\n"))
 }
 
 //go:generate go tool mockgen -destination=./mocks/runner.go -package=mocks . Runner

--- a/internal/river/bootstrap_test.go
+++ b/internal/river/bootstrap_test.go
@@ -61,7 +61,9 @@ func TestBootstrapWorker(t *testing.T) {
 			c.Assert(p.CloudNameAndRegion, qt.Equals, "aws/us-east-1")
 			c.Assert(p.CLIVersion, qt.Equals, "3.6.1")
 			c.Assert(p.LoginTokenRefreshURL, qt.Equals, "https://jimm.example.com/refresh")
-			c.Assert(p.UserConfig["some"], qt.Equals, "value")
+			c.Assert(p.BootstrapOptions.BootstrapBase, qt.Equals, "ubuntu@24.04")
+			c.Assert(p.BootstrapOptions.BootstrapConfig["some"], qt.Equals, "value")
+			c.Assert(p.BootstrapOptions.ControllerConfig["audit-log-enabled"], qt.Equals, "true")
 			c.Assert(p.JujuDataDir, qt.Not(qt.Equals), "")
 			st, err := os.Stat(p.JujuDataDir)
 			c.Assert(err, qt.IsNil)
@@ -86,8 +88,10 @@ func TestBootstrapWorker(t *testing.T) {
 		ControllerName:       "controller-name",
 		AgentVersion:         "3.6.0",
 		LoginTokenRefreshURL: "https://jimm.example.com/refresh",
-		UserConfig: map[string]string{
-			"some": "value",
+		BootstrapOptions: rivertypes.BootstrapOptions{
+			BootstrapBase:    "ubuntu@24.04",
+			BootstrapConfig:  map[string]string{"some": "value"},
+			ControllerConfig: map[string]string{"audit-log-enabled": "true"},
 		},
 	}, nil)
 

--- a/internal/rivertypes/types.go
+++ b/internal/rivertypes/types.go
@@ -58,8 +58,27 @@ type BootstrapArgs struct {
 	// JIMM Provided command arguments (i.e., ones that must be set by JIMM when bootstrapping).
 	LoginTokenRefreshURL string `json:"login-token-refresh-url"`
 
-	// User provided config
-	UserConfig map[string]string `json:"user-config"`
+	// Supported bootstrap settings.
+	BootstrapOptions BootstrapOptions `json:"bootstrap-options"`
+}
+
+// BootstrapOptions contains the supported bootstrap settings carried by River.
+type BootstrapOptions struct {
+	BootstrapBase         string                `json:"bootstrap-base,omitempty"`
+	BootstrapConstraints  map[string]string     `json:"bootstrap-constraints,omitempty"`
+	ModelConstraints      map[string]string     `json:"model-constraints,omitempty"`
+	ModelDefault          map[string]string     `json:"model-default,omitempty"`
+	StoragePool           *BootstrapStoragePool `json:"storage-pool,omitempty"`
+	BootstrapConfig       map[string]string     `json:"bootstrap-config,omitempty"`
+	ControllerConfig      map[string]string     `json:"controller-config,omitempty"`
+	ControllerModelConfig map[string]string     `json:"controller-model-config,omitempty"`
+}
+
+// BootstrapStoragePool contains storage-pool bootstrap settings carried by River.
+type BootstrapStoragePool struct {
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 const BootstrapJobKind = "bootstrap-controller"

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -263,7 +263,7 @@ type ControllerProfile struct {
 	// Cloud stores the cloud definition for the profile.
 	Cloud ControllerProfileCloud `json:"cloud" yaml:"cloud"`
 	// BootstrapOptions holds the reusable bootstrap settings saved in the profile.
-	BootstrapOptions ControllerProfileBootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
+	BootstrapOptions BootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
 }
 
 // ControllerProfileSummary contains the fields returned when listing controller profiles.
@@ -310,8 +310,9 @@ type ControllerProfileCloudRegion struct {
 	StorageEndpoint string `json:"storage-endpoint,omitempty" yaml:"storage-endpoint,omitempty"`
 }
 
-// ControllerProfileBootstrapOptions stores the reusable bootstrap settings supported by a profile.
-type ControllerProfileBootstrapOptions struct {
+// BootstrapOptions stores the supported bootstrap settings shared by
+// controller profiles and bootstrap requests.
+type BootstrapOptions struct {
 	// BootstrapBase specifies the base of the bootstrap machine, e.g. "ubuntu@24.04".
 	BootstrapBase string `json:"bootstrap-base,omitempty" yaml:"bootstrap-base,omitempty"`
 	// BootstrapConstraints specifies bootstrap machine constraints.
@@ -321,7 +322,7 @@ type ControllerProfileBootstrapOptions struct {
 	// ModelDefault specifies default model configuration values.
 	ModelDefault map[string]string `json:"model-default,omitempty" yaml:"model-default,omitempty"`
 	// StoragePool holds the options for an initial storage pool created in the controller model.
-	StoragePool *ControllerProfileStoragePool `json:"storage-pool,omitempty" yaml:"storage-pool,omitempty"`
+	StoragePool *BootstrapStoragePool `json:"storage-pool,omitempty" yaml:"storage-pool,omitempty"`
 	// BootstrapConfig holds bootstrap configuration values.
 	BootstrapConfig map[string]string `json:"bootstrap-config,omitempty" yaml:"bootstrap-config,omitempty"`
 	// ControllerConfig holds controller configuration.
@@ -330,8 +331,9 @@ type ControllerProfileBootstrapOptions struct {
 	ControllerModelConfig map[string]string `json:"controller-model-config,omitempty" yaml:"controller-model-config,omitempty"`
 }
 
-// ControllerProfileStoragePool stores the optional storage pool configuration for a profile.
-type ControllerProfileStoragePool struct {
+// BootstrapStoragePool stores the optional storage pool configuration used by
+// bootstrap settings.
+type BootstrapStoragePool struct {
 	// Name is the storage pool name and is required.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Type is the storage pool type and is required.
@@ -786,8 +788,8 @@ type BootstrapParams struct {
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.
 	ControllerName string `json:"controller-name"`
-	// Config holds configuration options for the bootstrap job.
-	Config map[string]string `json:"config"`
+	// BootstrapOptions holds the supported bootstrap settings for the job.
+	BootstrapOptions BootstrapOptions `json:"bootstrap-options"`
 
 	// ControllerVersion is the version of the controller to be bootstrapped.
 	ControllerVersion string `json:"controller-version"`

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -32,7 +32,7 @@ func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRe
 					StorageEndpoint:  "https://storage.example.com",
 				},
 			},
-			BootstrapOptions: apiparams.ControllerProfileBootstrapOptions{
+			BootstrapOptions: apiparams.BootstrapOptions{
 				BootstrapBase:         "ubuntu@24.04",
 				BootstrapConstraints:  map[string]string{"mem": "8G", "cores": "2"},
 				ModelConstraints:      map[string]string{"arch": "amd64"},
@@ -40,7 +40,7 @@ func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRe
 				BootstrapConfig:       map[string]string{"bootstrap-timeout": "20m"},
 				ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
 				ControllerModelConfig: map[string]string{"logging-config": "<root>=INFO"},
-				StoragePool: &apiparams.ControllerProfileStoragePool{
+				StoragePool: &apiparams.BootstrapStoragePool{
 					Name:       "controller-pool",
 					Type:       "ebs",
 					Attributes: map[string]string{"volume-type": "gp3"},
@@ -107,7 +107,7 @@ func TestControllerProfileValidation(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*built-in clouds like \"localhost\".*")
 
 	malformedPool := testControllerProfileRequest("bad-storage-pool")
-	malformedPool.BootstrapOptions.StoragePool = &apiparams.ControllerProfileStoragePool{Name: "controller-pool"}
+	malformedPool.BootstrapOptions.StoragePool = &apiparams.BootstrapStoragePool{Name: "controller-pool"}
 	_, err = client.SaveControllerProfile(&malformedPool)
 	c.Assert(err, qt.ErrorMatches, ".*storage pool requires both name and type.*")
 


### PR DESCRIPTION
## Description
This PR is built on #1906. See changes from commit 66736a60d773d7973cdca932a513fcb3c133e956

In this PR we extend the bootstrap manager and our `startBootstrap` API to accept a host of new fields when bootstrapping controllers. This allows almost all the options supported by `juju bootstrap` and aligns the bootstrap parameters with those of the controller-profile.

The e2e test has not yet changed to take advantage of these new fields as we still need to update the `jaas bootstrap` command and then the e2e tests in https://warthogs.atlassian.net/browse/JUJU-9427 and https://warthogs.atlassian.net/browse/JUJU-9428, respectively.

Resolves [JUJU-9426](https://warthogs.atlassian.net/browse/JUJU-9426), [JUJU-9429](https://warthogs.atlassian.net/browse/JUJU-9429)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-9426]: https://warthogs.atlassian.net/browse/JUJU-9426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[JUJU-9429]: https://warthogs.atlassian.net/browse/JUJU-9429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ