### PR TITLE
chore: remove more redundant uses of errors.E

### DIFF
--- a/cmd/jaas/cmd/grantauditlogaccess_test.go
+++ b/cmd/jaas/cmd/grantauditlogaccess_test.go
@@ -40,7 +40,7 @@ func TestGrantAuditLogAccessRun_APIError(t *testing.T) {
 
 	cmdMocks.client.EXPECT().
 		GrantAuditLogAccess(gomock.Any()).
-		Return(errors.E("unauthorised access")).
+		Return(errors.New("unauthorised access")).
 		Times(1)
 
 	cmdMocks.client.EXPECT().Close()

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -95,17 +95,17 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 
 	if parsedIssuerURL.Scheme == "" {
-		return errors.E("oauth issuer url has no scheme")
+		return errors.New("oauth issuer url has no scheme")
 	}
 
 	clientID := os.Getenv("JIMM_OAUTH_CLIENT_ID")
 	if clientID == "" {
-		return errors.E("no oauth client id")
+		return errors.New("no oauth client id")
 	}
 
 	clientSecret := os.Getenv("JIMM_OAUTH_CLIENT_SECRET")
 	if clientSecret == "" {
-		return errors.E("no oauth client secret")
+		return errors.New("no oauth client secret")
 	}
 
 	scopes := os.Getenv("JIMM_OAUTH_SCOPES")
@@ -115,7 +115,7 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 	zapctx.Info(ctx, "oauth scopes", zap.Any("scopes", scopesParsed))
 	if len(scopesParsed) == 0 {
-		return errors.E("no oauth client scopes present")
+		return errors.New("no oauth client scopes present")
 	}
 
 	insecureSecretStorage := false
@@ -137,29 +137,29 @@ func start(ctx context.Context, s *service.Service) error {
 	sessionCookieMaxAge := os.Getenv("JIMM_SESSION_COOKIE_MAX_AGE")
 	sessionCookieMaxAgeInt, err := strconv.Atoi(sessionCookieMaxAge)
 	if err != nil {
-		return errors.E("unable to parse jimm session cookie max age")
+		return errors.New("unable to parse jimm session cookie max age")
 	}
 	if sessionCookieMaxAgeInt < 0 {
-		return errors.E("jimm session cookie max age cannot be less than 0")
+		return errors.New("jimm session cookie max age cannot be less than 0")
 	}
 
 	sessionSecretKey := os.Getenv("JIMM_SESSION_SECRET_KEY")
 	if len(sessionSecretKey) < 64 {
-		return errors.E("jimm session store secret must be at least 64 characters")
+		return errors.New("jimm session store secret must be at least 64 characters")
 	}
 
 	hostKeyRaw := os.Getenv("JIMM_SSH_HOST_KEY")
 	if hostKeyRaw == "" {
-		return errors.E("empty hostkey from env variable")
+		return errors.New("empty hostkey from env variable")
 	}
 	maxConcurrentConnections, _ := strconv.Atoi(os.Getenv("JIMM_SSH_MAX_CONCURRENT_CONNECTIONS"))
 	publicHostKey, err := ssh.GetPublicKeyFromPrivateKey([]byte(hostKeyRaw))
 	if err != nil {
-		return errors.E("cannot parse hostkey from env variable")
+		return errors.New("cannot parse hostkey from env variable")
 	}
 	fingerprints, err := ssh.GetFingerprintsFromPrivateKey([]byte(hostKeyRaw))
 	if err != nil {
-		return errors.E("cannot parse hostkey from env variable")
+		return errors.New("cannot parse hostkey from env variable")
 	}
 
 	corsAllowedOrigins := strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), " ")
@@ -168,7 +168,7 @@ func start(ctx context.Context, s *service.Service) error {
 
 	sshPort := os.Getenv("JIMM_SSH_PORT")
 	if sshPort == "" {
-		return errors.E("empty ssh port from env variable")
+		return errors.New("empty ssh port from env variable")
 	}
 	sshPortInt, err := strconv.Atoi(sshPort)
 	if err != nil {
@@ -181,7 +181,7 @@ func start(ctx context.Context, s *service.Service) error {
 	if crossModelQueryTimeoutRaw != "" {
 		expiry, err := time.ParseDuration(crossModelQueryTimeoutRaw)
 		if err != nil {
-			return errors.E("cannot parse cross model query timeout into duration")
+			return errors.New("cannot parse cross model query timeout into duration")
 		} else {
 			crossModelQueryTimeout = expiry
 		}

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -261,28 +261,28 @@ type ServiceDependencies struct {
 // Validate checks that all required dependencies are present and returns an error if any are missing.
 func (s *ServiceDependencies) Validate() error {
 	if s.Database == nil {
-		return errors.E("missing database")
+		return errors.New("missing database")
 	}
 	if s.RiverClient == nil {
-		return errors.E("missing river client")
+		return errors.New("missing river client")
 	}
 	if s.OpenFGAClient == nil {
-		return errors.E("missing openfga client")
+		return errors.New("missing openfga client")
 	}
 	if s.CredentialStore == nil {
-		return errors.E("missing credential store")
+		return errors.New("missing credential store")
 	}
 	if s.JWTService == nil {
-		return errors.E("missing jwt service")
+		return errors.New("missing jwt service")
 	}
 	if s.JWKSService == nil {
-		return errors.E("missing jwks service")
+		return errors.New("missing jwks service")
 	}
 	if s.OAuthAuthenticator == nil {
-		return errors.E("missing oauth authenticator")
+		return errors.New("missing oauth authenticator")
 	}
 	if s.MigrationTokenGenerator == nil {
-		return errors.E("missing migration token generator")
+		return errors.New("missing migration token generator")
 	}
 	return nil
 }
@@ -407,10 +407,10 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 	if p.AuditLogRetentionPeriodInDays != "" {
 		retentionPeriod, err := strconv.Atoi(p.AuditLogRetentionPeriodInDays)
 		if err != nil {
-			return nil, errors.E("failed to parse audit log retention period")
+			return nil, errors.New("failed to parse audit log retention period")
 		}
 		if retentionPeriod < 0 {
-			return nil, errors.E("retention period cannot be less than 0")
+			return nil, errors.New("retention period cannot be less than 0")
 		}
 		auditLogRetentionDays = retentionPeriod
 	}
@@ -425,7 +425,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 	}
 
 	if p.DSN == "" {
-		return nil, errors.E("missing DSN")
+		return nil, errors.New("missing DSN")
 	}
 
 	database, err := openDB(ctx, p.DSN, p.LogSQL)
@@ -546,7 +546,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 // Callers can use this to inject mock dependencies while keeping handler setup identical.
 func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) (*Service, error) {
 	if deps == nil {
-		return nil, errors.E("missing service dependencies")
+		return nil, errors.New("missing service dependencies")
 	}
 	if err := deps.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid service dependencies: %w", err)
@@ -806,7 +806,7 @@ func setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmc
 		return vs, nil
 	}
 
-	return nil, errors.E("jimm cannot start without a credential store")
+	return nil, errors.New("jimm cannot start without a credential store")
 }
 
 func newVaultStore(ctx context.Context, p Params) (jimmcreds.CredentialStore, error) {

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -421,7 +421,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to parse public DNS name: %v", err))
+		return nil, fmt.Errorf("failed to parse public DNS name: %v", err)
 	}
 
 	if p.DSN == "" {
@@ -521,7 +521,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 		},
 	)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to setup authentication service: %w", err))
+		return nil, fmt.Errorf("failed to setup authentication service: %w", err)
 	}
 	deps.OAuthAuthenticator = authSvc
 	deps.MigrationTokenGenerator = authSvc
@@ -533,7 +533,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
 		})
 		if err != nil {
-			return nil, errors.E(fmt.Errorf("failed to setup authentication handler: %w", err))
+			return nil, fmt.Errorf("failed to setup authentication handler: %w", err)
 		}
 	} else {
 		zapctx.Warn(ctx, "Dashboard final redirect URL not set, OAuth HTTP handler will not be configured")
@@ -619,7 +619,7 @@ func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) 
 		ControllerUUID:         deps.ControllerUUID,
 	}, deps.Database, s.jimm.OfferAuthorizer)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to set up discharger: %v", err))
+		return nil, fmt.Errorf("failed to set up discharger: %v", err)
 	}
 	s.mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
 
@@ -751,7 +751,7 @@ func setupSessionStore(sessionSecret []byte, db *db.Database) (*pgstore.PGStore,
 
 	store, err := pgstore.NewPGStoreFromPool(sqlDb, sessionSecret)
 	if err != nil {
-		return nil, nil, errors.E(fmt.Errorf("failed to create session store: %w", err))
+		return nil, nil, fmt.Errorf("failed to create session store: %w", err)
 	}
 
 	// Cleanup expired session every 30 minutes
@@ -800,7 +800,7 @@ func setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmc
 
 	vs, err := newVaultStore(ctx, p)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("vault store error: %v", err))
+		return nil, fmt.Errorf("vault store error: %v", err)
 	}
 	if vs != nil {
 		return vs, nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -243,7 +243,7 @@ func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oa
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("authorisation code exchange failed: %v", err))
+		return nil, fmt.Errorf("authorisation code exchange failed: %v", err)
 	}
 
 	return t, nil
@@ -270,7 +270,7 @@ func (as *AuthenticationService) Device(ctx context.Context) (*oauth2.DeviceAuth
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("device auth call failed: %v", err))
+		return nil, fmt.Errorf("device auth call failed: %v", err)
 	}
 
 	return resp, nil
@@ -288,7 +288,7 @@ func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oau
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("device access token call failed: %v", err))
+		return nil, fmt.Errorf("device access token call failed: %v", err)
 	}
 
 	return t, nil
@@ -310,7 +310,7 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to verify id token: %v", err))
+		return nil, fmt.Errorf("failed to verify id token: %v", err)
 	}
 
 	return token, nil
@@ -328,7 +328,7 @@ func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
-		return "", errors.E(fmt.Errorf("failed to extract claims: %v", err))
+		return "", fmt.Errorf("failed to extract claims: %v", err)
 	}
 
 	return claims.Email, nil
@@ -343,12 +343,12 @@ func (as *AuthenticationService) MintSessionToken(email string) (string, error) 
 		Expiration(time.Now().Add(as.sessionTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to build access token: %v", err))
+		return "", fmt.Errorf("failed to build access token: %v", err)
 	}
 
 	freshToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to sign access token: %v", err))
+		return "", fmt.Errorf("failed to sign access token: %v", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(freshToken), nil
@@ -368,12 +368,12 @@ func (as *AuthenticationService) NewMigrationToken(ctx context.Context, username
 		Expiration(time.Now().Add(migrationTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to mint migration token: %v", err))
+		return "", fmt.Errorf("failed to mint migration token: %v", err)
 	}
 
 	migrationToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to sign migration token: %v", err))
+		return "", fmt.Errorf("failed to sign migration token: %v", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(migrationToken), nil
@@ -528,7 +528,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return ctx, errors.E(fmt.Errorf("failed to retrieve session: %v", err))
+		return ctx, fmt.Errorf("failed to retrieve session: %v", err)
 	}
 	session = sessionCrossOriginSafe(session, as.secureCookies)
 
@@ -541,7 +541,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	if err != nil {
 		// If the user's access token AND refresh token have expired
 		// then we will fail authentication here.
-		return ctx, errors.E(fmt.Errorf("failed to validate and update status token: %v", err))
+		return ctx, fmt.Errorf("failed to validate and update status token: %v", err)
 	}
 
 	ctx = ContextWithSessionIdentity(ctx, identityId)
@@ -562,7 +562,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to retrieve session: %v", err))
+		return fmt.Errorf("failed to retrieve session: %v", err)
 	}
 
 	identityId, ok := session.Values[SessionIdentityKey]
@@ -576,7 +576,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
-		return errors.E(fmt.Errorf("failed to delete session: %v", err))
+		return fmt.Errorf("failed to delete session: %v", err)
 	}
 
 	if err := as.UpdateIdentity(ctx, identityIdStr, &oauth2.Token{
@@ -585,7 +585,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 		Expiry:       time.Now(),
 		TokenType:    "",
 	}); err != nil {
-		return errors.E(fmt.Errorf("failed to update identity: %v", err))
+		return fmt.Errorf("failed to update identity: %v", err)
 	}
 
 	return nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -301,7 +301,7 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 	// Extract the ID Token from oauth2 token.
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		return nil, errors.E("failed to extract id token")
+		return nil, errors.New("failed to extract id token")
 	}
 
 	verifier := as.provider.Verifier(&oidc.Config{
@@ -324,7 +324,7 @@ func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
 		EmailVerified bool   `json:"email_verified"` // TODO(ale8k): Add verification logic
 	}
 	if idToken == nil {
-		return "", errors.E("id token is nil")
+		return "", errors.New("id token is nil")
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
@@ -567,7 +567,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		return errors.E("session is missing identity key")
+		return errors.New("session is missing identity key")
 	}
 
 	identityIdStr, ok := identityId.(string)
@@ -598,7 +598,7 @@ func (as *AuthenticationService) Whoami(ctx context.Context) (*params.WhoamiResp
 
 	identityId := SessionIdentityFromContext(ctx)
 	if identityId == "" {
-		return nil, errors.E("no identity in context")
+		return nil, errors.New("no identity in context")
 	}
 
 	// TODO(ale8k) CSS-8227: Add test case for this

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -51,7 +51,7 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	case offer.URL != "":
 		db = db.Where("url = ?", offer.URL)
 	default:
-		return errors.E("missing offer UUID or URL")
+		return errors.New("missing offer UUID or URL")
 	}
 
 	db = db.Preload("Model").Preload("Model.Controller")

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -118,7 +118,7 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 		offer := offer
 		err := d.GetApplicationOffer(ctx, &offer)
 		if err != nil {
-			return nil, errors.E(dbError(err))
+			return nil, dbError(err)
 		}
 		offers[i] = offer
 	}

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -26,7 +26,7 @@ func (d *Database) AddApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 
 	result := db.Create(offer)
 	if result.Error != nil {
-		return errors.E(dbError(result.Error))
+		return dbError(result.Error)
 	}
 	return nil
 }
@@ -81,7 +81,7 @@ func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.Ap
 
 	result := db.Delete(offer)
 	if result.Error != nil {
-		return errors.E(dbError(result.Error))
+		return dbError(result.Error)
 	}
 	return nil
 }
