### PR TITLE
chore: replace errors.E(err) with err

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -430,7 +430,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	database, err := openDB(ctx, p.DSN, p.LogSQL)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	db := &db.Database{DB: database}
 
@@ -441,7 +441,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	openFGAclient, err := newOpenFGAClient(ctx, p.OpenFGAParams)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	if err := ensureControllerAdministrators(ctx, openFGAclient, controllerUUID, p.ControllerAdmins); err != nil {
@@ -450,7 +450,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	credentialStore, err := setupCredentialStore(ctx, p, db)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	jwtExpiry := p.JWTExpiryDuration
@@ -494,7 +494,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	sessionStore, cleanupFuncs, err := setupSessionStore(p.CookieSessionKey, db)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	deps.cleanupFuncs = append(deps.cleanupFuncs, cleanupFuncs...)
 
@@ -577,7 +577,7 @@ func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) 
 	var err error
 	s.jimm, err = jimm.New(jimmParameters)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	s.mux = chi.NewRouter()
@@ -599,7 +599,7 @@ func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) 
 
 	rebacBackend, err := rebac_admin.SetupBackend(ctx, jujuapi.NewJIMMAdapter(s.jimm))
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	s.mux.Mount("/rebac", middleware.AuthenticateRebac("/rebac", rebacBackend.Handler(""), s.jimm.LoginManager))
@@ -746,7 +746,7 @@ func (s *Service) StartServices(ctx context.Context, svc *service.Service) {
 func setupSessionStore(sessionSecret []byte, db *db.Database) (*pgstore.PGStore, []func() error, error) {
 	sqlDb, err := db.DB.DB()
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	store, err := pgstore.NewPGStoreFromPool(sqlDb, sessionSecret)
@@ -848,7 +848,7 @@ func newOpenFGAClient(ctx context.Context, p OpenFGAParams) (*openfga.OFGAClient
 		AuthModelID: p.AuthModel,
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return openfga.NewOpenFGAClient(cofgaClient), nil
 }
@@ -864,12 +864,12 @@ func ensureControllerAdministrators(ctx context.Context, client *openfga.OFGACli
 		userTag := names.NewUserTag(username)
 		i, err := dbmodel.NewIdentity(userTag.Id())
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		user := openfga.NewUser(i, client)
 		isAdmin, err := openfga.IsAdministrator(ctx, user, controller)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		if !isAdmin {
 			tuples = append(tuples, openfga.Tuple{

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -429,7 +429,7 @@ func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email strin
 	// TODO(ale8k): Add test case for this
 	u, err := dbmodel.NewIdentity(email)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// TODO(babakks): If user does not exist, we will create one with an empty
@@ -438,7 +438,7 @@ func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email strin
 	// this should be changed and split apart so it is intentional what entities
 	// we are creating or fetching.
 	if err := db.GetIdentity(ctx, u); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	u.AccessToken = token.AccessToken
@@ -446,7 +446,7 @@ func (as *AuthenticationService) UpdateIdentity(ctx context.Context, email strin
 	u.AccessTokenExpiry = token.Expiry
 	u.AccessTokenType = token.TokenType
 	if err := db.UpdateIdentity(ctx, u); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -499,7 +499,7 @@ func (as *AuthenticationService) CreateBrowserSession(
 
 	session, err := as.sessionStore.Get(r, SessionName)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	session.IsNew = true                            // Sets cookie to a fresh new cookie
@@ -508,7 +508,7 @@ func (as *AuthenticationService) CreateBrowserSession(
 
 	session.Values[SessionIdentityKey] = email
 	if err = session.Save(r, w); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -547,7 +547,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	ctx = ContextWithSessionIdentity(ctx, identityId)
 
 	if err := as.extendSession(session, w, req); err != nil {
-		return ctx, errors.E(err)
+		return ctx, err
 	}
 
 	return ctx, nil
@@ -604,11 +604,11 @@ func (as *AuthenticationService) Whoami(ctx context.Context) (*params.WhoamiResp
 	// TODO(ale8k) CSS-8227: Add test case for this
 	u, err := dbmodel.NewIdentity(identityId)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	if err := as.db.GetIdentity(ctx, u); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return &params.WhoamiResponse{
@@ -632,11 +632,11 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 	// TODO(ale8k) CSS-8228: Add test case for this
 	u, err := dbmodel.NewIdentity(emailStr)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := db.GetIdentity(ctx, u); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	t := &oauth2.Token{
@@ -653,7 +653,7 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 	}
 
 	if err := as.refreshIdentitiesToken(ctx, emailStr, t); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -683,7 +683,7 @@ func (as *AuthenticationService) refreshIdentitiesToken(ctx context.Context, ema
 func (as *AuthenticationService) deleteSession(session *sessions.Session, w http.ResponseWriter, req *http.Request) error {
 
 	if err := as.modifySession(session, w, req, -1); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -692,7 +692,7 @@ func (as *AuthenticationService) deleteSession(session *sessions.Session, w http
 func (as *AuthenticationService) extendSession(session *sessions.Session, w http.ResponseWriter, req *http.Request) error {
 
 	if err := as.modifySession(session, w, req, as.sessionCookieMaxAge); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -703,7 +703,7 @@ func (as *AuthenticationService) modifySession(session *sessions.Session, w http
 	session.Options.MaxAge = maxAge
 
 	if err := session.Save(req, w); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -15,7 +15,7 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	const op = "db.AddApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -37,7 +37,7 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	const op = "db.GetApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -60,7 +60,7 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "application offer not found")
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.Ap
 	const op = "db.DeleteApplicationOffer"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -94,7 +94,7 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 		return nil, errors.E(errors.CodeBadRequest, "model name or owner not specified")
 	}
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -16,7 +16,7 @@ func (d *Database) AddAuditLogEntry(ctx context.Context, ale *dbmodel.AuditLogEn
 	const op = "db.AddAuditLogEntry"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -72,7 +72,7 @@ type AuditLogFilter struct {
 func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilter, f func(*dbmodel.AuditLogEntry) error) (err error) {
 	const op = "db.ForEachAuditLogEntry"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -107,13 +107,13 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 
 	rows, err := db.Rows()
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var ale dbmodel.AuditLogEntry
 		if err := db.ScanRows(rows, &ale); err != nil {
-			return errors.E(err)
+			return err
 		}
 		if err := f(&ale); err != nil {
 			return err
@@ -131,7 +131,7 @@ func (d *Database) DeleteAuditLogsBefore(ctx context.Context, before time.Time) 
 	const op = "db.DeleteAuditLogsBefore"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -19,7 +19,7 @@ import (
 func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	const op = "db.AddCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -32,7 +32,7 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 			return errors.E(fmt.Sprintf("cloud %q already exists", c.Name), err)
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -43,7 +43,7 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	const op = "db.GetCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -58,7 +58,7 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(fmt.Sprintf("cloud %q not found", c.Name), err)
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error) {
 	const op = "db.GetClouds"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -78,7 +78,7 @@ func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error)
 	db := d.DB.WithContext(ctx)
 	db = preloadCloud("", db)
 	if err := db.Find(&clouds).Error; err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return clouds, nil
 }
@@ -89,7 +89,7 @@ func (d *Database) GetClouds(ctx context.Context) (_ []dbmodel.Cloud, err error)
 func (d *Database) UpdateCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	const op = "db.UpdateCloud"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -134,7 +134,7 @@ func preloadCloud(prefix string, db *gorm.DB) *gorm.DB {
 func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) (err error) {
 	const op = "db.AddCloudRegion"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -147,7 +147,7 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 			return errors.E(fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -157,7 +157,7 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regionName string) (_ *dbmodel.CloudRegion, err error) {
 	const op = "db.FindRegion"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -180,7 +180,7 @@ func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regi
 func (d *Database) FindRegionByCloudName(ctx context.Context, cloudName, regionName string) (_ *dbmodel.CloudRegion, err error) {
 	const op = "db.FindRegion"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -203,7 +203,7 @@ func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 	const op = "db.DeleteCloud"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -222,7 +222,7 @@ func (d *Database) DeleteCloudRegionControllerPriority(ctx context.Context, c *d
 	const op = "db.DeleteCloudRegionControllerPriority"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -17,7 +17,7 @@ import (
 func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCredential) (err error) {
 	const op = "db.SetCloudCredential"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -47,7 +47,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCredential) (err error) {
 	const op = "db.GetCloudCredential"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -65,7 +65,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), err)
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 	const op = "db.ForEachCloudCredential"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -112,7 +112,7 @@ func (d *Database) DeleteCloudCredential(ctx context.Context, cred *dbmodel.Clou
 	const op = "db.DeleteCloudCredential"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -122,7 +122,7 @@ func (d *Database) DeleteCloudCredential(ctx context.Context, cred *dbmodel.Clou
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(cred).Error; err != nil {
 		err = dbError(err)
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -18,7 +18,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 	const op = "db.SetCloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -46,7 +46,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 				}
 				return nil
 			}
-			return errors.E(err)
+			return err
 		}
 
 		// update defaults
@@ -66,7 +66,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 	const op = "db.UpsertCloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -97,7 +97,7 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 		// try to fetch cloud defaults from the db
 		err := d.CloudDefaults(ctx, &dbDefaults)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 
 		// update defaults
@@ -117,7 +117,7 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -127,7 +127,7 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 	const op = "db.CloudDefaults"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -151,7 +151,7 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(errors.CodeNotFound, "cloudregiondefaults not found", err)
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (d *Database) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Iden
 	const op = "db.ModelDefaultsForCloud"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -16,7 +16,7 @@ import (
 func (d *Database) AddController(ctx context.Context, controller *dbmodel.Controller) (err error) {
 	const op = "db.AddController"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -36,7 +36,7 @@ func (d *Database) AddController(ctx context.Context, controller *dbmodel.Contro
 func (d *Database) GetController(ctx context.Context, controller *dbmodel.Controller) (err error) {
 	const op = "db.GetController"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -59,7 +59,7 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "controller not found")
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -74,7 +74,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -97,7 +97,7 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -110,10 +110,10 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "controller not found")
 		}
-		return errors.E(err)
+		return err
 	}
 	if err := db.Select(clause.Associations).Delete(controller).Error; err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Contro
 	const op = "db.ForEachController"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -155,7 +155,7 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 	const op = "db.ForEachControllerModel"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -180,7 +180,7 @@ func (d *Database) CountControllers(ctx context.Context) (count int, err error) 
 	const op = "db.CountControllers"
 
 	if err := d.ready(); err != nil {
-		return -1, errors.E(err)
+		return -1, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -82,7 +82,7 @@ func (d *Database) Migrate(ctx context.Context) error {
 
 	err := d.migrateFromSource(ctx, dbmodel.SQL, path.Join("sql", d.DB.Name()))
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -18,7 +18,7 @@ var newUUID = uuid.NewString
 func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.GroupEntry, err error) {
 	const op = "db.AddGroup"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -40,7 +40,7 @@ func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.Group
 func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 	const op = "db.CountGroups"
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()
@@ -59,7 +59,7 @@ func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err error) {
 	const op = "db.GetGroup"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if group.UUID == "" && group.Name == "" {
@@ -91,7 +91,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 func (d *Database) ListGroups(ctx context.Context, limit, offset int, match string) (_ []dbmodel.GroupEntry, err error) {
 	const op = "db.ListGroups"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -125,7 +125,7 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -149,7 +149,7 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -31,7 +31,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -53,7 +53,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 
 	// If we didn't create it, it must exist (or we raced and lost). Fetch it.
 	if err = d.DB.WithContext(ctx).Where("name = ?", u.Name).First(&u).Error; err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -71,7 +71,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -80,7 +80,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("name = ?", u.Name).First(&u).Error; err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err error) {
 	const op = "db.UpdateIdentity"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -108,7 +108,7 @@ func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err
 	db := d.DB.WithContext(ctx)
 	db = db.Omit("ApplicationOffers").Omit("Clouds").Omit("CloudCredentials").Omit("Models")
 	if err := db.Save(u).Error; err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -122,7 +122,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 	}
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -132,7 +132,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 	var credentials []dbmodel.CloudCredential
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(u).Where("cloud_name = ?", cloud).Association("CloudCredentials").Find(&credentials); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return credentials, nil
 }
@@ -142,7 +142,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match string) (_ []dbmodel.Identity, err error) {
 	const op = "db.ListIdentities"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -172,7 +172,7 @@ func (d *Database) CountIdentities(ctx context.Context) (_ int, err error) {
 	const op = "db.CountIdentities"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -182,7 +182,7 @@ func (d *Database) CountIdentities(ctx context.Context) (_ int, err error) {
 	db := d.DB.WithContext(ctx)
 	var count int64
 	if err := db.Model(&dbmodel.Identity{}).Count(&count).Error; err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	return int(count), nil
 }

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -21,7 +21,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 	const op = "db.AddJobLog"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -68,7 +68,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId int64, offset int) (lo
 	const op = "db.QueryJobLog"
 
 	if err := d.ready(); err != nil {
-		return loggies, nextOffsetValue, errors.E(err)
+		return loggies, nextOffsetValue, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -18,7 +18,7 @@ import (
 func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err error) {
 	const op = "db.AddModel"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -38,7 +38,7 @@ func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err erro
 func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err error) {
 	const op = "db.GetModel"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -46,7 +46,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -83,7 +83,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID uint) (_ []dbmodel.Model, err error) {
 	const op = "db.GetModelsUsingCredential"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -103,7 +103,7 @@ func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID ui
 func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err error) {
 	const op = "db.UpdateModel"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -121,7 +121,7 @@ func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err e
 func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err error) {
 	const op = "db.DeleteModel"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -150,7 +150,7 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 	const op = "db.ForEachModel"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -181,7 +181,7 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 	const op = "db.GetModelsByUUID"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -224,7 +224,7 @@ func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Contro
 	const op = "db.GetModelsByController"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -243,7 +243,7 @@ func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Cont
 	const op = "db.CountModelsByController"
 
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -18,7 +18,7 @@ import (
 func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = "db.AddOrUpdateIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -36,7 +36,7 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 			// If the model migration already exists, update it.
 			modelMigration.ID = lookup.ID
 		} else if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-			return errors.E(err)
+			return err
 		}
 
 		db := d.DB.WithContext(ctx)
@@ -78,7 +78,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "model migration not found")
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = "db.GetIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -107,7 +107,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "model migration not found")
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigration *dbmodel.IncomingModelMigration) (err error) {
 	const op = "db.DeleteIncomingModelMigration"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -134,7 +134,7 @@ func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigrat
 func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, createBefore time.Time) (migrations []dbmodel.IncomingModelMigration, err error) {
 	const op = "db.GetIncomingModelMigrations"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -74,7 +74,7 @@ type Resource struct {
 func (d *Database) ListResources(ctx context.Context, limit, offset int, namePrefixFilter, typeFilter string) (_ []Resource, err error) {
 	const op = "db.ListResources"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -14,7 +14,7 @@ import (
 func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEntry, err error) {
 	const op = "db.AddRole"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -36,7 +36,7 @@ func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEn
 func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err error) {
 	const op = "db.GetRole"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -72,7 +72,7 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -97,7 +97,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -115,7 +115,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 func (d *Database) ListRoles(ctx context.Context, limit, offset int, match string) (_ []dbmodel.RoleEntry, err error) {
 	const op = "db.ListRoles"
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -144,7 +144,7 @@ func (d *Database) ListRoles(ctx context.Context, limit, offset int, match strin
 func (d *Database) CountRoles(ctx context.Context) (count int, err error) {
 	const op = "db.CountRoles"
 	if err := d.ready(); err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
 	defer durationObserver()

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -33,7 +33,7 @@ func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
 		if err == gorm.ErrRecordNotFound {
 			return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 		}
-		return dbrootkeystore.RootKey{}, errors.E(err)
+		return dbrootkeystore.RootKey{}, err
 	}
 	return dbrootkeystore.RootKey{
 		Id:      rk.ID,
@@ -78,7 +78,7 @@ func (d *Database) InsertKey(key dbrootkeystore.RootKey) (err error) {
 	const op = "db.InsertKey"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -38,7 +38,7 @@ const (
 func (d *Database) UpsertSecret(ctx context.Context, secret *dbmodel.Secret) (err error) {
 	const op = "db.AddSecret"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -65,7 +65,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -95,7 +95,7 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 	}
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -115,7 +115,7 @@ func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map
 	const op = "database.Get"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -143,7 +143,7 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 	const op = "database.Put"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -164,7 +164,7 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 	const op = "database.GetControllerCredentials"
 
 	if err := d.ready(); err != nil {
-		return "", "", errors.E(err)
+		return "", "", err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -200,7 +200,7 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 	const op = "database.PutControllerCredentials"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -223,7 +223,7 @@ func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
 	const op = "database.CleanupJWKS"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -253,7 +253,7 @@ func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	const op = "database.GetJWKS"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -277,7 +277,7 @@ func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) 
 	const op = "database.GetJWKSPrivateKey"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -302,7 +302,7 @@ func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
 	const op = "database.GetJWKSExpiry"
 
 	if err := d.ready(); err != nil {
-		return time.Time{}, errors.E(err)
+		return time.Time{}, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -327,7 +327,7 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 	const op = "database.PutJWKS"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -348,7 +348,7 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 	const op = "database.PutJWKSPrivateKey"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -368,7 +368,7 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 	const op = "database.PutJWKSExpiry"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -388,7 +388,7 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 	const op = "database.CleanupOAuthSecrets"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -14,7 +14,7 @@ import (
 func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err error) {
 	const op = "db.AddSSHKey"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -37,7 +37,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 	const op = "db.RemoveSSHKeyByFingerprint"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -65,7 +65,7 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	const op = "db.RemoveSSHKeyByComment"
 
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -91,7 +91,7 @@ func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, 
 	const op = "db.ListSSHKeysForUser"
 
 	if err := d.ready(); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -14,7 +14,7 @@ import (
 func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
 	const op = "db.AddUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -33,7 +33,7 @@ func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.User
 func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
 	const op = "db.GetUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -66,7 +66,7 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.UserMapping) (err error) {
 	const op = "db.DeleteUserMapping"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -84,7 +84,7 @@ func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.U
 func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID string) (err error) {
 	const op = "db.DeleteUserMappingsByModelUUID"
 	if err := d.ready(); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -90,7 +90,7 @@ func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return entries, nil

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -40,7 +40,7 @@ func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name st
 
 	ge, err := j.store.AddGroup(ctx, name)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return ge, nil
 }
@@ -53,7 +53,7 @@ func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int
 	}
 	count, err := j.store.CountGroups(ctx)
 	if err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	return count, nil
 }
@@ -65,7 +65,7 @@ func (j *GroupManager) getGroup(ctx context.Context, user *openfga.User, group *
 		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := j.store.GetGroup(ctx, group); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return group, nil
 }
@@ -103,7 +103,7 @@ func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -130,12 +130,12 @@ func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = j.authSvc.RemoveGroup(ctx, group.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func (j *GroupManager) ListGroups(ctx context.Context, user *openfga.User, pagin
 
 	groups, err := j.store.ListGroups(ctx, pagination.Limit(), pagination.Offset(), match)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return groups, nil
 }

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -35,7 +35,7 @@ func (j *IdentityManager) FetchIdentity(ctx context.Context, id string) (*openfg
 
 	identity, err := dbmodel.NewIdentity(id)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	if err := j.store.FetchIdentity(ctx, identity); err != nil {
@@ -59,7 +59,7 @@ func (j *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User
 		users = append(users, *openfga.NewUser(&id, j.authSvc))
 	}
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return users, nil
 }
@@ -73,7 +73,7 @@ func (j *IdentityManager) CountIdentities(ctx context.Context, user *openfga.Use
 
 	count, err := j.store.CountIdentities(ctx)
 	if err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	return count, nil
 }

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -159,7 +159,7 @@ func New(p Parameters) (*JIMM, error) {
 	jimmResourceTag := names.NewControllerTag(j.UUID)
 
 	if err := j.Database.Migrate(context.Background()); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	roleManager, err := role.NewRoleManager(j.Database, j.OpenFGAClient)

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -40,7 +40,7 @@ func NewJobManager(jobQuerier JobQuerier) (*JobManager, error) {
 func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (JobInfo, error) {
 	jobRow, err := j.jobQuerier.GetJobInfo(ctx, jobID)
 	if err != nil {
-		return JobInfo{}, errors.E(err)
+		return JobInfo{}, err
 	}
 	var jobErrors []JobError
 	for _, err := range jobRow.Errors {
@@ -97,7 +97,7 @@ func (j *JobManager) ListJobs(ctx context.Context, req apiparams.ListJobsRequest
 
 	jobListResult, err := j.jobQuerier.ListJobs(ctx, p)
 	if err != nil {
-		return apiparams.ListJobsResponse{}, errors.E(err)
+		return apiparams.ListJobsResponse{}, err
 	}
 
 	jobs := make([]apiparams.ListJobInfo, len(jobListResult.Jobs))

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -50,7 +50,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "model not found")
 		}
-		return errors.E(err)
+		return err
 	}
 
 	isAdmin, err := openfga.IsAdministrator(ctx, user, model.ResourceTag())
@@ -77,12 +77,12 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return errors.E(fmt.Sprintf("offer %s already exists, please use a different name", offerURL.String()), errors.CodeAlreadyExists)
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.
-		return errors.E(err)
+		return err
 	}
 
 	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 
@@ -107,7 +107,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		if strings.Contains(err.Error(), "application offer already exists") {
 			return errors.E(err, errors.CodeAlreadyExists)
 		}
-		return errors.E(err)
+		return err
 	}
 
 	createdAppOffer, err := api.GetApplicationOffer(ctx, offerURL.String())
@@ -150,7 +150,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 
 	identity, err := dbmodel.NewIdentity(ownerId)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	ownerUser := openfga.NewUser(
@@ -188,12 +188,12 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "application offer not found")
 		}
-		return errors.E(err)
+		return err
 	}
 
 	accessLevel, err := j.getUserOfferAccess(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	switch accessLevel {
@@ -209,13 +209,13 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 
 	consumeDetails, err := api.GetApplicationOfferConsumeDetails(ctx, details.Offer.OfferURL)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	details.Offer = consumeDetails.Offer
 	details.ControllerInfo = consumeDetails.ControllerInfo
@@ -225,7 +225,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	// Filter out any juju local users.
 	users, err := j.listApplicationOfferUsers(ctx, offer.ResourceTag(), user.Identity, accessLevel == string(jujuparams.OfferAdminAccess))
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	details.Offer.Users = users
 
@@ -261,7 +261,7 @@ func (j *JujuManager) listApplicationOfferUsers(ctx context.Context, offer names
 	} {
 		usersWithRelation, err := openfga.ListUsersWithAccess(ctx, j.OpenFGAClient, offer, relation)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		for _, user := range usersWithRelation {
 			// if the user is in the users map, it must already have a higher
@@ -347,12 +347,12 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, errors.E(err, "application offer not found")
 		}
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	reader, err := user.IsApplicationOfferReader(ctx, offer.ResourceTag())
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	// if this user does not have access to this application offer
@@ -367,18 +367,18 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// and it would be non-trivial to make it do so.
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	defer api.Close()
 
 	offerDetails, err := api.GetApplicationOffer(ctx, offerURL)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	err = j.enrichOfferDetails(ctx, user, offerDetails)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return offerDetails, nil
@@ -407,7 +407,7 @@ func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offe
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -465,14 +465,14 @@ func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.U
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
 		return api.FindApplicationOffers(ctx, filters)
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return offers, nil
 }
@@ -498,7 +498,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 			OwnerIdentityName: f.OwnerName,
 		}
 		if err := j.Database.GetModel(ctx, &m); err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		controllers[m.Controller.ID] = &m.Controller
 	}
@@ -507,7 +507,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 		return api.ListApplicationOffers(ctx, filters)
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return offers, nil
 }
@@ -523,7 +523,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 			// could cause unneeded reconciliation.
 			api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
 			if err != nil {
-				return errors.E(err)
+				return err
 			}
 			defer api.Close()
 			controllerOffers, err := query(api)
@@ -531,7 +531,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 				if errors.ErrorCode(err) == errors.CodeNotFound {
 					return nil
 				}
-				return errors.E(err)
+				return err
 			}
 			for _, offer := range controllerOffers {
 				err = j.enrichOfferDetails(ctx, user, offer)
@@ -539,7 +539,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 					if stderrors.Is(err, noApplicationOfferAccessError) {
 						continue
 					}
-					return errors.E(err)
+					return err
 				}
 
 				offerDetails.addOffer(offer)
@@ -568,12 +568,12 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		URL: offerURL,
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isOfferAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -581,11 +581,11 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 	// add offer admin claim
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 	if err := f(&offer, api); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -33,12 +33,12 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 	cl.SetTag(tag)
 
 	if err := j.Database.GetCloud(ctx, &cl); err != nil {
-		return cl, errors.E(err)
+		return cl, err
 	}
 
 	accessLevel, err := j.permissionManager.GetUserCloudAccess(ctx, user, tag)
 	if err != nil {
-		return dbmodel.Cloud{}, errors.E(err)
+		return dbmodel.Cloud{}, err
 	}
 
 	switch accessLevel {
@@ -152,30 +152,30 @@ func (j *JujuManager) AddCloudToController(ctx context.Context, user *openfga.Us
 
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := j.checkControllerAdminAccess(ctx, user, controller); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := checkReservedCloudNames(tag, j.ReservedCloudNames); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := validateCloudRegion(ctx, j.Database, user, cloud, controllerName); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	dbCloud, err := j.addCloudToDatabase(ctx, controller, user, tag, cloud, force)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// TODO(ale8k): We've added the cloud to the db, but the access failed.
 	// This call needs to be idempotent.
 	if err := j.addCloudControllerRelation(ctx, dbCloud, *controller); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -271,7 +271,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 
 	region, err := j.determineHostCloudRegion(ctx, cloud.HostCloudRegion)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if region.Cloud.HostCloudRegion != "" {
@@ -285,7 +285,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	dbCloud.FromJujuCloud(cloud)
 	dbCloud.Name = tag.Id()
 	if err := j.Database.AddCloud(ctx, &dbCloud); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// Create the cloud on a host.
@@ -295,7 +295,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	ccloud, err := j.addControllerCloud(ctx, &controller, user, tag, cloud, force)
 	if err != nil {
 		// TODO(mhilton) remove the added cloud if adding it to the controller failed.
-		return errors.E(err)
+		return err
 	}
 	// Update the cloud in the database.
 	dbCloud.FromJujuCloud(*ccloud)
@@ -312,7 +312,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 		// At this point the cloud has been created on the
 		// controller and we know something about it. Trying to
 		// undo that will probably make things worse.
-		return errors.E(err)
+		return err
 	}
 
 	err = j.OpenFGAClient.AddCloudController(ctx, dbCloud.ResourceTag(), controller.ResourceTag())
@@ -347,17 +347,17 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
 	api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	defer api.Close()
 	if err := api.AddCloud(tag, cloud, force); err != nil {
 		if !jujuparams.IsCodeAlreadyExists(err) {
-			return nil, errors.E(err)
+			return nil, err
 		}
 	}
 	result, err := api.Cloud(tag)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return &result, nil
@@ -381,12 +381,12 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 	c.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &c); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, c.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
@@ -404,11 +404,11 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 	}
 	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 	if err := f(&c, api); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -439,7 +439,7 @@ func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct na
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -455,11 +455,11 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 	c.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &c); err != nil {
-		return errors.E(err)
+		return err
 	}
 	cloudAccess, err := j.permissionManager.GetUserCloudAccess(ctx, user, c.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if cloudAccess != "admin" {
 		// If the user doesn't have admin access on the cloud return
@@ -483,7 +483,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 		return api.UpdateCloud(ct, cloud)
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -511,7 +511,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 	})
 
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -527,7 +527,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	cloud.SetTag(ct)
 
 	if err := j.Database.GetCloud(ctx, &cloud); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -554,7 +554,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	api, err := j.dial(ctx, &controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 
@@ -563,7 +563,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	// relies on the controller failing the RemoveClouds API
 	// request if the cloud is in use.
 	if err := api.RemoveCloud(ct); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	delete(controllers, controllerName)
@@ -678,7 +678,7 @@ func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmode
 
 	ccloud, err := j.addControllerCloud(ctx, controller, user, tag, cloud, force)
 	if err != nil {
-		return dbCloud, errors.E(err)
+		return dbCloud, err
 	}
 
 	dbCloud.FromJujuCloud(*ccloud)
@@ -689,7 +689,7 @@ func (j *JujuManager) addCloudToDatabase(ctx context.Context, controller *dbmode
 		}}
 	}
 	if err := j.Database.AddCloud(ctx, &dbCloud); err != nil {
-		return dbCloud, errors.E(err)
+		return dbCloud, err
 	}
 
 	return dbCloud, nil

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -36,7 +36,7 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return &credential, nil
@@ -59,7 +59,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 			// It is not an error to revoke an non-existent credential
 			return nil
 		}
-		return errors.E(err)
+		return err
 	}
 
 	credential.Valid = sql.NullBool{
@@ -69,7 +69,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 
 	models, err := j.Database.GetModelsUsingCredential(ctx, credential.ID)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	// Before we accepted the force flag to remove the credential regardless of the references count.
 	// Now we want to ensure that the credential is not used by any models before removing it to maintain
@@ -82,7 +82,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 		Name: credential.CloudName,
 	}
 	if err = j.Database.GetCloud(ctx, &cloud); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	var controllers []dbmodel.Controller
@@ -106,7 +106,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 	})
 
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = j.Database.DeleteCloudCredential(ctx, &credential)
@@ -139,7 +139,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 		var u2 dbmodel.Identity
 		u2.SetTag(args.CredentialTag.Owner())
 		if err := j.Database.GetIdentity(ctx, &u2); err != nil {
-			return result, errors.E(err)
+			return result, err
 		}
 	}
 
@@ -148,19 +148,19 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return result, errors.E(err)
+		return result, err
 	}
 
 	// Confirm the cloud exists.
 	var cloud dbmodel.Cloud
 	cloud.SetTag(names.NewCloudTag(credential.CloudName))
 	if err = j.Database.GetCloud(ctx, &cloud); err != nil {
-		return result, errors.E(err)
+		return result, err
 	}
 
 	models, err := j.Database.GetModelsUsingCredential(ctx, credential.ID)
 	if err != nil {
-		return result, errors.E(err)
+		return result, err
 	}
 	var controllers []dbmodel.Controller
 	seen := make(map[uint]bool)
@@ -183,7 +183,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 			return err
 		})
 		if err != nil {
-			return result, errors.E(err)
+			return result, err
 		}
 	}
 	var modelsErr bool
@@ -200,7 +200,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 	}
 
 	if err := j.updateCredential(ctx, &credential, args.Credential.Attributes); err != nil {
-		return result, errors.E(err)
+		return result, err
 	}
 
 	err = j.forEachController(ctx, controllers, func(ctl *dbmodel.Controller, api API) error {
@@ -216,7 +216,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 		return nil
 	})
 	if err != nil {
-		return result, errors.E(err)
+		return result, err
 	}
 	return result, nil
 }
@@ -242,7 +242,7 @@ func (j *JujuManager) updateControllerCloudCredential(
 
 	attr, err := j.getCloudCredentialAttributes(ctx, cred)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	out, err := f(ctx, jujuparams.TaggedCredential{
@@ -254,7 +254,7 @@ func (j *JujuManager) updateControllerCloudCredential(
 	})
 
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	// Shouldn't happen, the Juju client presumes that
@@ -296,8 +296,6 @@ func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel
 	})
 	if err == errStop {
 		err = iterErr
-	} else if err != nil {
-		err = errors.E(err)
 	}
 	return err
 }
@@ -323,7 +321,6 @@ func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, user *op
 
 	attrs, err = j.getCloudCredentialAttributes(ctx, cred)
 	if err != nil {
-		err = errors.E(err)
 		return
 	}
 	if len(attrs) == 0 {
@@ -350,7 +347,7 @@ func (j *JujuManager) getCloudCredentialAttributes(ctx context.Context, cred *db
 
 	attr, err := j.CredentialStore.Get(ctx, cred.ResourceTag())
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return attr, nil
 }
@@ -359,12 +356,12 @@ func (j *JujuManager) getCloudCredentialAttributes(ctx context.Context, cred *db
 func (j *JujuManager) CopyCredential(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error) {
 	credential, err := j.GetCloudCredential(ctx, originalUser, cred)
 	if err != nil {
-		return names.CloudCredentialTag{}, nil, errors.E(err)
+		return names.CloudCredentialTag{}, nil, err
 	}
 
 	attr, err := j.getCloudCredentialAttributes(ctx, credential)
 	if err != nil {
-		return names.CloudCredentialTag{}, nil, errors.E(err)
+		return names.CloudCredentialTag{}, nil, err
 	}
 
 	newCredID := fmt.Sprintf("%s/%s/%s", cred.Cloud().Id(), newUser.Name, cred.Name())

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -41,7 +41,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 	}
 	err := j.Database.GetCloud(ctx, &cloud)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if region != "" {
 		found := false
@@ -61,7 +61,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 		Defaults:     configs,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func (j *JujuManager) UnsetModelDefaults(ctx context.Context, user *dbmodel.Iden
 	}
 	err := j.Database.UnsetCloudDefaults(ctx, &defaults, keys)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func (j *JujuManager) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.I
 			Message: err.Error(),
 			Code:    string(errors.ErrorCode(err)),
 		}
-		return result, errors.E(err)
+		return result, err
 	}
 
 	for _, cloudDefaults := range defaults {

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -321,7 +321,7 @@ func (j *JujuManager) EarliestControllerVersion(ctx context.Context) (version.Nu
 		return nil
 	})
 	if err != nil {
-		return version.Number{}, errors.E(err)
+		return version.Number{}, err
 	}
 	if v == nil {
 		return version.Number{}, nil
@@ -413,7 +413,7 @@ func (m *modelImporter) setModelOwner(ctx context.Context) error {
 
 	err := m.jimm.Database.GetIdentity(ctx, &owner)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	m.model.SetOwner(&owner)
 
@@ -532,19 +532,19 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 
 	importer, err := newModelImporter(j, newOwner)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := importer.fetchModelInfo(ctx, user, controllerName, modelTag); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := importer.setModelOwner(ctx); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := importer.addPermissions(ctx); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// TODO(CSS-5458): Remove the below section on cloud credentials once we no longer persist the relation between
@@ -552,15 +552,15 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 	// Update: We need to investigate this further, if a user updates their cloud-credential it will update the credential
 	// on this model.
 	if err := importer.setCloudCredential(ctx); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := importer.setModelCloud(ctx); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := importer.save(ctx); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -585,7 +585,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E("model not found", errors.CodeModelNotFound)
 		}
-		return errors.E(err)
+		return err
 	}
 
 	targetController := dbmodel.Controller{
@@ -596,19 +596,19 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E("controller not found", errors.CodeNotFound)
 		}
-		return errors.E(err)
+		return err
 	}
 
 	// check the model is known to the controller
 	api, err := j.dial(ctx, &targetController, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 
 	_, err = api.ModelInfo(ctx, modelTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	model.InternalMigrationSuccess(targetController.ID)
@@ -670,7 +670,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	err = j.Database.Transaction(func(tx *db.Database) error {
 		err := tx.ForUpdate().GetModel(ctx, &model)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 
 		if model.MigrationMode != dbmodel.MigrationModeNone {
@@ -719,7 +719,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	}, false)
 	if err != nil {
 		rollbackMigrationMode()
-		return result, errors.E(err)
+		return result, err
 	}
 
 	return result, nil
@@ -730,18 +730,18 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, user *openfga.User, 
 
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
-		return jujucontroller.Config{}, errors.E(err)
+		return jujucontroller.Config{}, err
 	}
 
 	api, err := j.dialController(ctx, controller, user)
 	if err != nil {
-		return jujucontroller.Config{}, errors.E(err)
+		return jujucontroller.Config{}, err
 	}
 	defer api.Close()
 
 	cfg, err := api.ControllerConfig(ctx)
 	if err != nil {
-		return cfg, errors.E(err)
+		return cfg, err
 	}
 	return cfg, nil
 }
@@ -761,12 +761,12 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerConnectionDetails{}, errors.E(err)
+		return ControllerConnectionDetails{}, err
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, model.Controller.Name)
 	if err != nil {
-		return ControllerConnectionDetails{}, errors.E(err)
+		return ControllerConnectionDetails{}, err
 	}
 
 	if username == "" || password == "" {

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -62,7 +62,7 @@ func (j *JujuManager) ControllerInfo(ctx context.Context, name string) (*dbmodel
 		Name: name,
 	}
 	if err := j.Database.GetController(ctx, &ctl); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return &ctl, nil
 }
@@ -83,7 +83,7 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return controllers, nil
@@ -111,7 +111,7 @@ func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga
 		return db.UpdateController(ctx, &c)
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -151,7 +151,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 		return db.DeleteController(ctx, &c)
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -171,17 +171,17 @@ func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, m
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	api, err := j.dial(ctx, &model.Controller, modelTag, nil)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	status, err := api.Status(ctx, patterns)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return status, nil
@@ -227,7 +227,7 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 
 	migrationTarget, _, err := fillMigrationTarget(j.Database, j.CredentialStore, targetController)
 	if err != nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(err)
+		return jujuparams.InitiateMigrationResult{}, err
 	}
 
 	model := dbmodel.Model{}
@@ -258,12 +258,12 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 
 	err = j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(err)
+		return jujuparams.InitiateMigrationResult{}, err
 	}
 	spec := jujuparams.MigrationSpec{ModelTag: model.ResourceTag().String(), TargetInfo: migrationTarget}
 	result, err := initiateInternalMigration(ctx, j, user, spec)
 	if err != nil {
-		return result, errors.E(err)
+		return result, err
 	}
 	return result, nil
 }
@@ -326,24 +326,24 @@ func (j *JujuManager) ListMigrationTargets(ctx context.Context, user *openfga.Us
 	var model dbmodel.Model
 	model.SetTag(modelTag)
 	if err := j.Database.GetModel(ctx, &model); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	currentVersion, err := version.Parse(model.Controller.AgentVersion)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	cloudRegion, err := j.Database.FindRegionByCloudName(ctx, model.CloudRegion.CloudName, model.CloudRegion.Name)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	var controllers []dbmodel.Controller
 	for _, ctl := range cloudRegion.Controllers {
 		candidateVersion, err := version.Parse(ctl.Controller.AgentVersion)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 
 		if model.Controller.ID != ctl.Controller.ID &&
@@ -394,7 +394,7 @@ func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.Use
 
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return &apiparams.ModelControllerInfo{

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -195,7 +195,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 
 	err = j.Database.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
@@ -587,11 +587,11 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 
 	err := tx.GetCloudCredential(ctx, cloudCredential)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 	region, err := tx.FindRegionByCloudName(ctx, description.CloudCredential().Cloud(), description.CloudRegion())
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	var importedModel *dbmodel.Model
@@ -686,13 +686,13 @@ func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migratio
 		// Delete the incoming model migration record.
 		err := j.Database.DeleteIncomingModelMigration(ctx, &migration)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 
 		// Delete user mappings for the model.
 		err = j.Database.DeleteUserMappingsByModelUUID(ctx, migration.ModelUUID.String)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 
 		// Delete the model record from JIMM's state.
@@ -704,7 +704,7 @@ func (j *JujuManager) cleanupPartialModelMigration(ctx context.Context, migratio
 		}
 		err = j.Database.DeleteModel(ctx, &model)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		return nil
 	})

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -58,12 +58,12 @@ type ModelCreateArgs struct {
 func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *ModelCreateArgs) (base.ModelInfo, error) {
 	owner, err := dbmodel.NewIdentity(args.Owner.Id())
 	if err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	err = j.Database.GetIdentity(ctx, owner)
 	if err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	// Only JIMM admins are able to add models on behalf of other users.
@@ -76,7 +76,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	builder = builder.WithAuthorizer(user)
 	builder = builder.WithName(args.Name)
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	if args.ControllerName != "" {
@@ -85,17 +85,17 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 		builder = builder.WithAnyController()
 	}
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	builder = builder.WithCloud(user, args.Cloud)
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	builder = builder.WithCloudRegion(args.CloudRegion)
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 	// fetch cloud defaults
 	cloudDefaults := dbmodel.CloudDefaults{
@@ -127,23 +127,23 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	if args.CloudCredential != (names.CloudCredentialTag{}) {
 		builder = builder.WithCloudCredential(args.CloudCredential)
 		if err := builder.Error(); err != nil {
-			return base.ModelInfo{}, errors.E(err)
+			return base.ModelInfo{}, err
 		}
 	}
 	builder = builder.CreateDatabaseModel()
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 	defer builder.Cleanup()
 
 	builder = builder.CreateControllerModel()
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	builder = builder.UpdateDatabaseModel()
 	if err := builder.Error(); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 
 	mi := builder.JujuModelInfo()
@@ -153,7 +153,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	controllerTag := builder.controller.ResourceTag()
 
 	if err := j.addModelPermissions(ctx, ownerUser, modelTag, controllerTag); err != nil {
-		return base.ModelInfo{}, errors.E(err)
+		return base.ModelInfo{}, err
 	}
 	return mi, nil
 }
@@ -207,7 +207,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 	var m dbmodel.Model
 	m.SetTag(mt)
 	if err := j.Database.GetModel(ctx, &m); err != nil {
-		return jujuclient.ModelInfo{}, errors.E(err)
+		return jujuclient.ModelInfo{}, err
 	}
 
 	if ok, err := user.IsModelReader(ctx, mt); !ok || err != nil {
@@ -216,13 +216,13 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return jujuclient.ModelInfo{}, errors.E(err)
+		return jujuclient.ModelInfo{}, err
 	}
 	defer api.Close()
 
 	modelInfo, err := j.modelInfo(ctx, user, &m, api)
 	if err != nil {
-		return jujuclient.ModelInfo{}, errors.E(err)
+		return jujuclient.ModelInfo{}, err
 	}
 
 	return j.mergeModelInfo(ctx, user, modelInfo, m)
@@ -340,7 +340,7 @@ func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	// we query the model summaries for each controller
@@ -390,7 +390,7 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 	} {
 		usersWithSpecifiedRelation, err := openfga.ListUsersWithAccess(ctx, j.OpenFGAClient, jimmModel.ResourceTag(), relation)
 		if err != nil {
-			return jujuclient.ModelInfo{}, errors.E(err)
+			return jujuclient.ModelInfo{}, err
 		}
 		for _, u := range usersWithSpecifiedRelation {
 			// Since we are checking user relations in decreasing level of
@@ -404,7 +404,7 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 
 	modelAccess, err := j.permissionManager.GetUserModelAccess(ctx, user, jimmModel.ResourceTag())
 	if err != nil {
-		return jujuclient.ModelInfo{}, errors.E(err)
+		return jujuclient.ModelInfo{}, err
 	}
 
 	users := make([]base.UserInfo, 0, len(userAccess))
@@ -456,7 +456,7 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 		return nil
 	})
 	if err != nil {
-		return ms, errors.E(err)
+		return ms, err
 	}
 	return ms, nil
 }
@@ -499,7 +499,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 
 		access, err := j.permissionManager.GetUserModelAccess(ctx, user, model.ResourceTag())
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		if access == "read" || access == "write" || access == "admin" {
 			if err := f(&model, access); err != nil {
@@ -516,7 +516,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 	case errStop:
 		return iterErr
 	default:
-		return errors.E(err)
+		return err
 	}
 }
 
@@ -547,7 +547,7 @@ func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f fu
 	case errStop:
 		return iterErr
 	default:
-		return errors.E(err)
+		return err
 	}
 }
 
@@ -575,7 +575,7 @@ func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt n
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// NOTE (alesstimec) If we remove OpenFGA relation now, the user
@@ -598,7 +598,7 @@ func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt name
 		return err
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return dump, nil
 }
@@ -614,7 +614,7 @@ func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt na
 		return err
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return dump, nil
 }
@@ -630,7 +630,7 @@ func (j *JujuManager) ValidateModelUpgrade(ctx context.Context, user *openfga.Us
 		return api.ValidateModelUpgrade(ctx, mt, force)
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -656,12 +656,12 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 	m.SetTag(mt)
 
 	if err := j.Database.GetModel(ctx, &m); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	hasAccess, err := user.HasModelRelation(ctx, mt, requireRelation)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if !hasAccess {
@@ -672,11 +672,11 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 	if err := f(&m, api); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -693,32 +693,32 @@ func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.U
 
 	err := j.Database.GetCloudCredential(ctx, &credential)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	var m *dbmodel.Model
 	err = j.doModelAdmin(ctx, user, modelTag, func(model *dbmodel.Model, api API) error {
 		_, err = j.updateControllerCloudCredential(ctx, &credential, api.UpdateCloudsCredentialForce)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 
 		err = api.ChangeModelCredential(ctx, modelTag, cloudCredentialTag)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		m = model
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	m.CloudCredential = credential
 	m.CloudCredentialID = credential.ID
 	err = j.Database.UpdateModel(ctx, m)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -33,7 +33,7 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 		return nil
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// Step 2: Loop over controllers and process their models

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -78,7 +78,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 		}
 		tempMap := make(map[string]any)
 		if err := json.Unmarshal(fb, &tempMap); err != nil {
-			return results, errors.E(err)
+			return results, err
 		}
 
 		queryCtx, cancel := context.WithTimeout(ctx, j.crossModelQueryTimeout)

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -404,7 +404,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 	}
 
 	if err := b.selectController(); err != nil {
-		b.err = errors.E(err)
+		b.err = err
 		return b
 	}
 	// if controller is still not selected, there's nothing
@@ -543,7 +543,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 
 	api, err := b.jujuManager.dial(b.ctx, b.controller, names.ModelTag{}, b.ofgaUser)
 	if err != nil {
-		b.err = errors.E(err)
+		b.err = err
 		return b
 	}
 	defer api.Close()
@@ -557,7 +557,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 
 	args, err := b.jujuModelCreateArgs()
 	if err != nil {
-		b.err = errors.E(err)
+		b.err = err
 		return b
 	}
 
@@ -595,7 +595,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 	// JWTs because Juju returns a different result on migrated models otherwise.
 	if err := api.GrantJIMMModelAdmin(b.ctx, names.NewModelTag(info.UUID)); err != nil {
 		zapctx.Error(b.ctx, "leaked model", zap.String("model", info.UUID), zaputil.Error(err))
-		b.err = errors.E(err)
+		b.err = err
 		return b
 	}
 

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -71,7 +71,7 @@ func (w *Watcher) WatchAllModelSummaries(ctx context.Context, interval time.Dura
 		if err != nil {
 			// Ignore temporary database errors.
 			if errors.ErrorCode(err) != errors.CodeDatabaseLocked {
-				return errors.E(err)
+				return err
 			}
 			zapctx.Warn(ctx, "temporary error polling for controllers", zap.Error(err))
 		}
@@ -111,7 +111,7 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 		ctl.UnavailableSince = db.Now()
 		updateController = true
 
-		return nil, errors.E(err)
+		return nil, err
 	}
 	if ctl.UnavailableSince.Valid {
 		ctl.UnavailableSince = sql.NullTime{}
@@ -130,7 +130,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	// connect to the controller
 	api, err := w.dialController(ctx, ctl)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer api.Close()
 
@@ -141,7 +141,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	// start the model summary watcher
 	watcher, err := api.WatchAllModelSummaries(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer func() {
 		if err := watcher.Stop(); err != nil {
@@ -158,7 +158,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 		// wait for updates from the all model summary watcher.
 		modelSummaries, err := watcher.Next()
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		// Sanitize the model abstracts.
 		for _, summary := range modelSummaries {

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -126,26 +126,26 @@ func (j *LoginManager) GetDeviceSessionToken(ctx context.Context, deviceOAuthRes
 
 	token, err := j.oAuthAuthenticator.DeviceAccessToken(ctx, deviceOAuthResponse)
 	if err != nil {
-		return "", errors.E(err)
+		return "", err
 	}
 
 	idToken, err := j.oAuthAuthenticator.ExtractAndVerifyIDToken(ctx, token)
 	if err != nil {
-		return "", errors.E(err)
+		return "", err
 	}
 
 	email, err := j.oAuthAuthenticator.Email(idToken)
 	if err != nil {
-		return "", errors.E(err)
+		return "", err
 	}
 
 	if err := j.oAuthAuthenticator.UpdateIdentity(ctx, email, token); err != nil {
-		return "", errors.E(err)
+		return "", err
 	}
 
 	encToken, err := j.oAuthAuthenticator.MintSessionToken(email)
 	if err != nil {
-		return "", errors.E(err)
+		return "", err
 	}
 
 	return string(encToken), nil
@@ -212,7 +212,7 @@ func (j *LoginManager) LoginWithSessionCookie(ctx context.Context, identityID st
 	user, err := j.UserLogin(ctx, identityID)
 	if err != nil {
 		logger.LogFailedLogin(ctx, identityID)
-		return nil, errors.E(err)
+		return nil, err
 	}
 	logger.LogSuccessfulLogin(ctx, identityID)
 	return user, nil
@@ -230,7 +230,7 @@ func (j *LoginManager) UserLogin(ctx context.Context, identifier string) (*openf
 	}
 	err = j.updateLastLogin(ctx, ofgaUser.Identity)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return ofgaUser, nil
 }
@@ -239,7 +239,7 @@ func (j *LoginManager) GetOrCreateIdentity(ctx context.Context, identifier strin
 
 	identity, err := dbmodel.NewIdentity(identifier)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	if err := j.store.GetIdentity(ctx, identity); err != nil {
@@ -249,7 +249,7 @@ func (j *LoginManager) GetOrCreateIdentity(ctx context.Context, identifier strin
 
 	isJimmAdmin, err := openfga.IsAdministrator(ctx, ofgaUser, j.jimmTag)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	ofgaUser.JimmAdmin = isJimmAdmin
 

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -155,12 +155,12 @@ func (j *PermissionManager) GrantAuditLogAccess(ctx context.Context, user *openf
 	targetUser.SetTag(targetUserTag)
 	err := j.store.GetIdentity(ctx, targetUser)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = openfga.NewUser(targetUser, j.authSvc).SetControllerAccess(ctx, j.jimmTag, ofganames.AuditLogViewerRelation)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -177,12 +177,12 @@ func (j *PermissionManager) RevokeAuditLogAccess(ctx context.Context, user *open
 	targetUser.SetTag(targetUserTag)
 	err := j.store.GetIdentity(ctx, targetUser)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	err = openfga.NewUser(targetUser, j.authSvc).UnsetAuditLogViewerAccess(ctx, j.jimmTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -209,7 +209,7 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 			}
 			check, err := openfga.CheckRelation(ctx, user, tag, relation)
 			if err != nil {
-				return cachedPerms, errors.E(err)
+				return cachedPerms, err
 			}
 			if !check {
 				return cachedPerms, errors.E(fmt.Sprintf("Missing permission for %s:%s", key, val))
@@ -277,7 +277,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
@@ -345,7 +345,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
@@ -423,7 +423,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !modelAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -501,7 +501,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, requiredAccess)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !modelAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -570,7 +570,7 @@ func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 
 	identity, err := dbmodel.NewIdentity(ut.Id())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	offer := dbmodel.ApplicationOffer{
@@ -578,12 +578,12 @@ func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 	}
 	if err := j.store.GetApplicationOffer(ctx, &offer); err != nil {
 		// If the offer is not found, we leak information about the existence of offers that do exist.
-		return errors.E(err)
+		return err
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isOfferAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -599,11 +599,11 @@ func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 	if targetAccessLevel != currentAccessLevel {
 		relation, err := ToOfferRelation(targetAccessLevel)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		err = targetUser.SetApplicationOfferAccess(ctx, offer.ResourceTag(), relation)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 	}
 
@@ -640,7 +640,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 
 	identity, err := dbmodel.NewIdentity(ut.Id())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	offer := dbmodel.ApplicationOffer{
@@ -648,12 +648,12 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	}
 	if err := j.store.GetApplicationOffer(ctx, &offer); err != nil {
 		// If the offer is not found, we leak information about the existence of offers that do exist.
-		return errors.E(err)
+		return err
 	}
 
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offer.ResourceTag())
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if !isOfferAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -662,7 +662,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	targetUser := openfga.NewUser(identity, j.authSvc)
 	targetRelation, err := ToOfferRelation(string(access))
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	err = targetUser.UnsetApplicationOfferAccess(ctx, offer.ResourceTag(), targetRelation)
 	if err != nil {

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -34,7 +34,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
 		end := i + BATCH_SIZE_OPENFGA
@@ -61,7 +61,7 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
 		end := i + BATCH_SIZE_OPENFGA
@@ -86,7 +86,7 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 	allowed := false
 	parsedTuple, err := j.parseTuple(ctx, tuple)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
 	// Admins can check any relation, non-admins can only check their own.
@@ -133,7 +133,7 @@ func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *op
 	if tuple.TargetObject != "" {
 		parsedTuple, err = j.parseTuple(ctx, tuple)
 		if err != nil {
-			return nil, "", errors.E(err)
+			return nil, "", err
 		}
 	} else if tuple.Object != "" {
 		return nil, "", errors.E(errors.CodeBadRequest, "it is invalid to pass an object without a target object.")
@@ -141,7 +141,7 @@ func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *op
 
 	responseTuples, ct, err := j.authSvc.ReadRelatedObjects(ctx, *parsedTuple, pageSize, continuationToken)
 	if err != nil {
-		return nil, "", errors.E(err)
+		return nil, "", err
 	}
 	return responseTuples, ct, nil
 }
@@ -158,7 +158,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 	}
 	responseTuples, nextToken, err := j.getObjectRelationsPage(ctx, object, pageSize, entitlementToken)
 	if err != nil {
-		return nil, e, errors.E(err)
+		return nil, e, err
 	}
 	// verify next page contains some entries. Otherwise return empty nextToken.
 	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
@@ -229,7 +229,7 @@ func (j *PermissionManager) parseTuples(ctx context.Context, tuples []apiparams.
 	for _, tuple := range tuples {
 		key, err := j.parseTuple(ctx, tuple)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		keys = append(keys, *key)
 	}

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -37,7 +37,7 @@ func (rm *RoleManager) AddRole(ctx context.Context, user *openfga.User, roleName
 
 	re, err := rm.store.AddRole(ctx, roleName)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return re, nil
 }
@@ -63,18 +63,18 @@ func (rm *RoleManager) RemoveRole(ctx context.Context, user *openfga.User, roleN
 	}
 	err := rm.store.GetRole(ctx, re)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	// TODO(ale8k):
 	// Would be nice to have a way to create a transaction to get, remove tuples, if successful, delete role
 	// somehow. We could pass a callback and change the db methods?
 	if err := rm.authSvc.RemoveRole(ctx, re.ResourceTag()); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err := rm.store.RemoveRole(ctx, re); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -88,7 +88,7 @@ func (rm *RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldNa
 
 	err := rm.store.UpdateRoleName(ctx, oldName, newName)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -103,7 +103,7 @@ func (rm *RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagina
 
 	res, err := rm.store.ListRoles(ctx, pagination.Limit(), pagination.Offset(), match)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return res, nil
 }
@@ -115,7 +115,7 @@ func (rm *RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int,
 	}
 	count, err := rm.store.CountRoles(ctx)
 	if err != nil {
-		return 0, errors.E(err)
+		return 0, err
 	}
 	return count, nil
 }
@@ -127,7 +127,7 @@ func (rm *RoleManager) getRole(ctx context.Context, user *openfga.User, role *db
 	}
 
 	if err := rm.store.GetRole(ctx, role); err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return role, nil

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -43,7 +43,7 @@ func (sm *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.Use
 	}
 	err := sm.store.AddSSHKey(ctx, &k)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -53,16 +53,16 @@ func (sm *SSHKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, 
 
 	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, claimUser, db.SSHKeyModelFilter{All: true})
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	publicKeyToCompare, err := gossh.ParsePublicKey(publicKey)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	for _, key := range dbKeys {
 		k, err := gossh.ParsePublicKey(key.PublicKey)
 		if err != nil {
-			return false, errors.E(err)
+			return false, err
 		}
 		if ssh.KeysEqual(k, publicKeyToCompare) {
 			return true, nil
@@ -77,13 +77,13 @@ func (sm *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.U
 
 	dbKeys, err := sm.store.ListSSHKeysForUser(ctx, user.Name, model)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	var pubKeys []PublicKey
 	for _, key := range dbKeys {
 		k, err := gossh.ParsePublicKey(key.PublicKey)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		pubKeys = append(pubKeys, PublicKey{PublicKey: k, Comment: key.KeyComment})
 	}
@@ -95,7 +95,7 @@ func (sm *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openf
 
 	err := sm.store.RemoveSSHKeyByComment(ctx, user.Name, model, comment)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (sm *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *o
 
 	err := sm.store.RemoveSSHKeyByFingerprint(ctx, user.Name, model, fingerprint)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -220,7 +220,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 
 	m, err := u.jujuManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if m.Controller.Name == targetControllerName {
 		zapctx.Info(ctx, "model is already on target controller, skipping migration", zap.String("model-uuid", modelUUID), zap.String("controller-name", targetControllerName))

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -168,7 +168,7 @@ func generateJWK(ctx context.Context) (jwk.Set, []byte, error) {
 	// and accept any negligible wire cost.
 	keySet, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	privateKeyPEM := pem.EncodeToMemory(
@@ -181,32 +181,32 @@ func generateJWK(ctx context.Context) (jwk.Set, []byte, error) {
 	// We also use the same methodology of generating UUIDs for our KID
 	kid, err := uuid.NewRandom()
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	jwks, err := jwk.FromRaw(keySet.PublicKey)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 	err = jwks.Set(jwk.KeyIDKey, kid.String())
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	err = jwks.Set(jwk.KeyUsageKey, "sig") // Couldn't find const for this...
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	err = jwks.Set(jwk.AlgorithmKey, jwa.RS256)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	ks := jwk.NewSet()
 	err = ks.AddKey(jwks)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	return ks, privateKeyPEM, nil

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -100,7 +100,7 @@ func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(err)
+		return jujuparams.LoginResult{}, err
 	}
 
 	return jujuparams.LoginResult{
@@ -122,7 +122,7 @@ func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.L
 	user, err := r.jimm.LoginManager().LoginWithSessionToken(ctx, req.SessionToken)
 	if err != nil {
 		// Avoid masking the error code on err below. The Juju CLI uses it to determine when to initiate login see [OAuthAuthenticator.VerifySessionToken].
-		return jujuparams.LoginResult{}, errors.E(err)
+		return jujuparams.LoginResult{}, err
 	}
 
 	// TODO(ale8k): This isn't needed I don't think as controller roots are unique
@@ -134,7 +134,7 @@ func (r *controllerRoot) LoginWithSessionToken(ctx context.Context, req params.L
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(err)
+		return jujuparams.LoginResult{}, err
 	}
 
 	return jujuparams.LoginResult{
@@ -162,7 +162,7 @@ func (r *controllerRoot) LoginWithClientCredentials(ctx context.Context, req par
 	// Get server version for LoginResult
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(err)
+		return jujuparams.LoginResult{}, err
 	}
 
 	return jujuparams.LoginResult{

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -70,7 +70,7 @@ func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicati
 		Endpoints:              args.Endpoints,
 	})
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.Us
 		},
 	}
 	if err := r.jimm.JujuManager().GetApplicationOfferConsumeDetails(ctx, user, &details, v); err != nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.E(err)
+		return jujuparams.ConsumeOfferDetails{}, err
 	}
 	return details, nil
 }
@@ -131,7 +131,7 @@ func (r *controllerRoot) ListApplicationOffers(ctx context.Context, args jujupar
 
 	offers, err := r.jimm.JujuManager().ListApplicationOffers(ctx, r.user, filters...)
 	if err != nil {
-		return results, errors.E(err)
+		return results, err
 	}
 	results.Results = offersToParams(offers)
 
@@ -148,7 +148,7 @@ func (r *controllerRoot) FindApplicationOffers(ctx context.Context, args jujupar
 
 	offers, err := r.jimm.JujuManager().FindApplicationOffers(ctx, r.user, filters...)
 	if err != nil {
-		return results, errors.E(err)
+		return results, err
 	}
 	results.Results = offersToParams(offers)
 
@@ -176,12 +176,12 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
 		if err := r.jimm.PermissionManager().GrantOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
-			return errors.E(err)
+			return err
 		}
 		return nil
 	case jujuparams.RevokeOfferAccess:
 		if err := r.jimm.PermissionManager().RevokeOfferAccess(ctx, r.user, change.OfferURL, ut, change.Access); err != nil {
-			return errors.E(err)
+			return err
 		}
 		return nil
 	default:

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -77,7 +77,7 @@ func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (j
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			cloudResults[i].Error = r.mapError(ctx, errors.E(err))
+			cloudResults[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		cloudResults[i].Cloud = new(jujuparams.Cloud)
@@ -99,7 +99,7 @@ func (r *controllerRoot) Clouds(ctx context.Context) (jujuparams.CloudsResult, e
 		return nil
 	})
 	if err != nil {
-		return res, errors.E(err)
+		return res, err
 	}
 	return res, nil
 }
@@ -111,7 +111,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 	for i, ent := range userclouds.UserClouds {
 		user, err := r.masquerade(ctx, ent.UserTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		cld, err := names.ParseCloudTag(ent.CloudTag)
@@ -124,7 +124,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 			return nil
 		})
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 		}
 	}
 
@@ -155,7 +155,7 @@ func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, _ boo
 		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -186,14 +186,14 @@ func (r *controllerRoot) credential(ctx context.Context, cloudCredentialTag stri
 
 	cred, err := r.jimm.JujuManager().GetCloudCredential(ctx, r.user, cct)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	cc := jujuparams.CloudCredential{
 		AuthType: cred.AuthType,
 	}
 	cc.Attributes, cc.Redacted, err = r.jimm.JujuManager().GetCloudCredentialAttributes(ctx, r.user, cred, false)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return &cc, nil
 }
@@ -203,7 +203,8 @@ func (r *controllerRoot) AddCloud(ctx context.Context, args jujuparams.AddCloudA
 	force := args.Force != nil && *args.Force
 
 	if err := r.jimm.JujuManager().AddHostedCloud(ctx, r.user, names.NewCloudTag(args.Name), cloudFromParams(args.Name, args.Cloud), force); err != nil {
-		return errors.E(err)
+
+		return err
 	}
 	return nil
 }
@@ -215,7 +216,7 @@ func (r *controllerRoot) AddCredentials(ctx context.Context, args jujuparams.Tag
 		Credentials: args.Credentials,
 	})
 	if err != nil {
-		return jujuparams.ErrorResults{}, errors.E(err)
+		return jujuparams.ErrorResults{}, err
 	}
 	results := collapseUpdateCredentialResults(args, updateResults)
 	return results, nil
@@ -289,7 +290,7 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 		var err error
 		content.Attributes, _, err = j.JujuManager().GetCloudCredentialAttributes(ctx, user, c, args.IncludeSecrets)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		mas := make([]jujuparams.ModelAccess, len(c.Models))
 		for i, m := range c.Models {
@@ -309,12 +310,12 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 		cct := names.NewCloudCredentialTag(fmt.Sprintf("%s/%s/%s", arg.CloudName, user.Name, arg.CredentialName))
 		cred, err := j.JujuManager().GetCloudCredential(ctx, user, cct)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		results[i].Result, err = credentialContents(cred)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 		}
 	}
 	if len(results) > 0 {
@@ -326,13 +327,13 @@ func (r *controllerRoot) getIdentityCredentials(ctx context.Context, user *openf
 		var err error
 		result.Result, err = credentialContents(c)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(err))
+			result.Error = r.mapError(ctx, err)
 		}
 		results = append(results, result)
 		return nil
 	})
 	if err != nil {
-		return jujuparams.CredentialContentResults{}, errors.E(err)
+		return jujuparams.CredentialContentResults{}, err
 	}
 	return jujuparams.CredentialContentResults{Results: results}, nil
 }
@@ -347,12 +348,12 @@ func (r *controllerRoot) RemoveClouds(ctx context.Context, args jujuparams.Entit
 	for i, entity := range args.Entities {
 		tag, err := names.ParseCloudTag(entity.Tag)
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(err))
+			result.Results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		err = r.jimm.JujuManager().RemoveCloud(ctx, r.user, tag)
 		if err != nil {
-			result.Results[i].Error = r.mapError(ctx, errors.E(err))
+			result.Results[i].Error = r.mapError(ctx, err)
 		}
 	}
 	return result, nil
@@ -377,7 +378,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 
 	ut, err := parseUserTag(change.UserTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	ct, err := names.ParseCloudTag(change.CloudTag)
 	if err != nil {
@@ -394,7 +395,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 		return errors.E(errors.CodeBadRequest, fmt.Sprintf("unsupported modify cloud action %q", change.Action))
 	}
 	if err := modifyf(ctx, r.user, ct, ut, change.Access); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -469,7 +470,7 @@ func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 
@@ -500,7 +501,7 @@ func (r *controllerRoot) ListCloudInfo(ctx context.Context, args jujuparams.List
 		return nil
 	})
 	if err != nil {
-		return jujuparams.ListCloudInfoResults{}, errors.E(err)
+		return jujuparams.ListCloudInfoResults{}, err
 	}
 
 	return jujuparams.ListCloudInfoResults{

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -98,7 +98,7 @@ func (r *controllerRoot) ControllerVersion(ctx context.Context) (jujuparams.Cont
 
 	srvVersion, err := r.jimm.JujuManager().EarliestControllerVersion(ctx)
 	if err != nil {
-		return jujuparams.ControllerVersionResults{}, errors.E(err)
+		return jujuparams.ControllerVersionResults{}, err
 	}
 	result := jujuparams.ControllerVersionResults{
 		Version:   srvVersion.String(),
@@ -113,7 +113,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 
 	err := r.setupUUIDGenerator()
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(err)
+		return jujuparams.SummaryWatcherID{}, err
 	}
 
 	id := fmt.Sprintf("%v", r.generator.Next())
@@ -121,7 +121,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 	getModels := func(ctx context.Context) ([]string, error) {
 		models, err := r.allModels(ctx)
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		modelUUIDs := make([]string, len(models.UserModels))
 		for i, model := range models.UserModels {
@@ -131,7 +131,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 	}
 	watcher, err := newModelSummaryWatcher(ctx, id, r.jimm.PubSubHub(), getModels)
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(err)
+		return jujuparams.SummaryWatcherID{}, err
 	}
 	r.watchers.register(watcher)
 
@@ -150,7 +150,7 @@ func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams
 
 	err := r.setupUUIDGenerator()
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(err)
+		return jujuparams.SummaryWatcherID{}, err
 	}
 
 	id := fmt.Sprintf("%v", r.generator.Next())
@@ -162,14 +162,14 @@ func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams
 			return nil
 		})
 		if err != nil {
-			return nil, errors.E(err)
+			return nil, err
 		}
 		return modelUUIDs, nil
 	}
 
 	watcher, err := newModelSummaryWatcher(ctx, id, r.jimm.PubSubHub(), getAllModels)
 	if err != nil {
-		return jujuparams.SummaryWatcherID{}, errors.E(err)
+		return jujuparams.SummaryWatcherID{}, err
 	}
 	r.watchers.register(watcher)
 
@@ -195,7 +195,7 @@ func (r *controllerRoot) allModels(ctx context.Context) (jujuparams.UserModelLis
 		return nil
 	})
 	if err != nil {
-		return jujuparams.UserModelList{}, errors.E(err)
+		return jujuparams.UserModelList{}, err
 	}
 	return jujuparams.UserModelList{
 		UserModels: models,
@@ -216,7 +216,7 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 		}
 		status, err := r.jimm.JujuManager().ModelStatus(ctx, r.user, mt)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		results[i] = toModelStatusParams(status)
@@ -231,7 +231,7 @@ func (r *controllerRoot) ControllerConfig(ctx context.Context) (jujuparams.Contr
 
 	config, err := r.jimm.ConfigManager().GetConfig()
 	if err != nil {
-		return jujuparams.ControllerConfigResult{}, errors.E(err)
+		return jujuparams.ControllerConfigResult{}, err
 	}
 	cfg := make(map[string]interface{})
 	cfg[jujucontroller.ControllerUUIDKey] = config.ControllerUUID
@@ -257,7 +257,7 @@ func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparam
 		}
 		access, err := r.jimm.PermissionManager().GetJimmControllerAccess(ctx, r.user, tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err))
+			results[i].Error = r.mapError(ctx, err)
 			continue
 		}
 		results[i].Result = &jujuparams.UserAccess{
@@ -279,7 +279,7 @@ func (r *controllerRoot) InitiateMigration(ctx context.Context, args jujuparams.
 	for i, spec := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateMigration(ctx, r.user, spec)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(err))
+			result.Error = r.mapError(ctx, err)
 		}
 		results[i] = result
 	}

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -129,7 +129,7 @@ func (r *controllerRoot) setupUUIDGenerator() error {
 	var err error
 	r.generator, err = fastuuid.NewGenerator()
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -186,7 +186,7 @@ func (r *controllerRoot) AddCloudToController(ctx context.Context, req apiparams
 
 	cloud := cloudFromParams(req.Name, req.Cloud)
 	if err := r.jimm.JujuManager().AddCloudToController(ctx, r.user, req.ControllerName, names.NewCloudTag(req.Name), cloud, force); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func (r *controllerRoot) AddCloudToController(ctx context.Context, req apiparams
 func (r *controllerRoot) AddModelToController(ctx context.Context, req apiparams.AddModelToControllerRequest) (jujuparams.ModelInfo, error) {
 	mca, err := toAddModelArgs(req.ModelCreateArgs, r.user.ResourceTag())
 	if err != nil {
-		return jujuparams.ModelInfo{}, errors.E(err)
+		return jujuparams.ModelInfo{}, err
 	}
 	// Add JIMM specific field.
 	mca.ControllerName = req.ControllerName
@@ -203,7 +203,7 @@ func (r *controllerRoot) AddModelToController(ctx context.Context, req apiparams
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, mca)
 	if err != nil {
 		servermon.ModelsCreatedFailCount.Inc()
-		return jujuparams.ModelInfo{}, errors.E(err)
+		return jujuparams.ModelInfo{}, err
 	}
 
 	servermon.ModelsCreatedCount.Inc()
@@ -270,7 +270,7 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListControllersResponse, error) {
 	dbControllers, err := r.jimm.JujuManager().ListControllers(ctx, r.user)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(err)
+		return apiparams.ListControllersResponse{}, err
 	}
 
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
@@ -291,11 +291,11 @@ func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.Rem
 
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(err)
+		return apiparams.ControllerInfo{}, err
 	}
 
 	if err := r.jimm.JujuManager().RemoveController(ctx, r.user, req.Name, req.Force); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(err)
+		return apiparams.ControllerInfo{}, err
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
@@ -304,11 +304,11 @@ func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.Rem
 func (r *controllerRoot) SetControllerDeprecated(ctx context.Context, req apiparams.SetControllerDeprecatedRequest) (apiparams.ControllerInfo, error) {
 
 	if err := r.jimm.JujuManager().SetControllerDeprecated(ctx, r.user, req.Name, req.Deprecated); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(err)
+		return apiparams.ControllerInfo{}, err
 	}
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(err)
+		return apiparams.ControllerInfo{}, err
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
@@ -366,11 +366,11 @@ func (r *controllerRoot) FindAuditEvents(ctx context.Context, req apiparams.Find
 
 	filter, err := auditParamsToFilter(req)
 	if err != nil {
-		return apiparams.AuditEvents{}, errors.E(err)
+		return apiparams.AuditEvents{}, err
 	}
 	entries, err := r.jimm.AuditLogManager().FindAuditEvents(ctx, r.user, filter)
 	if err != nil {
-		return apiparams.AuditEvents{}, errors.E(err)
+		return apiparams.AuditEvents{}, err
 	}
 
 	events := make([]apiparams.AuditEvent, len(entries))
@@ -394,7 +394,7 @@ func (r *controllerRoot) GrantAuditLogAccess(ctx context.Context, req apiparams.
 
 	err = r.jimm.PermissionManager().GrantAuditLogAccess(ctx, r.user, ut)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -411,7 +411,7 @@ func (r *controllerRoot) RevokeAuditLogAccess(ctx context.Context, req apiparams
 
 	err = r.jimm.PermissionManager().RevokeAuditLogAccess(ctx, r.user, ut)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -426,7 +426,7 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 
 	status, err := r.jimm.JujuManager().FullModelStatus(ctx, r.user, mt, req.Patterns)
 	if err != nil {
-		return jujuparams.FullStatus{}, errors.E(err)
+		return jujuparams.FullStatus{}, err
 	}
 
 	return *status, nil
@@ -446,7 +446,7 @@ func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.
 	}
 	err = r.jimm.JujuManager().UpdateMigratedModel(ctx, r.user, mt, req.TargetController)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -462,7 +462,7 @@ func (r *controllerRoot) ImportModel(ctx context.Context, req apiparams.ImportMo
 
 	err = r.jimm.JujuManager().ImportModel(ctx, r.user, req.Controller, mt, req.Owner)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -475,7 +475,7 @@ func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apip
 		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RemoveCloudFromController(ctx, r.user, req.ControllerName, ct); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -505,7 +505,7 @@ func (r *controllerRoot) PurgeLogs(ctx context.Context, req apiparams.PurgeLogsR
 
 	deleted_count, err := r.jimm.AuditLogManager().PurgeLogs(ctx, r.user, req.Date)
 	if err != nil {
-		return apiparams.PurgeLogsResponse{}, errors.E(err)
+		return apiparams.PurgeLogsResponse{}, err
 	}
 	return apiparams.PurgeLogsResponse{
 		DeletedCount: deleted_count,
@@ -522,7 +522,7 @@ func (r *controllerRoot) MigrateModel(ctx context.Context, args apiparams.Migrat
 	for i, arg := range args.Specs {
 		result, err := r.jimm.JujuManager().InitiateInternalMigration(ctx, r.user, arg.TargetModelNameOrUUID, arg.TargetController)
 		if err != nil {
-			result.Error = r.mapError(ctx, errors.E(err))
+			result.Error = r.mapError(ctx, err)
 		}
 		results[i] = result
 	}
@@ -578,7 +578,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 
 	resp.Token, err = r.jimm.JujuManager().PrepareModelMigration(ctx, r.user, mt.Id(), args.BackingControllerName, args.UserMapping)
 	if err != nil {
-		return resp, errors.E(err)
+		return resp, err
 	}
 
 	return resp, nil
@@ -599,7 +599,7 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 
 	dbControllers, err := r.jimm.JujuManager().ListMigrationTargets(ctx, r.user, mt)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(err)
+		return apiparams.ListControllersResponse{}, err
 	}
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
@@ -766,7 +766,7 @@ func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListU
 		}
 		u, err := r.jimm.IdentityManager().FetchIdentity(ctx, ut.Id())
 		if err != nil {
-			return jujuparams.CloudsResult{}, errors.E(err)
+			return jujuparams.CloudsResult{}, err
 		}
 
 		user = u
@@ -779,7 +779,7 @@ func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListU
 		return nil
 	})
 	if err != nil {
-		return res, errors.E(err)
+		return res, err
 	}
 	return res, nil
 }
@@ -807,7 +807,7 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 
 	response, err := r.jimm.JujuManager().ModelControllerInfo(ctx, r.user, qualifier)
 	if err != nil {
-		return apiparams.ModelControllerInfo{}, errors.E(err)
+		return apiparams.ModelControllerInfo{}, err
 	}
 
 	return *response, nil

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -78,12 +78,12 @@ func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.Mode
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return jujuparams.ErrorResults{}, errors.E(err)
+		return jujuparams.ErrorResults{}, err
 	}
 
 	results, err := r.jimm.JujuManager().CheckMachines(ctx, r.user, modelTag.Id())
 	if err != nil {
-		return jujuparams.ErrorResults{}, errors.E(err)
+		return jujuparams.ErrorResults{}, err
 	}
 	var errorResults []jujuparams.ErrorResult
 	for _, result := range results {
@@ -105,7 +105,7 @@ func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) e
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return r.jimm.JujuManager().AbortMigration(ctx, r.user, modelTag.Id())
 }
@@ -122,7 +122,7 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.Ado
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return r.jimm.JujuManager().AdoptResources(ctx, r.user, modelTag.Id(), args.SourceControllerVersion)
 }
@@ -137,12 +137,12 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return time.Time{}, errors.E(err)
+		return time.Time{}, err
 	}
 
 	t, err := r.jimm.JujuManager().LatestLogTime(ctx, r.user, modelTag.Id())
 	if err != nil {
-		return time.Time{}, errors.E(err)
+		return time.Time{}, err
 	}
 	return t, nil
 }
@@ -156,7 +156,7 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 
 	ownerTag, err := names.ParseUserTag(args.OwnerTag)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	model := juju.MigratingModelInfo{
@@ -169,7 +169,7 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 	}
 	err = r.jimm.JujuManager().Prechecks(ctx, r.user, model)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -134,7 +134,7 @@ func (r *controllerRoot) ListModelSummaries(ctx context.Context, _ jujuparams.Mo
 	}
 	res, err := r.jimm.JujuManager().ListModelSummaries(ctx, r.user, maskingControllerUUID)
 	if err != nil {
-		return jujuparams.ModelSummaryResults{}, errors.E(err)
+		return jujuparams.ModelSummaryResults{}, err
 	}
 
 	return toModelSummariesParams(res), nil
@@ -214,12 +214,12 @@ func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelC
 
 	mca, err := toAddModelArgs(args, r.user.ResourceTag())
 	if err != nil {
-		return jujuparams.ModelInfo{}, errors.E(err)
+		return jujuparams.ModelInfo{}, err
 	}
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, mca)
 	if err != nil {
 		servermon.ModelsCreatedFailCount.Inc()
-		return jujuparams.ModelInfo{}, errors.E(err)
+		return jujuparams.ModelInfo{}, err
 	}
 
 	servermon.ModelsCreatedCount.Inc()
@@ -346,7 +346,7 @@ func (r *controllerRoot) changeModelCredential(ctx context.Context, arg jujupara
 		return errors.E(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().ChangeModelCredential(ctx, r.user, mt, cct); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -38,7 +38,7 @@ func (r *controllerRoot) ModelSummaryWatcherNext(ctx context.Context, objID stri
 
 	w, err := r.watchers.get(objID)
 	if err != nil {
-		return jujuparams.SummaryWatcherNextResults{}, errors.E(err)
+		return jujuparams.SummaryWatcherNextResults{}, err
 	}
 	return w.Next()
 }
@@ -49,7 +49,7 @@ func (r *controllerRoot) ModelSummaryWatcherStop(ctx context.Context, objID stri
 
 	w, err := r.watchers.get(objID)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return w.Stop()
@@ -122,7 +122,7 @@ func newModelSummaryWatcher(ctx context.Context, id string, pubsub *pubsub.Hub, 
 	cleanupFunction, err := pubsub.SubscribeMatch(accessWatcher.match, watcher.pubsubHandler)
 	if err != nil {
 		cancelContext()
-		return nil, errors.E(err)
+		return nil, err
 	}
 	watcher.cleanup = func() {
 		cancelContext()

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -98,7 +98,7 @@ func (r *controllerRoot) ListRoles(ctx context.Context, req apiparams.ListRolesR
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
 	roles, err := r.jimm.RoleManager().ListRoles(ctx, r.user, pagination, "")
 	if err != nil {
-		return apiparams.ListRoleResponse{}, errors.E(err)
+		return apiparams.ListRoleResponse{}, err
 	}
 	rolesResponse := make([]apiparams.Role, len(roles))
 	for i, g := range roles {

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -71,7 +71,7 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 		Access:     permissions,
 	})
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	jwtString := base64.StdEncoding.EncodeToString(jwt)
 
@@ -101,7 +101,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	var loginRequest *jujuparams.LoginRequest
 	loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	var res jujuparams.LoginResult
@@ -318,7 +318,7 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 
 	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	ok = names.IsValidUser(user)
 	if !ok {
@@ -327,7 +327,7 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 	requestHeader := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
 	conn, err := rpc.Dial(c.ctx, c.ctl, modelTag, path, requestHeader, attrs)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	return conn, nil
 }
@@ -341,7 +341,7 @@ func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extr
 
 	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	header := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
@@ -353,7 +353,7 @@ func (c *Connection) ConnectControllerStream(path string, attrs url.Values, extr
 
 	conn, err := rpc.Dial(c.ctx, c.ctl, names.ModelTag{}, path, header, attrs)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return conn, nil

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -116,7 +116,7 @@ func (o *OFGAClient) setResourceAccess(ctx context.Context, object, target names
 		if strings.Contains(err.Error(), "cannot write a tuple which already exists") {
 			return nil
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -139,7 +139,7 @@ func (o *OFGAClient) unsetResourceAccess(ctx context.Context, object, target nam
 		if strings.Contains(err.Error(), "cannot delete a tuple which does not exist") {
 			return nil
 		}
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -298,12 +298,12 @@ func (o *OFGAClient) RemoveModel(ctx context.Context, model names.ModelTag) erro
 			Target: ofganames.ConvertTag(model),
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	// Remove the relation between the model and any application offers.
 	offerKind, err := ofganames.BlankKindTag(names.ApplicationOfferTagKind)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	if err := o.removeTuples(
 		ctx,
@@ -312,7 +312,7 @@ func (o *OFGAClient) RemoveModel(ctx context.Context, model names.ModelTag) erro
 			Target: offerKind,
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -330,7 +330,7 @@ func (o *OFGAClient) RemoveApplicationOffer(ctx context.Context, offer names.App
 			Target: ofganames.ConvertTag(offer),
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -345,7 +345,7 @@ func (o *OFGAClient) RemoveRole(ctx context.Context, role jimmnames.RoleTag) err
 			Target:   ofganames.ConvertTag(role),
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	// Next remove all access that a group had. I.e. group->model
 	// We need to loop through all resource types because the OpenFGA Read API does not provide
@@ -353,7 +353,7 @@ func (o *OFGAClient) RemoveRole(ctx context.Context, role jimmnames.RoleTag) err
 	for _, kind := range resourceTypes {
 		kt, err := ofganames.BlankKindTag(kind)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		newTuple := Tuple{
 			Object: ofganames.ConvertTagWithRelation(role, ofganames.AssigneeRelation),
@@ -361,7 +361,7 @@ func (o *OFGAClient) RemoveRole(ctx context.Context, role jimmnames.RoleTag) err
 		}
 		err = o.removeTuples(ctx, newTuple)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 	}
 	return nil
@@ -377,7 +377,7 @@ func (o *OFGAClient) RemoveGroup(ctx context.Context, group jimmnames.GroupTag) 
 			Target:   ofganames.ConvertTag(group),
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	// Next remove all access that a group had. I.e. group->model
 	// We need to loop through all resource types because the OpenFGA Read API does not provide
@@ -385,7 +385,7 @@ func (o *OFGAClient) RemoveGroup(ctx context.Context, group jimmnames.GroupTag) 
 	for _, kind := range resourceTypes {
 		kt, err := ofganames.BlankKindTag(kind)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 		newTuple := Tuple{
 			Object: ofganames.ConvertTagWithRelation(group, ofganames.MemberRelation),
@@ -393,7 +393,7 @@ func (o *OFGAClient) RemoveGroup(ctx context.Context, group jimmnames.GroupTag) 
 		}
 		err = o.removeTuples(ctx, newTuple)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 	}
 	return nil
@@ -407,7 +407,7 @@ func (o *OFGAClient) RemoveCloud(ctx context.Context, cloud names.CloudTag) erro
 			Target: ofganames.ConvertTag(cloud),
 		},
 	); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -39,7 +39,7 @@ type User struct {
 func (u *User) IsAllowedAddModelToController(ctx context.Context, resource names.ControllerTag) (bool, error) {
 	allowed, err := checkRelation(ctx, u, resource, ofganames.CanAddModelRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return allowed, nil
 }
@@ -49,7 +49,7 @@ func (u *User) IsAllowedAddModelToController(ctx context.Context, resource names
 func (u *User) IsAllowedAddModelToCloud(ctx context.Context, resource names.CloudTag) (bool, error) {
 	allowed, err := checkRelation(ctx, u, resource, ofganames.CanAddModelRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return allowed, nil
 }
@@ -58,7 +58,7 @@ func (u *User) IsAllowedAddModelToCloud(ctx context.Context, resource names.Clou
 func (u *User) IsApplicationOfferConsumer(ctx context.Context, resource names.ApplicationOfferTag) (bool, error) {
 	isConsumer, err := checkRelation(ctx, u, resource, ofganames.ConsumerRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return isConsumer, nil
 }
@@ -67,7 +67,7 @@ func (u *User) IsApplicationOfferConsumer(ctx context.Context, resource names.Ap
 func (u *User) IsApplicationOfferReader(ctx context.Context, resource names.ApplicationOfferTag) (bool, error) {
 	isReader, err := checkRelation(ctx, u, resource, ofganames.ReaderRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return isReader, nil
 }
@@ -76,7 +76,7 @@ func (u *User) IsApplicationOfferReader(ctx context.Context, resource names.Appl
 func (u *User) IsModelReader(ctx context.Context, resource names.ModelTag) (bool, error) {
 	isReader, err := checkRelation(ctx, u, resource, ofganames.ReaderRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return isReader, nil
 }
@@ -85,7 +85,7 @@ func (u *User) IsModelReader(ctx context.Context, resource names.ModelTag) (bool
 func (u *User) IsModelWriter(ctx context.Context, resource names.ModelTag) (bool, error) {
 	isWriter, err := checkRelation(ctx, u, resource, ofganames.WriterRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return isWriter, nil
 }
@@ -94,7 +94,7 @@ func (u *User) IsModelWriter(ctx context.Context, resource names.ModelTag) (bool
 func (u *User) IsModelAdmin(ctx context.Context, resource names.ModelTag) (bool, error) {
 	isAdmin, err := checkRelation(ctx, u, resource, ofganames.AdministratorRelation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return isAdmin, nil
 }
@@ -103,7 +103,7 @@ func (u *User) IsModelAdmin(ctx context.Context, resource names.ModelTag) (bool,
 func (u *User) HasModelRelation(ctx context.Context, resource names.ModelTag, relation Relation) (bool, error) {
 	hasRelation, err := checkRelation(ctx, u, resource, relation)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 	return hasRelation, nil
 }
@@ -353,7 +353,7 @@ func checkRelation[T ofganames.ResourceTagger](ctx context.Context, u *User, res
 		true,
 	)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 
 	return isAllowed, nil
@@ -376,7 +376,7 @@ func CheckRelation(ctx context.Context, u *User, resource names.Tag, relation Re
 		true,
 	)
 	if err != nil {
-		return false, errors.E(err)
+		return false, err
 	}
 
 	return isAllowed, nil
@@ -393,7 +393,7 @@ func IsAdministrator[T administratorT](ctx context.Context, u *User, resource T)
 			zap.String("user", u.Name),
 			zap.String("resource", resource.String()),
 		)
-		return false, errors.E(err)
+		return false, err
 	}
 	if isAdmin {
 		zapctx.Debug(

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -159,7 +159,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 		var err error
 		argsb, err = json.Marshal(args)
 		if err != nil {
-			return errors.E(err)
+			return err
 		}
 	}
 	req := &message{
@@ -185,7 +185,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 	req.RequestID = c.reqID
 	if err := c.conn.WriteJSON(req); err != nil {
 		c.broken = true
-		return errors.E(err)
+		return err
 	}
 	ch := make(chan struct{})
 	//nolint:staticcheck // Not sure why Martin made this a **. Ignore for now.
@@ -211,7 +211,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 		}
 		if resp != nil {
 			if err := json.Unmarshal([]byte((*respMsg).Response), &resp); err != nil {
-				return errors.E(err)
+				return err
 			}
 		}
 		return nil

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -439,7 +439,7 @@ func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
 	p.connectController.Do(func() {
 		connWithMetadata, err := p.createControllerConn(ctx)
 		if err != nil {
-			createConnErr = errors.E(err)
+			createConnErr = err
 			return
 		}
 
@@ -639,12 +639,12 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 	}
 	var lr jujuparams.LoginRequest
 	if err := json.Unmarshal(msg.Params, &lr); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	jwt, err := tokenGen.MakeToken(ctx, permissions)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	jwtString := base64.StdEncoding.EncodeToString(jwt)
@@ -653,7 +653,7 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 	// Marshal it again to JSON.
 	data, err := json.Marshal(lr)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	// And add it to the message.
 	msg.Params = data

--- a/internal/testutils/jimmtest/openfga.go
+++ b/internal/testutils/jimmtest/openfga.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openfga/language/pkg/go/transformer"
 	"gopkg.in/errgo.v1"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	auth_model "github.com/canonical/jimm/v3/openfga"
 )
@@ -128,16 +127,16 @@ func SetupTestOFGAClient(names ...string) (*openfga.OFGAClient, *cofga.Client, *
 func RemoveStore(ctx context.Context, name string) error {
 	conn, err := pgx.Connect(context.Background(), "postgresql://jimm:jimm@localhost/jimm")
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer conn.Close(ctx)
 	_, err = conn.Exec(ctx, fmt.Sprintf("DELETE FROM authorization_model WHERE store = (SELECT id FROM store WHERE name = '%s')", name))
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	_, err = conn.Exec(ctx, fmt.Sprintf("DELETE FROM store WHERE name = '%s';", name))
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -147,7 +146,7 @@ func RemoveStore(ctx context.Context, name string) error {
 func CreateStore(ctx context.Context, name string, id string) error {
 	conn, err := pgx.Connect(context.Background(), "postgresql://jimm:jimm@localhost/jimm")
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer conn.Close(ctx)
 	_, err = conn.Exec(
@@ -160,7 +159,7 @@ func CreateStore(ctx context.Context, name string, id string) error {
 		),
 	)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -169,7 +168,7 @@ func CreateStore(ctx context.Context, name string, id string) error {
 func TruncateOpenFgaTuples(ctx context.Context) error {
 	conn, err := pgx.Connect(context.Background(), "postgresql://jimm:jimm@localhost/jimm")
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	defer conn.Close(ctx)
 

--- a/internal/testutils/jimmtest/setup_jimm.go
+++ b/internal/testutils/jimmtest/setup_jimm.go
@@ -197,29 +197,29 @@ func jwkSetFromPrivateKeyFile() (jwk.Set, []byte, error) {
 
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	jwks, err := jwk.FromRaw(privateKey.PublicKey)
 	if err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	if err := jwks.Set(jwk.KeyIDKey, "test-kid"); err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	if err := jwks.Set(jwk.KeyUsageKey, "sig"); err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	if err := jwks.Set(jwk.AlgorithmKey, jwa.RS256); err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	ks := jwk.NewSet()
 	if err := ks.AddKey(jwks); err != nil {
-		return nil, nil, errors.E(err)
+		return nil, nil, err
 	}
 
 	return ks, testJWKSPrivateKey, nil

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -69,12 +69,12 @@ func (s *VaultStore) Get(ctx context.Context, tag names.CloudCredentialTag) (_ m
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.path(tag))
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	if secret == nil || secret.Data == nil {
 		return nil, nil
@@ -106,7 +106,7 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	data := make(map[string]interface{}, len(attr))
@@ -115,7 +115,7 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 	}
 	_, err = client.KVv2(s.KVPath).Put(ctx, s.path(tag), data)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -130,7 +130,7 @@ func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.path(tag))
 	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
@@ -138,7 +138,7 @@ func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (
 		err = nil
 	}
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -154,12 +154,12 @@ func (s *VaultStore) GetControllerCredentials(ctx context.Context, controllerNam
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return "", "", errors.E(err)
+		return "", "", err
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.controllerCredentialsPath(controllerName))
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return "", "", errors.E(err)
+		return "", "", err
 	}
 	if secret == nil || secret.Data == nil {
 		return "", "", nil
@@ -190,7 +190,7 @@ func (s *VaultStore) PutControllerCredentials(ctx context.Context, controllerNam
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	data := map[string]interface{}{
@@ -199,7 +199,7 @@ func (s *VaultStore) PutControllerCredentials(ctx context.Context, controllerNam
 	}
 	_, err = client.KVv2(s.KVPath).Put(ctx, s.controllerCredentialsPath(controllerName), data)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -214,19 +214,19 @@ func (s *VaultStore) CleanupJWKS(ctx context.Context) (err error) {
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSExpiryPath()); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSPath()); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	if err = client.KVv2(s.KVPath).Delete(ctx, s.getJWKSPrivateKeyPath()); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -241,12 +241,12 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	// This is how the current version of vaults API Read works,
@@ -265,7 +265,7 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 
 	ks, err := jwk.ParseString(jsonString)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return ks, nil
@@ -281,12 +281,12 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPrivateKeyPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	if secret == nil || secret.Data == nil {
@@ -299,7 +299,7 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 
 	keyPem, err := base64.StdEncoding.DecodeString(keyPemB64)
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 
 	return keyPem, nil
@@ -316,12 +316,12 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 	now := time.Now()
 	client, err := s.client(ctx)
 	if err != nil {
-		return now, errors.E(err)
+		return now, err
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSExpiryPath())
 	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
-		return now, errors.E(err)
+		return now, err
 	}
 
 	if secret == nil || secret.Data == nil {
@@ -337,7 +337,7 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 
 	t, err := time.Parse(time.RFC3339, expiry)
 	if err != nil {
-		return now, errors.E(err)
+		return now, err
 	}
 
 	return t, nil
@@ -356,17 +356,17 @@ func (s *VaultStore) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	jwksData := map[string]any{jwksKey: string(jwksJson)}
 	if _, err = client.KVv2(s.KVPath).Put(ctx, s.getJWKSPath(), jwksData); err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	return nil
@@ -382,12 +382,12 @@ func (s *VaultStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err err
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 
 	privateKeyData := map[string]interface{}{jwksPrivateKey: pem}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSPrivateKeyPath(), privateKeyData); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -402,11 +402,11 @@ func (s *VaultStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err e
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	expiryData := map[string]interface{}{jwksExpiryKey: expiry}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSExpiryPath(), expiryData); err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -444,7 +444,7 @@ func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controller
 
 	client, err := s.client(ctx)
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.controllerCredentialsPath(controllerName))
 	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
@@ -452,7 +452,7 @@ func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controller
 		err = nil
 	}
 	if err != nil {
-		return errors.E(err)
+		return err
 	}
 	return nil
 }
@@ -488,15 +488,15 @@ func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
 
 	ttl, err := authInfo.TokenTTL()
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	tok, err := authInfo.TokenID()
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	s.client_, err = s.Client.Clone()
 	if err != nil {
-		return nil, errors.E(err)
+		return nil, err
 	}
 	s.client_.SetToken(tok)
 	s.expires = now.Add(ttl - ttlLeeway)


### PR DESCRIPTION
## Description
Ran a find and replace of `errors.E(err)` -> `err`. A minor refactoring that gets rid of the unnecessary wrapping except for one usage in `internal/errors/errors_test.go`

I had to fix one file at `internal/jimm/juju/cloudcredential.go`