@@ -111,7 +111,7 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 	var offers []dbmodel.ApplicationOffer
 	result := db.Preload("Model").Find(&offers)
 	if result.Error != nil {
-		return nil, errors.E(dbError(result.Error))
+		return nil, dbError(result.Error)
 	}
 
 	for i, offer := range offers {

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -24,7 +24,7 @@ func (d *Database) AddAuditLogEntry(ctx context.Context, ale *dbmodel.AuditLogEn
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Create(ale).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/db/auditlog_test.go
+++ b/internal/db/auditlog_test.go
@@ -4,6 +4,7 @@ package db_test
 
 import (
 	"context"
+	stderr "errors"
 	"testing"
 	"time"
 
@@ -147,7 +148,7 @@ func (s *dbSuite) TestForEachAuditLogEntry(c *qt.C) {
 		return testError
 	})
 	c.Check(calls, qt.Equals, 1)
-	c.Check(err, qt.DeepEquals, testError)
+	c.Check(stderr.Is(err, testError), qt.IsTrue)
 }
 
 func (s *dbSuite) TestDeleteAuditLogsBefore(c *qt.C) {

--- a/internal/db/auditlog_test.go
+++ b/internal/db/auditlog_test.go
@@ -44,7 +44,7 @@ func (s *dbSuite) TestAddAuditLogEntry(c *qt.C) {
 	var ale2 dbmodel.AuditLogEntry
 	err = s.Database.ForEachAuditLogEntry(ctx, db.AuditLogFilter{}, func(ale *dbmodel.AuditLogEntry) error {
 		if ale2.ID != 0 {
-			return errors.E("too many results")
+			return errors.New("too many results")
 		}
 		ale2 = *ale
 		return nil
@@ -141,7 +141,7 @@ func (s *dbSuite) TestForEachAuditLogEntry(c *qt.C) {
 	}
 
 	var calls int
-	testError := errors.E("a test error")
+	testError := errors.New("a test error")
 	err = s.Database.ForEachAuditLogEntry(context.Background(), db.AuditLogFilter{}, func(_ *dbmodel.AuditLogEntry) error {
 		calls++
 		return testError

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -115,7 +115,7 @@ func (d *Database) UpdateCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 		return nil
 	})
 	if err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -170,7 +170,7 @@ func (d *Database) FindRegionByCloudType(ctx context.Context, providerType, regi
 
 	var region dbmodel.CloudRegion
 	if err := db.First(&region).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return &region, nil
 }
@@ -193,7 +193,7 @@ func (d *Database) FindRegionByCloudName(ctx context.Context, cloudName, regionN
 
 	var region dbmodel.CloudRegion
 	if err := db.First(&region).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return &region, nil
 }
@@ -212,7 +212,7 @@ func (d *Database) DeleteCloud(ctx context.Context, c *dbmodel.Cloud) (err error
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -231,7 +231,7 @@ func (d *Database) DeleteCloudRegionControllerPriority(ctx context.Context, c *d
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(c).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -37,7 +37,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 		},
 		DoUpdates: clause.AssignmentColumns([]string{"auth_type", "label", "valid"}),
 	}).Create(&cred).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func (d *Database) ForEachCloudCredential(ctx context.Context, identityName, clo
 
 	var creds []dbmodel.CloudCredential
 	if err := db.Find(&creds).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	for _, c := range creds {
 		if err := f(&c); err != nil {

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -42,7 +42,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				// if defaults do not exist, we create them
 				if err := db.Create(&defaults).Error; err != nil {
-					return errors.E(dbError(err))
+					return dbError(err)
 				}
 				return nil
 			}
@@ -61,7 +61,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 			},
 			DoUpdates: clause.AssignmentColumns([]string{"defaults"}),
 		}).Create(&dbDefaults).Error; err != nil {
-			return errors.E(dbError(err))
+			return dbError(err)
 		}
 		return nil
 	})
@@ -112,7 +112,7 @@ func (d *Database) UnsetCloudDefaults(ctx context.Context, defaults *dbmodel.Clo
 			},
 			DoUpdates: clause.AssignmentColumns([]string{"defaults"}),
 		}).Create(&dbDefaults).Error; err != nil {
-			return errors.E(dbError(err))
+			return dbError(err)
 		}
 		return nil
 	})

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -177,7 +177,7 @@ func (d *Database) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Iden
 	var defaults []dbmodel.CloudDefaults
 	result := db.Preload("Identity").Preload("Cloud").Find(&defaults)
 	if result.Error != nil {
-		return nil, errors.E(dbError(result.Error))
+		return nil, dbError(result.Error)
 	}
 	return defaults, nil
 }

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -26,7 +26,7 @@ func (d *Database) AddController(ctx context.Context, controller *dbmodel.Contro
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(controller).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -84,7 +84,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 	db := d.DB.WithContext(ctx)
 	db = db.Omit("CloudRegions").Omit("Models")
 	if err := db.Save(controller).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (d *Database) ForEachController(ctx context.Context, f func(*dbmodel.Contro
 
 	var controllers []dbmodel.Controller
 	if err := db.Order("name asc").Find(&controllers).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	for _, c := range controllers {
 		if err := f(&c); err != nil {
@@ -165,7 +165,7 @@ func (d *Database) ForEachControllerModel(ctx context.Context, ctl *dbmodel.Cont
 	var models []dbmodel.Model
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(ctl).Association("Models").Find(&models); err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	for _, m := range models {
 		if err := f(&m); err != nil {
@@ -190,7 +190,7 @@ func (d *Database) CountControllers(ctx context.Context) (count int, err error) 
 	db := d.DB.WithContext(ctx)
 	var count64 int64
 	if err := db.Model(&dbmodel.Controller{}).Count(&count64).Error; err != nil {
-		return -1, errors.E(dbError(err))
+		return -1, dbError(err)
 	}
 	return int(count64), nil
 }

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -147,7 +147,7 @@ func (s *dbSuite) TestForEachController(c *qt.C) {
 	env := jimmtest.ParseEnvironment(c, testForEachControllerEnv)
 	env.PopulateDB(c, s.Database)
 
-	testError := errors.E("test error")
+	testError := errors.New("test error")
 	err = s.Database.ForEachController(ctx, func(controller *dbmodel.Controller) error {
 		return testError
 	})
@@ -338,7 +338,7 @@ func (s *dbSuite) TestForEachControllerModel(c *qt.C) {
 	env.PopulateDB(c, s.Database)
 
 	ctl := env.Controller("test").DBObject(c, s.Database)
-	testError := errors.E("test error")
+	testError := errors.New("test error")
 	err = s.Database.ForEachControllerModel(ctx, &ctl, func(_ *dbmodel.Model) error {
 		return testError
 	})

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -96,7 +96,7 @@ func TestTransactionUnconfiguredDatabase(t *testing.T) {
 
 	var database db.Database
 	err := database.Transaction(func(d *db.Database) error {
-		return errors.E("unexpected function call")
+		return errors.New("unexpected function call")
 	})
 	c.Check(err, qt.ErrorMatches, `database not configured`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeServerConfiguration)
@@ -104,7 +104,7 @@ func TestTransactionUnconfiguredDatabase(t *testing.T) {
 
 func (s *dbSuite) TestTransaction(c *qt.C) {
 	err := s.Database.Transaction(func(d *db.Database) error {
-		return errors.E("unexpected function call")
+		return errors.New("unexpected function call")
 	})
 	c.Check(err, qt.ErrorMatches, `upgrade in progress`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeUpgradeInProgress)
@@ -120,7 +120,7 @@ func (s *dbSuite) TestTransaction(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	err = s.Database.Transaction(func(d *db.Database) error {
-		return errors.E("test error")
+		return errors.New("test error")
 	})
 	c.Check(err, qt.ErrorMatches, `test error`)
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -31,7 +31,7 @@ func (d *Database) AddGroup(ctx context.Context, name string) (ge *dbmodel.Group
 	}
 
 	if err := d.DB.WithContext(ctx).Create(ge).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return ge, nil
 }
@@ -49,7 +49,7 @@ func (d *Database) CountGroups(ctx context.Context) (count int, err error) {
 	var c int64
 	var g dbmodel.GroupEntry
 	if err := d.DB.WithContext(ctx).Model(g).Count(&c).Error; err != nil {
-		return 0, errors.E(dbError(err))
+		return 0, dbError(err)
 	}
 	count = int(c)
 	return count, nil
@@ -81,7 +81,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 		db = db.Where("name = ?", group.Name)
 	}
 	if err := db.First(&group).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -111,7 +111,7 @@ func (d *Database) ListGroups(ctx context.Context, limit, offset int, match stri
 	}
 	var groups []dbmodel.GroupEntry
 	if err := db.Find(&groups).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return groups, nil
 }
@@ -157,7 +157,7 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Delete(group).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -63,7 +63,7 @@ func (d *Database) GetGroup(ctx context.Context, group *dbmodel.GroupEntry) (err
 	}
 
 	if group.UUID == "" && group.Name == "" {
-		return errors.E("must specify uuid or name")
+		return errors.New("must specify uuid or name")
 	}
 
 	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
@@ -121,7 +121,7 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 	const op = "db.UpdateGroup"
 
 	if uuid == "" {
-		return errors.E("uuid must be specified")
+		return errors.New("uuid must be specified")
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -162,7 +162,7 @@ func (d *Database) ListIdentities(ctx context.Context, limit, offset int, match 
 	}
 	var identities []dbmodel.Identity
 	if err := db.Find(&identities).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return identities, nil
 }

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -92,7 +92,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId int64, offset int) (lo
 
 		result := query.Offset(offset).Order("line_number ASC").Find(&logs)
 		if result.Error != nil {
-			return errors.E(dbError(result.Error))
+			return dbError(result.Error)
 		}
 
 		// Get the next line number

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -53,7 +53,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 		}
 
 		if err := d.DB.WithContext(ctx).Create(log).Error; err != nil {
-			return errors.E(dbError(err))
+			return dbError(err)
 		}
 		return nil
 	})
@@ -83,7 +83,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId int64, offset int) (lo
 
 		var count int64
 		if err := query.Count(&count).Error; err != nil {
-			return errors.E(dbError(err))
+			return dbError(err)
 		}
 
 		if count == 0 {

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -94,7 +94,7 @@ func (d *Database) GetModelsUsingCredential(ctx context.Context, credentialID ui
 	var models []dbmodel.Model
 	result := db.Where("cloud_credential_id = ?", credentialID).Preload("Controller").Find(&models)
 	if result.Error != nil {
-		return nil, errors.E(dbError(result.Error))
+		return nil, dbError(result.Error)
 	}
 	return models, nil
 }

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -28,7 +28,7 @@ func (d *Database) AddModel(ctx context.Context, model *dbmodel.Model) (err erro
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(model).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -74,7 +74,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "model not found")
 		}
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -112,7 +112,7 @@ func (d *Database) UpdateModel(ctx context.Context, model *dbmodel.Model) (err e
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Save(model).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -138,7 +138,7 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 	}
 
 	if err := db.Delete(model).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (d *Database) ForEachModel(ctx context.Context, f func(m *dbmodel.Model) er
 
 	var models []dbmodel.Model
 	if err := db.Find(&models).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	for _, m := range models {
 		if err := f(&m); err != nil {
@@ -197,7 +197,7 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, errors.E(err, "model not found")
 		}
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return models, nil
 }
@@ -233,7 +233,7 @@ func (d *Database) GetModelsByController(ctx context.Context, ctl dbmodel.Contro
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Model(ctl).Association("Models").Find(&models); err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return models, nil
 }
@@ -254,7 +254,7 @@ func (d *Database) CountModelsByController(ctx context.Context, ctl dbmodel.Cont
 	asc := db.Model(ctl).Association("Models")
 	count = int(asc.Count())
 	if err := asc.Error; err != nil {
-		return 0, errors.E(dbError(err))
+		return 0, dbError(err)
 	}
 	return count, nil
 }

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -540,7 +540,7 @@ func (s *dbSuite) TestForEachModel(c *qt.C) {
 	env := jimmtest.ParseEnvironment(c, testForEachModelEnv)
 	env.PopulateDB(c, s.Database)
 
-	testError := errors.E("test error")
+	testError := errors.New("test error")
 	err = s.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
 		return testError
 	})

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -42,7 +42,7 @@ func (d *Database) AddOrUpdateIncomingModelMigration(ctx context.Context, modelM
 		db := d.DB.WithContext(ctx)
 
 		if err := db.Save(modelMigration).Error; err != nil {
-			return errors.E(dbError(err))
+			return dbError(err)
 		}
 
 		return nil
@@ -125,7 +125,7 @@ func (d *Database) DeleteIncomingModelMigration(ctx context.Context, modelMigrat
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(modelMigration).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func (d *Database) GetIncomingModelMigrationsCreatedBefore(ctx context.Context, 
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Where("created_at < ?", createBefore).Find(&migrations).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return migrations, nil
 }

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -140,7 +140,7 @@ func buildQuery(db *gorm.DB, offset, limit int, namePrefixFilter, typeFilter str
 		query = modelsQuery
 	default:
 		// this shouldn't happen because we have validated the entityFilter at API layer
-		return nil, errors.E("this entityType does not exist")
+		return nil, errors.New("this entityType does not exist")
 	}
 	return query.Order("id").Offset(offset).Limit(limit), nil
 }

--- a/internal/db/resource.go
+++ b/internal/db/resource.go
@@ -89,7 +89,7 @@ func (d *Database) ListResources(ctx context.Context, limit, offset int, namePre
 
 	var resources []Resource
 	if err := query.Find(&resources).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return resources, nil
 }

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -44,7 +44,7 @@ func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err er
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if role.UUID == "" && role.Name == "" {
-		return errors.E("must specify uuid or name")
+		return errors.New("must specify uuid or name")
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -68,7 +68,7 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 	const op = "db.UpdateRole"
 
 	if oldName == "" {
-		return errors.E("name must be specified")
+		return errors.New("name must be specified")
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -27,7 +27,7 @@ func (d *Database) AddRole(ctx context.Context, name string) (re *dbmodel.RoleEn
 	}
 
 	if err := d.DB.WithContext(ctx).Create(re).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return re, nil
 }
@@ -58,7 +58,7 @@ func (d *Database) GetRole(ctx context.Context, role *dbmodel.RoleEntry) (err er
 		db = db.Where("name = ?", role.Name)
 	}
 	if err := db.First(&role).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if err := d.DB.WithContext(ctx).Delete(role).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -135,7 +135,7 @@ func (d *Database) ListRoles(ctx context.Context, limit, offset int, match strin
 	}
 	var Roles []dbmodel.RoleEntry
 	if err := db.Find(&Roles).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 	return Roles, nil
 }
@@ -153,7 +153,7 @@ func (d *Database) CountRoles(ctx context.Context) (count int, err error) {
 	var c int64
 	var g dbmodel.RoleEntry
 	if err := d.DB.WithContext(ctx).Model(g).Count(&c).Error; err != nil {
-		return 0, errors.E(dbError(err))
+		return 0, dbError(err)
 	}
 	count = int(c)
 	return count, nil

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -10,7 +10,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
@@ -63,7 +62,7 @@ func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.
 		if err == gorm.ErrRecordNotFound {
 			return dbrootkeystore.RootKey{}, nil
 		}
-		return dbrootkeystore.RootKey{}, errors.E(dbError(err))
+		return dbrootkeystore.RootKey{}, dbError(err)
 	}
 	return dbrootkeystore.RootKey{
 		Id:      rk.ID,
@@ -92,7 +91,7 @@ func (d *Database) InsertKey(key dbrootkeystore.RootKey) (err error) {
 		RootKey:   key.RootKey,
 	}
 	if err := d.DB.Create(&rk).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -128,12 +128,12 @@ func (d *Database) Get(ctx context.Context, tag names.CloudCredentialTag) (_ map
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, nil
 		}
-		return nil, errors.E(fmt.Errorf("failed to get secret data: %w", err))
+		return nil, fmt.Errorf("failed to get secret data: %w", err)
 	}
 	var attr map[string]string
 	err = json.Unmarshal(secret.Data, &attr)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to unmarshal secret data: %w", err))
+		return nil, fmt.Errorf("failed to unmarshal secret data: %w", err)
 	}
 	return attr, nil
 }
@@ -152,7 +152,7 @@ func (d *Database) Put(ctx context.Context, tag names.CloudCredentialTag, attr m
 
 	dataJson, err := json.Marshal(attr)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to marshal secret data: %w", err))
+		return fmt.Errorf("failed to marshal secret data: %w", err)
 	}
 	secret := dbmodel.NewSecret(tag.Kind(), tag.String(), dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -177,12 +177,12 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 		return "", "", nil
 	}
 	if err != nil {
-		return "", "", errors.E(fmt.Errorf("failed to get secret data: %w", err))
+		return "", "", fmt.Errorf("failed to get secret data: %w", err)
 	}
 	var secretData map[string]string
 	err = json.Unmarshal(secret.Data, &secretData)
 	if err != nil {
-		return "", "", errors.E(fmt.Errorf("failed to unmarshal secret data: %w", err))
+		return "", "", fmt.Errorf("failed to unmarshal secret data: %w", err)
 	}
 	username, ok := secretData[usernameKey]
 	if !ok {
@@ -212,7 +212,7 @@ func (d *Database) PutControllerCredentials(ctx context.Context, controllerName 
 	secretData[passwordKey] = password
 	dataJson, err := json.Marshal(secretData)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to marshal secret data: %w", err))
+		return fmt.Errorf("failed to marshal secret data: %w", err)
 	}
 	secret := dbmodel.NewSecret(names.ControllerTagKind, controllerName, dataJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -233,17 +233,17 @@ func (d *Database) CleanupJWKS(ctx context.Context) (err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to cleanup jwks public key: %w", err))
+		return fmt.Errorf("failed to cleanup jwks public key: %w", err)
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to cleanup jwks private key: %w", err))
+		return fmt.Errorf("failed to cleanup jwks private key: %w", err)
 	}
 	secret = dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.DeleteSecret(ctx, &secret)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to cleanup jwks expiry info: %w", err))
+		return fmt.Errorf("failed to cleanup jwks expiry info: %w", err)
 	}
 	return nil
 }
@@ -263,11 +263,11 @@ func (d *Database) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to get jwks data: %w", err))
+		return nil, fmt.Errorf("failed to get jwks data: %w", err)
 	}
 	ks, err := jwk.ParseString(string(secret.Data))
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to parse jwk data: %w", err))
+		return nil, fmt.Errorf("failed to parse jwk data: %w", err)
 	}
 	return ks, nil
 }
@@ -287,12 +287,12 @@ func (d *Database) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error) 
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to get jwks private key: %w", err))
+		return nil, fmt.Errorf("failed to get jwks private key: %w", err)
 	}
 	var pem []byte
 	err = json.Unmarshal(secret.Data, &pem)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to unmarshal pem data: %w", err))
+		return nil, fmt.Errorf("failed to unmarshal pem data: %w", err)
 	}
 	return pem, nil
 }
@@ -312,12 +312,12 @@ func (d *Database) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error) {
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, nil)
 	err = d.GetSecret(ctx, &secret)
 	if err != nil {
-		return time.Time{}, errors.E(fmt.Errorf("failed to get jwks expiry: %w", err))
+		return time.Time{}, fmt.Errorf("failed to get jwks expiry: %w", err)
 	}
 	var expiryTime time.Time
 	err = json.Unmarshal(secret.Data, &expiryTime)
 	if err != nil {
-		return time.Time{}, errors.E(fmt.Errorf("failed to unmarshal jwks expiry data: %w", err))
+		return time.Time{}, fmt.Errorf("failed to unmarshal jwks expiry data: %w", err)
 	}
 	return expiryTime, nil
 }
@@ -336,7 +336,7 @@ func (d *Database) PutJWKS(ctx context.Context, jwks jwk.Set) (err error) {
 
 	jwksJson, err := json.Marshal(jwks)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to marshal jwks data: %w", err))
+		return fmt.Errorf("failed to marshal jwks data: %w", err)
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPublicKeyTag, jwksJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -357,7 +357,7 @@ func (d *Database) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err error
 
 	privateKeyJson, err := json.Marshal(pem)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to marshal jwks private key: %w", err))
+		return fmt.Errorf("failed to marshal jwks private key: %w", err)
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksPrivateKeyTag, privateKeyJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -377,7 +377,7 @@ func (d *Database) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err err
 
 	expiryJson, err := json.Marshal(expiry)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to marshal jwks expiry data: %w", err))
+		return fmt.Errorf("failed to marshal jwks expiry data: %w", err)
 	}
 	secret := dbmodel.NewSecret(jwksKind, jwksExpiryTag, expiryJson)
 	return d.UpsertSecret(ctx, &secret)
@@ -397,11 +397,11 @@ func (d *Database) CleanupOAuthSecrets(ctx context.Context) (err error) {
 
 	secret := dbmodel.NewSecret(oauthKind, oauthKeyTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		return errors.E(fmt.Errorf("failed to cleanup OAuth key: %w", err))
+		return fmt.Errorf("failed to cleanup OAuth key: %w", err)
 	}
 	secret = dbmodel.NewSecret(oauthKind, oauthSessionStoreSecretTag, nil)
 	if err := d.DeleteSecret(ctx, &secret); err != nil {
-		return errors.E(fmt.Errorf("failed to cleanup OAuth session store secret: %w", err))
+		return fmt.Errorf("failed to cleanup OAuth session store secret: %w", err)
 	}
 	return nil
 }

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -186,11 +186,11 @@ func (d *Database) GetControllerCredentials(ctx context.Context, controllerName 
 	}
 	username, ok := secretData[usernameKey]
 	if !ok {
-		return "", "", errors.E("missing username")
+		return "", "", errors.New("missing username")
 	}
 	password, ok := secretData[passwordKey]
 	if !ok {
-		return "", "", errors.E("missing password")
+		return "", "", errors.New("missing password")
 	}
 	return username, password, nil
 }

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -51,7 +51,7 @@ func (d *Database) UpsertSecret(ctx context.Context, secret *dbmodel.Secret) (er
 		DoUpdates: clause.AssignmentColumns([]string{"time", "data"}),
 	})
 	if err := db.Create(secret).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -81,7 +81,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "secret not found")
 		}
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Unscoped().Where("tag = ? AND type = ?", secret.Tag, secret.Type).Delete(&dbmodel.Secret{}).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -50,7 +50,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 		Delete(&dbmodel.SSHKey{})
 
 	if err := query.Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 
 	if query.RowsAffected == 0 {
@@ -76,7 +76,7 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 		Where("model_uuid = ?", model.ModelUUID).
 		Delete(&dbmodel.SSHKey{})
 	if err := query.Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 
 	if query.RowsAffected == 0 {
@@ -103,7 +103,7 @@ func (d *Database) ListSSHKeysForUser(ctx context.Context, identityName string, 
 	}
 	if err := query.
 		Find(&keys).Error; err != nil {
-		return nil, errors.E(dbError(err))
+		return nil, dbError(err)
 	}
 
 	return keys, nil

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -24,7 +24,7 @@ func (d *Database) AddUserMapping(ctx context.Context, userMapping *dbmodel.User
 	db := d.DB.WithContext(ctx)
 
 	if err := db.Create(userMapping).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.E(err, "user mapping not found")
 		}
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -75,7 +75,7 @@ func (d *Database) DeleteUserMapping(ctx context.Context, userMapping *dbmodel.U
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Delete(userMapping).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (d *Database) DeleteUserMappingsByModelUUID(ctx context.Context, modelUUID 
 
 	db := d.DB.WithContext(ctx)
 	if err := db.Where("model_uuid = ?", modelUUID).Delete(&dbmodel.UserMapping{}).Error; err != nil {
-		return errors.E(dbError(err))
+		return dbError(err)
 	}
 	return nil
 }

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -83,13 +83,13 @@ func Deserialize(raw []byte, targetControllerVersion version.Number) (Model, err
 	case 9:
 		desc, err := descriptionv9.Deserialize(raw)
 		if err != nil {
-			return nil, errors.E(fmt.Errorf("failed to deserialize v9 model description: %w", err))
+			return nil, fmt.Errorf("failed to deserialize v9 model description: %w", err)
 		}
 		return &migrationDescriptionV9{desc: desc}, nil
 	case 10:
 		desc, err := descriptionv10.Deserialize(raw)
 		if err != nil {
-			return nil, errors.E(fmt.Errorf("failed to deserialize v10 model description: %w", err))
+			return nil, fmt.Errorf("failed to deserialize v10 model description: %w", err)
 		}
 		return &migrationDescriptionV10{desc: desc}, nil
 	default:
@@ -104,7 +104,7 @@ func migrationDescriptionVersion(controllerVersion version.Number) (int, error) 
 
 	switch {
 	case v.Compare(version.MustParse("3.6.9")) < 0:
-		return 0, errors.E(fmt.Errorf("unsupported controller version %s, must be at least 3.6.9", controllerVersion))
+		return 0, fmt.Errorf("unsupported controller version %s, must be at least 3.6.9", controllerVersion)
 	case v.Compare(version.MustParse("3.6.9")) >= 0 && v.Compare(version.MustParse("3.6.12")) <= 0:
 		return 9, nil
 	case v.Compare(version.MustParse("3.6.13")) == 0:
@@ -123,7 +123,7 @@ func TryDetermineModelUUID(raw []byte) (string, error) {
 	}
 	modelUUIDStr, ok := model.Config()[config.UUIDKey].(string)
 	if !ok {
-		return "", errors.E(fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+		return "", fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey)
 	}
 	return modelUUIDStr, nil
 }

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -93,7 +93,7 @@ func Deserialize(raw []byte, targetControllerVersion version.Number) (Model, err
 		}
 		return &migrationDescriptionV10{desc: desc}, nil
 	default:
-		return nil, errors.E("unsupported description version")
+		return nil, errors.New("unsupported description version")
 	}
 }
 

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -40,7 +40,7 @@ type OfferAuthorizer interface {
 func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, offerAuthorizer OfferAuthorizer) (*MacaroonDischarger, error) {
 	var kp bakery.KeyPair
 	if cfg.PublicKey == "" || cfg.PrivateKey == "" {
-		return nil, errors.E("missing bakery private/public key")
+		return nil, errors.New("missing bakery private/public key")
 	} else {
 		if err := kp.Private.UnmarshalText([]byte(cfg.PrivateKey)); err != nil {
 			return nil, errors.E(err, "cannot unmarshal private key")
@@ -50,7 +50,7 @@ func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, offerA
 		}
 	}
 	if offerAuthorizer == nil {
-		return nil, errors.E("userMappingManager cannot be nil")
+		return nil, errors.New("userMappingManager cannot be nil")
 	}
 
 	checker := checkers.New(jjmacaroon.MacaroonNamespace)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -59,6 +59,12 @@ func (e *Error) ErrorInfo() map[string]any {
 	return e.Info
 }
 
+// New constructs a new error with the given message.
+// It is a wrapper around the stdlib errors.New function.
+func New(text string) error {
+	return stderr.New(text)
+}
+
 // E constructs errors for use throughout the JIMM application. An error
 // is constructed by processing the given arguments. The meaning of the
 // arguments is as follows:

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -49,7 +49,7 @@ func TestEWithInfo(t *testing.T) {
 	c.Check(err.(*errors.Error).Info, qt.DeepEquals, info)
 	c.Check(errors.ErrorInfo(err), qt.DeepEquals, info)
 
-	err = errors.E("plain-error")
+	err = errors.New("plain-error")
 	c.Check(err, qt.ErrorMatches, `plain-error`)
 	c.Check(errors.ErrorInfo(err), qt.DeepEquals, map[string]any(nil))
 }

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -105,7 +105,7 @@ func (j *AuditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, bef
 	}
 	count, err := j.store.DeleteAuditLogsBefore(ctx, before)
 	if err != nil {
-		return 0, errors.E(fmt.Errorf("failed to purge logs: %w", err))
+		return 0, fmt.Errorf("failed to purge logs: %w", err)
 	}
 	return count, nil
 }

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -32,13 +32,13 @@ type AuditLogManager struct {
 // creation, and removal.
 func NewAuditLogManager(store *db.Database, authSvc *openfga.OFGAClient, jimmTag names.ControllerTag, retentionDays int) (*AuditLogManager, error) {
 	if store == nil {
-		return nil, errors.E("auditlog store cannot be nil")
+		return nil, errors.New("auditlog store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("auditlog authorisation service cannot be nil")
+		return nil, errors.New("auditlog authorisation service cannot be nil")
 	}
 	if jimmTag.String() == "" {
-		return nil, errors.E("auditlog jimm tag cannot be empty")
+		return nil, errors.New("auditlog jimm tag cannot be empty")
 	}
 	return &AuditLogManager{store, authSvc, jimmTag, retentionDays}, nil
 }

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -268,7 +268,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		return 0, fmt.Errorf("failed to enqueue bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.E(fmt.Errorf("a bootstrap job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
+		return 0, errors.E("a bootstrap job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
 	}
 
 	return job.Job.ID, nil
@@ -552,7 +552,7 @@ func (b *BootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 		return 0, fmt.Errorf("failed to start bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.E(fmt.Errorf("a destroy job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
+		return 0, errors.E("a destroy job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
 	}
 
 	return job.Job.ID, nil

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -246,7 +246,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 	}
 
 	if err := params.validate(); err != nil {
-		return 0, errors.E(fmt.Errorf("invalid bootstrap parameters: %v", err))
+		return 0, fmt.Errorf("invalid bootstrap parameters: %v", err)
 	}
 
 	bootstrapArgs := rivertypes.BootstrapArgs{
@@ -265,7 +265,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 	}
 	job, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs)
 	if err != nil {
-		return 0, errors.E(fmt.Errorf("failed to enqueue bootstrap job: %w", err))
+		return 0, fmt.Errorf("failed to enqueue bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
 		return 0, errors.E(fmt.Errorf("a bootstrap job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
@@ -342,7 +342,7 @@ func (b *BootstrapManager) BootstrapController(
 		return errors.E(errors.CodeAlreadyExists, fmt.Errorf("controller %q already exists", p.ControllerName))
 	}
 	if errors.ErrorCode(err) != errors.CodeNotFound {
-		return errors.E(fmt.Errorf("failed to check if controller exists: %w", err))
+		return fmt.Errorf("failed to check if controller exists: %w", err)
 	}
 
 	b.writeJobLog(ctx, p.JobID,
@@ -360,7 +360,7 @@ func (b *BootstrapManager) BootstrapController(
 		},
 	)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get Juju binary: %w", err))
+		return fmt.Errorf("failed to get Juju binary: %w", err)
 	}
 	zapctx.Debug(ctx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 	defer binaryDone(binary)
@@ -368,7 +368,7 @@ func (b *BootstrapManager) BootstrapController(
 	jujuCmds := cmdFactory.New(binary.FullPath, p.JujuDataDir)
 
 	if err := b.runBootstrap(ctx, p, jujuCmds, user); err != nil {
-		return errors.E(fmt.Errorf("run bootstrap failed: %w", err))
+		return fmt.Errorf("run bootstrap failed: %w", err)
 	}
 	return nil
 }
@@ -401,7 +401,7 @@ func (b *BootstrapManager) runBootstrap(
 		},
 	)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to run bootstrap command: %w", err))
+		return fmt.Errorf("failed to run bootstrap command: %w", err)
 	}
 	defer cleanup()
 
@@ -421,8 +421,8 @@ func (b *BootstrapManager) runBootstrap(
 	controllerCleanup := func(err error, controllerDetails *jujuclient.ControllerDetails) error {
 		cleanupErr := b.tryCleanupController(ctx, executor, p.JobID, p.ControllerName)
 		if cleanupErr == nil {
-			return errors.E(fmt.Errorf("error post-bootstrap: %w\n"+
-				"the controller has been automatically destroyed", err))
+			return fmt.Errorf("error post-bootstrap: %w\n"+
+				"the controller has been automatically destroyed", err)
 		}
 		var controllerDetailsStr string
 		if controllerDetails != nil {
@@ -432,13 +432,13 @@ func (b *BootstrapManager) runBootstrap(
 
 		zapctx.Error(ctx, "failed to cleanup controller after failing to add it to JIMM",
 			zap.NamedError("BootstrapError", err), zap.NamedError("CleanupError", cleanupErr))
-		return errors.E(fmt.Errorf("error post-bootstrap: %w\n"+
+		return fmt.Errorf("error post-bootstrap: %w\n"+
 			"automatic cleanup of the controller also failed: %w\n"+
 			"\n"+
 			"WARNING: resources associated with the controller may remain dangling in your environment.\n"+
 			"Manual intervention is required, either attach the controller to JIMM or destroy it.\n"+
 			"\n"+
-			"Controller details:\n%s", err, cleanupErr, controllerDetailsStr))
+			"Controller details:\n%s", err, cleanupErr, controllerDetailsStr)
 
 	}
 
@@ -498,7 +498,7 @@ func (b *BootstrapManager) tryCleanupController(ctx context.Context, jujuCmd Juj
 		},
 	)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to run destroy-controller command: %w", err))
+		return fmt.Errorf("failed to run destroy-controller command: %w", err)
 	}
 
 	err = b.consumeCommandOutput(ctx, outputCh, jobID)
@@ -513,7 +513,7 @@ func (b *BootstrapManager) consumeCommandOutput(ctx context.Context, outputCh <-
 	for output := range outputCh {
 		if output.Err != nil {
 			b.writeJobLog(ctx, jobId, output.Err.Error())
-			return errors.E(fmt.Errorf("command failed: %w", output.Err))
+			return fmt.Errorf("command failed: %w", output.Err)
 		}
 		zapctx.Debug(ctx, "command output", zap.Int64("job-id", jobId), zap.String("line", output.Line))
 		b.writeJobLog(ctx, jobId, output.Line)
@@ -549,7 +549,7 @@ func (b *BootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 
 	job, err := b.jobQueue.EnqueueDestroyController(ctx, destroyArgs)
 	if err != nil {
-		return 0, errors.E(fmt.Errorf("failed to start bootstrap job: %w", err))
+		return 0, fmt.Errorf("failed to start bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
 		return 0, errors.E(fmt.Errorf("a destroy job is already in progress - please wait for it to complete before starting a new one"), errors.CodeInProgress)
@@ -588,7 +588,7 @@ func (b *BootstrapManager) DestroyController(
 		},
 	)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get Juju binary: %w", err))
+		return fmt.Errorf("failed to get Juju binary: %w", err)
 	}
 	zapctx.Debug(ctx, "Juju binary downloaded, using Juju binary", zap.String("binary-path", binary.FullPath))
 	defer func() {
@@ -599,7 +599,7 @@ func (b *BootstrapManager) DestroyController(
 
 	username, password, err := b.credentialStore.GetControllerCredentials(ctx, p.ControllerName)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get controller credentials: %w", err))
+		return fmt.Errorf("failed to get controller credentials: %w", err)
 	}
 
 	// Update the context from this point to prevent it from being cancelled when the parent is cancelled.
@@ -627,7 +627,7 @@ func (b *BootstrapManager) DestroyController(
 		},
 	)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to run destroy-controller command: %w", err))
+		return fmt.Errorf("failed to run destroy-controller command: %w", err)
 	}
 	err = b.consumeCommandOutput(ctx, outputCh, p.JobID)
 	if err != nil {
@@ -638,7 +638,7 @@ func (b *BootstrapManager) DestroyController(
 	zapctx.Debug(ctx, "controller destroyed, removing from jimm")
 	err = b.jujuManager.RemoveController(ctx, user, p.ControllerName, true)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to remove controller: %w", err))
+		return fmt.Errorf("failed to remove controller: %w", err)
 	}
 
 	return nil

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -111,13 +111,13 @@ func NewBootstrapManager(
 	credentialStore CredentialStore,
 ) (*BootstrapManager, error) {
 	if store == nil {
-		return nil, errors.E("store cannot be nil")
+		return nil, errors.New("store cannot be nil")
 	}
 	if jujuManager == nil {
-		return nil, errors.E("juju manager cannot be nil")
+		return nil, errors.New("juju manager cannot be nil")
 	}
 	if binaryStore == nil {
-		return nil, errors.E("binary store cannot be nil")
+		return nil, errors.New("binary store cannot be nil")
 	}
 	// validate the JWKs endpoint URL if provided.
 	if jimmWellknownJWKSEndpoint != "" {
@@ -127,10 +127,10 @@ func NewBootstrapManager(
 		}
 	}
 	if credentialStore == nil {
-		return nil, errors.E("credential store cannot be nil")
+		return nil, errors.New("credential store cannot be nil")
 	}
 	if jobQueue == nil {
-		return nil, errors.E("job queue cannot be nil")
+		return nil, errors.New("job queue cannot be nil")
 	}
 	return &BootstrapManager{
 		store:                     store,
@@ -194,7 +194,7 @@ func toParamsJobState(ctx context.Context, state rivertype.JobState) params.JobS
 func (b *BootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobID int64) error {
 
 	if user == nil {
-		return errors.E("user cannot be nil")
+		return errors.New("user cannot be nil")
 	}
 
 	_, err := b.jobQueue.CancelJob(ctx, jobID)
@@ -242,7 +242,7 @@ func (b *BootstrapManager) WaitForJobCompletion(ctx context.Context, jobId int64
 func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params BootstrapParams) (int64, error) {
 
 	if b.jimmWellknownJWKSEndpoint == "" {
-		return 0, errors.E("bootstrap login token refresh URL is not configured. Cannot proceed with bootstrap. Please configure it and try again.")
+		return 0, errors.New("bootstrap login token refresh URL is not configured. Cannot proceed with bootstrap. Please configure it and try again.")
 	}
 
 	if err := params.validate(); err != nil {
@@ -331,7 +331,7 @@ func (b *BootstrapManager) BootstrapController(
 	// Lock the bootstrap concurrently with destroy to avoid misuse of the store commands.
 	isLocked := jujuCLILock.TryLock()
 	if !isLocked {
-		return errors.E("another bootstrap or destroy operation is currently running, please wait for it to finish before starting a new one")
+		return errors.New("another bootstrap or destroy operation is currently running, please wait for it to finish before starting a new one")
 	}
 	defer jujuCLILock.Unlock()
 
@@ -569,7 +569,7 @@ func (b *BootstrapManager) DestroyController(
 	// Lock the destroy concurrently with bootstrap to avoid misuse of the store commands.
 	isLocked := jujuCLILock.TryLock()
 	if !isLocked {
-		return errors.E("another bootstrap or destroy operation is currently running, please wait for it to finish before starting a new one")
+		return errors.New("another bootstrap or destroy operation is currently running, please wait for it to finish before starting a new one")
 	}
 	defer jujuCLILock.Unlock()
 

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -242,7 +242,7 @@ func (s *bootstrapManagerSuite) TestGetJobInfo_JobNotFound(c *qt.C) {
 	manager, err := bootstrap.NewBootstrapManager(mocks.store, mocks.jobQueue, mocks.jujuManager, mocks.binaryStore, loginTokenRefreshURLParam, mocks.credentialStore)
 	c.Assert(err, qt.IsNil)
 
-	mocks.jobQueue.EXPECT().GetJobInfo(gomock.Any(), jobID).Return(nil, errors.E("not found"))
+	mocks.jobQueue.EXPECT().GetJobInfo(gomock.Any(), jobID).Return(nil, errors.New("not found"))
 
 	_, err = manager.GetJobInfo(ctx, s.adminUser, jobID, 0)
 	c.Assert(err, qt.ErrorMatches, "failed to get job info: .*")
@@ -293,7 +293,7 @@ func (s *bootstrapManagerSuite) TestWaitForJobCompletion_JobNotFound(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	jobID := int64(3)
-	mocks.jobQueue.EXPECT().WaitForJobCompletion(gomock.Any(), jobID).Return(nil, errors.E("not found"))
+	mocks.jobQueue.EXPECT().WaitForJobCompletion(gomock.Any(), jobID).Return(nil, errors.New("not found"))
 
 	err = manager.WaitForJobCompletion(ctx, jobID, bootstrap.WaitConfig{})
 	c.Assert(err, qt.ErrorMatches, ".*error while waiting for job completion: not found")
@@ -349,7 +349,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -477,7 +477,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ControllerRetrievalFails(c *qt.
 	mocks.store.EXPECT().GetController(
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
-	).Return(errors.E("oh noes, we couldnt'se get the controller"))
+	).Return(errors.New("oh noes, we couldnt'se get the controller"))
 
 	err = manager.BootstrapController(testCtx, p, mocks.commandFactory, user)
 	c.Assert(err, qt.ErrorMatches, "failed to check if controller exists: oh noes, we couldnt'se get the controller")
@@ -500,7 +500,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -512,7 +512,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 	).Return(
 		nil,
-		errors.E("test error"),
+		errors.New("test error"),
 	)
 
 	err = manager.BootstrapController(testCtx, p, mocks.commandFactory, user)
@@ -538,7 +538,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -571,7 +571,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 		}(),
 		mocks.clientStore,
 		func() {},
-		errors.E("executor test error"),
+		errors.New("executor test error"),
 	)
 	mocks.commandFactory.EXPECT().New(binaryPath, p.JujuDataDir).
 		Return(mocks.executor)
@@ -600,7 +600,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -667,7 +667,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -726,7 +726,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 	)
 	mocks.clientStore.EXPECT().AccountDetails(p.ControllerName).Return(
 		nil,
-		errors.E("client store failed to get account details"),
+		errors.New("client store failed to get account details"),
 	)
 	mocks.executor.EXPECT().DestroyController(
 		gomock.Any(),
@@ -770,7 +770,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -829,7 +829,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 	)
 	mocks.clientStore.EXPECT().AccountDetails(p.ControllerName).Return(
 		nil,
-		errors.E("account details test error"),
+		errors.New("account details test error"),
 	)
 	mocks.executor.EXPECT().DestroyController(
 		gomock.Any(),
@@ -873,7 +873,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -957,7 +957,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		},
 		gomock.Any(),
 	).Return(
-		errors.E("add controller test error"),
+		errors.New("add controller test error"),
 	)
 	mocks.executor.EXPECT().DestroyController(
 		gomock.Any(),
@@ -1001,7 +1001,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1064,7 +1064,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		nil,
 	)
 	mocks.jujuManager.EXPECT().AddController(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		errors.E("add controller test error"),
+		errors.New("add controller test error"),
 	)
 	mocks.executor.EXPECT().DestroyController(
 		gomock.Any(),
@@ -1073,7 +1073,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		},
 	).Return(
 		nil,
-		errors.E("cleanup controller test failure"),
+		errors.New("cleanup controller test failure"),
 	)
 
 	err = manager.BootstrapController(testCtx, p, mocks.commandFactory, user)
@@ -1102,7 +1102,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.E("test err")),
+		errors.E(errors.CodeNotFound, errors.New("test err")),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -349,7 +349,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -500,7 +500,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -538,7 +538,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -600,7 +600,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -667,7 +667,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -770,7 +770,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -873,7 +873,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1001,7 +1001,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1102,7 +1102,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, errors.New("test err")),
+		errors.E(errors.CodeNotFound, "test error"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -23,10 +23,10 @@ type GroupManager struct {
 // creation, modification, and removal.
 func NewGroupManager(store *db.Database, authSvc *openfga.OFGAClient) (*GroupManager, error) {
 	if store == nil {
-		return nil, errors.E("group store cannot be nil")
+		return nil, errors.New("group store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("group authorisation service cannot be nil")
+		return nil, errors.New("group authorisation service cannot be nil")
 	}
 	return &GroupManager{store, authSvc}, nil
 }

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -21,10 +21,10 @@ type IdentityManager struct {
 // NewIdentityManager returns a new identityManager that persists the roles in the provided store.
 func NewIdentityManager(store *db.Database, authSvc *openfga.OFGAClient) (*IdentityManager, error) {
 	if store == nil {
-		return nil, errors.E("identity store cannot be nil")
+		return nil, errors.New("identity store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("identity authorisation service cannot be nil")
+		return nil, errors.New("identity authorisation service cannot be nil")
 	}
 	return &IdentityManager{store, authSvc}, nil
 }

--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -102,43 +102,43 @@ type Parameters struct {
 
 func (p *Parameters) Validate() error {
 	if p.Database == nil {
-		return errors.E("missing database")
+		return errors.New("missing database")
 	}
 
 	if p.Dialer == nil {
-		return errors.E("missing dialer")
+		return errors.New("missing dialer")
 	}
 
 	if p.CredentialStore == nil {
-		return errors.E("missing credential store")
+		return errors.New("missing credential store")
 	}
 
 	if p.Pubsub == nil {
-		return errors.E("missing pubsub hub")
+		return errors.New("missing pubsub hub")
 	}
 
 	if p.UUID == "" {
-		return errors.E("missing uuid")
+		return errors.New("missing uuid")
 	}
 
 	if p.OpenFGAClient == nil {
-		return errors.E("missing openfga client")
+		return errors.New("missing openfga client")
 	}
 
 	if p.JWTService == nil {
-		return errors.E("missing jwt service")
+		return errors.New("missing jwt service")
 	}
 
 	if p.OAuthAuthenticator == nil {
-		return errors.E("missing oauth authenticator")
+		return errors.New("missing oauth authenticator")
 	}
 
 	if p.MigrationTokenGenerator == nil {
-		return errors.E("missing migration token generator")
+		return errors.New("missing migration token generator")
 	}
 
 	if p.CrossModelQueryTimeout <= 0 {
-		return errors.E("missing cross model query timeout")
+		return errors.New("missing cross model query timeout")
 	}
 
 	return nil

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -31,7 +31,7 @@ type JobManager struct {
 // abilities for asynchronous jobs within JIMM.
 func NewJobManager(jobQuerier JobQuerier) (*JobManager, error) {
 	if jobQuerier == nil {
-		return nil, errors.E("job querier cannot be nil")
+		return nil, errors.New("job querier cannot be nil")
 
 	}
 	return &JobManager{jobQuerier}, nil

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -75,7 +75,7 @@ func TestGetJobInfo_QueryError(t *testing.T) {
 	jobID := int64(123)
 
 	deps.jobQuerier.EXPECT().GetJobInfo(gomock.Any(), int64(123)).
-		Return(nil, errors.E("query error"))
+		Return(nil, errors.New("query error"))
 
 	_, err := deps.jobManager.GetJobInfo(ctx, jobID)
 	c.Assert(err, quicktest.IsNotNil)

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -289,19 +289,19 @@ func (j *JujuManager) listApplicationOfferUsers(ctx context.Context, offer names
 	return userDetails, nil
 }
 
-var noApplicationOfferAccessError = errors.E("no application offer access")
+var noApplicationOfferAccessError = errors.New("no application offer access")
 
 // enrichOfferDetails replaces fields on an application offer's details with information
 // where JIMM is authoritative. It returns a noApplicationOfferAccessError if the user
 // does not have access to the offer.
 func (j *JujuManager) enrichOfferDetails(ctx context.Context, user *openfga.User, offerDetail *crossmodel.ApplicationOfferDetails) error {
 	if offerDetail == nil {
-		return errors.E("offerDetail cannot be nil")
+		return errors.New("offerDetail cannot be nil")
 	}
 	// TODO (alesstimec) Optimize this: currently check all possible
 	// permission levels for an offer, this is suboptimal.
 	if !names.IsValidApplicationOffer(offerDetail.OfferUUID) {
-		return errors.E("invalid application offer UUID")
+		return errors.New("invalid application offer UUID")
 	}
 	offerTag := names.NewApplicationOfferTag(offerDetail.OfferUUID)
 	accessLevel, err := j.getUserOfferAccess(ctx, user, offerTag)
@@ -487,7 +487,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 	controllers := make(map[uint]*dbmodel.Controller)
 	for _, f := range filters {
 		if f.ModelName == "" {
-			return nil, errors.E("application offer filter must specify a model name")
+			return nil, errors.New("application offer filter must specify a model name")
 		}
 		if f.OwnerName == "" {
 			f.OwnerName = user.Name

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -55,7 +55,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 
 	isAdmin, err := openfga.IsAdministrator(ctx, user, model.ResourceTag())
 	if err != nil {
-		return errors.E(fmt.Errorf("failed administrator check: %w", err))
+		return fmt.Errorf("failed administrator check: %w", err)
 	}
 	if !isAdmin {
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
@@ -112,7 +112,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 
 	createdAppOffer, err := api.GetApplicationOffer(ctx, offerURL.String())
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to fetch details of the created application offer: %w", err))
+		return fmt.Errorf("failed to fetch details of the created application offer: %w", err)
 	}
 
 	doc := dbmodel.ApplicationOffer{
@@ -128,7 +128,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return nil
 	})
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to store the created application offer: %w", err))
+		return fmt.Errorf("failed to store the created application offer: %w", err)
 	}
 
 	if err := j.OpenFGAClient.AddModelApplicationOffer(
@@ -418,21 +418,21 @@ func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offe
 func (j *JujuManager) getUserOfferAccess(ctx context.Context, user *openfga.User, offerTag names.ApplicationOfferTag) (string, error) {
 	isOfferAdmin, err := openfga.IsAdministrator(ctx, user, offerTag)
 	if err != nil {
-		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
+		return "", fmt.Errorf("openfga check failed: %w", err)
 	}
 	if isOfferAdmin {
 		return string(jujuparams.OfferAdminAccess), nil
 	}
 	isOfferConsumer, err := user.IsApplicationOfferConsumer(ctx, offerTag)
 	if err != nil {
-		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
+		return "", fmt.Errorf("openfga check failed: %w", err)
 	}
 	if isOfferConsumer {
 		return string(jujuparams.OfferConsumeAccess), nil
 	}
 	isOfferReader, err := user.IsApplicationOfferReader(ctx, offerTag)
 	if err != nil {
-		return "", errors.E(fmt.Errorf("openfga check failed: %w", err))
+		return "", fmt.Errorf("openfga check failed: %w", err)
 	}
 	if isOfferReader {
 		return string(jujuparams.OfferReadAccess), nil

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -779,7 +779,7 @@ func TestOffer(t *testing.T) {
 			return nil, nil
 		},
 		offer: func(context.Context, jujuclient.OfferParams) error {
-			return errors.E("a silly error")
+			return errors.New("a silly error")
 		},
 		createEnv: func(c *qt.C, db *db.Database, client *openfga.OFGAClient) (dbmodel.Identity, juju.AddApplicationOfferParams, dbmodel.ApplicationOffer, func(*qt.C, error)) {
 			ctx := context.Background()
@@ -1063,7 +1063,7 @@ func TestOffer(t *testing.T) {
 	}, {
 		about: "fail to fetch application offer details",
 		getApplicationOffer: func(ctx context.Context, s string) (*crossmodel.ApplicationOfferDetails, error) {
-			return nil, errors.E("a silly error")
+			return nil, errors.New("a silly error")
 		},
 		offer: func(context.Context, jujuclient.OfferParams) error {
 			return nil
@@ -1150,7 +1150,7 @@ func TestOffer(t *testing.T) {
 			return nil, nil
 		},
 		offer: func(context.Context, jujuclient.OfferParams) error {
-			return errors.E("application offer already exists")
+			return errors.New("application offer already exists")
 		},
 		createEnv: func(c *qt.C, db *db.Database, client *openfga.OFGAClient) (dbmodel.Identity, juju.AddApplicationOfferParams, dbmodel.ApplicationOffer, func(*qt.C, error)) {
 			ctx := context.Background()

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -70,7 +70,7 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 	}
 
 	if ctrlCount == 0 {
-		return errors.E("no controllers registered")
+		return errors.New("no controllers registered")
 	}
 
 	clouds, err := j.Database.GetClouds(ctx)

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -66,7 +66,7 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 
 	ctrlCount, err := j.Database.CountControllers(ctx)
 	if err != nil {
-		return errors.E(fmt.Errorf("cannot get count controllers: %w", err))
+		return fmt.Errorf("cannot get count controllers: %w", err)
 	}
 
 	if ctrlCount == 0 {

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -656,7 +656,7 @@ var addHostedCloudTests = []struct {
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:      "DialError",
-	dialError: errors.E("dial error"),
+	dialError: errors.New("dial error"),
 	username:  "alice@canonical.com",
 	cloudName: "new-cloud",
 	cloud: jujucloud.Cloud{
@@ -671,7 +671,7 @@ var addHostedCloudTests = []struct {
 }, {
 	name: "AddCloudError",
 	addCloud: func(names.CloudTag, jujucloud.Cloud, bool) error {
-		return errors.E("addcloud error")
+		return errors.New("addcloud error")
 	},
 	username:  "alice@canonical.com",
 	cloudName: "new-cloud",
@@ -917,7 +917,7 @@ var addHostedCloudToControllerTests = []struct {
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:           "DialError",
-	dialError:      errors.E("dial error"),
+	dialError:      errors.New("dial error"),
 	username:       "alice@canonical.com",
 	controllerName: "test-controller",
 	cloudName:      "new-cloud",
@@ -933,7 +933,7 @@ var addHostedCloudToControllerTests = []struct {
 }, {
 	name: "AddCloudError",
 	addCloud: func(names.CloudTag, jujucloud.Cloud, bool) error {
-		return errors.E("addcloud error")
+		return errors.New("addcloud error")
 	},
 	username:       "alice@canonical.com",
 	controllerName: "test-controller",
@@ -1050,7 +1050,7 @@ var removeCloudTests = []struct {
 	env:  removeCloudTestEnv,
 	removeCloud: func(ct names.CloudTag) error {
 		if ct.Id() != "test" {
-			return errors.E("bad cloud tag")
+			return errors.New("bad cloud tag")
 		}
 		return nil
 	},
@@ -1066,7 +1066,7 @@ var removeCloudTests = []struct {
 }, {
 	name:        "DialError",
 	env:         removeCloudTestEnv,
-	dialError:   errors.E("test dial error"),
+	dialError:   errors.New("test dial error"),
 	username:    "alice@canonical.com",
 	cloud:       "test",
 	expectError: `test dial error`,
@@ -1074,7 +1074,7 @@ var removeCloudTests = []struct {
 	name: "APIError",
 	env:  removeCloudTestEnv,
 	removeCloud: func(mt names.CloudTag) error {
-		return errors.E("test error")
+		return errors.New("test error")
 	},
 	username:    "alice@canonical.com",
 	cloud:       "test",
@@ -1248,7 +1248,7 @@ var updateCloudTests = []struct {
 		env:  updateCloudTestEnv,
 		updateCloud: func(ct names.CloudTag, c jujucloud.Cloud) error {
 			if ct.Id() != "test" {
-				return errors.E("bad cloud tag")
+				return errors.New("bad cloud tag")
 			}
 			return nil
 		},
@@ -1296,7 +1296,7 @@ var updateCloudTests = []struct {
 	}, {
 		name:        "DialError",
 		env:         updateCloudTestEnv,
-		dialError:   errors.E("test dial error"),
+		dialError:   errors.New("test dial error"),
 		username:    "alice@canonical.com",
 		cloud:       "test",
 		expectError: `test dial error`,
@@ -1304,7 +1304,7 @@ var updateCloudTests = []struct {
 		name: "APIError",
 		env:  updateCloudTestEnv,
 		updateCloud: func(names.CloudTag, jujucloud.Cloud) error {
-			return errors.E("test error")
+			return errors.New("test error")
 		},
 		username:    "alice@canonical.com",
 		cloud:       "test",
@@ -1433,7 +1433,7 @@ var removeCloudFromControllerTests = []struct {
 	env:  removeCloudFromControllerTestEnv,
 	removeCloud: func(ct names.CloudTag) error {
 		if ct.Id() != "test" {
-			return errors.E("bad cloud tag")
+			return errors.New("bad cloud tag")
 		}
 		return nil
 	},
@@ -1457,7 +1457,7 @@ var removeCloudFromControllerTests = []struct {
 	env:  removeCloudFromControllerTestEnv,
 	removeCloud: func(ct names.CloudTag) error {
 		if ct.Id() != "test-cloud-2" {
-			return errors.E("bad cloud tag")
+			return errors.New("bad cloud tag")
 		}
 		return nil
 	},
@@ -1482,7 +1482,7 @@ var removeCloudFromControllerTests = []struct {
 }, {
 	name:           "DialError",
 	env:            removeCloudFromControllerTestEnv,
-	dialError:      errors.E("test dial error"),
+	dialError:      errors.New("test dial error"),
 	username:       "alice@canonical.com",
 	cloud:          "test",
 	controllerName: "controller-2",
@@ -1491,7 +1491,7 @@ var removeCloudFromControllerTests = []struct {
 	name: "APIError",
 	env:  removeCloudFromControllerTestEnv,
 	removeCloud: func(mt names.CloudTag) error {
-		return errors.E("test error")
+		return errors.New("test error")
 	},
 	username:       "alice@canonical.com",
 	cloud:          "test",

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -285,7 +285,7 @@ func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel
 		cloud = ct.Id()
 	}
 
-	errStop := errors.E("stop")
+	errStop := errors.New("stop")
 	var iterErr error
 	err := j.Database.ForEachCloudCredential(ctx, u.Name, cloud, func(cred *dbmodel.CloudCredential) error {
 		iterErr = f(cred)

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -225,10 +225,10 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 func (j *JujuManager) updateCredential(ctx context.Context, credential *dbmodel.CloudCredential, attr map[string]string) error {
 
 	if err := j.Database.SetCloudCredential(ctx, credential); err != nil {
-		return errors.E(fmt.Errorf("failed to store credential id: %w", err))
+		return fmt.Errorf("failed to store credential id: %w", err)
 	}
 	if err := j.CredentialStore.Put(ctx, credential.ResourceTag(), attr); err != nil {
-		return errors.E(fmt.Errorf("failed to store credentials: %w", err))
+		return fmt.Errorf("failed to store credentials: %w", err)
 	}
 
 	return nil

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -163,7 +163,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 	}, {
 		about:                  "update credential error returned by controller",
 		jimmAdmin:              true,
-		updateCredentialErrors: []error{nil, errors.E("test error")},
+		updateCredentialErrors: []error{nil, errors.New("test error")},
 		createEnv: func(c *qt.C, j *juju.JujuManager) (*dbmodel.Identity, juju.UpdateCloudCredentialArgs, dbmodel.CloudCredential, string) {
 			u, err := dbmodel.NewIdentity("alice@canonical.com")
 			c.Assert(err, qt.IsNil)
@@ -259,7 +259,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 	}, {
 		about:                  "check credential error returned by controller",
 		jimmAdmin:              true,
-		checkCredentialErrors:  []error{errors.E("test error")},
+		checkCredentialErrors:  []error{errors.New("test error")},
 		updateCredentialErrors: []error{nil},
 		createEnv: func(c *qt.C, j *juju.JujuManager) (*dbmodel.Identity, juju.UpdateCloudCredentialArgs, dbmodel.CloudCredential, string) {
 			u, err := dbmodel.NewIdentity("alice@canonical.com")
@@ -475,7 +475,7 @@ func TestUpdateCloudCredential(t *testing.T) {
 		},
 	}, {
 		about:                 "skip check, which would return an error",
-		checkCredentialErrors: []error{errors.E("test error")},
+		checkCredentialErrors: []error{errors.New("test error")},
 		jimmAdmin:             true,
 		createEnv: func(c *qt.C, j *juju.JujuManager) (*dbmodel.Identity, juju.UpdateCloudCredentialArgs, dbmodel.CloudCredential, string) {
 			u, err := dbmodel.NewIdentity("alice@canonical.com")
@@ -1138,7 +1138,7 @@ func TestRevokeCloudCredential(t *testing.T) {
 		},
 	}, {
 		about:                  "error revoking credential on controller",
-		revokeCredentialErrors: []error{errors.E("test error")},
+		revokeCredentialErrors: []error{errors.New("test error")},
 		createEnv: func(c *qt.C, j *juju.JujuManager, client *openfga.OFGAClient) (*dbmodel.Identity, names.CloudCredentialTag, string) {
 			u, err := dbmodel.NewIdentity("alice@canonical.com")
 			c.Assert(err, qt.IsNil)

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -406,7 +406,7 @@ func (m *modelImporter) setModelOwner(ctx context.Context) error {
 	}
 
 	if ownerTag.IsLocal() {
-		return errors.E("cannot import model from local user, try --owner to switch the model owner")
+		return errors.New("cannot import model from local user, try --owner to switch the model owner")
 	}
 	owner := dbmodel.Identity{}
 	owner.SetTag(ownerTag)
@@ -477,7 +477,7 @@ func (m *modelImporter) setModelCloud(ctx context.Context) error {
 	if m.modelInfo.CloudRegion != "" {
 		cr := cloud.Region(m.modelInfo.CloudRegion)
 		if cr.Name != m.modelInfo.CloudRegion {
-			return errors.E("cloud region not found")
+			return errors.New("cloud region not found")
 		}
 
 		m.model.CloudRegionID = cr.ID

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -206,13 +206,13 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	api, err := j.dialController(ctx, ctl, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial the controller: %v", err))
+		return fmt.Errorf("failed to dial the controller: %v", err)
 	}
 	defer api.Close()
 
 	cloudSpec, err := api.CloudSpec(ctx)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get model summary: %v", err))
+		return fmt.Errorf("failed to get model summary: %v", err)
 	}
 
 	ctl.CloudName = cloudSpec.Name
@@ -253,7 +253,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 			return errors.E(err, fmt.Sprintf("controller %q already exists", ctl.Name))
 		}
 
-		return errors.E(fmt.Errorf("failed to add controller: %w", err))
+		return fmt.Errorf("failed to add controller: %w", err)
 	}
 
 	for _, cloud := range dbClouds {
@@ -614,7 +614,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	model.InternalMigrationSuccess(targetController.ID)
 	err = j.Database.UpdateModel(ctx, &model)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to update model: %w", err))
+		return fmt.Errorf("failed to update model: %w", err)
 	}
 
 	return nil
@@ -674,7 +674,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		}
 
 		if model.MigrationMode != dbmodel.MigrationModeNone {
-			return errors.E(fmt.Errorf("model is already in migration mode %q", model.MigrationMode))
+			return fmt.Errorf("model is already in migration mode %q", model.MigrationMode)
 		}
 
 		if internalMigration {
@@ -686,7 +686,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		return tx.UpdateModel(ctx, &model)
 	})
 	if err != nil {
-		return result, errors.E(fmt.Errorf("failed to update the model's migration mode: %v", err))
+		return result, fmt.Errorf("failed to update the model's migration mode: %v", err)
 	}
 
 	// Until we have better handling for partial failures we try to revert

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1139,7 +1139,7 @@ func TestUpdateMigratedModel(t *testing.T) {
 		model:            names.NewModelTag("00000002-0000-0000-0000-000000000002"),
 		targetController: "controller-2",
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
-			return jujuclient.ModelInfo{}, errors.E("an error")
+			return jujuclient.ModelInfo{}, errors.New("an error")
 		},
 		expectedError: "an error",
 		jimmAdmin:     true,
@@ -1335,7 +1335,7 @@ func TestInitiateMigration(t *testing.T) {
 			},
 		},
 		initiateMigrationResults: []result{{
-			err: errors.E("mocked error"),
+			err: errors.New("mocked error"),
 		}},
 		expectedError: "mocked error",
 	}, {

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -308,12 +308,12 @@ func (j *JujuManager) PrepareModelMigration(
 		return nil
 	})
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to add incoming model migration details: %w", err))
+		return "", fmt.Errorf("failed to add incoming model migration details: %w", err)
 	}
 
 	migrationToken, err := j.migrationTokenGenerator.NewMigrationToken(ctx, user.Name)
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to generate migration token: %w", err))
+		return "", fmt.Errorf("failed to generate migration token: %w", err)
 	}
 
 	return migrationToken, nil

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -206,7 +206,7 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 		return jujuparams.MigrationTargetInfo{}, 0, err
 	}
 	if adminUser == "" || adminPass == "" {
-		return jujuparams.MigrationTargetInfo{}, 0, errors.E("missing target controller credentials")
+		return jujuparams.MigrationTargetInfo{}, 0, errors.New("missing target controller credentials")
 	}
 	// Should we verify controller can access the cloud where the model is currently hosted?
 	apiControllerInfo := dbController.ToAPIControllerInfo()
@@ -236,15 +236,15 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 	if err != nil {
 		s := strings.Split(modelNameOrUUID, "/")
 		if len(s) != 2 {
-			return jujuparams.InitiateMigrationResult{}, errors.E("invalid model target")
+			return jujuparams.InitiateMigrationResult{}, errors.New("invalid model target")
 		}
 
 		owner, name := s[0], s[1]
 		if !names.IsValidUser(owner) {
-			return jujuparams.InitiateMigrationResult{}, errors.E("invalid user name")
+			return jujuparams.InitiateMigrationResult{}, errors.New("invalid user name")
 		}
 		if !names.IsValidModelName(name) {
-			return jujuparams.InitiateMigrationResult{}, errors.E("invalid model name")
+			return jujuparams.InitiateMigrationResult{}, errors.New("invalid model name")
 		}
 
 		model.Name = name
@@ -292,7 +292,7 @@ func (j *JujuManager) PrepareModelMigration(
 		}
 		err := d.GetModel(ctx, model)
 		if err == nil {
-			return errors.E("model migration for the specified model is already in progress/completed")
+			return errors.New("model migration for the specified model is already in progress/completed")
 		} else if errors.ErrorCode(err) != errors.CodeNotFound {
 			return err
 		}

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -42,25 +42,25 @@ func NewJujuManager(
 	migrationTokenGenerator MigrationTokenGenerator,
 ) (*JujuManager, error) {
 	if store == nil {
-		return nil, errors.E("role store cannot be nil")
+		return nil, errors.New("role store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("role authorisation service cannot be nil")
+		return nil, errors.New("role authorisation service cannot be nil")
 	}
 	if credentialStore == nil {
-		return nil, errors.E("credential store cannot be nil")
+		return nil, errors.New("credential store cannot be nil")
 	}
 	if permissionManager == nil {
-		return nil, errors.E("permission manager cannot be nil")
+		return nil, errors.New("permission manager cannot be nil")
 	}
 	if resourceTag.Id() == "" {
-		return nil, errors.E("invalid jimm controller tag")
+		return nil, errors.New("invalid jimm controller tag")
 	}
 	if crossModelQueryTimeout <= 0 {
-		return nil, errors.E("cross model query timeout must be greater than 0")
+		return nil, errors.New("cross model query timeout must be greater than 0")
 	}
 	if migrationTokenGenerator == nil {
-		return nil, errors.E("migration token generator cannot be nil")
+		return nil, errors.New("migration token generator cannot be nil")
 	}
 	return &JujuManager{
 		Database:                store,

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -44,18 +44,18 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+		return fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	err = api.Abort(modelUUID)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to abort migration: %w", err))
+		return fmt.Errorf("failed to abort migration: %w", err)
 	}
 
 	err = j.Database.DeleteIncomingModelMigration(ctx, &incomingModel)
@@ -97,18 +97,18 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to get model migration %q: %w", modelUUID, err))
+		return nil, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return nil, fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	machineErrors, err := api.CheckMachines(modelUUID)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to check machines: %w", err))
+		return nil, fmt.Errorf("failed to check machines: %w", err)
 	}
 	return machineErrors, nil
 }
@@ -129,7 +129,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
 		}
-		return ControllerConnectionDetails{}, errors.E(fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err))
+		return ControllerConnectionDetails{}, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err)
 	}
 
 	username, password, err := j.CredentialStore.GetControllerCredentials(ctx, incomingModel.TargetController.Name)
@@ -159,32 +159,32 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get model migration %q: %w", model.UUID, err))
+		return fmt.Errorf("failed to get model migration %q: %w", model.UUID, err)
 	}
 
 	targetControllerVersion, err := version.Parse(incomingModel.TargetController.AgentVersion)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to parse target controller agent version %q: %w", incomingModel.TargetController.AgentVersion, err))
+		return fmt.Errorf("failed to parse target controller agent version %q: %w", incomingModel.TargetController.AgentVersion, err)
 	}
 
 	modelDescription, err := description.Deserialize(model.RawModelDescription, targetControllerVersion)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to deserialize model description: %w", err))
+		return fmt.Errorf("failed to deserialize model description: %w", err)
 	}
 
 	err = j.validateUserMapping(modelDescription, incomingModel.UserMapping)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to validate user mapping: %w", err))
+		return fmt.Errorf("failed to validate user mapping: %w", err)
 	}
 
 	model.Owner, err = j.modifyMigrationInfo(modelDescription, incomingModel.UserMapping)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to modify migration info: %w", err))
+		return fmt.Errorf("failed to modify migration info: %w", err)
 	}
 
 	_, err = j.Database.FindRegionByCloudName(ctx, modelDescription.CloudCredential().Cloud(), modelDescription.CloudRegion())
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to find region for cloud %q: %w", modelDescription.CloudCredential().Cloud(), err))
+		return fmt.Errorf("failed to find region for cloud %q: %w", modelDescription.CloudCredential().Cloud(), err)
 	}
 
 	cloudCredential := &dbmodel.CloudCredential{
@@ -200,13 +200,13 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 
 	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	serializedModel, err := modelDescription.Serialize()
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to serialize model description: %w", err))
+		return fmt.Errorf("failed to serialize model description: %w", err)
 	}
 	err = api.Prechecks(jujuparams.MigrationModelInfo{
 		UUID:                   model.UUID,
@@ -217,7 +217,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 		ModelDescription:       serializedModel,
 	})
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to run pre-checks for migration: %w", err))
+		return fmt.Errorf("failed to run pre-checks for migration: %w", err)
 	}
 	return nil
 }
@@ -273,18 +273,18 @@ func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, mo
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err))
+		return fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err)
 	}
 
 	api, err := j.dialController(ctx, &model.Controller, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	err = api.AdoptResources(modelUUID, sourceControllerVersion)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to adopt resources: %w", err))
+		return fmt.Errorf("failed to adopt resources: %w", err)
 	}
 	return nil
 }
@@ -304,16 +304,16 @@ func (j *JujuManager) modifyMigrationInfo(model description.Model, userMapping d
 	if !ok {
 		// If the owner is not found in the user mappings, we return an error.
 		// This is to ensure that the migration does not proceed with an invalid owner.
-		return names.UserTag{}, errors.E(fmt.Errorf("no external user mapping found for local user %q", model.Owner().Id()))
+		return names.UserTag{}, fmt.Errorf("no external user mapping found for local user %q", model.Owner().Id())
 	}
 	if !names.IsValidUser(newOwner) {
-		return names.UserTag{}, errors.E(fmt.Errorf("invalid external user mapping %q for local user %q", newOwner, model.Owner().Id()))
+		return names.UserTag{}, fmt.Errorf("invalid external user mapping %q for local user %q", newOwner, model.Owner().Id())
 	}
 
 	newOwnerTag := names.NewUserTag(newOwner)
 	err := modifyModelDescription(model, userMapping)
 	if err != nil {
-		return names.UserTag{}, errors.E(fmt.Errorf("failed to modify model description: %w", err))
+		return names.UserTag{}, fmt.Errorf("failed to modify model description: %w", err)
 	}
 	return newOwnerTag, nil
 }
@@ -326,7 +326,7 @@ func modifyModelDescription(modelDescription description.Model, userMapping dbmo
 		// If the owner is a local user, we replace it with the external mapping.
 		newOwner, ok := userMapping[modelDescription.Owner().Id()]
 		if !ok {
-			return errors.E(fmt.Errorf("no external user mapping found for local user %q", modelDescription.Owner().Id()))
+			return fmt.Errorf("no external user mapping found for local user %q", modelDescription.Owner().Id())
 		}
 		modelDescription.SetOwner(names.NewUserTag(newOwner))
 	}
@@ -339,18 +339,18 @@ func modifyModelDescription(modelDescription description.Model, userMapping dbmo
 		return fmt.Errorf("model description must contain a cloud credential")
 	}
 	if !names.IsValidCloud(credentials.Cloud()) {
-		return errors.E(fmt.Errorf("invalid cloud name %q", credentials.Cloud()))
+		return fmt.Errorf("invalid cloud name %q", credentials.Cloud())
 	}
 	cloudTag := names.NewCloudTag(credentials.Cloud())
 
 	if !names.IsValidUser(credentials.Owner()) {
-		return errors.E(fmt.Errorf("invalid cloud credential owner %q", credentials.Owner()))
+		return fmt.Errorf("invalid cloud credential owner %q", credentials.Owner())
 	}
 	ownerTag := names.NewUserTag(credentials.Owner())
 	if ownerTag.IsLocal() {
 		newOwner, ok := userMapping[ownerTag.Id()]
 		if !ok {
-			return errors.E(fmt.Errorf("no external user mapping found for cloud credential local user %q", modelDescription.Owner().Id()))
+			return fmt.Errorf("no external user mapping found for cloud credential local user %q", modelDescription.Owner().Id())
 		}
 		ownerTag = names.NewUserTag(newOwner)
 	}
@@ -377,18 +377,18 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, user *openfga.User, mod
 	}
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
-		return time.Time{}, errors.E(fmt.Errorf("failed to get model %q: %w", modelUUID, err))
+		return time.Time{}, fmt.Errorf("failed to get model %q: %w", modelUUID, err)
 	}
 
 	api, err := j.dialController(ctx, &model.Controller, user)
 	if err != nil {
-		return time.Time{}, errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return time.Time{}, fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	t, err := api.LatestLogTime(modelUUID)
 	if err != nil {
-		return time.Time{}, errors.E(fmt.Errorf("failed to get latest log time for model %q: %w", modelUUID, err))
+		return time.Time{}, fmt.Errorf("failed to get latest log time for model %q: %w", modelUUID, err)
 	}
 	return t, nil
 }
@@ -405,17 +405,17 @@ func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag
 	}
 	err := j.Database.GetIncomingModelMigration(ctx, &modelMigration)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err))
+		return fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err)
 	}
 	api, err := j.dialController(ctx, &modelMigration.TargetController, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	err = api.Activate(modelTag.Id(), migrationInfo, relatedModels)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+		return fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err)
 	}
 
 	// This is done in a transaction to ensure that the model migration is only deleted
@@ -434,7 +434,7 @@ func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag
 			}
 			err = db.AddUserMapping(ctx, userMapping)
 			if err != nil {
-				return errors.E(fmt.Errorf("failed to add user mapping for model %q: %w", modelTag.Id(), err))
+				return fmt.Errorf("failed to add user mapping for model %q: %w", modelTag.Id(), err)
 			}
 		}
 		model := dbmodel.Model{
@@ -445,24 +445,24 @@ func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag
 		}
 		err = db.GetModel(ctx, &model)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to get model %q: %w", modelTag.Id(), err))
+			return fmt.Errorf("failed to get model %q: %w", modelTag.Id(), err)
 		}
 		model.MigrationMode = dbmodel.MigrationModeNone
 		model.Life = state.Alive.String()
 
 		err = db.UpdateModel(ctx, &model)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to update model %q: %w", modelTag.Id(), err))
+			return fmt.Errorf("failed to update model %q: %w", modelTag.Id(), err)
 		}
 
 		err = db.DeleteIncomingModelMigration(ctx, &modelMigration)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to delete model migration for model %q: %w", modelTag.Id(), err))
+			return fmt.Errorf("failed to delete model migration for model %q: %w", modelTag.Id(), err)
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err))
+		return fmt.Errorf("failed to activate model %q: %w", modelTag.Id(), err)
 	}
 	return nil
 }
@@ -481,7 +481,7 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	// version so that we re-encode the description correctly.
 	modelUUID, err := description.TryDetermineModelUUID(serialized.Bytes)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to determine model UUID: %w", err))
+		return fmt.Errorf("failed to determine model UUID: %w", err)
 	}
 
 	var (
@@ -504,27 +504,27 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 		noWait := false
 		err = d.GetIncomingModelMigrationWithLock(ctx, incomingMigration, noWait)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to get incoming model migration: %w", err))
+			return fmt.Errorf("failed to get incoming model migration: %w", err)
 		}
 
 		controllerVersion, err := version.Parse(incomingMigration.TargetController.AgentVersion)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to parse target controller agent version %q: %w", incomingMigration.TargetController.AgentVersion, err))
+			return fmt.Errorf("failed to parse target controller agent version %q: %w", incomingMigration.TargetController.AgentVersion, err)
 		}
 
 		modelDescription, err = description.Deserialize(serialized.Bytes, controllerVersion)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to deserialize model description: %w", err))
+			return fmt.Errorf("failed to deserialize model description: %w", err)
 		}
 
 		err = modifyModelDescription(modelDescription, incomingMigration.UserMapping)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to modify model description: %w", err))
+			return fmt.Errorf("failed to modify model description: %w", err)
 		}
 
 		model, offers, err = importFromDescription(ctx, d, incomingMigration.TargetController.ID, modelDescription)
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to import model from description: %w", err))
+			return fmt.Errorf("failed to import model from description: %w", err)
 		}
 		return nil
 	})
@@ -537,24 +537,24 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	controllerTag := incomingMigration.TargetController.ResourceTag()
 	err = j.addModelAndOfferPermissions(ctx, user, model, offers, controllerTag)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to add resource permissions: %w", err))
+		return fmt.Errorf("failed to add resource permissions: %w", err)
 	}
 
 	// Call the import method on the target controller to import the model.
 	api, err := j.dialController(ctx, &incomingMigration.TargetController, user)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial controller: %w", err))
+		return fmt.Errorf("failed to dial controller: %w", err)
 	}
 	defer api.Close()
 
 	serializedDescrition, err := modelDescription.Serialize()
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to serialize model description: %w", err))
+		return fmt.Errorf("failed to serialize model description: %w", err)
 	}
 	err = api.Import(serializedDescrition)
 	if err != nil {
 		// TODO: handle migration failure in a cleanup routine.
-		return errors.E(fmt.Errorf("failed to import model: %w", err))
+		return fmt.Errorf("failed to import model: %w", err)
 	}
 
 	return nil
@@ -568,16 +568,16 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 func importFromDescription(ctx context.Context, tx *db.Database, targetControllerID uint, description description.Model) (*dbmodel.Model, []*dbmodel.ApplicationOffer, error) {
 	modelNameStr, ok := description.Config()[config.NameKey].(string)
 	if !ok {
-		return nil, nil, errors.E(fmt.Errorf("model config must contain a string value for key %q", config.NameKey))
+		return nil, nil, fmt.Errorf("model config must contain a string value for key %q", config.NameKey)
 	}
 
 	modelUUIDStr, ok := description.Config()[config.UUIDKey].(string)
 	if !ok {
-		return nil, nil, errors.E(fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey))
+		return nil, nil, fmt.Errorf("model config must contain a string value for key %q", config.UUIDKey)
 	}
 
 	if description.CloudCredential() == nil {
-		return nil, nil, errors.E(fmt.Errorf("model description must contain a cloud credential"))
+		return nil, nil, fmt.Errorf("model description must contain a cloud credential")
 	}
 	cloudCredential := &dbmodel.CloudCredential{
 		CloudName:         description.CloudCredential().Cloud(),
@@ -611,7 +611,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 	}
 	err = tx.AddModel(ctx, &model)
 	if err != nil {
-		return nil, nil, errors.E(fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err))
+		return nil, nil, fmt.Errorf("failed to add model %q: %w", modelUUIDStr, err)
 	}
 	importedModel = &model
 
@@ -630,7 +630,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
 					return nil, nil, fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
 				}
-				return nil, nil, errors.E(fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err))
+				return nil, nil, fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err)
 			}
 
 			importedOffers = append(importedOffers, &dbOffer)
@@ -646,13 +646,13 @@ func (j *JujuManager) addModelAndOfferPermissions(ctx context.Context, user *ope
 
 	modelTag := model.ResourceTag()
 	if err := j.addModelPermissions(ctx, user, modelTag, ct); err != nil {
-		return errors.E(fmt.Errorf("failed to add model permissions: %w", err))
+		return fmt.Errorf("failed to add model permissions: %w", err)
 	}
 
 	for _, offer := range offers {
 		err := j.OpenFGAClient.AddModelApplicationOffer(ctx, modelTag, offer.ResourceTag())
 		if err != nil {
-			return errors.E(fmt.Errorf("failed to add application offer permissions: %w", err))
+			return fmt.Errorf("failed to add application offer permissions: %w", err)
 		}
 	}
 	return nil
@@ -666,7 +666,7 @@ func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
 	// Get all incoming model migrations that have exceeded the timeout.
 	migrations, err := j.Database.GetIncomingModelMigrationsCreatedBefore(ctx, time.Now().Add(-TIMEOUT_PENDING_MIGRATION))
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get incoming model migrations: %w", err))
+		return fmt.Errorf("failed to get incoming model migrations: %w", err)
 	}
 	var errs []error
 	for _, migration := range migrations {

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -561,7 +561,7 @@ func TestPrechecks_ControllerUnreachable(t *testing.T) {
 
 	api := &jimmtest.API{
 		Prechecks_: func(mmi params.MigrationModelInfo) error {
-			return errors.E("controller unreachable")
+			return errors.New("controller unreachable")
 		},
 	}
 
@@ -843,7 +843,7 @@ func TestActivate_APIFailure(t *testing.T) {
 	// Simulate an API failure.
 	api := &jimmtest.API{
 		Activate_: func(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error {
-			return errors.E("API failure")
+			return errors.New("API failure")
 		},
 	}
 
@@ -1265,7 +1265,7 @@ func TestImport_APIFailure(t *testing.T) {
 	// of the model description, where the owner is replaced with an external user.
 	api := &jimmtest.API{
 		Import_: func(bytes []byte) error {
-			return errors.E("API failure")
+			return errors.New("API failure")
 		},
 	}
 

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -286,7 +286,7 @@ func (j *JujuManager) reactToModelInfoSuccess(ctx context.Context, model *dbmode
 		if modelInfo.MigrationStatus != nil && modelInfo.MigrationStatus.End != nil {
 			model.MigrationFailed()
 			if err := j.Database.UpdateModel(ctx, model); err != nil {
-				return jujuclient.ModelInfo{}, errors.E(fmt.Errorf("failed to update model after failed migration: %w", err))
+				return jujuclient.ModelInfo{}, fmt.Errorf("failed to update model after failed migration: %w", err)
 			}
 			return modelInfo, nil
 		}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -104,7 +104,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	}
 	err = j.Database.CloudDefaults(ctx, &cloudDefaults)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return base.ModelInfo{}, errors.E("failed to fetch cloud defaults")
+		return base.ModelInfo{}, errors.New("failed to fetch cloud defaults")
 	}
 	builder = builder.WithConfig(cloudDefaults.Defaults)
 
@@ -116,7 +116,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 	}
 	err = j.Database.CloudDefaults(ctx, &cloudRegionDefaults)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return base.ModelInfo{}, errors.E("failed to fetch cloud defaults")
+		return base.ModelInfo{}, errors.New("failed to fetch cloud defaults")
 	}
 	builder = builder.WithConfig(cloudRegionDefaults.Defaults)
 
@@ -246,7 +246,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.U
 		err := j.maybeCleanupModel(ctx, errFromAPI, model)
 		if err != nil {
 			zapctx.Error(ctx, "error cleaning model", zap.Error(err))
-			return jujuclient.ModelInfo{}, errors.E("internal server error")
+			return jujuclient.ModelInfo{}, errors.New("internal server error")
 		}
 		// propagate the error to the caller.
 		return jujuclient.ModelInfo{}, errFromAPI
@@ -254,7 +254,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.U
 		err := j.checkModelMigratedInternal(ctx, errFromAPI, model)
 		if err != nil {
 			zapctx.Error(ctx, "error checking model migration", zap.Error(err))
-			return jujuclient.ModelInfo{}, errors.E("internal server error")
+			return jujuclient.ModelInfo{}, errors.New("internal server error")
 		}
 		// If the model has been migrated internally, we call api.ModelInfo again
 		// to get the updated model information from the new controller.
@@ -271,7 +271,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.U
 	case dbmodel.MigrationModeExporting, dbmodel.MigrationModeImporting:
 		return jujuclient.ModelInfo{}, errFromAPI
 	default:
-		return jujuclient.ModelInfo{}, errors.E("model in unsupported migration mode")
+		return jujuclient.ModelInfo{}, errors.New("model in unsupported migration mode")
 	}
 
 }
@@ -292,7 +292,7 @@ func (j *JujuManager) reactToModelInfoSuccess(ctx context.Context, model *dbmode
 		}
 		return modelInfo, nil
 	default:
-		return jujuclient.ModelInfo{}, errors.E("model in unsupported migration mode")
+		return jujuclient.ModelInfo{}, errors.New("model in unsupported migration mode")
 	}
 
 }
@@ -492,7 +492,7 @@ func (j *JujuManager) deleteModel(ctx context.Context, mt names.ModelTag) error 
 // returned unmodified and iteration will stop immediately. The given
 // function should not update the database.
 func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, f func(*dbmodel.Model, string) error) error {
-	errStop := errors.E("stop")
+	errStop := errors.New("stop")
 	var iterErr error
 	err := j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
 		model := *m
@@ -532,7 +532,7 @@ func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f fu
 		return errors.E(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	errStop := errors.E("stop")
+	errStop := errors.New("stop")
 	var iterErr error
 	err := j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
 		if err := f(m, jujuparams.UserAccessPermission("admin")); err != nil {

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -81,27 +81,27 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI
 	// Parse the redirect error to get the new controller details.
 	errInfo := errors.ErrorInfo(errFromAPI)
 	if errInfo == nil {
-		return errors.E(fmt.Errorf("missing error info in redirect error: %w", errFromAPI))
+		return fmt.Errorf("missing error info in redirect error: %w", errFromAPI)
 	}
 
 	var redirectInfo params.RedirectErrorInfo
 	err := params.Error{Info: errInfo}.UnmarshalInfo(&redirectInfo)
 	if err != nil {
-		return errors.E(fmt.Errorf("cannot unmarshal redirect error info: %w", err))
+		return fmt.Errorf("cannot unmarshal redirect error info: %w", err)
 	}
 
 	// We expect this controller will be known to JIMM.
 	controller := dbmodel.Controller{Name: redirectInfo.ControllerAlias}
 	err = j.Database.GetController(ctx, &controller)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI))
+		return fmt.Errorf("failed to get controller %q: %w", redirectInfo.ControllerAlias, errFromAPI)
 	}
 
 	m.InternalMigrationSuccess(controller.ID)
 
 	err = j.Database.UpdateModel(ctx, m)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to update model after migration: %w", errFromAPI))
+		return fmt.Errorf("failed to update model after migration: %w", errFromAPI)
 	}
 	zapctx.Info(ctx, "model successfully migrated to controller", zap.String("model", m.UUID.String), zap.String("controller_name", controller.Name))
 	return nil
@@ -117,7 +117,7 @@ func (j *JujuManager) maybeCleanupModel(ctx context.Context, errFromAPI error, m
 	modelDeleted := (errors.ErrorCode(errFromAPI) == errors.CodeNotFound || errors.ErrorCode(errFromAPI) == errors.CodeUnauthorized)
 	if modelDeleted {
 		if err := j.deleteModel(ctx, m.ResourceTag()); err != nil {
-			return errors.E(fmt.Errorf("failed to delete model: %w", err))
+			return fmt.Errorf("failed to delete model: %w", err)
 		}
 	}
 	return nil

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -123,7 +123,7 @@ func TestModelCleanup(t *testing.T) {
 				case s.env.Models[1].UUID:
 					return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
 				case s.env.Models[2].UUID:
-					return jujuclient.ModelInfo{}, errors.E(fmt.Errorf("unexpected call to ModelInfo_ for model %s", model.Id()))
+					return jujuclient.ModelInfo{}, fmt.Errorf("unexpected call to ModelInfo_ for model %s", model.Id())
 				default:
 					return jujuclient.ModelInfo{}, errors.E("new error")
 				}

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -125,7 +125,7 @@ func TestModelCleanup(t *testing.T) {
 				case s.env.Models[2].UUID:
 					return jujuclient.ModelInfo{}, fmt.Errorf("unexpected call to ModelInfo_ for model %s", model.Id())
 				default:
-					return jujuclient.ModelInfo{}, errors.E("new error")
+					return jujuclient.ModelInfo{}, errors.New("new error")
 				}
 			},
 			DestroyModel_: func(ctx context.Context, tag names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
@@ -249,7 +249,7 @@ func TestPollModelsDyingControllerErrors(t *testing.T) {
 	s.jujuManager.Dialer = &jimmtest.Dialer{
 		API: &jimmtest.API{
 			ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-				return jujuclient.ModelInfo{}, errors.E("controller not available")
+				return jujuclient.ModelInfo{}, errors.New("controller not available")
 			},
 			DestroyModel_: func(ctx context.Context, tag names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
 				return nil

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -45,7 +45,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 
 	models, err := j.Database.GetModelsByUUID(ctx, modelUUIDs)
 	if err != nil {
-		return results, errors.E("failed to get models for user")
+		return results, errors.New("failed to get models for user")
 	}
 
 	for _, model := range models {
@@ -163,7 +163,7 @@ func (f *formatterParamsRetriever) GetParams(ctx context.Context, model dbmodel.
 func (f *formatterParamsRetriever) dialModel(ctx context.Context) error {
 	modelTag, ok := f.model.Tag().(names.ModelTag)
 	if !ok {
-		return errors.E("failed to parse model tag")
+		return errors.New("failed to parse model tag")
 	}
 	api, err := f.jujuManager.dial(ctx, &f.model.Controller, modelTag, nil)
 	if err != nil {

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -408,7 +408,7 @@ func TestQueryModelsJq(t *testing.T) {
 						return &model5, nil
 					},
 					ListFilesystems_: func(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
-						return []jujuparams.FilesystemDetailsListResult{}, errors.E("forcing an error on model 5")
+						return []jujuparams.FilesystemDetailsListResult{}, errors.New("forcing an error on model 5")
 					},
 					ListVolumes_: func(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
 						return []jujuparams.VolumeDetailsListResult{}, nil

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -597,7 +597,7 @@ controllers:
 		return nil
 	},
 	createModel: func(ctx context.Context, args *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
-		return base.ModelInfo{}, errors.E("a test error")
+		return base.ModelInfo{}, errors.New("a test error")
 	},
 	username:     "alice@canonical.com",
 	jimmAdmin:    true,
@@ -734,7 +734,7 @@ controllers:
     access: add-model
 `[1:],
 	updateCredential: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
-		return nil, errors.E("a silly error")
+		return nil, errors.New("a silly error")
 	},
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
@@ -1592,7 +1592,7 @@ func createModel(template string) func(context.Context, *jujuclient.CreateModelA
 func assertConfig(config map[string]interface{}, fnc func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error)) func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 	return func(ctx context.Context, args *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 		if args.Cloud == "" {
-			return base.ModelInfo{}, errors.E("cloud not specified")
+			return base.ModelInfo{}, errors.New("cloud not specified")
 		}
 		if len(config) != len(args.Config) {
 			return base.ModelInfo{}, errors.E(fmt.Sprintf("expected %d config settings, got %d", len(config), len(args.Config)))
@@ -2119,7 +2119,7 @@ var modelStatusTests = []struct {
 	env:  modelStatusTestEnv,
 	modelStatus: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
 		if modelTag.Id() != "00000002-0000-0000-0000-000000000001" {
-			return base.ModelStatus{}, errors.E("incorrect model tag")
+			return base.ModelStatus{}, errors.New("incorrect model tag")
 		}
 		ms := base.ModelStatus{}
 		ms.UUID = modelTag.Id()
@@ -2146,7 +2146,7 @@ var modelStatusTests = []struct {
 	name: "APIError",
 	env:  modelStatusTestEnv,
 	modelStatus: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
-		return base.ModelStatus{}, errors.E("test error")
+		return base.ModelStatus{}, errors.New("test error")
 	},
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
@@ -2326,7 +2326,7 @@ func TestForEachModel(t *testing.T) {
 	bob := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	err := j.ForEachModel(ctx, bob, func(_ *dbmodel.Model, _ jujuparams.UserAccessPermission) error {
-		return errors.E("function called unexpectedly")
+		return errors.New("function called unexpectedly")
 	})
 	c.Check(err, qt.ErrorMatches, `unauthorized`)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeUnauthorized)
@@ -2667,19 +2667,19 @@ var destroyModelTests = []struct {
 	env:  destroyModelTestEnv,
 	destroyModel: func(ctx context.Context, tag names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
 		if tag.Id() != "00000002-0000-0000-0000-000000000001" {
-			return errors.E("incorrect model uuid")
+			return errors.New("incorrect model uuid")
 		}
 		if destroyStorage == nil || *destroyStorage != true {
-			return errors.E("invalid destroyStorage")
+			return errors.New("invalid destroyStorage")
 		}
 		if force == nil || *force != false {
-			return errors.E("invalid force")
+			return errors.New("invalid force")
 		}
 		if maxWait == nil || *maxWait != time.Second {
-			return errors.E("invalid maxWait")
+			return errors.New("invalid maxWait")
 		}
 		if timeout == nil || *timeout != time.Second {
-			return errors.E("invalid timeout")
+			return errors.New("invalid timeout")
 		}
 		return nil
 	},
@@ -2702,7 +2702,7 @@ var destroyModelTests = []struct {
 }, {
 	name:         "DialError",
 	env:          destroyModelTestEnv,
-	dialError:    errors.E("dial error"),
+	dialError:    errors.New("dial error"),
 	username:     "alice@canonical.com",
 	uuid:         "00000002-0000-0000-0000-000000000001",
 	expectError:  `dial error`,
@@ -2711,7 +2711,7 @@ var destroyModelTests = []struct {
 	name: "APIError",
 	env:  destroyModelTestEnv,
 	destroyModel: func(ctx context.Context, tag names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
-		return errors.E("api error")
+		return errors.New("api error")
 	},
 	username:     "charlie@canonical.com",
 	uuid:         "00000002-0000-0000-0000-000000000001",
@@ -2798,10 +2798,10 @@ var dumpModelTests = []struct {
 	env:  destroyModelTestEnv,
 	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
 		if tag.Id() != "00000002-0000-0000-0000-000000000001" {
-			return nil, errors.E("incorrect model uuid")
+			return nil, errors.New("incorrect model uuid")
 		}
 		if simplified != true {
-			return nil, errors.E("invalid simplified")
+			return nil, errors.New("invalid simplified")
 		}
 		return map[string]interface{}{}, nil
 	},
@@ -2819,7 +2819,7 @@ var dumpModelTests = []struct {
 }, {
 	name:        "DialError",
 	env:         destroyModelTestEnv,
-	dialError:   errors.E("dial error"),
+	dialError:   errors.New("dial error"),
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
 	expectError: `dial error`,
@@ -2827,7 +2827,7 @@ var dumpModelTests = []struct {
 	name: "APIError",
 	env:  destroyModelTestEnv,
 	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
-		return map[string]interface{}{}, errors.E("api error")
+		return map[string]interface{}{}, errors.New("api error")
 	},
 	username:    "charlie@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
@@ -2901,7 +2901,7 @@ var dumpModelDBTests = []struct {
 	env:  destroyModelTestEnv,
 	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
 		if tag.Id() != "00000002-0000-0000-0000-000000000001" {
-			return nil, errors.E("incorrect model uuid")
+			return nil, errors.New("incorrect model uuid")
 		}
 		return map[string]interface{}{"model": "dump"}, nil
 	},
@@ -2920,7 +2920,7 @@ var dumpModelDBTests = []struct {
 }, {
 	name:        "DialError",
 	env:         destroyModelTestEnv,
-	dialError:   errors.E("dial error"),
+	dialError:   errors.New("dial error"),
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
 	expectError: `dial error`,
@@ -2928,7 +2928,7 @@ var dumpModelDBTests = []struct {
 	name: "APIError",
 	env:  destroyModelTestEnv,
 	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
-		return nil, errors.E("api error")
+		return nil, errors.New("api error")
 	},
 	username:    "charlie@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
@@ -3003,10 +3003,10 @@ var validateModelUpgradeTests = []struct {
 	env:  destroyModelTestEnv,
 	validateModelUpgrade: func(ctx context.Context, model names.ModelTag, force bool) error {
 		if model.Id() != "00000002-0000-0000-0000-000000000001" {
-			return errors.E("incorrect model uuid")
+			return errors.New("incorrect model uuid")
 		}
 		if force != true {
-			return errors.E("incorrect force")
+			return errors.New("incorrect force")
 		}
 		return nil
 	},
@@ -3018,7 +3018,7 @@ var validateModelUpgradeTests = []struct {
 	env:  destroyModelTestEnv,
 	validateModelUpgrade: func(ctx context.Context, model names.ModelTag, force bool) error {
 		if force != false {
-			return errors.E("incorrect force")
+			return errors.New("incorrect force")
 		}
 		return nil
 	},
@@ -3027,7 +3027,7 @@ var validateModelUpgradeTests = []struct {
 }, {
 	name:        "DialError",
 	env:         destroyModelTestEnv,
-	dialError:   errors.E("dial error"),
+	dialError:   errors.New("dial error"),
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
 	expectError: `dial error`,
@@ -3035,7 +3035,7 @@ var validateModelUpgradeTests = []struct {
 	name: "APIError",
 	env:  destroyModelTestEnv,
 	validateModelUpgrade: func(ctx context.Context, model names.ModelTag, force bool) error {
-		return errors.E("api error")
+		return errors.New("api error")
 	},
 	username:    "charlie@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
@@ -3130,16 +3130,16 @@ var updateModelCredentialTests = []struct {
 	env:  updateModelCredentialTestEnv,
 	updateCredential: func(_ context.Context, taggedCredential jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 		if taggedCredential.Tag != "cloudcred-test-cloud_alice@canonical.com_cred-2" {
-			return nil, errors.E("bad cloud credential tag")
+			return nil, errors.New("bad cloud credential tag")
 		}
 		return []jujuparams.UpdateCredentialResult{{}}, nil
 	},
 	changeModelCredential: func(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
 		if model.Id() != "00000002-0000-0000-0000-000000000001" {
-			return errors.E("bad model tag")
+			return errors.New("bad model tag")
 		}
 		if credential.Id() != "test-cloud/alice@canonical.com/cred-2" {
-			return errors.E("bad cloud credential tag")
+			return errors.New("bad cloud credential tag")
 		}
 		return nil
 	},
@@ -3177,16 +3177,16 @@ var updateModelCredentialTests = []struct {
 	env:  updateModelCredentialTestEnv,
 	updateCredential: func(_ context.Context, taggedCredential jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 		if taggedCredential.Tag != "cloudcred-test-cloud_alice@canonical.com_cred-2" {
-			return nil, errors.E("bad cloud credential tag")
+			return nil, errors.New("bad cloud credential tag")
 		}
 		return []jujuparams.UpdateCredentialResult{{}}, nil
 	},
 	changeModelCredential: func(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
 		if model.Id() != "00000002-0000-0000-0000-000000000001" {
-			return errors.E("bad model tag")
+			return errors.New("bad model tag")
 		}
 		if credential.Id() != "test-cloud/alice@canonical.com/cred-2" {
-			return errors.E("bad cloud credential tag")
+			return errors.New("bad cloud credential tag")
 		}
 		return nil
 	},
@@ -3208,16 +3208,16 @@ var updateModelCredentialTests = []struct {
 	env:  updateModelCredentialTestEnv,
 	updateCredential: func(_ context.Context, taggedCredential jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 		if taggedCredential.Tag != "cloudcred-test-cloud_alice@canonical.com_cred-2" {
-			return nil, errors.E("bad cloud credential tag")
+			return nil, errors.New("bad cloud credential tag")
 		}
 		return []jujuparams.UpdateCredentialResult{{}}, nil
 	},
 	changeModelCredential: func(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
 		if model.Id() != "00000002-0000-0000-0000-000000000001" {
-			return errors.E("bad model tag")
+			return errors.New("bad model tag")
 		}
 		if credential.Id() != "test-cloud/alice@canonical.com/cred-2" {
-			return errors.E("bad cloud credential tag")
+			return errors.New("bad cloud credential tag")
 		}
 		return nil
 	},
@@ -3230,7 +3230,7 @@ var updateModelCredentialTests = []struct {
 	name: "update credential returns an error",
 	env:  updateModelCredentialTestEnv,
 	updateCredential: func(_ context.Context, taggedCredential jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
-		return nil, errors.E("an error")
+		return nil, errors.New("an error")
 	},
 	username:    "alice@canonical.com",
 	credential:  "test-cloud/alice@canonical.com/cred-2",
@@ -3241,12 +3241,12 @@ var updateModelCredentialTests = []struct {
 	env:  updateModelCredentialTestEnv,
 	updateCredential: func(_ context.Context, taggedCredential jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 		if taggedCredential.Tag != "cloudcred-test-cloud_alice@canonical.com_cred-2" {
-			return nil, errors.E("bad cloud credential tag")
+			return nil, errors.New("bad cloud credential tag")
 		}
 		return []jujuparams.UpdateCredentialResult{{}}, nil
 	},
 	changeModelCredential: func(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
-		return errors.E("an error")
+		return errors.New("an error")
 	},
 	username:    "alice@canonical.com",
 	credential:  "test-cloud/alice@canonical.com/cred-2",
@@ -3583,7 +3583,7 @@ var modelListTests = []struct {
 		expectedError:      "failed to list models.*",
 		listModelsMockByControllerName: map[string]func(context.Context) ([]base.UserModel, error){
 			"controller-1": func(ctx context.Context) ([]base.UserModel, error) {
-				return []base.UserModel{}, errors.E("test error")
+				return []base.UserModel{}, errors.New("test error")
 			},
 		},
 	},

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -437,7 +437,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 			b.err = errors.E(err, fmt.Sprintf("model %s/%s already exists", b.owner.Name, b.name))
 			return b
 		} else {
-			b.err = errors.E(fmt.Errorf("failed to store model information: %w", err))
+			b.err = fmt.Errorf("failed to store model information: %w", err)
 			return b
 		}
 	}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -76,19 +76,19 @@ func (b *modelBuilder) Error() error {
 
 func (b *modelBuilder) jujuModelCreateArgs() (*jujuclient.CreateModelArgs, error) {
 	if b.name == "" {
-		return nil, errors.E("model name not specified")
+		return nil, errors.New("model name not specified")
 	}
 	if b.owner == nil {
-		return nil, errors.E("model owner not specified")
+		return nil, errors.New("model owner not specified")
 	}
 	if b.cloud == nil {
-		return nil, errors.E("cloud not specified")
+		return nil, errors.New("cloud not specified")
 	}
 	if b.cloudRegionID == 0 {
-		return nil, errors.E("cloud region not specified")
+		return nil, errors.New("cloud region not specified")
 	}
 	if b.credential == nil {
-		return nil, errors.E("credentials not specified")
+		return nil, errors.New("credentials not specified")
 	}
 
 	args := &jujuclient.CreateModelArgs{
@@ -154,7 +154,7 @@ func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
 		return b
 	}
 	if b.ofgaUser == nil {
-		b.err = errors.E("authorizer not specified")
+		b.err = errors.New("authorizer not specified")
 		return b
 	}
 	targetController := dbmodel.Controller{
@@ -188,7 +188,7 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 		return b
 	}
 	if b.ofgaUser == nil {
-		b.err = errors.E("authorizer not specified")
+		b.err = errors.New("authorizer not specified")
 		return b
 	}
 	var candidateControllers []candidateController
@@ -216,7 +216,7 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 	// Error early with a helpful message if no
 	// candidate controllers are available.
 	if len(b.candidates) == 0 {
-		b.err = errors.E("no available controllers - check permissions to controllers and list of available controllers")
+		b.err = errors.New("no available controllers - check permissions to controllers and list of available controllers")
 	}
 	return b
 }
@@ -229,7 +229,7 @@ func (b *modelBuilder) WithCloud(user *openfga.User, cloud names.CloudTag) *mode
 		return b
 	}
 	if b.ofgaUser == nil {
-		b.err = errors.E("authorizer not specified")
+		b.err = errors.New("authorizer not specified")
 		return b
 	}
 
@@ -310,7 +310,7 @@ func (b *modelBuilder) WithCloudRegion(region string) *modelBuilder {
 		return b
 	}
 	if b.cloud == nil {
-		b.err = errors.E("cloud not specified")
+		b.err = errors.New("cloud not specified")
 		return b
 	}
 
@@ -394,12 +394,12 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 
 	// if model name is not specified we error and abort
 	if b.name == "" {
-		b.err = errors.E("model name not specified")
+		b.err = errors.New("model name not specified")
 		return b
 	}
 	// if the model owner is not specified we error and abort
 	if b.owner == nil {
-		b.err = errors.E("owner not specified")
+		b.err = errors.New("owner not specified")
 		return b
 	}
 
@@ -411,7 +411,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 	// we can do - either a cloud or a cloud region was specified
 	// by this point and a controller should've been selected
 	if b.controller == nil {
-		b.err = errors.E("unable to determine a suitable controller")
+		b.err = errors.New("unable to determine a suitable controller")
 		return b
 	}
 
@@ -509,10 +509,10 @@ func (b *modelBuilder) selectController() error {
 
 func (b *modelBuilder) selectCloudCredentials() error {
 	if b.owner == nil {
-		return errors.E("user not specified")
+		return errors.New("user not specified")
 	}
 	if b.cloud == nil {
-		return errors.E("cloud not specified")
+		return errors.New("cloud not specified")
 	}
 	credentials, err := b.jujuManager.Database.GetIdentityCloudCredentials(b.ctx, b.owner, b.cloud.Name)
 	if err != nil {
@@ -526,7 +526,7 @@ func (b *modelBuilder) selectCloudCredentials() error {
 		b.credential = &credential
 		return nil
 	}
-	return errors.E("valid cloud credentials not found")
+	return errors.New("valid cloud credentials not found")
 }
 
 // CreateControllerModel uses provided information to create a new
@@ -537,7 +537,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 	}
 
 	if b.model == nil {
-		b.err = errors.E("model not specified")
+		b.err = errors.New("model not specified")
 		return b
 	}
 

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -226,7 +226,7 @@ func TestWatcherSetsControllerUnavailable(t *testing.T) {
 			DB: testdb.PostgresDB(c, nil),
 		},
 		&jimmtest.Dialer{
-			Err: errors.E("test error"),
+			Err: errors.New("test error"),
 		},
 		&testPublisher{},
 		controllerUnavailableChannel,
@@ -355,7 +355,7 @@ func TestWatcherUpdatesControllerVersion(t *testing.T) {
 				SupportsModelSummaryWatcher_: true,
 				WatchAllModelSummaries_: func(ctx context.Context) (jujuclient.SummaryWatcher, error) {
 					dialerCalled <- struct{}{}
-					return nil, errors.E("some-error")
+					return nil, errors.New("some-error")
 				},
 			},
 			AgentVersion: "3.6.12",

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -93,7 +93,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	defer auth.mu.Unlock()
 
 	if user == nil {
-		return nil, errors.E("user not specified")
+		return nil, errors.New("user not specified")
 	}
 	auth.user = user
 
@@ -103,7 +103,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 
 	var modelAccess string
 	if auth.mt.Id() == "" {
-		return nil, errors.E("model not set")
+		return nil, errors.New("model not set")
 	}
 	modelAccess, authErr = auth.accessChecker.GetUserModelAccess(ctx, auth.user, auth.mt)
 	if authErr != nil {
@@ -113,7 +113,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	auth.accessMapCache[auth.mt.String()] = modelAccess
 
 	if auth.ct.Id() == "" {
-		return nil, errors.E("controller not set")
+		return nil, errors.New("controller not set")
 	}
 	var controllerAccess string
 	controllerAccess, authErr = auth.accessChecker.GetUserControllerAccess(ctx, auth.user, auth.ct)
@@ -156,11 +156,11 @@ func (auth *LoginTokenGenerator) MakeToken(ctx context.Context, permissionMap ma
 	defer auth.mu.Unlock()
 
 	if auth.callCount >= 10 {
-		return nil, errors.E("Permission check limit exceeded")
+		return nil, errors.New("Permission check limit exceeded")
 	}
 	auth.callCount++
 	if auth.user == nil {
-		return nil, errors.E("User authorization missing.")
+		return nil, errors.New("User authorization missing.")
 	}
 	if permissionMap != nil {
 		var err error

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -126,7 +126,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	ctl.SetTag(auth.ct)
 	err := auth.database.GetController(ctx, &ctl)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to fetch controller: %w", err))
+		return nil, fmt.Errorf("failed to fetch controller: %w", err)
 	}
 	clouds := make(map[names.CloudTag]bool)
 	for _, cloudRegion := range ctl.CloudRegions {
@@ -135,7 +135,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 	for cloudTag := range clouds {
 		accessLevel, err := auth.accessChecker.GetUserCloudAccess(ctx, auth.user, cloudTag)
 		if err != nil {
-			return nil, errors.E(fmt.Errorf("failed to check user's cloud access: %w", err))
+			return nil, fmt.Errorf("failed to check user's cloud access: %w", err)
 		}
 		auth.accessMapCache[cloudTag.String()] = accessLevel
 	}

--- a/internal/jimm/jujuauth/logintokens_test.go
+++ b/internal/jimm/jujuauth/logintokens_test.go
@@ -153,7 +153,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 		about:    "model access check fails",
 		username: "eve@canonical.com",
 		accessChecker: &testAccessChecker{
-			modelAccessCheckErr: errors.E("a test error"),
+			modelAccessCheckErr: errors.New("a test error"),
 		},
 		jwtService:    &testJWTService{},
 		expectedError: "a test error",
@@ -164,14 +164,14 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 			modelAccess: map[string]string{
 				mt.String(): "admin",
 			},
-			controllerAccessCheckErr: errors.E("a test error"),
+			controllerAccessCheckErr: errors.New("a test error"),
 		},
 		expectedError: "a test error",
 	}, {
 		about:    "get controller from db fails",
 		username: "eve@canonical.com",
 		database: &testDatabase{
-			err: errors.E("a test error"),
+			err: errors.New("a test error"),
 		},
 		accessChecker: &testAccessChecker{
 			modelAccess: map[string]string{
@@ -203,7 +203,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 			controllerAccess: map[string]string{
 				ct.String(): "superuser",
 			},
-			cloudAccessCheckErr: errors.E("a test error"),
+			cloudAccessCheckErr: errors.New("a test error"),
 		},
 		expectedError: "failed to check user's cloud access: a test error",
 	}, {
@@ -232,7 +232,7 @@ func TestJWTGeneratorMakeLoginToken(t *testing.T) {
 			},
 		},
 		jwtService: &testJWTService{
-			newJWTError: errors.E("a test error"),
+			newJWTError: errors.New("a test error"),
 		},
 		expectedError: "a test error",
 	}}
@@ -288,7 +288,7 @@ func TestJWTGeneratorMakeToken(t *testing.T) {
 		permissions: map[string]interface{}{
 			"entity1": "access_level1",
 		},
-		checkPermissionsError: errors.E("a test error"),
+		checkPermissionsError: errors.New("a test error"),
 		expectedError:         "a test error",
 	}, {
 		about:      "additional permissions need checking",

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -91,16 +91,16 @@ type LoginManager struct {
 // NewLoginManager returns a new loginManager that persists the roles in the provided store.
 func NewLoginManager(store *db.Database, authSvc *openfga.OFGAClient, oAuthAuthenticator OAuthAuthenticator, jimmTag names.ControllerTag) (*LoginManager, error) {
 	if store == nil {
-		return nil, errors.E("login store cannot be nil")
+		return nil, errors.New("login store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("login authorisation service cannot be nil")
+		return nil, errors.New("login authorisation service cannot be nil")
 	}
 	if oAuthAuthenticator == nil {
-		return nil, errors.E("oauth service cannot be nil")
+		return nil, errors.New("oauth service cannot be nil")
 	}
 	if jimmTag.Id() == "" {
-		return nil, errors.E("invalid jimm controller tag")
+		return nil, errors.New("invalid jimm controller tag")
 	}
 	return &LoginManager{store, authSvc, oAuthAuthenticator, jimmTag}, nil
 }
@@ -207,7 +207,7 @@ func (j *LoginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 func (j *LoginManager) LoginWithSessionCookie(ctx context.Context, identityID string) (*openfga.User, error) {
 
 	if identityID == "" {
-		return nil, errors.E("missing cookie identity")
+		return nil, errors.New("missing cookie identity")
 	}
 	user, err := j.UserLogin(ctx, identityID)
 	if err != nil {

--- a/internal/jimm/offer/authorizer.go
+++ b/internal/jimm/offer/authorizer.go
@@ -23,10 +23,10 @@ type OfferAuthorizer struct {
 // check if a user is a consumer of an application offer.
 func NewOfferAuthorizer(store *db.Database, authSvc *openfga.OFGAClient) (*OfferAuthorizer, error) {
 	if store == nil {
-		return nil, errors.E("group store cannot be nil")
+		return nil, errors.New("group store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("group authorisation service cannot be nil")
+		return nil, errors.New("group authorisation service cannot be nil")
 	}
 	return &OfferAuthorizer{store, authSvc}, nil
 }

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -248,7 +248,7 @@ func (j *PermissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Check if the user is jimm administrator.
 	isAdmin, err := openfga.IsAdministrator(ctx, targetUserTag, j.jimmTag)
 	if err != nil {
-		return "", errors.E(fmt.Errorf("failed to check access rights: %w", err))
+		return "", fmt.Errorf("failed to check access rights: %w", err)
 	}
 	if isAdmin {
 		return "superuser", nil
@@ -320,7 +320,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zap.String("cloud", string(ct.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(fmt.Errorf("failed to set cloud access: %w", err))
+		return fmt.Errorf("failed to set cloud access: %w", err)
 	}
 	return nil
 }
@@ -398,7 +398,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zap.String("cloud", string(ct.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(fmt.Errorf("failed to unset cloud access: %w", err))
+		return fmt.Errorf("failed to unset cloud access: %w", err)
 	}
 
 	return nil
@@ -471,7 +471,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zap.String("model", string(mt.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(fmt.Errorf("failed to set model access: %w", err))
+		return fmt.Errorf("failed to set model access: %w", err)
 	}
 	return nil
 }
@@ -560,7 +560,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zap.String("model", string(mt.Id())),
 			zap.String("access", string(access)),
 		)
-		return errors.E(fmt.Errorf("failed to unset model access: %w", err))
+		return fmt.Errorf("failed to unset model access: %w", err)
 	}
 	return nil
 }

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -76,7 +76,7 @@ func ToControllerRelation(accessLevel string) (openfga.Relation, error) {
 	case "superuser":
 		return ofganames.AdministratorRelation, nil
 	default:
-		return ofganames.NoRelation, errors.E("unknown controller access")
+		return ofganames.NoRelation, errors.New("unknown controller access")
 	}
 }
 
@@ -91,7 +91,7 @@ func ToCloudRelation(accessLevel string) (openfga.Relation, error) {
 	case "add-model":
 		return ofganames.CanAddModelRelation, nil
 	default:
-		return ofganames.NoRelation, errors.E("unknown cloud access")
+		return ofganames.NoRelation, errors.New("unknown cloud access")
 	}
 }
 
@@ -105,7 +105,7 @@ func ToModelRelation(accessLevel string) (openfga.Relation, error) {
 	case "read":
 		return ofganames.ReaderRelation, nil
 	default:
-		return ofganames.NoRelation, errors.E("unknown model access")
+		return ofganames.NoRelation, errors.New("unknown model access")
 	}
 }
 
@@ -121,7 +121,7 @@ func ToOfferRelation(accessLevel string) (openfga.Relation, error) {
 	case string(jujuparams.OfferReadAccess):
 		return ofganames.ReaderRelation, nil
 	default:
-		return ofganames.NoRelation, errors.E("unknown application offer access")
+		return ofganames.NoRelation, errors.New("unknown application offer access")
 	}
 }
 
@@ -692,7 +692,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	}
 
 	if stillHasAccess {
-		return errors.E("unable to completely revoke given access due to other relations; try to remove them as well")
+		return errors.New("unable to completely revoke given access due to other relations; try to remove them as well")
 	}
 	return nil
 }

--- a/internal/jimm/permissions/permissionmanager.go
+++ b/internal/jimm/permissions/permissionmanager.go
@@ -23,10 +23,10 @@ type PermissionManager struct {
 // permission handling and resolution of JAAS tags.
 func NewManager(store *db.Database, authSvc *openfga.OFGAClient, uuid string, tag names.ControllerTag) (*PermissionManager, error) {
 	if store == nil {
-		return nil, errors.E("permission store cannot be nil")
+		return nil, errors.New("permission store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("permission authorisation service cannot be nil")
+		return nil, errors.New("permission authorisation service cannot be nil")
 	}
 	return &PermissionManager{store, authSvc, uuid, tag}, nil
 }

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -179,7 +179,7 @@ func (t *tagResolver) userTag(ctx context.Context) (*ofga.Entity, error) {
 	valid := names.IsValidUser(t.trailer)
 	if !valid {
 		// TODO(ale8k): Return custom error for validation check at JujuAPI
-		return nil, errors.E("invalid user")
+		return nil, errors.New("invalid user")
 	}
 	return ofganames.ConvertTagWithRelation(names.NewUserTag(t.trailer), t.relation), nil
 }
@@ -219,7 +219,7 @@ func (t *tagResolver) controllerTag(ctx context.Context, jimmUUID string, db *db
 
 	err := db.GetController(ctx, &controller)
 	if err != nil {
-		return nil, errors.E("controller not found")
+		return nil, errors.New("controller not found")
 	}
 	return ofganames.ConvertTagWithRelation(controller.ResourceTag(), t.relation), nil
 }
@@ -256,14 +256,14 @@ func (t *tagResolver) modelTag(ctx context.Context, db *db.Database) (*ofga.Enti
 	model := dbmodel.Model{}
 	matches := modelOwnerAndNameMatcher.FindStringSubmatch(t.trailer)
 	if len(matches) != 3 {
-		return nil, errors.E("model name format incorrect, expected <model-owner>/<model-name>")
+		return nil, errors.New("model name format incorrect, expected <model-owner>/<model-name>")
 	}
 	model.OwnerIdentityName = matches[1]
 	model.Name = matches[2]
 
 	err := db.GetModel(ctx, &model)
 	if err != nil {
-		return nil, errors.E("model not found")
+		return nil, errors.New("model not found")
 	}
 
 	return ofganames.ConvertTagWithRelation(model.ResourceTag(), t.relation), nil
@@ -282,7 +282,7 @@ func (t *tagResolver) applicationOfferTag(ctx context.Context, db *db.Database) 
 
 	err := db.GetApplicationOffer(ctx, &offer)
 	if err != nil {
-		return nil, errors.E("application offer not found")
+		return nil, errors.New("application offer not found")
 	}
 
 	return ofganames.ConvertTagWithRelation(offer.ResourceTag(), t.relation), nil
@@ -301,7 +301,7 @@ func (t *tagResolver) cloudTag(ctx context.Context, db *db.Database) (*ofga.Enti
 
 	err := db.GetCloud(ctx, &cloud)
 	if err != nil {
-		return nil, errors.E("cloud not found")
+		return nil, errors.New("cloud not found")
 	}
 
 	return ofganames.ConvertTagWithRelation(cloud.ResourceTag(), t.relation), nil

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -318,7 +318,7 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 	ctx := context.Background()
 	resolver, tagKind, err := newTagResolver(tag)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to setup tag resolver: %w", err))
+		return nil, fmt.Errorf("failed to setup tag resolver: %w", err)
 	}
 
 	switch tagKind {

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -21,10 +21,10 @@ type RoleManager struct {
 // NewRoleManager returns a new RoleManager that persists the roles in the provided store.
 func NewRoleManager(store *db.Database, authSvc *openfga.OFGAClient) (*RoleManager, error) {
 	if store == nil {
-		return nil, errors.E("role store cannot be nil")
+		return nil, errors.New("role store cannot be nil")
 	}
 	if authSvc == nil {
-		return nil, errors.E("role authorisation service cannot be nil")
+		return nil, errors.New("role authorisation service cannot be nil")
 	}
 	return &RoleManager{store, authSvc}, nil
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -76,19 +76,19 @@ type SSHManagerParams struct {
 
 func (p *SSHManagerParams) validate() error {
 	if p.IdentityManager == nil {
-		return errors.E("identityManager cannot be nil")
+		return errors.New("identityManager cannot be nil")
 	}
 	if p.JujuManager == nil {
-		return errors.E("jujuManager cannot be nil")
+		return errors.New("jujuManager cannot be nil")
 	}
 	if p.SSHKeyManager == nil {
-		return errors.E("sshManager cannot be nil")
+		return errors.New("sshManager cannot be nil")
 	}
 	if p.JWTFactory == nil {
-		return errors.E("jwtFactory cannot be nil")
+		return errors.New("jwtFactory cannot be nil")
 	}
 	if p.Dialer == nil {
-		return errors.E("dialer cannot be nil")
+		return errors.New("dialer cannot be nil")
 	}
 	return nil
 }
@@ -166,7 +166,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 
 	publicKey, _ := ctx.Value(ssh.ContextKeyPublicKey).(ssh.PublicKey)
 	if publicKey == nil {
-		return DialInfo{}, errors.E("cannot find user's public key")
+		return DialInfo{}, errors.New("cannot find user's public key")
 	}
 
 	tokenArgs := jujuauth.SSHTokenArgs{

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -22,7 +22,7 @@ type SSHKeyManager struct {
 // NewSSHKeyManager returns a new sshKeyManager that handles ssh keys.
 func NewSSHKeyManager(store *db.Database) (*SSHKeyManager, error) {
 	if store == nil {
-		return nil, errors.E("role store cannot be nil")
+		return nil, errors.New("role store cannot be nil")
 	}
 	return &SSHKeyManager{store}, nil
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -103,7 +103,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 
 	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to dial target controller: %w", err))
+		return fmt.Errorf("failed to dial target controller: %w", err)
 	}
 
 	if err := retry.Call(
@@ -134,10 +134,10 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 					return nil
 				}
 				if err != nil {
-					return errors.E(fmt.Errorf("failed to upgrade model: %w", err))
+					return fmt.Errorf("failed to upgrade model: %w", err)
 				}
 
-				return errors.E(fmt.Errorf("model upgrade started/in-progress"))
+				return fmt.Errorf("model upgrade started/in-progress")
 			},
 			NotifyFunc: func(lastError error, attempt int) {
 				zapctx.Debug(ctx, "model upgrade attempt", zap.Error(lastError), zap.Int("attempt", attempt))
@@ -145,7 +145,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 			Clock: clock.WallClock,
 		},
 	); err != nil {
-		return errors.E(fmt.Errorf("failed to complete upgrade: %w", err))
+		return fmt.Errorf("failed to complete upgrade: %w", err)
 	}
 	return nil
 }
@@ -191,7 +191,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		TargetControllerName: targetControllerName,
 	})
 	if err != nil {
-		return 0, errors.E(fmt.Errorf("failed to enqueue model migration and upgrade job: %w", err))
+		return 0, fmt.Errorf("failed to enqueue model migration and upgrade job: %w", err)
 	}
 
 	if job.UniqueSkippedAsDuplicate {
@@ -230,7 +230,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 	zapctx.Debug(ctx, "Attempting to initiate internal migration")
 	_, err = u.jujuManager.InitiateInternalMigration(ctx, user, modelUUID, targetControllerName)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to initiate internal migration: %w", err))
+		return fmt.Errorf("failed to initiate internal migration: %w", err)
 	}
 
 	modelNotMigratedErr := errors.E("model has not yet migrated to target controller")
@@ -270,7 +270,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 			Clock: clock.WallClock,
 		},
 	); err != nil {
-		return errors.E(fmt.Errorf("failed to confirm internal migration completed: %w", err))
+		return fmt.Errorf("failed to confirm internal migration completed: %w", err)
 	}
 
 	return nil

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -67,16 +67,16 @@ func NewUpgradeManager(
 	enqueuer UpgradeEnqueuer,
 ) (*UpgradeManager, error) {
 	if jujumanager == nil {
-		return nil, errors.E("juju manager cannot be nil")
+		return nil, errors.New("juju manager cannot be nil")
 	}
 	if store == nil {
-		return nil, errors.E("store cannot be nil")
+		return nil, errors.New("store cannot be nil")
 	}
 	if dialer == nil {
-		return nil, errors.E("dialer cannot be nil")
+		return nil, errors.New("dialer cannot be nil")
 	}
 	if enqueuer == nil {
-		return nil, errors.E("enqueuer cannot be nil")
+		return nil, errors.New("enqueuer cannot be nil")
 	}
 	return &UpgradeManager{
 		jujuManager: jujumanager,
@@ -127,7 +127,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 				// UpgradeModel is safe to call multiple times.
 				_, err = api.UpgradeModel(modelUUID, targetVersion, "", false, false)
 				if jujuparams.IsCodeUpgradeInProgress(err) {
-					err = errors.E("upgrade in progress")
+					err = errors.New("upgrade in progress")
 				}
 				if jujuerrors.Is(err, jujuerrors.AlreadyExists) {
 					// Model is already upgraded
@@ -233,7 +233,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 		return fmt.Errorf("failed to initiate internal migration: %w", err)
 	}
 
-	modelNotMigratedErr := errors.E("model has not yet migrated to target controller")
+	modelNotMigratedErr := errors.New("model has not yet migrated to target controller")
 
 	if err := retry.Call(
 		retry.CallArgs{

--- a/internal/jimmhttp/auth_handler.go
+++ b/internal/jimmhttp/auth_handler.go
@@ -69,10 +69,10 @@ type BrowserOAuthAuthenticator interface {
 // NewOAuthHandler returns a new OAuth handler.
 func NewOAuthHandler(p OAuthHandlerParams) (*OAuthHandler, error) {
 	if p.Authenticator == nil {
-		return nil, errors.E("nil authenticator")
+		return nil, errors.New("nil authenticator")
 	}
 	if p.DashboardFinalRedirectURL == "" {
-		return nil, errors.E("final redirect url not specified")
+		return nil, errors.New("final redirect url not specified")
 	}
 	return &OAuthHandler{
 		Router:                    chi.NewRouter(),
@@ -120,20 +120,20 @@ func (oah *OAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	stateByCookie, err := r.Cookie(auth.StateKey)
 	if err != nil {
-		usrErr := errors.E("no state cookie present")
+		usrErr := errors.New("no state cookie present")
 		writeError(ctx, w, http.StatusForbidden, usrErr, "no state cookie present")
 		return
 	}
 	stateByURL := r.URL.Query().Get("state")
 	if stateByCookie.Value != stateByURL {
-		err := errors.E("state does not match")
+		err := errors.New("state does not match")
 		writeError(ctx, w, http.StatusForbidden, err, "state does not match")
 		return
 	}
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
-		err := errors.E("missing auth code")
+		err := errors.New("missing auth code")
 		writeError(ctx, w, http.StatusForbidden, err, "no authorisation code present")
 		return
 	}

--- a/internal/jimmhttp/debug_handler_test.go
+++ b/internal/jimmhttp/debug_handler_test.go
@@ -75,7 +75,7 @@ func TestDebugStatusStatusError(t *testing.T) {
 	c := qt.New(t)
 
 	rr := setupDebugHandlerAndRecorder(c, jimmhttp.MakeStatusCheck("Test", func(context.Context) (interface{}, error) {
-		return nil, errors.E("test error")
+		return nil, errors.New("test error")
 	}), "/status")
 
 	resp := rr.Result()

--- a/internal/jimmhttp/rebac_admin/backend.go
+++ b/internal/jimmhttp/rebac_admin/backend.go
@@ -38,7 +38,7 @@ func SetupBackend(ctx context.Context, jimm jujuapi.JIMM) (*rebac_handlers.ReBAC
 		RolesErrorMapper:        securityEventLogger,
 	})
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to create rebac admin backend: %w", err))
+		return nil, fmt.Errorf("failed to create rebac admin backend: %w", err)
 	}
 
 	return rebacBackend, nil

--- a/internal/jimmhttp/rebac_admin/resources.go
+++ b/internal/jimmhttp/rebac_admin/resources.go
@@ -89,7 +89,7 @@ func validateAndConvertResourceFilter(typeFilter string) (string, error) {
 	case Model:
 		return db.ModelsQueryKey, nil
 	default:
-		return "", errors.E("this resource type is not supported")
+		return "", errors.New("this resource type is not supported")
 
 	}
 }

--- a/internal/jimmhttp/websocket_test.go
+++ b/internal/jimmhttp/websocket_test.go
@@ -113,7 +113,7 @@ func TestWSHandlerNilServer(t *testing.T) {
 type authFailServer struct{}
 
 func (s authFailServer) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
-	return ctx, errors.E("authentication failed")
+	return ctx, errors.New("authentication failed")
 }
 
 func (s authFailServer) ServeWS(ctx context.Context, conn *websocket.Conn) {}

--- a/internal/jimmjwx/jwks.go
+++ b/internal/jimmjwx/jwks.go
@@ -16,8 +16,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"go.uber.org/zap"
-
-	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 // CredentialStore defines the interface for a store that can manage
@@ -96,7 +94,7 @@ func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTim
 			if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
 				zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
 			}
-			return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
+			return fmt.Errorf("failed to put JWKS: %w", err)
 		}
 	} else {
 		// Check it has expired.
@@ -109,7 +107,7 @@ func rotateJWKS(ctx context.Context, credStore CredentialStore, initialExpiryTim
 				if jwksErr := credStore.CleanupJWKS(ctx); jwksErr != nil {
 					zapctx.Error(ctx, "failed to cleanup jwks", zap.Error(jwksErr))
 				}
-				return errors.E(fmt.Errorf("failed to put JWKS: %w", err))
+				return fmt.Errorf("failed to put JWKS: %w", err)
 			}
 			zapctx.Debug(ctx, "set a new JWKS", zap.String("expiry", expires.String()))
 		}
@@ -133,7 +131,7 @@ func (jwks *JWKSService) StartJWKSRotator(ctx context.Context, checkRotateRequir
 	credStore := jwks.credentialStore
 
 	if err := rotateJWKS(ctx, credStore, initialRotateRequiredTime); err != nil {
-		return errors.E(fmt.Errorf("rotate jwks: %w", err))
+		return fmt.Errorf("rotate jwks: %w", err)
 	}
 
 	// The rotation method is as follows, if an expiry is not present, we know

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -122,7 +122,7 @@ func (j *JWTService) NewJWT(ctx context.Context, params JWTParams) ([]byte, erro
 
 	pubKey, ok := jwkSet.Key(jwkSet.Len() - 1)
 	if !ok {
-		return nil, errors.E("no jwk found")
+		return nil, errors.New("no jwk found")
 	}
 	pkeyPem, err := j.Store.GetJWKSPrivateKey(ctx)
 	if err != nil {
@@ -167,7 +167,7 @@ func (j *JWTService) NewJWT(ctx context.Context, params JWTParams) ([]byte, erro
 
 	for k, v := range params.ExtraClaims {
 		if k == accessClaim {
-			return nil, errors.E("access is a reserved claim")
+			return nil, errors.New("access is a reserved claim")
 		}
 		builder = builder.Claim(k, v)
 	}

--- a/internal/jujuapi/accesscontrol.go
+++ b/internal/jujuapi/accesscontrol.go
@@ -35,7 +35,7 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 
 	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
 	if err != nil {
-		return resp, errors.E(fmt.Errorf("failed to add group: %w", err))
+		return resp, fmt.Errorf("failed to add group: %w", err)
 	}
 	resp = apiparams.AddGroupResponse{Group: apiparams.Group{
 		Name:      groupEntry.Name,
@@ -63,7 +63,7 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 		return apiparams.Group{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		return apiparams.Group{}, errors.E(fmt.Errorf("failed to get group: %w", err))
+		return apiparams.Group{}, fmt.Errorf("failed to get group: %w", err)
 	}
 
 	return apiparams.Group{
@@ -82,7 +82,7 @@ func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGr
 	}
 
 	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {
-		return errors.E(fmt.Errorf("failed to rename group: %w", err))
+		return fmt.Errorf("failed to rename group: %w", err)
 	}
 	return nil
 }
@@ -91,7 +91,7 @@ func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGr
 func (r *controllerRoot) RemoveGroup(ctx context.Context, req apiparams.RemoveGroupRequest) error {
 
 	if err := r.jimm.GroupManager().RemoveGroup(ctx, r.user, req.Name); err != nil {
-		return errors.E(fmt.Errorf("failed to remove group: %w", err))
+		return fmt.Errorf("failed to remove group: %w", err)
 	}
 	return nil
 }
@@ -102,7 +102,7 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 	pagination := pagination.NewOffsetFilter(req.Limit, req.Offset)
 	groups, err := r.jimm.GroupManager().ListGroups(ctx, r.user, pagination, "")
 	if err != nil {
-		return apiparams.ListGroupResponse{}, errors.E(fmt.Errorf("failed to list groups: %w", err))
+		return apiparams.ListGroupResponse{}, fmt.Errorf("failed to list groups: %w", err)
 	}
 	groupsResponse := make([]apiparams.Group, len(groups))
 	for i, g := range groups {
@@ -122,7 +122,7 @@ func (r *controllerRoot) ListGroups(ctx context.Context, req apiparams.ListGroup
 func (r *controllerRoot) AddRelation(ctx context.Context, req apiparams.AddRelationRequest) error {
 
 	if err := r.jimm.PermissionManager().AddRelation(ctx, r.user, req.Tuples); err != nil {
-		return errors.E(fmt.Errorf("failed to add relation: %w", err))
+		return fmt.Errorf("failed to add relation: %w", err)
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func (r *controllerRoot) RemoveRelation(ctx context.Context, req apiparams.Remov
 
 	err := r.jimm.PermissionManager().RemoveRelation(ctx, r.user, req.Tuples)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to remove relation: %w", err))
+		return fmt.Errorf("failed to remove relation: %w", err)
 	}
 	return nil
 }
@@ -148,7 +148,7 @@ func (r *controllerRoot) CheckRelation(ctx context.Context, req apiparams.CheckR
 	allowed, err := r.jimm.PermissionManager().CheckRelation(ctx, r.user, req.Tuple, false)
 	if err != nil {
 		checkResp.Error = err.Error()
-		return checkResp, errors.E(fmt.Errorf("failed to check relation: %w", err))
+		return checkResp, fmt.Errorf("failed to check relation: %w", err)
 	}
 	checkResp.Allowed = allowed
 	zapctx.Debug(ctx, "check request", zap.String("allowed", strconv.FormatBool(allowed)))
@@ -163,7 +163,7 @@ func (r *controllerRoot) CheckRelations(ctx context.Context, req apiparams.Check
 
 	results, err := r.jimm.PermissionManager().CheckRelations(ctx, r.user, req.Tuples)
 	if err != nil {
-		return checksResp, errors.E(fmt.Errorf("failed to check relations: %w", err))
+		return checksResp, fmt.Errorf("failed to check relations: %w", err)
 	}
 	for _, result := range results {
 		resp := apiparams.CheckRelationResponse{
@@ -183,7 +183,7 @@ func (r *controllerRoot) ListRelationshipTuples(ctx context.Context, req apipara
 
 	responseTuples, ct, err := r.jimm.PermissionManager().ListRelationshipTuples(ctx, r.user, req.Tuple, req.PageSize, req.ContinuationToken)
 	if err != nil {
-		return apiparams.ListRelationshipTuplesResponse{}, errors.E(fmt.Errorf("failed to list relations: %w", err))
+		return apiparams.ListRelationshipTuplesResponse{}, fmt.Errorf("failed to list relations: %w", err)
 	}
 	errors := []string{}
 	tuples := make([]apiparams.RelationshipTuple, len(responseTuples))

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -272,7 +272,7 @@ func TestDestroyOffers(t *testing.T) {
 		DestroyOffer_: func(ctx context.Context, user *openfga.User, offerURL string, force bool) error {
 			called++
 			if offerURL == "owner@canonical.com/test-model.fail" {
-				return errors.E("cannot destroy offer")
+				return errors.New("cannot destroy offer")
 			}
 			c.Check(force, qt.IsTrue)
 			return nil

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -52,7 +52,7 @@ func TestInitiateMigration(t *testing.T) {
 	}, {
 		about: "controller returns an error",
 		initiateMigration: func(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
-			return jujuparams.InitiateMigrationResult{}, errors.E("a silly error")
+			return jujuparams.InitiateMigrationResult{}, errors.New("a silly error")
 		},
 		args: jujuparams.InitiateMigrationArgs{
 			Specs: []jujuparams.MigrationSpec{{

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -261,7 +261,7 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 		AdminPassword:     req.Password,
 	}
 	if err := r.jimm.JujuManager().AddController(ctx, r.user, &ctl, ctlCreds); err != nil {
-		return apiparams.ControllerInfo{}, errors.E(fmt.Errorf("failed to add controller: %w", err))
+		return apiparams.ControllerInfo{}, fmt.Errorf("failed to add controller: %w", err)
 	}
 	return ctl.ToAPIControllerInfo(), nil
 }
@@ -641,7 +641,7 @@ func (r *controllerRoot) StopBootstrap(ctx context.Context, req apiparams.StopBo
 
 	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to stop job: %v", err))
+		return fmt.Errorf("failed to stop job: %v", err)
 	}
 	return nil
 }
@@ -688,7 +688,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrapJob(ctx, r.user, params)
 	if err != nil {
-		return apiparams.StartBootstrapResponse{}, errors.E(fmt.Errorf("failed to start bootstrap job: %v", err))
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start bootstrap job: %v", err)
 	}
 	return apiparams.StartBootstrapResponse{
 		JobID: strconv.FormatInt(jobID, 10),
@@ -704,7 +704,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 
 	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.ControllerName)
 	if err != nil {
-		return apiparams.StartBootstrapResponse{}, errors.E(fmt.Errorf("failed to fetch controller info: %w", err))
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to fetch controller info: %w", err)
 	}
 
 	if len(ctrl.Models) != 0 {
@@ -722,7 +722,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 		CACertificate:  ctrl.CACertificate,
 	})
 	if err != nil {
-		return apiparams.StartBootstrapResponse{}, errors.E(fmt.Errorf("failed to start destroy-controller job: %v", err))
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start destroy-controller job: %v", err)
 	}
 
 	return apiparams.StartBootstrapResponse{
@@ -826,7 +826,7 @@ func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoReque
 
 	jobInfo, err := r.jimm.JobManager().GetJobInfo(ctx, jobID)
 	if err != nil {
-		return apiparams.JobInfoResponse{}, errors.E(fmt.Errorf("failed to get job info: %v", err))
+		return apiparams.JobInfoResponse{}, fmt.Errorf("failed to get job info: %v", err)
 	}
 
 	return toJobInfoParams(jobInfo), nil

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -556,7 +556,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	}
 
 	if !names.IsValidControllerName(args.BackingControllerName) {
-		return resp, errors.E("invalid controller name")
+		return resp, errors.New("invalid controller name")
 	}
 
 	// Check each key is a valid local user and each value is a valid user and has a domain

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -383,7 +383,7 @@ func TestBootstrapStart(t *testing.T) {
 	c.Assert(response.JobID, qt.Not(qt.Equals), "")
 
 	// Test start bootstrap fails
-	startBootstrapErr = errors.E("foo")
+	startBootstrapErr = errors.New("foo")
 	_, err = root.StartBootstrap(ctx, params)
 	c.Assert(err, qt.Not(qt.IsNil))
 	c.Assert(err.Error(), qt.Matches, "failed to start bootstrap job: foo")
@@ -628,7 +628,7 @@ func TestModelControllerInfo(t *testing.T) {
 		jujuManager: func(c *qt.C) jujuapi.JujuManager {
 			return &mocks.JujuManager{
 				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
-					return nil, errors.E("model not found")
+					return nil, errors.New("model not found")
 				},
 			}
 		},
@@ -704,7 +704,7 @@ func TestModelControllerInfo(t *testing.T) {
 		jujuManager: func(c *qt.C) jujuapi.JujuManager {
 			return &mocks.JujuManager{
 				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
-					return nil, errors.E("model not found")
+					return nil, errors.New("model not found")
 				},
 			}
 		},

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -182,7 +182,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(fmt.Errorf("invalid model tag: %w", err))
+		return fmt.Errorf("invalid model tag: %w", err)
 	}
 	// The controller tag is optional, so we parse it only if provided.
 	// It is only provided when args.CrossModelUUIDs is not empty.
@@ -191,7 +191,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 		controllerTag, err = names.ParseControllerTag(args.ControllerTag)
 		if err != nil {
 
-			return errors.E(fmt.Errorf("invalid controller tag: %w", err))
+			return fmt.Errorf("invalid controller tag: %w", err)
 		}
 	}
 
@@ -220,7 +220,7 @@ func (r *controllerRoot) Import(ctx context.Context, serialized jujuparams.Seria
 
 	err := r.jimm.JujuManager().Import(ctx, r.user, serialized)
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to import model: %w", err))
+		return fmt.Errorf("failed to import model: %w", err)
 	}
 	return nil
 }

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -25,7 +25,7 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 
 	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
 	if err != nil {
-		return resp, errors.E(fmt.Errorf("failed to add role: %w", err))
+		return resp, fmt.Errorf("failed to add role: %w", err)
 	}
 	resp = apiparams.AddRoleResponse{Role: apiparams.Role{
 		Name:      roleEntry.Name,
@@ -55,7 +55,7 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
-		return apiparams.Role{}, errors.E(fmt.Errorf("failed to get role: %w", err))
+		return apiparams.Role{}, fmt.Errorf("failed to get role: %w", err)
 	}
 
 	return apiparams.Role{
@@ -74,7 +74,7 @@ func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRol
 	}
 
 	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
-		return errors.E(fmt.Errorf("failed to rename role: %w", err))
+		return fmt.Errorf("failed to rename role: %w", err)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRol
 	}
 
 	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {
-		return errors.E(fmt.Errorf("failed to remove role: %w", err))
+		return fmt.Errorf("failed to remove role: %w", err)
 	}
 	return nil
 }

--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -58,7 +58,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	// FromJujuModelCreateArgs converts jujuparams.ModelCreateArgs into AddModelArgs.
 	var a juju.ModelCreateArgs
 	if args.Name == "" {
-		return nil, errors.E("name not specified")
+		return nil, errors.New("name not specified")
 	}
 	a.Name = args.Name
 	a.Config = args.Config
@@ -87,7 +87,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 			return nil, errors.E(err, "invalid cloud credential tag")
 		}
 		if a.Cloud.Id() != "" && ct.Cloud().Id() != a.Cloud.Id() {
-			return nil, errors.E("cloud credential cloud mismatch")
+			return nil, errors.New("cloud credential cloud mismatch")
 		}
 
 		a.CloudCredential = ct

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -176,7 +176,7 @@ func mustGetSubexpIndex(regex *regexp.Regexp, name string) int {
 func modelInfoFromPath(path string) (uuid string, finalPath string, err error) {
 	matches := extractPathInfo.FindStringSubmatch(path)
 	if len(matches) != 3 {
-		return "", "", errors.E("invalid path")
+		return "", "", errors.New("invalid path")
 	}
 	return matches[modelIndex], matches[finalPathIndex], nil
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -214,7 +214,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 		zapctx.Debug(ctx, "grabbing model info from path", zap.String("path", path))
 		uuid, finalPath, err := modelInfoFromPath(path)
 		if err != nil {
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(fmt.Errorf("error parsing path: %w", err))
+			return rpcproxy.WebsocketConnectionWithMetadata{}, fmt.Errorf("error parsing path: %w", err)
 		}
 		m := dbmodel.Model{
 			UUID: sql.NullString{

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -313,7 +313,7 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 
 	modelTag, ok := c.ModelTag()
 	if !ok {
-		return nil, errors.E("no model found")
+		return nil, errors.New("no model found")
 	}
 
 	user, pass, err := c.dialer.ControllerCredentialsStore.GetControllerCredentials(c.ctx, c.ctl.Name)
@@ -322,7 +322,7 @@ func (c *Connection) ConnectStream(path string, attrs url.Values) (base.Stream, 
 	}
 	ok = names.IsValidUser(user)
 	if !ok {
-		return nil, errors.E("invalid/missing controller credentials")
+		return nil, errors.New("invalid/missing controller credentials")
 	}
 	requestHeader := jujuhttp.BasicAuthHeader(names.NewUserTag(user).String(), pass)
 	conn, err := rpc.Dial(c.ctx, c.ctl, modelTag, path, requestHeader, attrs)

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -139,7 +139,7 @@ func (c Connection) ModelStatus(ctx context.Context, modelTag names.ModelTag) (b
 		return base.ModelStatus{}, err
 	}
 	if len(statuses) == 0 {
-		return base.ModelStatus{}, errors.E("no status returned for model")
+		return base.ModelStatus{}, errors.New("no status returned for model")
 	}
 	if statuses[0].Error != nil {
 		return base.ModelStatus{}, statuses[0].Error

--- a/internal/middleware/authn.go
+++ b/internal/middleware/authn.go
@@ -132,7 +132,7 @@ func IdentityFromContext(ctx context.Context) (*openfga.User, error) {
 	identity := ctx.Value(identityContextKey{})
 	user, ok := identity.(*openfga.User)
 	if !ok {
-		return nil, errors.E("cannot extract user from context")
+		return nil, errors.New("cannot extract user from context")
 	}
 	return user, nil
 }

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -114,7 +114,7 @@ func BlankKindTag(kind string) (*Tag, error) {
 			Kind: cofga.Kind(kind),
 		}, nil
 	default:
-		return nil, errors.E("unknown tag kind")
+		return nil, errors.New("unknown tag kind")
 	}
 }
 
@@ -136,11 +136,11 @@ func ConvertJujuRelation(relation string) (cofga.Relation, error) {
 	// Below are controller specific permissions that
 	// are not represented in JIMM's OpenFGA model.
 	case string(permission.LoginAccess):
-		return NoRelation, errors.E("login access unused")
+		return NoRelation, errors.New("login access unused")
 	case string(permission.SuperuserAccess):
-		return NoRelation, errors.E("superuser access unused")
+		return NoRelation, errors.New("superuser access unused")
 	default:
-		return NoRelation, errors.E("unknown relation")
+		return NoRelation, errors.New("unknown relation")
 	}
 }
 

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -102,7 +102,7 @@ func publicAccessAdaptor(tt cofga.TimestampedTuple) cofga.TimestampedTuple {
 // Note that the action is idempotent (does not return error if the relation already exists).
 func (o *OFGAClient) setResourceAccess(ctx context.Context, object, target names.Tag, relation Relation) error {
 	if object == nil || target == nil {
-		return errors.E("missing object or target for relation")
+		return errors.New("missing object or target for relation")
 	}
 	err := o.AddRelation(ctx, Tuple{
 		Object:   ofganames.ConvertGenericTag(object),
@@ -125,7 +125,7 @@ func (o *OFGAClient) setResourceAccess(ctx context.Context, object, target names
 // Note that the action is idempotent (does not return error if the relation does not exist).
 func (o *OFGAClient) unsetResourceAccess(ctx context.Context, object, target names.Tag, relation Relation) error {
 	if object == nil || target == nil {
-		return errors.E("missing object or target for relation")
+		return errors.New("missing object or target for relation")
 	}
 	err := o.RemoveRelation(ctx, Tuple{
 		Object:   ofganames.ConvertGenericTag(object),

--- a/internal/pubsub/hub.go
+++ b/internal/pubsub/hub.go
@@ -99,10 +99,10 @@ func (h *Hub) SubscribeMatch(modelMatcher func(string) bool, handler HandlerFunc
 	defer h.mu.Unlock()
 
 	if handler == nil {
-		return func() {}, errors.E("handler not specified")
+		return func() {}, errors.New("handler not specified")
 	}
 	if modelMatcher == nil {
-		return func() {}, errors.E("model matcher not specified")
+		return func() {}, errors.New("model matcher not specified")
 	}
 	idx := h.idx
 	h.idx++

--- a/internal/river/bootstrap.go
+++ b/internal/river/bootstrap.go
@@ -22,13 +22,13 @@ import (
 // newBootstrapWorker creates a new bootstrapWorker.
 func newBootstrapWorker(openfgaClient *openfga.OFGAClient, store Store, bootstrapManager BootstrapManager) (*bootstrapWorker, error) {
 	if openfgaClient == nil {
-		return nil, errors.E("openfgaClient is required")
+		return nil, errors.New("openfgaClient is required")
 	}
 	if bootstrapManager == nil {
-		return nil, errors.E("bootstrapManager is required")
+		return nil, errors.New("bootstrapManager is required")
 	}
 	if store == nil {
-		return nil, errors.E("store is required")
+		return nil, errors.New("store is required")
 	}
 
 	return &bootstrapWorker{

--- a/internal/river/bootstrap.go
+++ b/internal/river/bootstrap.go
@@ -65,7 +65,7 @@ func (w *bootstrapWorker) Work(ctx context.Context, job *river.Job[rivertypes.Bo
 
 	temp, err := os.MkdirTemp("", "juju-data-dir")
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
+		return fmt.Errorf("failed to create temporary directory for Juju data: %w", err)
 	}
 	defer func() {
 		if err := os.RemoveAll(temp); err != nil {

--- a/internal/river/destroycontroller.go
+++ b/internal/river/destroycontroller.go
@@ -65,7 +65,7 @@ func (w *destroyControllerWorker) Work(ctx context.Context, job *river.Job[river
 
 	temp, err := os.MkdirTemp("", "juju-data-dir")
 	if err != nil {
-		return errors.E(fmt.Errorf("failed to create temporary directory for Juju data: %w", err))
+		return fmt.Errorf("failed to create temporary directory for Juju data: %w", err)
 	}
 	defer func() {
 		if err := os.RemoveAll(temp); err != nil {

--- a/internal/river/destroycontroller.go
+++ b/internal/river/destroycontroller.go
@@ -22,13 +22,13 @@ import (
 // newDestroyControllerWorker creates a new destroyControllerWorker.
 func newDestroyControllerWorker(openfgaClient *openfga.OFGAClient, store Store, bootstrapManager BootstrapManager) (*destroyControllerWorker, error) {
 	if openfgaClient == nil {
-		return nil, errors.E("openfgaClient is required")
+		return nil, errors.New("openfgaClient is required")
 	}
 	if bootstrapManager == nil {
-		return nil, errors.E("bootstrapManager is required")
+		return nil, errors.New("bootstrapManager is required")
 	}
 	if store == nil {
-		return nil, errors.E("store is required")
+		return nil, errors.New("store is required")
 	}
 
 	return &destroyControllerWorker{

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -17,13 +17,13 @@ import (
 // newMigrationWorker creates a new upgradeMigrationWorker.
 func newMigrationWorker(openfgaClient *openfga.OFGAClient, store Store, upgradeManager UpgradeManager) (*migrationWorker, error) {
 	if openfgaClient == nil {
-		return nil, errors.E("openfgaClient is required")
+		return nil, errors.New("openfgaClient is required")
 	}
 	if store == nil {
-		return nil, errors.E("store is required")
+		return nil, errors.New("store is required")
 	}
 	if upgradeManager == nil {
-		return nil, errors.E("upgradeManager is required")
+		return nil, errors.New("upgradeManager is required")
 	}
 
 	return &migrationWorker{

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -15,7 +15,7 @@ import (
 
 func newUpgradeWorker(upgradeManager UpgradeManager) (*upgradeWorker, error) {
 	if upgradeManager == nil {
-		return nil, errors.E("upgradeManager is required")
+		return nil, errors.New("upgradeManager is required")
 	}
 
 	return &upgradeWorker{

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -84,7 +84,7 @@ func (c *Client) recv() {
 		if msg.RequestID == 0 {
 			// Use a 0 request ID to indicate that the message
 			// received was not a valid RPC message.
-			c.handleError(errors.E("received invalid RPC message"))
+			c.handleError(errors.New("received invalid RPC message"))
 			break
 		}
 		if msg.isRequest() {

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -100,7 +100,7 @@ func TestCallClosedWithoutResponse(t *testing.T) {
 		c.Check(req["type"], qt.Equals, "test")
 		c.Check(req["id"], qt.Equals, "1234")
 		c.Check(req["request"], qt.Equals, "Test")
-		return errors.E("test error")
+		return errors.New("test error")
 	})
 	defer srv.Close()
 	conn, err := srv.dialer.Dial(context.Background(), srv.URL, nil)

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -143,7 +143,7 @@ func websocketURL(s string, mt names.ModelTag, finalPath string, attrs url.Value
 // connection.
 func dialAll(ctx context.Context, dialer *Dialer, urls []string, headers http.Header) (*websocket.Conn, error) {
 	if len(urls) == 0 {
-		return nil, errors.E("no urls to dial")
+		return nil, errors.New("no urls to dial")
 	}
 	conn, err := dialAllHelper(ctx, dialer, urls, headers)
 	if err != nil {

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -45,7 +45,7 @@ func (d Dialer) DialWebsocket(ctx context.Context, url string, headers http.Head
 	}
 	conn, resp, err := dialer.DialContext(ctx, url, headers)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("basic dial failed: %w", err))
+		return nil, fmt.Errorf("basic dial failed: %w", err)
 	}
 	defer resp.Body.Close()
 	return conn, nil

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -112,16 +112,16 @@ type ProxyHelpers struct {
 func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 
 	if helpers.ConnectController == nil {
-		return errors.E("missing controller connect function")
+		return errors.New("missing controller connect function")
 	}
 	if helpers.AuditLog == nil {
-		return errors.E("missing audit log function")
+		return errors.New("missing audit log function")
 	}
 	if helpers.LoginService == nil {
-		return errors.E("missing login service function")
+		return errors.New("missing login service function")
 	}
 	if helpers.RedirectInfo == nil {
-		return errors.E("missing redirect info function")
+		return errors.New("missing redirect info function")
 	}
 	errChan := make(chan error, 2)
 	msgInFlight := inflightMsgs{messages: make(map[uint64]*message)}
@@ -154,7 +154,7 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 			zapctx.Debug(ctx, "Proxy error", zap.Error(err))
 		}
 	case <-ctx.Done():
-		err = errors.E("Context cancelled")
+		err = errors.New("Context cancelled")
 		zapctx.Debug(ctx, "Context cancelled")
 	}
 	// Close the client connection to ensure everything is cleaned up.
@@ -594,7 +594,7 @@ func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any
 			for k, v := range e.Error.Info {
 				accessLevel, ok := v.(string)
 				if !ok {
-					return nil, errors.E("unknown permission level")
+					return nil, errors.New("unknown permission level")
 				}
 				if permissionMap == nil {
 					permissionMap = make(map[string]any)
@@ -635,7 +635,7 @@ func addJWT(ctx context.Context, msg *message, permissions map[string]interface{
 
 	// First we unmarshal the existing LoginRequest.
 	if msg == nil {
-		return errors.E("nil messsage")
+		return errors.New("nil messsage")
 	}
 	var lr jujuparams.LoginRequest
 	if err := json.Unmarshal(msg.Params, &lr); err != nil {

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -328,7 +328,7 @@ func (p *modelProxy) auditLogMessage(msg *message, isResponse bool) error {
 		if msg.Response != nil {
 			err := json.Unmarshal(msg.Response, &allErrors)
 			if err != nil {
-				return errors.E(fmt.Errorf("failed to unmarshal message response: %w", err))
+				return fmt.Errorf("failed to unmarshal message response: %w", err)
 			}
 		}
 		singleError := jujuparams.ErrorResult{Error: &jujuparams.Error{Message: msg.Error, Code: msg.ErrorCode, Info: msg.ErrorInfo}}

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -84,7 +84,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			RequestID: 1,
 			Error:     "a silly error",
 		},
-		oauthAuthenticatorError: errors.E("a silly error"),
+		oauthAuthenticatorError: errors.New("a silly error"),
 	}, {
 		about: "get device session token call - client gets response with a session token",
 		messageToSend: rpcproxy.Message{
@@ -109,7 +109,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			RequestID: 1,
 			Error:     "a silly error",
 		},
-		oauthAuthenticatorError: errors.E("a silly error"),
+		oauthAuthenticatorError: errors.New("a silly error"),
 	}, {
 		about: "login with session token - a login message is sent to the controller",
 		messageToSend: rpcproxy.Message{
@@ -425,11 +425,11 @@ func (j *mockLoginService) LoginClientCredentials(ctx context.Context, clientID 
 		return nil, j.err
 	}
 	if clientID != j.clientID || clientSecret != j.clientSecret {
-		return nil, errors.E("invalid client credentials")
+		return nil, errors.New("invalid client credentials")
 	}
 	clientIdWithDomain, err := jimmnames.EnsureValidServiceAccountId(clientID)
 	if err != nil {
-		return nil, errors.E("invalid client credential ID")
+		return nil, errors.New("invalid client credential ID")
 	}
 	identity, err := dbmodel.NewIdentity(clientIdWithDomain)
 	if err != nil {

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -129,7 +129,7 @@ func (s *sshSuite) Init(c *qt.C) {
 			},
 			DialInfo_: func(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.DialInfo, error) {
 				if modelUUID != s.virtualHostname.ModelUUID() {
-					return jimmssh.DialInfo{}, errors.E("permission denied")
+					return jimmssh.DialInfo{}, errors.New("permission denied")
 				}
 				return jimmssh.DialInfo{}, nil
 			},

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -53,20 +53,20 @@ func CreateRandomKeycloakUser() (*KeycloakUser, error) {
 
 	adminCLIToken, err := getAdminCLIAccessToken()
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to authenticate admin CLI user: %w", err))
+		return nil, fmt.Errorf("failed to authenticate admin CLI user: %w", err)
 	}
 
 	if err := addKeycloakUser(adminCLIToken, email, username); err != nil {
-		return nil, errors.E(fmt.Errorf("failed to add keycloak user (%q, %q): %w", email, username, err))
+		return nil, fmt.Errorf("failed to add keycloak user (%q, %q): %w", email, username, err)
 	}
 
 	id, err := getKeycloakUserId(adminCLIToken, username)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("failed to retrieve ID for newly added keycloak user (%q, %q): %w", email, username, err))
+		return nil, fmt.Errorf("failed to retrieve ID for newly added keycloak user (%q, %q): %w", email, username, err)
 	}
 
 	if err := setKeycloakUserPassword(adminCLIToken, id, password); err != nil {
-		return nil, errors.E(fmt.Errorf("failed to set password for newly added keycloak user (%q, %q, %q): %w", email, username, password, err))
+		return nil, fmt.Errorf("failed to set password for newly added keycloak user (%q, %q, %q): %w", email, username, password, err)
 	}
 	return &KeycloakUser{
 		Id:       id,

--- a/internal/testutils/jimmtest/setup_jimm.go
+++ b/internal/testutils/jimmtest/setup_jimm.go
@@ -192,7 +192,7 @@ func SetupJimmEnv(c *qt.C, opts ...SetupOption) JIMMEnv {
 func jwkSetFromPrivateKeyFile() (jwk.Set, []byte, error) {
 	block, _ := pem.Decode(testJWKSPrivateKey)
 	if block == nil {
-		return nil, nil, errors.E("failed to decode PEM block from private key file")
+		return nil, nil, errors.New("failed to decode PEM block from private key file")
 	}
 
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -475,12 +475,12 @@ func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
 		roleSecretID,
 	)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("unable to initialize approle auth method: %w", err))
+		return nil, fmt.Errorf("unable to initialize approle auth method: %w", err)
 	}
 
 	authInfo, err := s.Client.Auth().Login(ctx, appRoleAuth)
 	if err != nil {
-		return nil, errors.E(fmt.Errorf("unable to login to approle auth method: %w", err))
+		return nil, fmt.Errorf("unable to login to approle auth method: %w", err)
 	}
 	if authInfo == nil {
 		return nil, errors.E("no auth info was returned after login")

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -260,7 +260,7 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 
 	jsonString, ok := secret.Data[jwksKey].(string)
 	if !ok {
-		return nil, errors.E("invalid type for jwks")
+		return nil, errors.New("invalid type for jwks")
 	}
 
 	ks, err := jwk.ParseString(jsonString)
@@ -332,7 +332,7 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 
 	expiry, ok := secret.Data[jwksExpiryKey].(string)
 	if !ok {
-		return now, errors.E("failed to retrieve expiry")
+		return now, errors.New("failed to retrieve expiry")
 	}
 
 	t, err := time.Parse(time.RFC3339, expiry)
@@ -483,7 +483,7 @@ func (s *VaultStore) client(ctx context.Context) (*api.Client, error) {
 		return nil, fmt.Errorf("unable to login to approle auth method: %w", err)
 	}
 	if authInfo == nil {
-		return nil, errors.E("no auth info was returned after login")
+		return nil, errors.New("no auth info was returned after login")
 	}
 
 	ttl, err := authInfo.TokenTTL()


### PR DESCRIPTION
## Description
This PR follows on from #1915 to remove more unnecessary uses of `errors.E()`. It also introduces a simple `errors.New()` which calls the stdlib `errors.New()` so that we can remove more instances of `errors.E`. These changes include,
- `errors.E(fmt.Errorf(...))` -> `fmt.Errorf()`
- `errors.E(dbError(err))` -> `dbError(err)`
- `errors.E("msg")` -> `errors.New("msg")`
- `errors.E(dbError(result.Error))` -> `dbError(result.Error)`

Any uses of errors.E that inject error codes, etc are left in-tact.