### PR TITLE
feat: remove errors.E

### DIFF
--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -118,7 +118,7 @@ func (c *registerControllerCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 	if c.controllerName != params.Name {
-		return errors.New(fmt.Sprintf("provided controller name doesn't match, %s != %s", c.controllerName, params.Name))
+		return fmt.Errorf("provided controller name doesn't match, %s != %s", c.controllerName, params.Name)
 	}
 	if c.dryRun {
 		return c.out.Write(ctxt, params)

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -172,7 +172,7 @@ func start(ctx context.Context, s *service.Service) error {
 	}
 	sshPortInt, err := strconv.Atoi(sshPort)
 	if err != nil {
-		return errors.E("failed to parse ssh port", zap.Error(err))
+		return fmt.Errorf("failed to parse ssh port: %w", err)
 	}
 	jimmUUID := os.Getenv("JIMM_UUID")
 	publicDnsName := os.Getenv("JIMM_DNS_NAME")

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -779,7 +779,7 @@ func openDB(ctx context.Context, dsn string, logSQL bool) (*gorm.DB, error) {
 	case strings.HasPrefix(dsn, "postgres:") || strings.HasPrefix(dsn, "postgresql:"):
 		dialect = postgres.Open(dsn)
 	default:
-		return nil, errors.MsgWithCode("unsupported DSN", errors.CodeServerConfiguration)
+		return nil, errors.Codef(errors.CodeServerConfiguration, "unsupported DSN")
 	}
 	return gorm.Open(dialect, &gorm.Config{
 		Logger: &logger.GormLogger{LogSQL: logSQL},

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -416,7 +416,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 	}
 
 	if _, err := url.Parse(p.DashboardFinalRedirectURL); err != nil {
-		return nil, errors.E(err, "failed to parse final redirect url for the dashboard")
+		return nil, fmt.Errorf("failed to parse final redirect url for the dashboard: %w", err)
 	}
 
 	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
@@ -445,7 +445,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 	}
 
 	if err := ensureControllerAdministrators(ctx, openFGAclient, controllerUUID, p.ControllerAdmins); err != nil {
-		return nil, errors.E(err, "failed to ensure controller admins")
+		return nil, fmt.Errorf("failed to ensure controller admins: %w", err)
 	}
 
 	credentialStore, err := setupCredentialStore(ctx, p, db)
@@ -779,7 +779,7 @@ func openDB(ctx context.Context, dsn string, logSQL bool) (*gorm.DB, error) {
 	case strings.HasPrefix(dsn, "postgres:") || strings.HasPrefix(dsn, "postgresql:"):
 		dialect = postgres.Open(dsn)
 	default:
-		return nil, errors.E(errors.CodeServerConfiguration, "unsupported DSN")
+		return nil, errors.MsgWithCode("unsupported DSN", errors.CodeServerConfiguration)
 	}
 	return gorm.Open(dialect, &gorm.Config{
 		Logger: &logger.GormLogger{LogSQL: logSQL},

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -174,7 +174,7 @@ func NewAuthenticationService(ctx context.Context, params AuthenticationServiceP
 
 	provider, err := oidc.NewProvider(ctx, params.IssuerURL)
 	if err != nil {
-		return nil, errors.ErrWithCode(fmt.Errorf("failed to create oidc provider: %v", err), errors.CodeServerConfiguration)
+		return nil, errors.Codef(errors.CodeServerConfiguration, "failed to create oidc provider: %v", err)
 	}
 
 	authSvc := &AuthenticationService{
@@ -397,7 +397,7 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 	}()
 
 	if len(token) == 0 {
-		return nil, errors.MsgWithCode("no token presented", errors.CodeSessionTokenInvalid)
+		return nil, errors.Codef(errors.CodeSessionTokenInvalid, "no token presented")
 	}
 
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
@@ -408,13 +408,13 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 	parsedToken, err := jwt.Parse(decodedToken, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
 		if stderrors.Is(err, jwt.ErrTokenExpired()) {
-			return nil, errors.MsgWithCode("JIMM session token expired", errors.CodeSessionTokenInvalid)
+			return nil, errors.Codef(errors.CodeSessionTokenInvalid, "JIMM session token expired")
 		}
 		return nil, err
 	}
 
 	if _, err = mail.ParseAddress(parsedToken.Subject()); err != nil {
-		return nil, errors.MsgWithCode("failed to parse email", errors.CodeSessionTokenInvalid)
+		return nil, errors.Codef(errors.CodeSessionTokenInvalid, "failed to parse email")
 	}
 
 	return parsedToken, nil
@@ -472,7 +472,7 @@ func (as *AuthenticationService) VerifyClientCredentials(ctx context.Context, cl
 
 	_, err = cfg.Token(ctx)
 	if err != nil {
-		return errors.ErrWithCode(fmt.Errorf("invalid client credentials: %v", err), errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "invalid client credentials: %v", err)
 	}
 	return nil
 }
@@ -534,7 +534,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		return ctx, errors.MsgWithCode("session is missing identity key", errors.CodeForbidden)
+		return ctx, errors.Codef(errors.CodeForbidden, "session is missing identity key")
 	}
 
 	err = as.validateAndUpdateAccessToken(ctx, identityId)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -174,7 +174,7 @@ func NewAuthenticationService(ctx context.Context, params AuthenticationServiceP
 
 	provider, err := oidc.NewProvider(ctx, params.IssuerURL)
 	if err != nil {
-		return nil, errors.E(errors.CodeServerConfiguration, fmt.Errorf("failed to create oidc provider: %v", err))
+		return nil, errors.ErrWithCode(fmt.Errorf("failed to create oidc provider: %v", err), errors.CodeServerConfiguration)
 	}
 
 	authSvc := &AuthenticationService{
@@ -223,7 +223,7 @@ func (as *AuthenticationService) AuthCodeURL() (string, string, error) {
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", "", errors.E(fmt.Sprintf("failed to generate state secret: %s", err.Error()))
+		return "", "", errors.New(fmt.Sprintf("failed to generate state secret: %s", err.Error()))
 	}
 	state := base64.RawURLEncoding.EncodeToString(b)
 	return as.oauthConfig.AuthCodeURL(state), state, nil
@@ -397,24 +397,24 @@ func (as *AuthenticationService) VerifySessionToken(token string) (_ jwt.Token, 
 	}()
 
 	if len(token) == 0 {
-		return nil, errors.E(errors.CodeSessionTokenInvalid, "no token presented")
+		return nil, errors.MsgWithCode("no token presented", errors.CodeSessionTokenInvalid)
 	}
 
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
-		return nil, errors.E(err, "failed to decode token")
+		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
 
 	parsedToken, err := jwt.Parse(decodedToken, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
 		if stderrors.Is(err, jwt.ErrTokenExpired()) {
-			return nil, errors.E(errors.CodeSessionTokenInvalid, "JIMM session token expired")
+			return nil, errors.MsgWithCode("JIMM session token expired", errors.CodeSessionTokenInvalid)
 		}
 		return nil, err
 	}
 
 	if _, err = mail.ParseAddress(parsedToken.Subject()); err != nil {
-		return nil, errors.E(errors.CodeSessionTokenInvalid, "failed to parse email")
+		return nil, errors.MsgWithCode("failed to parse email", errors.CodeSessionTokenInvalid)
 	}
 
 	return parsedToken, nil
@@ -472,7 +472,7 @@ func (as *AuthenticationService) VerifyClientCredentials(ctx context.Context, cl
 
 	_, err = cfg.Token(ctx)
 	if err != nil {
-		return errors.E(errors.CodeUnauthorized, fmt.Errorf("invalid client credentials: %v", err))
+		return errors.ErrWithCode(fmt.Errorf("invalid client credentials: %v", err), errors.CodeUnauthorized)
 	}
 	return nil
 }
@@ -534,7 +534,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	identityId, ok := session.Values[SessionIdentityKey]
 	if !ok {
-		return ctx, errors.E(errors.CodeForbidden, "session is missing identity key")
+		return ctx, errors.MsgWithCode("session is missing identity key", errors.CodeForbidden)
 	}
 
 	err = as.validateAndUpdateAccessToken(ctx, identityId)
@@ -572,7 +572,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	identityIdStr, ok := identityId.(string)
 	if !ok {
-		return errors.E(fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
+		return errors.New(fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
@@ -624,7 +624,7 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 
 	emailStr, ok := email.(string)
 	if !ok {
-		return errors.E(fmt.Sprintf("failed to cast email: got %T, expected %T", email, emailStr))
+		return errors.New(fmt.Sprintf("failed to cast email: got %T, expected %T", email, emailStr))
 	}
 
 	db := as.db
@@ -670,11 +670,11 @@ func (as *AuthenticationService) refreshIdentitiesToken(ctx context.Context, ema
 	// Get a new access and refresh token (token source only has Token())
 	newToken, err := tSrc.Token()
 	if err != nil {
-		return errors.E(err, fmt.Errorf("failed to refresh token: %w", err))
+		return fmt.Errorf("failed to refresh token: %w", err)
 	}
 
 	if err := as.UpdateIdentity(ctx, email, newToken); err != nil {
-		return errors.E(err, fmt.Errorf("failed to update identity: %w", err))
+		return fmt.Errorf("failed to update identity: %w", err)
 	}
 
 	return nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -223,7 +223,7 @@ func (as *AuthenticationService) AuthCodeURL() (string, string, error) {
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", "", errors.New(fmt.Sprintf("failed to generate state secret: %s", err.Error()))
+		return "", "", fmt.Errorf("failed to generate state secret: %s", err.Error())
 	}
 	state := base64.RawURLEncoding.EncodeToString(b)
 	return as.oauthConfig.AuthCodeURL(state), state, nil
@@ -572,7 +572,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	identityIdStr, ok := identityId.(string)
 	if !ok {
-		return errors.New(fmt.Sprintf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId))
+		return fmt.Errorf("session identity key could not be parsed: expected %T, got %T", identityIdStr, identityId)
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
@@ -624,7 +624,7 @@ func (as *AuthenticationService) validateAndUpdateAccessToken(ctx context.Contex
 
 	emailStr, ok := email.(string)
 	if !ok {
-		return errors.New(fmt.Sprintf("failed to cast email: got %T, expected %T", email, emailStr))
+		return fmt.Errorf("failed to cast email: got %T, expected %T", email, emailStr)
 	}
 
 	db := as.db

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -59,7 +58,7 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	if err := db.First(&offer).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("application offer not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "application offer not found")
 		}
 		return err
 	}

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -92,7 +92,7 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 	const op = "db.FindApplicationOfferByModel"
 
 	if modelName == "" || modelOwner == "" {
-		return nil, errors.MsgWithCode("model name or owner not specified", errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "model name or owner not specified")
 	}
 	if err := d.ready(); err != nil {
 		return nil, err

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -58,7 +59,7 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	if err := db.First(&offer).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "application offer not found")
+			return fmt.Errorf("application offer not found: %w", err)
 		}
 		return err
 	}
@@ -91,7 +92,7 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 	const op = "db.FindApplicationOfferByModel"
 
 	if modelName == "" || modelOwner == "" {
-		return nil, errors.E(errors.CodeBadRequest, "model name or owner not specified")
+		return nil, errors.MsgWithCode("model name or owner not specified", errors.CodeBadRequest)
 	}
 	if err := d.ready(); err != nil {
 		return nil, err

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
@@ -120,7 +119,7 @@ func (d *Database) ForEachAuditLogEntry(ctx context.Context, filter AuditLogFilt
 		}
 	}
 	if rows.Err() != nil {
-		return errors.E(rows.Err())
+		return rows.Err()
 	}
 	return nil
 }
@@ -144,7 +143,7 @@ func (d *Database) DeleteAuditLogsBefore(ctx context.Context, before time.Time) 
 		Where("time < ?", before).
 		Delete(&dbmodel.AuditLogEntry{})
 	if tx.Error != nil {
-		return 0, errors.E(dbError(tx.Error))
+		return 0, dbError(tx.Error)
 	}
 	return tx.RowsAffected, nil
 }

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"gorm.io/gorm"
 
@@ -30,7 +29,7 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.Create(c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud %q already exists", c.Name), err)
+			return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", c.Name)
 		}
 		return err
 	}
@@ -56,7 +55,7 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.First(&c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud %q not found", c.Name), err)
+			return errors.Codef(errors.CodeNotFound, "cloud %q not found", err)
 		}
 		return err
 	}
@@ -145,7 +144,7 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 	if err := db.Create(cr).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
+			return errors.Codef(errors.CodeAlreadyExists, "cloud-region %s/%s already exists", cr.CloudName, cr.Name)
 		}
 		return err
 	}

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -30,7 +30,7 @@ func (d *Database) AddCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.Create(c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(fmt.Sprintf("cloud %q already exists", c.Name), err)
+			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud %q already exists", c.Name), err)
 		}
 		return err
 	}
@@ -56,7 +56,7 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.First(&c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(fmt.Sprintf("cloud %q not found", c.Name), err)
+			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud %q not found", c.Name), err)
 		}
 		return err
 	}
@@ -145,7 +145,7 @@ func (d *Database) AddCloudRegion(ctx context.Context, cr *dbmodel.CloudRegion) 
 	if err := db.Create(cr).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
+			return fmt.Errorf("%s: %w", fmt.Sprintf("cloud-region %s/%s already exists", cr.CloudName, cr.Name), err)
 		}
 		return err
 	}

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -55,7 +55,7 @@ func (d *Database) GetCloud(ctx context.Context, c *dbmodel.Cloud) (err error) {
 	if err := db.First(&c).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.Codef(errors.CodeNotFound, "cloud %q not found", err)
+			return errors.Codef(errors.CodeNotFound, "cloud %q not found", c.Name)
 		}
 		return err
 	}

--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -87,7 +87,7 @@ func (s *dbSuite) TestGetCloud(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	err = s.Database.GetCloud(ctx, &cl)
-	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found`)
+	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found.*`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
 	cl2 := dbmodel.Cloud{
@@ -355,7 +355,7 @@ func (s *dbSuite) TestDeleteCloud(c *qt.C) {
 		Name: cl.Name,
 	}
 	err = s.Database.GetCloud(ctx, &cl2)
-	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found`)
+	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found.*`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 

--- a/internal/db/cloud_test.go
+++ b/internal/db/cloud_test.go
@@ -87,7 +87,7 @@ func (s *dbSuite) TestGetCloud(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 
 	err = s.Database.GetCloud(ctx, &cl)
-	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found.*`)
+	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
 	cl2 := dbmodel.Cloud{
@@ -355,7 +355,7 @@ func (s *dbSuite) TestDeleteCloud(c *qt.C) {
 		Name: cl.Name,
 	}
 	err = s.Database.GetCloud(ctx, &cl2)
-	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found.*`)
+	c.Check(err, qt.ErrorMatches, `cloud "test-cloud" not found`)
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"gorm.io/gorm/clause"
 
@@ -25,7 +24,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.MsgWithCode(fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name)
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -55,7 +54,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.MsgWithCode(fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name)
 	}
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("Cloud")
@@ -63,10 +62,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	if err := db.Where("cloud_name = ? AND owner_identity_name = ? AND name = ?", cred.CloudName, cred.OwnerIdentityName, cred.Name).First(&cred).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.ErrWithCode(
-				fmt.Errorf("cloudcredential %q not found: %w", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name, err),
-				errors.CodeNotFound,
-			)
+			return errors.Codef(errors.CodeNotFound, "cloudcredential %q not found: %w", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name, err)
 		}
 		return err
 	}

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -62,7 +62,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	if err := db.Where("cloud_name = ? AND owner_identity_name = ? AND name = ?", cred.CloudName, cred.OwnerIdentityName, cred.Name).First(&cred).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.Codef(errors.CodeNotFound, "cloudcredential %q not found: %w", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name, err)
+			return errors.Codef(errors.CodeNotFound, "cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name)
 		}
 		return err
 	}

--- a/internal/db/cloudcredential.go
+++ b/internal/db/cloudcredential.go
@@ -25,7 +25,7 @@ func (d *Database) SetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
+		return errors.MsgWithCode(fmt.Sprintf("invalid cloudcredential tag %q", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), errors.CodeBadRequest)
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -55,7 +55,7 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if cred.CloudName == "" || cred.OwnerIdentityName == "" || cred.Name == "" {
-		return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name))
+		return errors.MsgWithCode(fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), errors.CodeNotFound)
 	}
 	db := d.DB.WithContext(ctx)
 	db = db.Preload("Cloud")
@@ -63,7 +63,10 @@ func (d *Database) GetCloudCredential(ctx context.Context, cred *dbmodel.CloudCr
 	if err := db.Where("cloud_name = ? AND owner_identity_name = ? AND name = ?", cred.CloudName, cred.OwnerIdentityName, cred.Name).First(&cred).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(errors.CodeNotFound, fmt.Sprintf("cloudcredential %q not found", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name), err)
+			return errors.ErrWithCode(
+				fmt.Errorf("cloudcredential %q not found: %w", cred.CloudName+"/"+cred.OwnerIdentityName+"/"+cred.Name, err),
+				errors.CodeNotFound,
+			)
 		}
 		return err
 	}

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -250,7 +250,7 @@ var forEachCloudCredentialTests = []struct {
 	name:     "IterationError",
 	username: "alice@canonical.com",
 	f: func(*dbmodel.CloudCredential) error {
-		return errors.MsgWithCode("test error", errors.Code("test code"))
+		return errors.Codef(errors.Code("test code"), "test error")
 	},
 	expectError:     "test error",
 	expectErrorCode: "test code",

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -339,6 +339,6 @@ func (s *dbSuite) TestDeleteCloudCredential(c *qt.C) {
 		Name:              cred.Name,
 	}
 	err = s.Database.GetCloudCredential(context.Background(), &dbCred)
-	c.Assert(err, qt.ErrorMatches, `cloudcredential \S+ not found.*`)
+	c.Assert(err, qt.ErrorMatches, `cloudcredential \S+ not found`)
 
 }

--- a/internal/db/cloudcredential_test.go
+++ b/internal/db/cloudcredential_test.go
@@ -250,7 +250,7 @@ var forEachCloudCredentialTests = []struct {
 	name:     "IterationError",
 	username: "alice@canonical.com",
 	f: func(*dbmodel.CloudCredential) error {
-		return errors.E("test error", errors.Code("test code"))
+		return errors.MsgWithCode("test error", errors.Code("test code"))
 	},
 	expectError:     "test error",
 	expectErrorCode: "test code",
@@ -339,6 +339,6 @@ func (s *dbSuite) TestDeleteCloudCredential(c *qt.C) {
 		Name:              cred.Name,
 	}
 	err = s.Database.GetCloudCredential(context.Background(), &dbCred)
-	c.Assert(err, qt.ErrorMatches, `cloudcredential \S+ not found`)
+	c.Assert(err, qt.ErrorMatches, `cloudcredential \S+ not found.*`)
 
 }

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -149,7 +149,7 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 	if result.Error != nil {
 		err := dbError(result.Error)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.MsgWithCode("cloudregiondefaults not found", errors.CodeNotFound)
+			return errors.Codef(errors.CodeNotFound, "cloudregiondefaults not found")
 		}
 		return err
 	}

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -149,7 +149,7 @@ func (d *Database) CloudDefaults(ctx context.Context, defaults *dbmodel.CloudDef
 	if result.Error != nil {
 		err := dbError(result.Error)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(errors.CodeNotFound, "cloudregiondefaults not found", err)
+			return errors.MsgWithCode("cloudregiondefaults not found", errors.CodeNotFound)
 		}
 		return err
 	}

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"gorm.io/gorm/clause"
 
@@ -58,7 +57,7 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 	if err := db.First(&controller).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("controller not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "controller not found")
 		}
 		return err
 	}
@@ -109,7 +108,7 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 	if err := db.Delete(controller).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("controller not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "controller not found")
 		}
 		return err
 	}

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm/clause"
 
@@ -51,13 +52,13 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 	case controller.Name != "":
 		db = db.Where("name = ?", controller.Name)
 	default:
-		return errors.E(errors.CodeBadRequest, "controller UUID or name must be provided")
+		return errors.MsgWithCode("controller UUID or name must be provided", errors.CodeBadRequest)
 	}
 	db = db.Preload("CloudRegions").Preload("CloudRegions.CloudRegion").Preload("CloudRegions.CloudRegion.Cloud")
 	if err := db.First(&controller).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "controller not found")
+			return fmt.Errorf("controller not found: %w", err)
 		}
 		return err
 	}
@@ -70,7 +71,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 	const op = "db.UpdateController"
 
 	if controller.ID == 0 {
-		return errors.E(errors.CodeNotFound, `controller not found`)
+		return errors.MsgWithCode(`controller not found`, errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
@@ -93,7 +94,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Controller) (err error) {
 	const op = "db.DeleteController"
 	if controller.ID == 0 {
-		return errors.E(errors.CodeNotFound, `controller not found`)
+		return errors.MsgWithCode(`controller not found`, errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
@@ -108,7 +109,7 @@ func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Con
 	if err := db.Delete(controller).Error; err != nil {
 		err := dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "controller not found")
+			return fmt.Errorf("controller not found: %w", err)
 		}
 		return err
 	}

--- a/internal/db/controller.go
+++ b/internal/db/controller.go
@@ -52,7 +52,7 @@ func (d *Database) GetController(ctx context.Context, controller *dbmodel.Contro
 	case controller.Name != "":
 		db = db.Where("name = ?", controller.Name)
 	default:
-		return errors.MsgWithCode("controller UUID or name must be provided", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "controller UUID or name must be provided")
 	}
 	db = db.Preload("CloudRegions").Preload("CloudRegions.CloudRegion").Preload("CloudRegions.CloudRegion.Cloud")
 	if err := db.First(&controller).Error; err != nil {
@@ -71,7 +71,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 	const op = "db.UpdateController"
 
 	if controller.ID == 0 {
-		return errors.MsgWithCode(`controller not found`, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, `controller not found`)
 	}
 
 	if err := d.ready(); err != nil {
@@ -94,7 +94,7 @@ func (d *Database) UpdateController(ctx context.Context, controller *dbmodel.Con
 func (d *Database) DeleteController(ctx context.Context, controller *dbmodel.Controller) (err error) {
 	const op = "db.DeleteController"
 	if controller.ID == 0 {
-		return errors.MsgWithCode(`controller not found`, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, `controller not found`)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -262,7 +262,7 @@ func (s *dbSuite) TestDeleteController(c *qt.C) {
 		Name: controller.Name,
 	}
 	err = s.Database.GetController(context.Background(), &dbController)
-	c.Assert(err, qt.ErrorMatches, "controller not found.*")
+	c.Assert(err, qt.ErrorMatches, "controller not found")
 
 	err = s.Database.DeleteController(context.Background(), &dbmodel.Controller{})
 	c.Assert(err, qt.ErrorMatches, "controller not found")

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -96,9 +96,7 @@ func (s *dbSuite) TestGetController(c *qt.C) {
 	}
 	err = s.Database.GetController(context.Background(), &dbController)
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
-	c.Assert(ok, qt.IsTrue)
-	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 func TestForEachControllerUnconfiguredDatabase(t *testing.T) {
@@ -264,7 +262,7 @@ func (s *dbSuite) TestDeleteController(c *qt.C) {
 		Name: controller.Name,
 	}
 	err = s.Database.GetController(context.Background(), &dbController)
-	c.Assert(err, qt.ErrorMatches, "controller not found")
+	c.Assert(err, qt.ErrorMatches, "controller not found.*")
 
 	err = s.Database.DeleteController(context.Background(), &dbmodel.Controller{})
 	c.Assert(err, qt.ErrorMatches, "controller not found")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -77,7 +77,7 @@ func (d *Database) Transaction(f func(*Database) error) error {
 // with a code of errors.CodeServerConfiguration will be returned.
 func (d *Database) Migrate(ctx context.Context) error {
 	if d == nil || d.DB == nil {
-		return errors.E(errors.CodeServerConfiguration, "database not configured")
+		return errors.MsgWithCode("database not configured", errors.CodeServerConfiguration)
 	}
 
 	err := d.migrateFromSource(ctx, dbmodel.SQL, path.Join("sql", d.DB.Name()))
@@ -149,10 +149,10 @@ func (d *Database) migrateFromSource(ctx context.Context, fs embed.FS, sqlPath s
 // returned if the database is not yet initialised.
 func (d *Database) ready() error {
 	if d == nil || d.DB == nil {
-		return errors.E(errors.CodeServerConfiguration, "database not configured")
+		return errors.MsgWithCode("database not configured", errors.CodeServerConfiguration)
 	}
 	if atomic.LoadUint32(&d.migrated) == 0 {
-		return errors.E(errors.CodeUpgradeInProgress)
+		return errors.ErrWithCode(nil, errors.CodeUpgradeInProgress)
 	}
 	return nil
 }
@@ -161,10 +161,10 @@ func (d *Database) ready() error {
 func (d *Database) Close() error {
 	sqlDB, err := d.DB.DB()
 	if err != nil {
-		return errors.E(err, "failed to get the internal DB object")
+		return fmt.Errorf("failed to get the internal DB object: %w", err)
 	}
 	if err := sqlDB.Close(); err != nil {
-		return errors.E(err, "failed to close database connection")
+		return fmt.Errorf("failed to close database connection: %w", err)
 	}
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -77,7 +77,7 @@ func (d *Database) Transaction(f func(*Database) error) error {
 // with a code of errors.CodeServerConfiguration will be returned.
 func (d *Database) Migrate(ctx context.Context) error {
 	if d == nil || d.DB == nil {
-		return errors.MsgWithCode("database not configured", errors.CodeServerConfiguration)
+		return errors.Codef(errors.CodeServerConfiguration, "database not configured")
 	}
 
 	err := d.migrateFromSource(ctx, dbmodel.SQL, path.Join("sql", d.DB.Name()))
@@ -149,10 +149,10 @@ func (d *Database) migrateFromSource(ctx context.Context, fs embed.FS, sqlPath s
 // returned if the database is not yet initialised.
 func (d *Database) ready() error {
 	if d == nil || d.DB == nil {
-		return errors.MsgWithCode("database not configured", errors.CodeServerConfiguration)
+		return errors.Codef(errors.CodeServerConfiguration, "database not configured")
 	}
 	if atomic.LoadUint32(&d.migrated) == 0 {
-		return errors.ErrWithCode(nil, errors.CodeUpgradeInProgress)
+		return errors.Codef(errors.CodeUpgradeInProgress, "upgrade in progress")
 	}
 	return nil
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -31,5 +31,5 @@ func dbError(err error) error {
 		}
 	}
 
-	return errors.E(code, err)
+	return errors.ErrWithCode(err, code)
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -31,5 +31,5 @@ func dbError(err error) error {
 		}
 	}
 
-	return errors.ErrWithCode(err, code)
+	return errors.Codef(code, "%w", err)
 }

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -135,7 +135,7 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 	model := d.DB.WithContext(ctx).Model(&dbmodel.GroupEntry{})
 	model.Where("uuid = ?", uuid)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.MsgWithCode("group not found", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "group not found")
 	}
 	return nil
 }
@@ -145,7 +145,7 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 	const op = "db.RemoveGroup"
 
 	if group.ID == 0 && group.UUID == "" {
-		return errors.MsgWithCode("neither UUID or ID specified", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "neither UUID or ID specified")
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/group.go
+++ b/internal/db/group.go
@@ -135,7 +135,7 @@ func (d *Database) UpdateGroupName(ctx context.Context, uuid, name string) (err 
 	model := d.DB.WithContext(ctx).Model(&dbmodel.GroupEntry{})
 	model.Where("uuid = ?", uuid)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.E(errors.CodeNotFound, "group not found")
+		return errors.MsgWithCode("group not found", errors.CodeNotFound)
 	}
 	return nil
 }
@@ -145,7 +145,7 @@ func (d *Database) RemoveGroup(ctx context.Context, group *dbmodel.GroupEntry) (
 	const op = "db.RemoveGroup"
 
 	if group.ID == 0 && group.UUID == "" {
-		return errors.E("neither UUID or ID specified", errors.CodeNotFound)
+		return errors.MsgWithCode("neither UUID or ID specified", errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -27,7 +27,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 	const op = "db.GetIdentity"
 
 	if u.Name == "" {
-		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
+		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
@@ -42,7 +42,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 		DoNothing: true,
 	}).Create(&u)
 	if result.Error != nil {
-		return errors.E(result.Error)
+		return result.Error
 	}
 
 	// Check if a new identity was created.
@@ -67,7 +67,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 	const op = "db.FetchIdentity"
 
 	if u.Name == "" {
-		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
+		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {
@@ -102,7 +102,7 @@ func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if u.Name == "" {
-		return errors.E(errors.CodeNotFound, `invalid identity name ""`)
+		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -118,7 +118,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 	const op = "db.GetIdentityCloudCredentials"
 
 	if u.Name == "" || cloud == "" {
-		return nil, errors.E(errors.CodeNotFound, `cloudcredential not found`)
+		return nil, errors.MsgWithCode(`cloudcredential not found`, errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/identity.go
+++ b/internal/db/identity.go
@@ -27,7 +27,7 @@ func (d *Database) GetIdentity(ctx context.Context, u *dbmodel.Identity) (err er
 	const op = "db.GetIdentity"
 
 	if u.Name == "" {
-		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	if err := d.ready(); err != nil {
@@ -67,7 +67,7 @@ func (d *Database) FetchIdentity(ctx context.Context, u *dbmodel.Identity) (err 
 	const op = "db.FetchIdentity"
 
 	if u.Name == "" {
-		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	if err := d.ready(); err != nil {
@@ -102,7 +102,7 @@ func (d *Database) UpdateIdentity(ctx context.Context, u *dbmodel.Identity) (err
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
 	if u.Name == "" {
-		return errors.MsgWithCode(`invalid identity name ""`, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, `invalid identity name ""`)
 	}
 
 	db := d.DB.WithContext(ctx)
@@ -118,7 +118,7 @@ func (d *Database) GetIdentityCloudCredentials(ctx context.Context, u *dbmodel.I
 	const op = "db.GetIdentityCloudCredentials"
 
 	if u.Name == "" || cloud == "" {
-		return nil, errors.MsgWithCode(`cloudcredential not found`, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, `cloudcredential not found`)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
@@ -31,7 +30,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 	return d.Transaction(func(d *Database) error {
 		// Blocks all other operations, including reads, writes, and other locks.
 		if err := d.DB.Exec(jobLoglockQuery).Error; err != nil {
-			return errors.E("failed to lock job_logs table", err)
+			return fmt.Errorf("failed to lock job_logs table: %w", err)
 		}
 
 		// Get the current line number for this job.
@@ -42,7 +41,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error
 		if err != nil {
-			return errors.E("failed to get current line number", err)
+			return fmt.Errorf("failed to get current line number: %w", err)
 		}
 
 		nextLineNumber := currentLineNumber + 1
@@ -103,7 +102,7 @@ func (d *Database) QueryJobLog(ctx context.Context, jobId int64, offset int) (lo
 			Select("COALESCE(MAX(line_number), 0)").
 			Scan(&currentLineNumber).Error
 		if err != nil {
-			return errors.E("failed to get current line number", err)
+			return fmt.Errorf("failed to get current line number: %w", err)
 		}
 
 		nextOffsetValue = currentLineNumber

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -30,7 +30,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 	return d.Transaction(func(d *Database) error {
 		// Blocks all other operations, including reads, writes, and other locks.
 		if err := d.DB.Exec(jobLoglockQuery).Error; err != nil {
-			return fmt.Errorf("failed to lock job_logs table: %w", err)
+			return fmt.Errorf("failed to lock job_logs table")
 		}
 
 		// Get the current line number for this job.

--- a/internal/db/job_logs_test.go
+++ b/internal/db/job_logs_test.go
@@ -143,5 +143,5 @@ func (s *dbSuite) TestJobLogs_lockJobLogs(c *qt.C) {
 	<-lockAcquired
 
 	err = s.Database.AddJobLog(ctx, jobID, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
-	c.Assert(err, qt.ErrorMatches, "failed to lock job_logs table.*")
+	c.Assert(err, qt.ErrorMatches, "failed to lock job_logs table")
 }

--- a/internal/db/job_logs_test.go
+++ b/internal/db/job_logs_test.go
@@ -143,5 +143,5 @@ func (s *dbSuite) TestJobLogs_lockJobLogs(c *qt.C) {
 	<-lockAcquired
 
 	err = s.Database.AddJobLog(ctx, jobID, "Creating Juju controller \"diglett\" on the-most-amazing-cloud")
-	c.Assert(err, qt.ErrorMatches, "failed to lock job_logs table")
+	c.Assert(err, qt.ErrorMatches, "failed to lock job_logs table.*")
 }

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm"
 
@@ -64,7 +65,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 		// TODO: fix ordering of where fields and handle error to represent what is *actually* required.
 		db = db.Where("controller_id = ?", model.ControllerID)
 	default:
-		return errors.E("missing id or uuid", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing id or uuid", errors.CodeBadRequest)
 	}
 
 	db = preloadModel("", db)
@@ -72,9 +73,9 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 	if err := db.First(&model).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "model not found")
+			return fmt.Errorf("model not found: %w", err)
 		}
-		return dbError(err)
+		return err
 	}
 	return nil
 }
@@ -134,7 +135,7 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 	case model.ID != 0:
 		db = db.Where("id = ?", model.ID)
 	default:
-		return errors.E("missing id or uuid", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing id or uuid", errors.CodeBadRequest)
 	}
 
 	if err := db.Delete(model).Error; err != nil {
@@ -195,7 +196,7 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 	if err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(err, "model not found")
+			return nil, fmt.Errorf("model not found: %w", err)
 		}
 		return nil, dbError(err)
 	}

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -65,7 +65,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 		// TODO: fix ordering of where fields and handle error to represent what is *actually* required.
 		db = db.Where("controller_id = ?", model.ControllerID)
 	default:
-		return errors.MsgWithCode("missing id or uuid", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing id or uuid")
 	}
 
 	db = preloadModel("", db)
@@ -135,7 +135,7 @@ func (d *Database) DeleteModel(ctx context.Context, model *dbmodel.Model) (err e
 	case model.ID != 0:
 		db = db.Where("id = ?", model.ID)
 	default:
-		return errors.MsgWithCode("missing id or uuid", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing id or uuid")
 	}
 
 	if err := db.Delete(model).Error; err != nil {

--- a/internal/db/model.go
+++ b/internal/db/model.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"gorm.io/gorm"
 
@@ -73,7 +72,7 @@ func (d *Database) GetModel(ctx context.Context, model *dbmodel.Model) (err erro
 	if err := db.First(&model).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("model not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "model not found")
 		}
 		return err
 	}
@@ -196,7 +195,7 @@ func (d *Database) GetModelsByUUID(ctx context.Context, modelUUIDs []string) (_ 
 	if err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, fmt.Errorf("model not found: %w", err)
+			return nil, errors.Codef(errors.CodeNotFound, "model not found")
 		}
 		return nil, dbError(err)
 	}

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -167,9 +167,7 @@ func (s *dbSuite) TestGetModel(c *qt.C) {
 	}
 	err = s.Database.GetModel(context.Background(), &dbModel)
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
-	c.Assert(ok, qt.IsTrue)
-	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
 	dbModel = dbmodel.Model{
 		Name:              model.Name,

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm/clause"
@@ -65,7 +66,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.E("missing uuid", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing uuid", errors.CodeBadRequest)
 	}
 
 	lockingClause := clause.Locking{Strength: "UPDATE"}
@@ -76,7 +77,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "model migration not found")
+			return fmt.Errorf("model migration not found: %w", err)
 		}
 		return err
 	}
@@ -99,13 +100,13 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.E("missing uuid", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing uuid", errors.CodeBadRequest)
 	}
 
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "model migration not found")
+			return fmt.Errorf("model migration not found: %w", err)
 		}
 		return err
 	}

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -66,7 +66,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.MsgWithCode("missing uuid", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing uuid")
 	}
 
 	lockingClause := clause.Locking{Strength: "UPDATE"}
@@ -100,7 +100,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 	case modelMigration.ModelUUID.Valid:
 		db = db.Where("model_uuid = ?", modelMigration.ModelUUID.String)
 	default:
-		return errors.MsgWithCode("missing uuid", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing uuid")
 	}
 
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {

--- a/internal/db/modelmigration.go
+++ b/internal/db/modelmigration.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"gorm.io/gorm/clause"
@@ -77,7 +76,7 @@ func (d *Database) GetIncomingModelMigrationWithLock(ctx context.Context, modelM
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("model migration not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "model migration not found")
 		}
 		return err
 	}
@@ -106,7 +105,7 @@ func (d *Database) GetIncomingModelMigration(ctx context.Context, modelMigration
 	if err := db.Preload("TargetController").First(&modelMigration).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("model migration not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "model migration not found")
 		}
 		return err
 	}

--- a/internal/db/modelmigration_test.go
+++ b/internal/db/modelmigration_test.go
@@ -99,9 +99,7 @@ func (s *dbSuite) TestGetModelMigration(c *qt.C) {
 	lookup = dbmodel.IncomingModelMigration{ModelUUID: sql.NullString{String: "no-such-uuid", Valid: true}}
 	err = s.Database.GetIncomingModelMigration(context.Background(), &lookup)
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
-	c.Assert(ok, qt.IsTrue)
-	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 func (s *dbSuite) TestGetModelMigrationWithLock_NoWait(c *qt.C) {

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -82,7 +82,7 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 	model := d.DB.WithContext(ctx).Model(&dbmodel.RoleEntry{})
 	model.Where("name = ?", oldName)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.MsgWithCode("role not found", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "role not found")
 	}
 
 	return nil
@@ -93,7 +93,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 	const op = "db.RemoveRole"
 
 	if role.ID == 0 && role.UUID == "" {
-		return errors.MsgWithCode("neither role UUID or ID specified", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "neither role UUID or ID specified")
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/role.go
+++ b/internal/db/role.go
@@ -82,7 +82,7 @@ func (d *Database) UpdateRoleName(ctx context.Context, oldName, name string) (er
 	model := d.DB.WithContext(ctx).Model(&dbmodel.RoleEntry{})
 	model.Where("name = ?", oldName)
 	if model.Update("name", name).RowsAffected == 0 {
-		return errors.E(errors.CodeNotFound, "role not found")
+		return errors.MsgWithCode("role not found", errors.CodeNotFound)
 	}
 
 	return nil
@@ -93,7 +93,7 @@ func (d *Database) RemoveRole(ctx context.Context, role *dbmodel.RoleEntry) (err
 	const op = "db.RemoveRole"
 
 	if role.ID == 0 && role.UUID == "" {
-		return errors.E("neither role UUID or ID specified", errors.CodeNotFound)
+		return errors.MsgWithCode("neither role UUID or ID specified", errors.CodeNotFound)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -79,7 +79,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	if err := db.First(&secret).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("secret not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "secret not found")
 		}
 		return dbError(err)
 	}

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -61,7 +61,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	const op = "db.GetSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.MsgWithCode("missing secret tag and type", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing secret tag and type")
 	}
 
 	if err := d.ready(); err != nil {
@@ -91,7 +91,7 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 	const op = "db.DeleteSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.MsgWithCode("missing secret tag and type", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing secret tag and type")
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -61,7 +61,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	const op = "db.GetSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.E("missing secret tag and type", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing secret tag and type", errors.CodeBadRequest)
 	}
 
 	if err := d.ready(); err != nil {
@@ -79,7 +79,7 @@ func (d *Database) GetSecret(ctx context.Context, secret *dbmodel.Secret) (err e
 	if err := db.First(&secret).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "secret not found")
+			return fmt.Errorf("secret not found: %w", err)
 		}
 		return dbError(err)
 	}
@@ -91,7 +91,7 @@ func (d *Database) DeleteSecret(ctx context.Context, secret *dbmodel.Secret) (er
 	const op = "db.DeleteSecret"
 
 	if secret.Tag == "" || secret.Type == "" {
-		return errors.E("missing secret tag and type", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing secret tag and type", errors.CodeBadRequest)
 	}
 
 	if err := d.ready(); err != nil {

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -27,7 +27,7 @@ func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err e
 			// we don't return an error if a user tries to add the same key twice.
 			return nil
 		}
-		return errors.E(dbErr)
+		return dbErr
 	}
 	return nil
 }
@@ -54,7 +54,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.E(errors.CodeNotFound, "key not found")
+		return errors.MsgWithCode("key not found", errors.CodeNotFound)
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.E(errors.CodeNotFound, "key not found")
+		return errors.MsgWithCode("key not found", errors.CodeNotFound)
 	}
 
 	return nil

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -54,7 +54,7 @@ func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName s
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.MsgWithCode("key not found", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "key not found")
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	}
 
 	if query.RowsAffected == 0 {
-		return errors.MsgWithCode("key not found", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "key not found")
 	}
 
 	return nil

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -4,7 +4,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -56,7 +55,7 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 	if err := db.First(&userMapping).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("user mapping not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "user mapping not found")
 		}
 		return err
 	}

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -45,19 +46,19 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 	case userMapping.ModelUUID.Valid && userMapping.LocalUser != "":
 		db = db.Where("model_uuid = ? AND local_user = ?", userMapping.ModelUUID.String, userMapping.LocalUser)
 	case !userMapping.ModelUUID.Valid:
-		return errors.E("missing model UUID", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing model UUID", errors.CodeBadRequest)
 	case userMapping.LocalUser == "":
-		return errors.E("missing local user", errors.CodeBadRequest)
+		return errors.MsgWithCode("missing local user", errors.CodeBadRequest)
 	default:
-		return errors.E("invalid parameters", errors.CodeBadRequest)
+		return errors.MsgWithCode("invalid parameters", errors.CodeBadRequest)
 	}
 
 	if err := db.First(&userMapping).Error; err != nil {
 		err = dbError(err)
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "user mapping not found")
+			return fmt.Errorf("user mapping not found: %w", err)
 		}
-		return dbError(err)
+		return err
 	}
 	return nil
 }

--- a/internal/db/usermapping.go
+++ b/internal/db/usermapping.go
@@ -46,11 +46,11 @@ func (d *Database) GetUserMapping(ctx context.Context, userMapping *dbmodel.User
 	case userMapping.ModelUUID.Valid && userMapping.LocalUser != "":
 		db = db.Where("model_uuid = ? AND local_user = ?", userMapping.ModelUUID.String, userMapping.LocalUser)
 	case !userMapping.ModelUUID.Valid:
-		return errors.MsgWithCode("missing model UUID", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing model UUID")
 	case userMapping.LocalUser == "":
-		return errors.MsgWithCode("missing local user", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "missing local user")
 	default:
-		return errors.MsgWithCode("invalid parameters", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid parameters")
 	}
 
 	if err := db.First(&userMapping).Error; err != nil {

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -119,7 +119,7 @@ func migrationDescriptionVersion(controllerVersion version.Number) (int, error) 
 func TryDetermineModelUUID(raw []byte) (string, error) {
 	model, err := descriptionv10.Deserialize(raw)
 	if err != nil {
-		return "", errors.E("failed to deserialize model description: %w", err)
+		return "", fmt.Errorf("failed to deserialize model description: %w", err)
 	}
 	modelUUIDStr, ok := model.Config()[config.UUIDKey].(string)
 	if !ok {

--- a/internal/discharger/discharger.go
+++ b/internal/discharger/discharger.go
@@ -4,6 +4,7 @@ package discharger
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -43,10 +44,10 @@ func NewMacaroonDischarger(cfg MacaroonDischargerConfig, db *db.Database, offerA
 		return nil, errors.New("missing bakery private/public key")
 	} else {
 		if err := kp.Private.UnmarshalText([]byte(cfg.PrivateKey)); err != nil {
-			return nil, errors.E(err, "cannot unmarshal private key")
+			return nil, fmt.Errorf("cannot unmarshal private key: %w", err)
 		}
 		if err := kp.Public.UnmarshalText([]byte(cfg.PublicKey)); err != nil {
-			return nil, errors.E(err, "cannot unmarshal public key")
+			return nil, fmt.Errorf("cannot unmarshal public key: %w", err)
 		}
 	}
 	if offerAuthorizer == nil {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -71,7 +71,7 @@ func New(text string) error {
 // If the format string includes a %w verb and the corresponding argument is an error,
 // that error will be wrapped and can be retrieved using errors.Unwrap.
 //
-// To attach a code to an error without adding context use %w or %v as necessary:
+// To attach a code to an error without adding context use %w or %v as necessary, i.e.:
 // `errors.Codef(code, "%w", err)`
 // or
 // `errors.Codef(code, "%v", err)`

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -5,11 +5,8 @@ package errors
 
 import (
 	stderr "errors"
-	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/zaputil/zapctx"
-	"go.uber.org/zap"
 
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -65,58 +62,20 @@ func New(text string) error {
 	return stderr.New(text)
 }
 
-// E constructs errors for use throughout the JIMM application. An error
-// is constructed by processing the given arguments. The meaning of the
-// arguments is as follows:
-//
-//	errors.Code - string code classifying the error.
-//	error       - underlying error that caused the new error.
-//	string      - A human readable message describing the error.
-//
-// E will panic if no arguments are provided.
-func E(args ...interface{}) error {
-	if len(args) == 0 {
-		panic("call to errors.E with no arguments")
+// ErrWithCode constructs an error with an explicit code.
+func ErrWithCode(err error, code Code) error {
+	return &Error{
+		Code: code,
+		Err:  err,
 	}
-	var setCode bool
-	var setInfo bool
-	var e Error
-	for _, arg := range args {
-		switch v := arg.(type) {
-		case Code:
-			setCode = true
-			e.Code = v
-		case error:
-			e.Err = v
-		case string:
-			e.Message = v
-		case map[string]any:
-			setInfo = true
-			e.Info = v
-		default:
-			zapctx.Default.DPanic("unknown type passed to errors.E", zap.String("type", fmt.Sprintf("%T", arg)), zap.Any("value", arg))
-			return fmt.Errorf("unknown type (%T) passed to errors.E", arg)
-		}
-	}
-	if setCode {
-		return &e
-	}
+}
 
-	// If the caller didn't explicitly set the code/info for this error, attempt
-	// to copy the code/info from the wrapped error. The interface used to
-	// extract the details is compatible with both the Error type and juju
-	// API Error types.
-	if !setCode {
-		if code := ErrorCode(e.Err); code != "" {
-			e.Code = code
-		}
+// MsgWithCode constructs an error with a message and an explicit code.
+func MsgWithCode(msg string, code Code) error {
+	return &Error{
+		Code:    code,
+		Message: msg,
 	}
-	if !setInfo {
-		if info := ErrorInfo(e.Err); info != nil {
-			e.Info = info
-		}
-	}
-	return &e
 }
 
 // A Code is a code which describes the class of error. Where possible

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -5,6 +5,7 @@ package errors
 
 import (
 	stderr "errors"
+	"fmt"
 
 	jujuparams "github.com/juju/juju/rpc/params"
 
@@ -62,19 +63,22 @@ func New(text string) error {
 	return stderr.New(text)
 }
 
-// ErrWithCode constructs an error with an explicit code.
-func ErrWithCode(err error, code Code) error {
+// Codef constructs an error with a formatted message and an explicit code.
+//
+// The message is formatted using fmt.Errorf with the provided format and args.
+// The code is attached to the error and can be retrieved using the ErrorCode function.
+//
+// If the format string includes a %w verb and the corresponding argument is an error,
+// that error will be wrapped and can be retrieved using errors.Unwrap.
+//
+// To attach a code to an error without adding context use %w or %v as necessary:
+// `errors.Codef(code, "%w", err)`
+// or
+// `errors.Codef(code, "%v", err)`
+func Codef(code Code, format string, args ...any) error {
 	return &Error{
 		Code: code,
-		Err:  err,
-	}
-}
-
-// MsgWithCode constructs an error with a message and an explicit code.
-func MsgWithCode(msg string, code Code) error {
-	return &Error{
-		Code:    code,
-		Message: msg,
+		Err:  fmt.Errorf(format, args...),
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -12,42 +12,31 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
-func TestEEmptyArguments(t *testing.T) {
-	c := qt.New(t)
-
-	c.Assert(func() {
-		_ = errors.E()
-	}, qt.PanicMatches, `call to errors.E with no arguments`)
-}
-
-func TestEUnknownType(t *testing.T) {
-	c := qt.New(t)
-	c.Check(errors.E(42), qt.ErrorMatches, `unknown type \(int\) passed to errors.E`)
-}
-
-func TestE(t *testing.T) {
+func TestErrWithCode(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
-	err := errors.E(code, "an error happened")
+	wrapped := errors.New("an error happened")
+	err := errors.ErrWithCode(wrapped, code)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
-
-	err = errors.E(err)
-	c.Check(err, qt.ErrorMatches, `an error happened`)
-	c.Check(errors.ErrorCode(err), qt.Equals, code)
+	errValue, ok := err.(*errors.Error)
+	c.Assert(ok, qt.IsTrue)
+	c.Check(errValue.Code, qt.Equals, code)
+	c.Check(errValue.Err, qt.Equals, wrapped)
 }
 
-func TestEWithInfo(t *testing.T) {
+func TestMsgWithCode(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
-	info := map[string]any{"key": "value"}
-	err := errors.E(code, "an error happened", info)
+	err := errors.MsgWithCode("an error happened", code)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
-	c.Check(err.(*errors.Error).Info, qt.DeepEquals, info)
-	c.Check(errors.ErrorInfo(err), qt.DeepEquals, info)
+	errValue, ok := err.(*errors.Error)
+	c.Assert(ok, qt.IsTrue)
+	c.Check(errValue.Code, qt.Equals, code)
+	c.Check(errValue.Message, qt.Equals, "an error happened")
 
 	err = errors.New("plain-error")
 	c.Check(err, qt.ErrorMatches, `plain-error`)

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -3,6 +3,7 @@
 package errors_test
 
 import (
+	stderr "errors"
 	"fmt"
 	"testing"
 
@@ -12,35 +13,40 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
-func TestErrWithCode(t *testing.T) {
+func TestCodefWrapsError(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
 	wrapped := errors.New("an error happened")
-	err := errors.ErrWithCode(wrapped, code)
+	err := errors.Codef(code, "%w", wrapped)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 	errValue, ok := err.(*errors.Error)
 	c.Assert(ok, qt.IsTrue)
 	c.Check(errValue.Code, qt.Equals, code)
-	c.Check(errValue.Err, qt.Equals, wrapped)
+	c.Assert(errValue.Err, qt.IsNotNil)
+	c.Check(errValue.Err.Error(), qt.Equals, wrapped.Error())
+	c.Check(stderr.Is(errValue.Err, wrapped), qt.IsTrue)
+	c.Check(stderr.Is(err, wrapped), qt.IsTrue)
 }
 
-func TestMsgWithCode(t *testing.T) {
+func TestCodefFormatsString(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
-	err := errors.MsgWithCode("an error happened", code)
+	err := errors.Codef(code, "an error happened")
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 	errValue, ok := err.(*errors.Error)
 	c.Assert(ok, qt.IsTrue)
 	c.Check(errValue.Code, qt.Equals, code)
-	c.Check(errValue.Message, qt.Equals, "an error happened")
+	c.Assert(errValue.Err, qt.IsNotNil)
+	c.Check(errValue.Err.Error(), qt.Equals, "an error happened")
+	c.Check(errValue.Message, qt.Equals, "")
 
-	err = errors.New("plain-error")
-	c.Check(err, qt.ErrorMatches, `plain-error`)
-	c.Check(errors.ErrorInfo(err), qt.DeepEquals, map[string]any(nil))
+	err = errors.Codef(code, "formatted %s", "message")
+	c.Check(err, qt.ErrorMatches, `formatted message`)
+	c.Check(errors.ErrorCode(err), qt.Equals, code)
 }
 
 func TestErrorCodeWithJujuRPC(t *testing.T) {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -21,11 +21,13 @@ func TestCodefWrapsError(t *testing.T) {
 	err := errors.Codef(code, "%w", wrapped)
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
+
 	errValue, ok := err.(*errors.Error)
 	c.Assert(ok, qt.IsTrue)
 	c.Check(errValue.Code, qt.Equals, code)
 	c.Assert(errValue.Err, qt.IsNotNil)
 	c.Check(errValue.Err.Error(), qt.Equals, wrapped.Error())
+	c.Check(errValue.Message, qt.Equals, "")
 	c.Check(stderr.Is(errValue.Err, wrapped), qt.IsTrue)
 	c.Check(stderr.Is(err, wrapped), qt.IsTrue)
 }
@@ -34,19 +36,34 @@ func TestCodefFormatsString(t *testing.T) {
 	c := qt.New(t)
 
 	code := errors.Code("test code")
-	err := errors.Codef(code, "an error happened")
-	c.Check(err, qt.ErrorMatches, `an error happened`)
-	c.Check(errors.ErrorCode(err), qt.Equals, code)
-	errValue, ok := err.(*errors.Error)
-	c.Assert(ok, qt.IsTrue)
-	c.Check(errValue.Code, qt.Equals, code)
-	c.Assert(errValue.Err, qt.IsNotNil)
-	c.Check(errValue.Err.Error(), qt.Equals, "an error happened")
-	c.Check(errValue.Message, qt.Equals, "")
-
-	err = errors.Codef(code, "formatted %s", "message")
+	err := errors.Codef(code, "formatted %s", "message")
 	c.Check(err, qt.ErrorMatches, `formatted message`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
+}
+
+func TestErrorInfo(t *testing.T) {
+	c := qt.New(t)
+
+	info := map[string]any{"key": "value"}
+	err := error(&errors.Error{
+		Message: "error with info",
+		Info:    info,
+	})
+	c.Check(err, qt.ErrorMatches, `error with info`)
+	c.Check(errors.ErrorInfo(err), qt.DeepEquals, info)
+}
+
+func TestErrorMessageOrder(t *testing.T) {
+	c := qt.New(t)
+
+	err := &errors.Error{Code: errors.Code("a code")}
+	c.Check(err.Error(), qt.Equals, "a code")
+
+	err = &errors.Error{Err: errors.New("a wrapped err"), Code: errors.Code("a code")}
+	c.Check(err.Error(), qt.Equals, "a wrapped err")
+
+	err = &errors.Error{Message: "a message", Err: errors.New("a wrapped err"), Code: errors.Code("a code")}
+	c.Check(err.Error(), qt.Equals, "a message")
 }
 
 func TestErrorCodeWithJujuRPC(t *testing.T) {

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -81,7 +81,7 @@ func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 
 	access := user.GetAuditLogViewerAccess(ctx, j.jimmTag)
 	if access != ofganames.AuditLogViewerRelation {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var entries []dbmodel.AuditLogEntry
@@ -101,7 +101,7 @@ func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 // returned.
 func (j *AuditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, before time.Time) (int64, error) {
 	if !user.JimmAdmin {
-		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return 0, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := j.store.DeleteAuditLogsBefore(ctx, before)
 	if err != nil {

--- a/internal/jimm/auditlog/auditlog.go
+++ b/internal/jimm/auditlog/auditlog.go
@@ -81,7 +81,7 @@ func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 
 	access := user.GetAuditLogViewerAccess(ctx, j.jimmTag)
 	if access != ofganames.AuditLogViewerRelation {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var entries []dbmodel.AuditLogEntry
@@ -101,7 +101,7 @@ func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.Use
 // returned.
 func (j *AuditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, before time.Time) (int64, error) {
 	if !user.JimmAdmin {
-		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	count, err := j.store.DeleteAuditLogsBefore(ctx, before)
 	if err != nil {

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -123,7 +123,7 @@ func NewBootstrapManager(
 	if jimmWellknownJWKSEndpoint != "" {
 		// Scheme is not optional, so we aren't using ParseURLWithOptionalScheme here.
 		if _, err := url.Parse(jimmWellknownJWKSEndpoint); err != nil {
-			return nil, errors.E(err, "failed to parse bootstrap login token refresh URL")
+			return nil, fmt.Errorf("failed to parse bootstrap login token refresh URL: %w", err)
 		}
 	}
 	if credentialStore == nil {
@@ -199,7 +199,7 @@ func (b *BootstrapManager) StopJob(ctx context.Context, user *openfga.User, jobI
 
 	_, err := b.jobQueue.CancelJob(ctx, jobID)
 	if err != nil {
-		return errors.E("failed to stop job", err)
+		return fmt.Errorf("failed to stop job: %w", err)
 	}
 
 	return nil
@@ -268,7 +268,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		return 0, fmt.Errorf("failed to enqueue bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.E("a bootstrap job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
+		return 0, errors.MsgWithCode("a bootstrap job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
 	}
 
 	return job.Job.ID, nil
@@ -339,7 +339,7 @@ func (b *BootstrapManager) BootstrapController(
 	// succeed when trying to add the controller to JIMM.
 	err := b.store.GetController(ctx, &dbmodel.Controller{Name: p.ControllerName})
 	if err == nil {
-		return errors.E(errors.CodeAlreadyExists, fmt.Errorf("controller %q already exists", p.ControllerName))
+		return errors.ErrWithCode(fmt.Errorf("controller %q already exists", p.ControllerName), errors.CodeAlreadyExists)
 	}
 	if errors.ErrorCode(err) != errors.CodeNotFound {
 		return fmt.Errorf("failed to check if controller exists: %w", err)
@@ -552,7 +552,7 @@ func (b *BootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 		return 0, fmt.Errorf("failed to start bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.E("a destroy job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
+		return 0, errors.MsgWithCode("a destroy job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
 	}
 
 	return job.Job.ID, nil

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -268,7 +268,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 		return 0, fmt.Errorf("failed to enqueue bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.MsgWithCode("a bootstrap job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
+		return 0, errors.Codef(errors.CodeInProgress, "a bootstrap job is already in progress - please wait for it to complete before starting a new one")
 	}
 
 	return job.Job.ID, nil
@@ -339,7 +339,7 @@ func (b *BootstrapManager) BootstrapController(
 	// succeed when trying to add the controller to JIMM.
 	err := b.store.GetController(ctx, &dbmodel.Controller{Name: p.ControllerName})
 	if err == nil {
-		return errors.ErrWithCode(fmt.Errorf("controller %q already exists", p.ControllerName), errors.CodeAlreadyExists)
+		return errors.Codef(errors.CodeAlreadyExists, "controller %q already exists", p.ControllerName)
 	}
 	if errors.ErrorCode(err) != errors.CodeNotFound {
 		return fmt.Errorf("failed to check if controller exists: %w", err)
@@ -552,7 +552,7 @@ func (b *BootstrapManager) StartDestroyControllerJob(ctx context.Context, user *
 		return 0, fmt.Errorf("failed to start bootstrap job: %w", err)
 	}
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.MsgWithCode("a destroy job is already in progress - please wait for it to complete before starting a new one", errors.CodeInProgress)
+		return 0, errors.Codef(errors.CodeInProgress, "a destroy job is already in progress - please wait for it to complete before starting a new one")
 	}
 
 	return job.Job.ID, nil

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -349,7 +349,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -500,7 +500,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test err"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -538,7 +538,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -600,7 +600,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -628,7 +628,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 	).Return(
 		func() chan jujucommands.OutputLine {
 			outputCh := make(chan jujucommands.OutputLine, 1)
-			outputCh <- jujucommands.OutputLine{Err: errors.E(testOutputLineError)}
+			outputCh <- jujucommands.OutputLine{Err: errors.New(testOutputLineError)}
 			close(outputCh)
 			return outputCh
 		}(),
@@ -667,7 +667,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -770,7 +770,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -873,7 +873,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1001,7 +1001,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1102,7 +1102,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.E(errors.CodeNotFound, "test error"),
+		errors.MsgWithCode("test err", errors.CodeNotFound),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1136,7 +1136,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 		}
 
 		outputCh := make(chan jujucommands.OutputLine, 1)
-		outputCh <- jujucommands.OutputLine{Line: "ignored", Err: errors.E(failedBootstrapErr)}
+		outputCh <- jujucommands.OutputLine{Line: "ignored", Err: errors.New(failedBootstrapErr)}
 		close(outputCh)
 		return outputCh, mocks.clientStore, func() { cleanupCalled = true }, nil
 	})

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -349,7 +349,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -500,7 +500,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_BinaryStoreGetFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -538,7 +538,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ExecutorFails(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -600,7 +600,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ReturnsEarlyIfLineErrors(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -667,7 +667,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -770,7 +770,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_ClientStoreFailsToGetAccountDet
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -873,7 +873,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1001,7 +1001,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),
@@ -1102,7 +1102,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CancelledJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: p.ControllerName},
 	).Return(
-		errors.MsgWithCode("test err", errors.CodeNotFound),
+		errors.Codef(errors.CodeNotFound, "test err"),
 	)
 	mocks.binaryStore.EXPECT().Get(
 		gomock.Any(),

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -9,7 +9,6 @@ import (
 
 	jujucloud "github.com/juju/juju/cloud"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/rivertypes"
 )
 
@@ -74,7 +73,7 @@ func (p BootstrapParams) validate() error {
 
 	// If there are validation errors, return them as a single error.
 	if msgs != nil {
-		return errors.New(fmt.Sprintf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n")))
+		return fmt.Errorf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n"))
 	}
 	return nil
 }

--- a/internal/jimm/bootstrap/types.go
+++ b/internal/jimm/bootstrap/types.go
@@ -74,7 +74,7 @@ func (p BootstrapParams) validate() error {
 
 	// If there are validation errors, return them as a single error.
 	if msgs != nil {
-		return errors.E(fmt.Sprintf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n")))
+		return errors.New(fmt.Sprintf("invalid bootstrap parameters:\n%s", strings.Join(msgs, "\n")))
 	}
 	return nil
 }

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -35,7 +35,7 @@ func NewGroupManager(store *db.Database, authSvc *openfga.OFGAClient) (*GroupMan
 func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ge, err := j.store.AddGroup(ctx, name)
@@ -49,7 +49,7 @@ func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name st
 func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int, error) {
 
 	if !user.JimmAdmin {
-		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return 0, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := j.store.CountGroups(ctx)
 	if err != nil {
@@ -62,7 +62,7 @@ func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int
 func (j *GroupManager) getGroup(ctx context.Context, user *openfga.User, group *dbmodel.GroupEntry) (*dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	if err := j.store.GetGroup(ctx, group); err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (j *GroupManager) GetGroupByName(ctx context.Context, user *openfga.User, n
 func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -113,7 +113,7 @@ func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -145,7 +145,7 @@ func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name
 func (j *GroupManager) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	groups, err := j.store.ListGroups(ctx, pagination.Limit(), pagination.Offset(), match)

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -35,7 +35,7 @@ func NewGroupManager(store *db.Database, authSvc *openfga.OFGAClient) (*GroupMan
 func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	ge, err := j.store.AddGroup(ctx, name)
@@ -49,7 +49,7 @@ func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name st
 func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int, error) {
 
 	if !user.JimmAdmin {
-		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	count, err := j.store.CountGroups(ctx)
 	if err != nil {
@@ -62,7 +62,7 @@ func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int
 func (j *GroupManager) getGroup(ctx context.Context, user *openfga.User, group *dbmodel.GroupEntry) (*dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	if err := j.store.GetGroup(ctx, group); err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (j *GroupManager) GetGroupByName(ctx context.Context, user *openfga.User, n
 func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -113,7 +113,7 @@ func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldN
 func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	group := &dbmodel.GroupEntry{
@@ -145,7 +145,7 @@ func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name
 func (j *GroupManager) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	groups, err := j.store.ListGroups(ctx, pagination.Limit(), pagination.Offset(), match)

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -50,7 +50,7 @@ func (j *IdentityManager) FetchIdentity(ctx context.Context, id string) (*openfg
 func (j *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	identities, err := j.store.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), match)
 	var users []openfga.User
@@ -68,7 +68,7 @@ func (j *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User
 func (j *IdentityManager) CountIdentities(ctx context.Context, user *openfga.User) (int, error) {
 
 	if !user.JimmAdmin {
-		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return 0, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	count, err := j.store.CountIdentities(ctx)

--- a/internal/jimm/identity/identity.go
+++ b/internal/jimm/identity/identity.go
@@ -50,7 +50,7 @@ func (j *IdentityManager) FetchIdentity(ctx context.Context, id string) (*openfg
 func (j *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	identities, err := j.store.ListIdentities(ctx, pagination.Limit(), pagination.Offset(), match)
 	var users []openfga.User
@@ -68,7 +68,7 @@ func (j *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User
 func (j *IdentityManager) CountIdentities(ctx context.Context, user *openfga.User) (int, error) {
 
 	if !user.JimmAdmin {
-		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	count, err := j.store.CountIdentities(ctx)

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -73,7 +73,7 @@ func (j *JobManager) ListJobs(ctx context.Context, req apiparams.ListJobsRequest
 		count = defaultListJobsCount
 	}
 	if count > maxListJobsCount {
-		return apiparams.ListJobsResponse{}, errors.E(errors.CodeBadRequest, fmt.Sprintf("count must be between 1 and %d.", maxListJobsCount))
+		return apiparams.ListJobsResponse{}, errors.MsgWithCode(fmt.Sprintf("count must be between 1 and %d.", maxListJobsCount), errors.CodeBadRequest)
 	}
 
 	p := river.NewJobListParams().First(count)
@@ -90,7 +90,7 @@ func (j *JobManager) ListJobs(ctx context.Context, req apiparams.ListJobsRequest
 	if req.Cursor != "" {
 		cursor := &river.JobListCursor{}
 		if err := cursor.UnmarshalText([]byte(req.Cursor)); err != nil {
-			return apiparams.ListJobsResponse{}, errors.E("invalid cursor: %w", err)
+			return apiparams.ListJobsResponse{}, fmt.Errorf("invalid cursor: %w", err)
 		}
 		p = p.After(cursor)
 	}
@@ -116,7 +116,7 @@ func (j *JobManager) ListJobs(ctx context.Context, req apiparams.ListJobsRequest
 	if jobListResult.LastCursor != nil {
 		cursorBytes, err := jobListResult.LastCursor.MarshalText()
 		if err != nil {
-			return apiparams.ListJobsResponse{}, errors.E("failed to marshal cursor: %w", err)
+			return apiparams.ListJobsResponse{}, fmt.Errorf("failed to marshal cursor: %w", err)
 		}
 		nextCursor = string(cursorBytes)
 	}
@@ -150,7 +150,7 @@ func convertJobStates(statuses []apiparams.JobStatus) ([]rivertype.JobState, err
 		case apiparams.StatusPending:
 			riverStates = append(riverStates, rivertype.JobStateAvailable, rivertype.JobStateScheduled)
 		default:
-			return nil, errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid job status: %s", status))
+			return nil, errors.MsgWithCode(fmt.Sprintf("invalid job status: %s", status), errors.CodeBadRequest)
 		}
 	}
 

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -73,7 +73,7 @@ func (j *JobManager) ListJobs(ctx context.Context, req apiparams.ListJobsRequest
 		count = defaultListJobsCount
 	}
 	if count > maxListJobsCount {
-		return apiparams.ListJobsResponse{}, errors.MsgWithCode(fmt.Sprintf("count must be between 1 and %d.", maxListJobsCount), errors.CodeBadRequest)
+		return apiparams.ListJobsResponse{}, errors.Codef(errors.CodeBadRequest, "count must be between 1 and %d.", maxListJobsCount)
 	}
 
 	p := river.NewJobListParams().First(count)
@@ -150,7 +150,7 @@ func convertJobStates(statuses []apiparams.JobStatus) ([]rivertype.JobState, err
 		case apiparams.StatusPending:
 			riverStates = append(riverStates, rivertype.JobStateAvailable, rivertype.JobStateScheduled)
 		default:
-			return nil, errors.MsgWithCode(fmt.Sprintf("invalid job status: %s", status), errors.CodeBadRequest)
+			return nil, errors.Codef(errors.CodeBadRequest, "invalid job status: %s", status)
 		}
 	}
 

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -48,7 +48,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	if err := j.Database.GetModel(ctx, &model); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "model not found")
+			return fmt.Errorf("model not found: %w", err)
 		}
 		return err
 	}
@@ -58,7 +58,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return fmt.Errorf("failed administrator check: %w", err)
 	}
 	if !isAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	offerURL := crossmodel.OfferURL{
@@ -74,7 +74,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	offerCheck.URL = offerURL.String()
 	err = j.Database.GetApplicationOffer(ctx, &offerCheck)
 	if err == nil {
-		return errors.E(fmt.Sprintf("offer %s already exists, please use a different name", offerURL.String()), errors.CodeAlreadyExists)
+		return errors.MsgWithCode(fmt.Sprintf("offer %s already exists, please use a different name", offerURL.String()), errors.CodeAlreadyExists)
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.
 		return err
@@ -105,7 +105,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		})
 	if err != nil {
 		if strings.Contains(err.Error(), "application offer already exists") {
-			return errors.E(err, errors.CodeAlreadyExists)
+			return errors.ErrWithCode(err, errors.CodeAlreadyExists)
 		}
 		return err
 	}
@@ -186,7 +186,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(err, "application offer not found")
+			return fmt.Errorf("application offer not found: %w", err)
 		}
 		return err
 	}
@@ -200,11 +200,11 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	case string(jujuparams.OfferAdminAccess):
 	case string(jujuparams.OfferConsumeAccess):
 	case string(jujuparams.OfferReadAccess):
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	default:
 		// TODO (ashipika)
 		//   - think about the returned error code
-		return errors.E(errors.CodeNotFound)
+		return errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
@@ -345,7 +345,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	err := j.Database.GetApplicationOffer(ctx, &offer)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(err, "application offer not found")
+			return nil, fmt.Errorf("application offer not found: %w", err)
 		}
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// if this user does not have access to this application offer
 	// we return a not found error.
 	if !reader {
-		return nil, errors.E(errors.CodeNotFound, "application offer not found")
+		return nil, errors.MsgWithCode("application offer not found", errors.CodeNotFound)
 	}
 
 	// Always collect application-offer admin details from the
@@ -456,7 +456,7 @@ func (o *offers) addOffer(offer *crossmodel.ApplicationOfferDetails) {
 func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 
 	if len(filters) == 0 {
-		return nil, errors.E(errors.CodeBadRequest, "at least one filter must be specified")
+		return nil, errors.MsgWithCode("at least one filter must be specified", errors.CodeBadRequest)
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
@@ -481,7 +481,7 @@ func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.U
 func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 
 	if len(filters) == 0 {
-		return nil, errors.E(errors.CodeBadRequest, "at least one filter must be specified")
+		return nil, errors.MsgWithCode("at least one filter must be specified", errors.CodeBadRequest)
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
@@ -576,7 +576,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	// add offer admin claim
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -48,7 +48,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	if err := j.Database.GetModel(ctx, &model); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("model not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "model %q not found", offer.ModelTag.Id())
 		}
 		return err
 	}
@@ -186,7 +186,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return fmt.Errorf("application offer not found: %w", err)
+			return errors.Codef(errors.CodeNotFound, "application offer %q not found", offer.URL)
 		}
 		return err
 	}
@@ -345,7 +345,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	err := j.Database.GetApplicationOffer(ctx, &offer)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, fmt.Errorf("application offer not found: %w", err)
+			return nil, errors.Codef(errors.CodeNotFound, "application offer %q not found", offerURL)
 		}
 		return nil, err
 	}

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -48,7 +48,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 	if err := j.Database.GetModel(ctx, &model); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.Codef(errors.CodeNotFound, "model %q not found", offer.ModelTag.Id())
+			return errors.Codef(errors.CodeNotFound, "model not found")
 		}
 		return err
 	}
@@ -186,7 +186,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.Codef(errors.CodeNotFound, "application offer %q not found", offer.URL)
+			return errors.Codef(errors.CodeNotFound, "application offer not found")
 		}
 		return err
 	}
@@ -345,7 +345,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	err := j.Database.GetApplicationOffer(ctx, &offer)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.Codef(errors.CodeNotFound, "application offer %q not found", offerURL)
+			return nil, errors.Codef(errors.CodeNotFound, "application offer not found")
 		}
 		return nil, err
 	}

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -58,7 +58,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return fmt.Errorf("failed administrator check: %w", err)
 	}
 	if !isAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	offerURL := crossmodel.OfferURL{
@@ -74,7 +74,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	offerCheck.URL = offerURL.String()
 	err = j.Database.GetApplicationOffer(ctx, &offerCheck)
 	if err == nil {
-		return errors.MsgWithCode(fmt.Sprintf("offer %s already exists, please use a different name", offerURL.String()), errors.CodeAlreadyExists)
+		return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.
 		return err
@@ -105,7 +105,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		})
 	if err != nil {
 		if strings.Contains(err.Error(), "application offer already exists") {
-			return errors.ErrWithCode(err, errors.CodeAlreadyExists)
+			return errors.Codef(errors.CodeAlreadyExists, "%w", err)
 		}
 		return err
 	}
@@ -200,11 +200,11 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	case string(jujuparams.OfferAdminAccess):
 	case string(jujuparams.OfferConsumeAccess):
 	case string(jujuparams.OfferReadAccess):
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	default:
 		// TODO (ashipika)
 		//   - think about the returned error code
-		return errors.ErrWithCode(nil, errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "not found")
 	}
 
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
@@ -358,7 +358,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// if this user does not have access to this application offer
 	// we return a not found error.
 	if !reader {
-		return nil, errors.MsgWithCode("application offer not found", errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "application offer not found")
 	}
 
 	// Always collect application-offer admin details from the
@@ -456,7 +456,7 @@ func (o *offers) addOffer(offer *crossmodel.ApplicationOfferDetails) {
 func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 
 	if len(filters) == 0 {
-		return nil, errors.MsgWithCode("at least one filter must be specified", errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
@@ -481,7 +481,7 @@ func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.U
 func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 
 	if len(filters) == 0 {
-		return nil, errors.MsgWithCode("at least one filter must be specified", errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
@@ -576,7 +576,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	// add offer admin claim
 	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -420,7 +420,7 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 				OfferURL: "no-such-offer",
 			},
 		},
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}}
 
 	for _, test := range tests {
@@ -629,12 +629,12 @@ func TestGetApplicationOffer(t *testing.T) {
 		about:         "user without access cannot get the application offer",
 		user:          u2,
 		offerURL:      "test-offer-url",
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}, {
 		about:         "not found",
 		user:          u1,
 		offerURL:      "offer-not-found",
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}}
 
 	for _, test := range tests {
@@ -883,7 +883,7 @@ func TestOffer(t *testing.T) {
 			offer := dbmodel.ApplicationOffer{}
 
 			return *u, offerParams, offer, func(c *qt.C, err error) {
-				c.Assert(err, qt.ErrorMatches, "model not found.*")
+				c.Assert(err, qt.ErrorMatches, "model not found")
 			}
 		},
 	}, {
@@ -1470,7 +1470,7 @@ func TestDestroyOffer(t *testing.T) {
 		parameterFunc: func(env *environment) (dbmodel.Identity, string) {
 			return env.users[0], "no-such-offer"
 		},
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}, {
 		about:        "controller returns an error",
 		destroyError: "a silly error",

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -892,7 +892,7 @@ func TestOffer(t *testing.T) {
 			return nil, nil
 		},
 		offer: func(context.Context, jujuclient.OfferParams) error {
-			return errors.E(errors.CodeNotFound, "application test-app")
+			return errors.MsgWithCode("application test-app", errors.CodeNotFound)
 		},
 		createEnv: func(c *qt.C, db *db.Database, client *openfga.OFGAClient) (dbmodel.Identity, juju.AddApplicationOfferParams, dbmodel.ApplicationOffer, func(*qt.C, error)) {
 			ctx := context.Background()
@@ -1502,7 +1502,7 @@ func TestDestroyOffer(t *testing.T) {
 
 			if test.destroyError != "" {
 				select {
-				case destroyErrorsChannel <- errors.E(test.destroyError):
+				case destroyErrorsChannel <- errors.New(test.destroyError):
 				default:
 				}
 			}
@@ -2045,7 +2045,7 @@ func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
 			API: &jimmtest.API{
 				FindApplicationOffers_: func(ctx context.Context, filters []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 					controller1Dialed = true
-					return nil, errors.E(errors.CodeNotFound, "offer not found")
+					return nil, errors.MsgWithCode("offer not found", errors.CodeNotFound)
 				},
 			},
 		},

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -420,7 +420,7 @@ func TestGetApplicationOfferConsumeDetails(t *testing.T) {
 				OfferURL: "no-such-offer",
 			},
 		},
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}}
 
 	for _, test := range tests {
@@ -629,12 +629,12 @@ func TestGetApplicationOffer(t *testing.T) {
 		about:         "user without access cannot get the application offer",
 		user:          u2,
 		offerURL:      "test-offer-url",
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}, {
 		about:         "not found",
 		user:          u1,
 		offerURL:      "offer-not-found",
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}}
 
 	for _, test := range tests {
@@ -883,7 +883,7 @@ func TestOffer(t *testing.T) {
 			offer := dbmodel.ApplicationOffer{}
 
 			return *u, offerParams, offer, func(c *qt.C, err error) {
-				c.Assert(err, qt.ErrorMatches, "model not found")
+				c.Assert(err, qt.ErrorMatches, "model not found.*")
 			}
 		},
 	}, {
@@ -1470,7 +1470,7 @@ func TestDestroyOffer(t *testing.T) {
 		parameterFunc: func(env *environment) (dbmodel.Identity, string) {
 			return env.users[0], "no-such-offer"
 		},
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}, {
 		about:        "controller returns an error",
 		destroyError: "a silly error",

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -892,7 +892,7 @@ func TestOffer(t *testing.T) {
 			return nil, nil
 		},
 		offer: func(context.Context, jujuclient.OfferParams) error {
-			return errors.MsgWithCode("application test-app", errors.CodeNotFound)
+			return errors.Codef(errors.CodeNotFound, "application test-app")
 		},
 		createEnv: func(c *qt.C, db *db.Database, client *openfga.OFGAClient) (dbmodel.Identity, juju.AddApplicationOfferParams, dbmodel.ApplicationOffer, func(*qt.C, error)) {
 			ctx := context.Background()
@@ -2045,7 +2045,7 @@ func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
 			API: &jimmtest.API{
 				FindApplicationOffers_: func(ctx context.Context, filters []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 					controller1Dialed = true
-					return nil, errors.MsgWithCode("offer not found", errors.CodeNotFound)
+					return nil, errors.Codef(errors.CodeNotFound, "offer not found")
 				},
 			},
 		},

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -43,7 +43,7 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 
 	switch accessLevel {
 	case "":
-		return dbmodel.Cloud{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return dbmodel.Cloud{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	case "admin":
 		return cl, nil
 	default:
@@ -100,7 +100,7 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 func (j *JujuManager) ForEachCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	clds, err := j.Database.GetClouds(ctx)
@@ -188,20 +188,20 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 			Name: hostCloudRegion,
 		}
 		if err := j.Database.GetCloud(ctx, &cl); err != nil {
-			return nil, errors.MsgWithCode(fmt.Sprintf("unable to find host cloud %q", hostCloudRegion), errors.CodeNotFound)
+			return nil, errors.Codef(errors.CodeNotFound, "unable to find host cloud %q", hostCloudRegion)
 		}
 		if len(cl.Regions) > 1 {
-			return nil, errors.MsgWithCode(fmt.Sprintf("unable to determine a unique region for host cloud %q - consider specifying the host cloud region", hostCloudRegion), errors.CodeBadRequest)
+			return nil, errors.Codef(errors.CodeBadRequest, "unable to determine a unique region for host cloud %q - consider specifying the host cloud region", hostCloudRegion)
 		}
 		if len(cl.Regions) == 0 {
-			return nil, errors.MsgWithCode(fmt.Sprintf("the host cloud %q does not have a valid region", hostCloudRegion), errors.CodeBadRequest)
+			return nil, errors.Codef(errors.CodeBadRequest, "the host cloud %q does not have a valid region", hostCloudRegion)
 		}
 		return &cl.Regions[0], nil
 	}
 
 	parts := strings.Split(hostCloudRegion, "/")
 	if len(parts) != 2 || parts[0] == "" {
-		return nil, errors.MsgWithCode(fmt.Sprintf("invalid cloud/region format %q", hostCloudRegion), errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "invalid cloud/region format %q", hostCloudRegion)
 	}
 
 	findRegionFunctions := []func(context.Context, string, string) (*dbmodel.CloudRegion, error){
@@ -219,7 +219,7 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 	}
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.ErrWithCode(fmt.Errorf("%s: %w", fmt.Sprintf("unable to find cloud/region %q", hostCloudRegion), err), errors.CodeNotFound)
+			return nil, errors.Codef(errors.CodeNotFound, "unable to find cloud/region %q: %w", hostCloudRegion, err)
 		}
 		return nil, err
 	}
@@ -257,16 +257,16 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	}
 	for _, n := range reservedNames {
 		if tag.Id() == n {
-			return errors.MsgWithCode(fmt.Sprintf("cloud %q already exists", tag.Id()), errors.CodeAlreadyExists)
+			return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
 		}
 	}
 
 	// Validate that the requested cloud is valid.
 	if cloud.Type != "kubernetes" {
-		return errors.MsgWithCode(fmt.Sprintf("unsupported cloud type %q", cloud.Type), errors.CodeIncompatibleClouds)
+		return errors.Codef(errors.CodeIncompatibleClouds, "unsupported cloud type %q", cloud.Type)
 	}
 	if cloud.HostCloudRegion == "" {
-		return errors.MsgWithCode("cloud host region not specified", errors.CodeCloudRegionRequired)
+		return errors.Codef(errors.CodeCloudRegionRequired, "cloud host region not specified")
 	}
 
 	region, err := j.determineHostCloudRegion(ctx, cloud.HostCloudRegion)
@@ -277,7 +277,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	if region.Cloud.HostCloudRegion != "" {
 		// Do not support creating a new cloud on an already hosted
 		// cloud.
-		return errors.MsgWithCode(fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
+		return errors.Codef(errors.CodeIncompatibleClouds, "cloud already hosted %q", cloud.HostCloudRegion)
 	}
 
 	// Create the cloud locally, to reserve the name.
@@ -391,7 +391,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	// Ensure we always have at least 1 region for the cloud with at least 1 controller
 	// managing that region.
@@ -464,7 +464,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 	if cloudAccess != "admin" {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var controllers []dbmodel.Controller
@@ -532,12 +532,12 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.ErrWithCode(fmt.Errorf("unauthorized: %w", err), errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	if !isAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	controllers := make(map[string]dbmodel.Controller)
@@ -549,7 +549,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	controller, ok := controllers[controllerName]
 	if !ok {
-		return errors.MsgWithCode("cloud not hosted by controller", errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "cloud not hosted by controller")
 	}
 
 	api, err := j.dial(ctx, &controller, names.ModelTag{}, user)
@@ -622,13 +622,13 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 
 	parts := strings.SplitN(cloud.HostCloudRegion, "/", 2)
 	if len(parts) != 2 || parts[0] == "" {
-		return errors.MsgWithCode(fmt.Sprintf("cloud host region %q has invalid cloud/region format", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
+		return errors.Codef(errors.CodeIncompatibleClouds, "cloud host region %q has invalid cloud/region format", cloud.HostCloudRegion)
 	}
 
 	region, err := db.FindRegionByCloudType(ctx, parts[0], parts[1])
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.MsgWithCode(fmt.Sprintf("unable to find cloud/region %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
+			return errors.Codef(errors.CodeIncompatibleClouds, "unable to find cloud/region %q", cloud.HostCloudRegion)
 		}
 		return err
 	}
@@ -638,11 +638,11 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 		return err
 	}
 	if !allowedAddModel {
-		return errors.MsgWithCode(fmt.Sprintf("missing access to %q", cloud.HostCloudRegion), errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "missing access to %q", cloud.HostCloudRegion)
 	}
 
 	if region.Cloud.HostCloudRegion != "" {
-		return errors.MsgWithCode(fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
+		return errors.Codef(errors.CodeIncompatibleClouds, "cloud already hosted %q", cloud.HostCloudRegion)
 	}
 
 	for _, rc := range region.Controllers {
@@ -650,7 +650,7 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 			return nil
 		}
 	}
-	return errors.MsgWithCode("controller not found", errors.CodeNotFound)
+	return errors.Codef(errors.CodeNotFound, "controller not found")
 }
 
 // checkReservedCloudNames checks if the tag intended to be added to JIMM
@@ -662,7 +662,7 @@ func checkReservedCloudNames(tag names.CloudTag, reservedCloudNames []string) er
 	}
 	for _, n := range reservedNames {
 		if tag.Id() == n {
-			return errors.MsgWithCode(fmt.Sprintf("cloud %q already exists", tag.Id()), errors.CodeAlreadyExists)
+			return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
 		}
 	}
 	return nil

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -219,7 +219,7 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 	}
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.Codef(errors.CodeNotFound, "unable to find cloud/region %q: %w", hostCloudRegion, err)
+			return nil, errors.Codef(errors.CodeNotFound, "unable to find cloud/region %q", hostCloudRegion)
 		}
 		return nil, err
 	}

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -43,7 +43,7 @@ func (j *JujuManager) GetCloud(ctx context.Context, user *openfga.User, tag name
 
 	switch accessLevel {
 	case "":
-		return dbmodel.Cloud{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return dbmodel.Cloud{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	case "admin":
 		return cl, nil
 	default:
@@ -75,7 +75,7 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 
 	clouds, err := j.Database.GetClouds(ctx)
 	if err != nil {
-		return errors.E(err, "cannot load clouds")
+		return fmt.Errorf("cannot load clouds: %w", err)
 	}
 	for _, cloud := range clouds {
 		userAccess := permissions.ToCloudAccessString(user.GetCloudAccess(ctx, cloud.ResourceTag()))
@@ -100,12 +100,12 @@ func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, 
 func (j *JujuManager) ForEachCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	clds, err := j.Database.GetClouds(ctx)
 	if err != nil {
-		return errors.E("cannot load clouds", err)
+		return fmt.Errorf("cannot load clouds: %w", err)
 	}
 
 	for i := range clds {
@@ -188,20 +188,20 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 			Name: hostCloudRegion,
 		}
 		if err := j.Database.GetCloud(ctx, &cl); err != nil {
-			return nil, errors.E(errors.CodeNotFound, "unable to find host cloud %q", hostCloudRegion)
+			return nil, errors.MsgWithCode(fmt.Sprintf("unable to find host cloud %q", hostCloudRegion), errors.CodeNotFound)
 		}
 		if len(cl.Regions) > 1 {
-			return nil, errors.E(errors.CodeBadRequest, "unable to determine a unique region for host cloud %q - consider specifying the host cloud region", hostCloudRegion)
+			return nil, errors.MsgWithCode(fmt.Sprintf("unable to determine a unique region for host cloud %q - consider specifying the host cloud region", hostCloudRegion), errors.CodeBadRequest)
 		}
 		if len(cl.Regions) == 0 {
-			return nil, errors.E(errors.CodeBadRequest, "the host cloud %q does not have a valid region", hostCloudRegion)
+			return nil, errors.MsgWithCode(fmt.Sprintf("the host cloud %q does not have a valid region", hostCloudRegion), errors.CodeBadRequest)
 		}
 		return &cl.Regions[0], nil
 	}
 
 	parts := strings.Split(hostCloudRegion, "/")
 	if len(parts) != 2 || parts[0] == "" {
-		return nil, errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid cloud/region format %q", hostCloudRegion))
+		return nil, errors.MsgWithCode(fmt.Sprintf("invalid cloud/region format %q", hostCloudRegion), errors.CodeBadRequest)
 	}
 
 	findRegionFunctions := []func(context.Context, string, string) (*dbmodel.CloudRegion, error){
@@ -219,7 +219,7 @@ func (j *JujuManager) determineHostCloudRegion(ctx context.Context, hostCloudReg
 	}
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return nil, errors.E(err, errors.CodeNotFound, fmt.Sprintf("unable to find cloud/region %q", hostCloudRegion))
+			return nil, errors.ErrWithCode(fmt.Errorf("%s: %w", fmt.Sprintf("unable to find cloud/region %q", hostCloudRegion), err), errors.CodeNotFound)
 		}
 		return nil, err
 	}
@@ -257,16 +257,16 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	}
 	for _, n := range reservedNames {
 		if tag.Id() == n {
-			return errors.E(errors.CodeAlreadyExists, fmt.Sprintf("cloud %q already exists", tag.Id()))
+			return errors.MsgWithCode(fmt.Sprintf("cloud %q already exists", tag.Id()), errors.CodeAlreadyExists)
 		}
 	}
 
 	// Validate that the requested cloud is valid.
 	if cloud.Type != "kubernetes" {
-		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("unsupported cloud type %q", cloud.Type))
+		return errors.MsgWithCode(fmt.Sprintf("unsupported cloud type %q", cloud.Type), errors.CodeIncompatibleClouds)
 	}
 	if cloud.HostCloudRegion == "" {
-		return errors.E(errors.CodeCloudRegionRequired, "cloud host region not specified")
+		return errors.MsgWithCode("cloud host region not specified", errors.CodeCloudRegionRequired)
 	}
 
 	region, err := j.determineHostCloudRegion(ctx, cloud.HostCloudRegion)
@@ -277,7 +277,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	if region.Cloud.HostCloudRegion != "" {
 		// Do not support creating a new cloud on an already hosted
 		// cloud.
-		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion))
+		return errors.MsgWithCode(fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
 	}
 
 	// Create the cloud locally, to reserve the name.
@@ -391,7 +391,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	// Ensure we always have at least 1 region for the cloud with at least 1 controller
 	// managing that region.
@@ -400,7 +400,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		if len(c.Regions) > 0 {
 			zapctx.Error(ctx, "number of controllers available for cloud/region", zap.Int("controllers", len(c.Regions[0].Controllers)))
 		}
-		return errors.E(fmt.Sprintf("cloud administration not available for %s", ct.Id()))
+		return errors.New(fmt.Sprintf("cloud administration not available for %s", ct.Id()))
 	}
 	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, user)
 	if err != nil {
@@ -430,7 +430,7 @@ func (j *JujuManager) RemoveCloud(ctx context.Context, user *openfga.User, ct na
 		}
 
 		if err := j.Database.DeleteCloud(ctx, c); err != nil {
-			return errors.E(err, "cannot update database after updating controller")
+			return fmt.Errorf("cannot update database after updating controller: %w", err)
 		}
 
 		if err := j.OpenFGAClient.RemoveCloud(ctx, ct); err != nil {
@@ -464,7 +464,7 @@ func (j *JujuManager) UpdateCloud(ctx context.Context, user *openfga.User, ct na
 	if cloudAccess != "admin" {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var controllers []dbmodel.Controller
@@ -532,12 +532,12 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
 	if err != nil {
-		return errors.E(err, errors.CodeUnauthorized, "unauthorized")
+		return errors.ErrWithCode(fmt.Errorf("unauthorized: %w", err), errors.CodeUnauthorized)
 	}
 	if !isAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	controllers := make(map[string]dbmodel.Controller)
@@ -549,7 +549,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 
 	controller, ok := controllers[controllerName]
 	if !ok {
-		return errors.E("cloud not hosted by controller", errors.CodeNotFound)
+		return errors.MsgWithCode("cloud not hosted by controller", errors.CodeNotFound)
 	}
 
 	api, err := j.dial(ctx, &controller, names.ModelTag{}, user)
@@ -571,7 +571,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	// if this was the only cloud controller, we delete the cloud
 	if len(controllers) == 0 {
 		if err := j.Database.DeleteCloud(ctx, &cloud); err != nil {
-			return errors.E(err, "failed to delete cloud after updating controller")
+			return fmt.Errorf("failed to delete cloud after updating controller: %w", err)
 		}
 		return nil
 	}
@@ -582,7 +582,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 		for _, crp := range cr.Controllers {
 			crp := crp
 			if err := j.Database.DeleteCloudRegionControllerPriority(ctx, &crp); err != nil {
-				return errors.E(err, "cannot update database after updating controller")
+				return fmt.Errorf("cannot update database after updating controller: %w", err)
 			}
 		}
 	}
@@ -622,13 +622,13 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 
 	parts := strings.SplitN(cloud.HostCloudRegion, "/", 2)
 	if len(parts) != 2 || parts[0] == "" {
-		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("cloud host region %q has invalid cloud/region format", cloud.HostCloudRegion))
+		return errors.MsgWithCode(fmt.Sprintf("cloud host region %q has invalid cloud/region format", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
 	}
 
 	region, err := db.FindRegionByCloudType(ctx, parts[0], parts[1])
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("unable to find cloud/region %q", cloud.HostCloudRegion))
+			return errors.MsgWithCode(fmt.Sprintf("unable to find cloud/region %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
 		}
 		return err
 	}
@@ -638,11 +638,11 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 		return err
 	}
 	if !allowedAddModel {
-		return errors.E(errors.CodeUnauthorized, fmt.Sprintf("missing access to %q", cloud.HostCloudRegion))
+		return errors.MsgWithCode(fmt.Sprintf("missing access to %q", cloud.HostCloudRegion), errors.CodeUnauthorized)
 	}
 
 	if region.Cloud.HostCloudRegion != "" {
-		return errors.E(errors.CodeIncompatibleClouds, fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion))
+		return errors.MsgWithCode(fmt.Sprintf("cloud already hosted %q", cloud.HostCloudRegion), errors.CodeIncompatibleClouds)
 	}
 
 	for _, rc := range region.Controllers {
@@ -650,7 +650,7 @@ func validateCloudRegion(ctx context.Context, db *db.Database, user *openfga.Use
 			return nil
 		}
 	}
-	return errors.E(errors.CodeNotFound, "controller not found")
+	return errors.MsgWithCode("controller not found", errors.CodeNotFound)
 }
 
 // checkReservedCloudNames checks if the tag intended to be added to JIMM
@@ -662,7 +662,7 @@ func checkReservedCloudNames(tag names.CloudTag, reservedCloudNames []string) er
 	}
 	for _, n := range reservedNames {
 		if tag.Id() == n {
-			return errors.E(errors.CodeAlreadyExists, fmt.Sprintf("cloud %q already exists", tag.Id()))
+			return errors.MsgWithCode(fmt.Sprintf("cloud %q already exists", tag.Id()), errors.CodeAlreadyExists)
 		}
 	}
 	return nil

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -400,7 +400,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		if len(c.Regions) > 0 {
 			zapctx.Error(ctx, "number of controllers available for cloud/region", zap.Int("controllers", len(c.Regions[0].Controllers)))
 		}
-		return errors.New(fmt.Sprintf("cloud administration not available for %s", ct.Id()))
+		return fmt.Errorf("cloud administration not available for %s", ct.Id())
 	}
 	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, user)
 	if err != nil {

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -596,7 +596,7 @@ var addHostedCloudTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `cloud "existing-cloud" already exists`,
+	expectError:     `cloud "existing-cloud" already exists.*`,
 	expectErrorCode: errors.CodeAlreadyExists,
 }, {
 	name:      "InvalidCloudType",

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -624,7 +624,7 @@ var addHostedCloudTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "ec2/default"`,
+	expectError:     `unable to find cloud/region "ec2/default".*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:      "InvalidHostCloudRegion",
@@ -838,7 +838,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `controller not found`,
+	expectError:     `controller not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:           "CloudWithReservedName",
@@ -868,7 +868,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "ec2/default"`,
+	expectError:     `unable to find cloud/region "ec2/default".*`,
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:           "InvalidHostCloudRegion",
@@ -898,7 +898,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "test-provider3/test-region-3"`,
+	expectError:     `unable to find cloud/region "test-provider3/test-region-3".*`,
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:           "HostCloudIsHosted",
@@ -1043,7 +1043,7 @@ var removeCloudTests = []struct {
 	name:            "CloudNotFound",
 	username:        "alice@canonical.com",
 	cloud:           "test2",
-	expectError:     `cloud "test2" not found`,
+	expectError:     `cloud "test2" not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "Success",
@@ -1171,7 +1171,7 @@ var updateCloudTests = []struct {
 	name:            "CloudNotFound",
 	username:        "alice@canonical.com",
 	cloud:           "test2",
-	expectError:     `cloud "test2" not found`,
+	expectError:     `cloud "test2" not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, /* NOTE (alesstimec) Need to figure out what makes test-cloud
 	                        a public cloud giving alice@canonical.com the right
@@ -1426,7 +1426,7 @@ var removeCloudFromControllerTests = []struct {
 	username:        "alice@canonical.com",
 	cloud:           "test2",
 	controllerName:  "controller-2",
-	expectError:     `cloud "test2" not found`,
+	expectError:     `cloud "test2" not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "Success - with other controllers for the cloud",

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -596,7 +596,7 @@ var addHostedCloudTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `cloud "existing-cloud" already exists.*`,
+	expectError:     `cloud "existing-cloud" already exists`,
 	expectErrorCode: errors.CodeAlreadyExists,
 }, {
 	name:      "InvalidCloudType",

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -624,7 +624,7 @@ var addHostedCloudTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "ec2/default".*`,
+	expectError:     `unable to find cloud/region "ec2/default"`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:      "InvalidHostCloudRegion",
@@ -838,7 +838,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `controller not found.*`,
+	expectError:     `controller not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:           "CloudWithReservedName",
@@ -868,7 +868,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "ec2/default".*`,
+	expectError:     `unable to find cloud/region "ec2/default"`,
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:           "InvalidHostCloudRegion",
@@ -898,7 +898,7 @@ var addHostedCloudToControllerTests = []struct {
 		IdentityEndpoint: "https://example.com/identity",
 		StorageEndpoint:  "https://example.com/storage",
 	},
-	expectError:     `unable to find cloud/region "test-provider3/test-region-3".*`,
+	expectError:     `unable to find cloud/region "test-provider3/test-region-3"`,
 	expectErrorCode: errors.CodeIncompatibleClouds,
 }, {
 	name:           "HostCloudIsHosted",
@@ -1043,7 +1043,7 @@ var removeCloudTests = []struct {
 	name:            "CloudNotFound",
 	username:        "alice@canonical.com",
 	cloud:           "test2",
-	expectError:     `cloud "test2" not found.*`,
+	expectError:     `cloud "test2" not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "Success",
@@ -1171,7 +1171,7 @@ var updateCloudTests = []struct {
 	name:            "CloudNotFound",
 	username:        "alice@canonical.com",
 	cloud:           "test2",
-	expectError:     `cloud "test2" not found.*`,
+	expectError:     `cloud "test2" not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, /* NOTE (alesstimec) Need to figure out what makes test-cloud
 	                        a public cloud giving alice@canonical.com the right
@@ -1426,7 +1426,7 @@ var removeCloudFromControllerTests = []struct {
 	username:        "alice@canonical.com",
 	cloud:           "test2",
 	controllerName:  "controller-2",
-	expectError:     `cloud "test2" not found.*`,
+	expectError:     `cloud "test2" not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "Success - with other controllers for the cloud",

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -28,7 +28,7 @@ import (
 func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error) {
 
 	if !user.JimmAdmin && user.Name != tag.Owner().Id() {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var credential dbmodel.CloudCredential
@@ -47,7 +47,7 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
 
 	if user.Name != tag.Owner().Id() {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var credential dbmodel.CloudCredential
@@ -75,7 +75,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 	// Now we want to ensure that the credential is not used by any models before removing it to maintain
 	// referential integrity.
 	if len(models) > 0 {
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("cloud credential still used by %d model(s)", len(models)))
+		return errors.MsgWithCode(fmt.Sprintf("cloud credential still used by %d model(s)", len(models)), errors.CodeBadRequest)
 	}
 
 	cloud := dbmodel.Cloud{
@@ -111,7 +111,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 
 	err = j.Database.DeleteCloudCredential(ctx, &credential)
 	if err != nil {
-		return errors.E(err, "failed to revoke credential in local database")
+		return fmt.Errorf("failed to revoke credential in local database: %w", err)
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 	var result []jujuparams.UpdateCredentialModelResult
 	if user.Tag() != args.CredentialTag.Owner() {
 		if !user.JimmAdmin {
-			return result, errors.E(errors.CodeUnauthorized, "unauthorized")
+			return result, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 		}
 		// ensure the user we are adding the credential for exists.
 		var u2 dbmodel.Identity
@@ -266,7 +266,7 @@ func (j *JujuManager) updateControllerCloudCredential(
 	}
 
 	if out[0].Error != nil {
-		return out[0].Models, errors.E(out[0].Error)
+		return out[0].Models, out[0].Error
 	}
 
 	return out[0].Models, nil
@@ -311,11 +311,11 @@ func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, user *op
 	if hidden {
 		// Controller superusers cannot read hidden credential attributes.
 		if user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+			return nil, nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 		}
 	} else {
 		if !user.JimmAdmin && user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+			return nil, nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 		}
 	}
 
@@ -366,7 +366,7 @@ func (j *JujuManager) CopyCredential(ctx context.Context, originalUser *openfga.
 
 	newCredID := fmt.Sprintf("%s/%s/%s", cred.Cloud().Id(), newUser.Name, cred.Name())
 	if !names.IsValidCloudCredential(newCredID) {
-		return names.CloudCredentialTag{}, nil, errors.E(fmt.Sprintf("new credential ID %s is not a valid cloud credential tag", newCredID))
+		return names.CloudCredentialTag{}, nil, errors.New(fmt.Sprintf("new credential ID %s is not a valid cloud credential tag", newCredID))
 	}
 
 	newCredential := jujuparams.CloudCredential{

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -28,7 +28,7 @@ import (
 func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error) {
 
 	if !user.JimmAdmin && user.Name != tag.Owner().Id() {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var credential dbmodel.CloudCredential
@@ -47,7 +47,7 @@ func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User
 func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
 
 	if user.Name != tag.Owner().Id() {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var credential dbmodel.CloudCredential
@@ -75,7 +75,7 @@ func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.I
 	// Now we want to ensure that the credential is not used by any models before removing it to maintain
 	// referential integrity.
 	if len(models) > 0 {
-		return errors.MsgWithCode(fmt.Sprintf("cloud credential still used by %d model(s)", len(models)), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "cloud credential still used by %d model(s)", len(models))
 	}
 
 	cloud := dbmodel.Cloud{
@@ -133,7 +133,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 	var result []jujuparams.UpdateCredentialModelResult
 	if user.Tag() != args.CredentialTag.Owner() {
 		if !user.JimmAdmin {
-			return result, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+			return result, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 		}
 		// ensure the user we are adding the credential for exists.
 		var u2 dbmodel.Identity
@@ -311,11 +311,11 @@ func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, user *op
 	if hidden {
 		// Controller superusers cannot read hidden credential attributes.
 		if user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+			return nil, nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 		}
 	} else {
 		if !user.JimmAdmin && user.Name != cred.OwnerIdentityName {
-			return nil, nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+			return nil, nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 		}
 	}
 

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -366,7 +366,7 @@ func (j *JujuManager) CopyCredential(ctx context.Context, originalUser *openfga.
 
 	newCredID := fmt.Sprintf("%s/%s/%s", cred.Cloud().Id(), newUser.Name, cred.Name())
 	if !names.IsValidCloudCredential(newCredID) {
-		return names.CloudCredentialTag{}, nil, errors.New(fmt.Sprintf("new credential ID %s is not a valid cloud credential tag", newCredID))
+		return names.CloudCredentialTag{}, nil, fmt.Errorf("new credential ID %s is not a valid cloud credential tag", newCredID)
 	}
 
 	newCredential := jujuparams.CloudCredential{

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1383,7 +1383,7 @@ func TestGetCloudCredential(t *testing.T) {
 
 			tag := names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential-1")
 
-			return u, tag, dbmodel.CloudCredential{}, `cloudcredential "test-cloud/alice@canonical.com/test-credential-1" not found`
+			return u, tag, dbmodel.CloudCredential{}, `cloudcredential "test-cloud/alice@canonical.com/test-credential-1" not found.*`
 		},
 	}}
 	for _, test := range tests {
@@ -1465,7 +1465,7 @@ var forEachUserCloudCredentialTests = []struct {
 	env:      forEachUserCloudCredentialEnv,
 	username: "alice@canonical.com",
 	f: func(*dbmodel.CloudCredential) error {
-		return errors.E("test error", errors.Code("test code"))
+		return errors.MsgWithCode("test error", errors.Code("test code"))
 	},
 	expectError:     "test error",
 	expectErrorCode: "test code",
@@ -1740,50 +1740,50 @@ func (s testCloudCredentialAttributeStore) Put(_ context.Context, tag names.Clou
 }
 
 func (s testCloudCredentialAttributeStore) GetControllerCredentials(ctx context.Context, controllerName string) (string, string, error) {
-	return "", "", errors.E(errors.CodeNotImplemented)
+	return "", "", errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) PutControllerCredentials(ctx context.Context, controllerName string, username string, password string) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKS(ctx context.Context) (jwk.Set, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKSPrivateKey(ctx context.Context) ([]byte, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKSExpiry(ctx context.Context) (time.Time, error) {
-	return time.Now(), errors.E(errors.CodeNotImplemented)
+	return time.Now(), errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) PutJWKS(ctx context.Context, jwks jwk.Set) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 func (s testCloudCredentialAttributeStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) CleanupJWKS(ctx context.Context) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) CleanupOAuthSecrets(ctx context.Context) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) GetOAuthSecret(ctx context.Context) ([]byte, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func (s testCloudCredentialAttributeStore) PutOAuthSecret(ctx context.Context, raw []byte) error {
-	return errors.E(errors.CodeNotImplemented)
+	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 func TestCopyCredential(t *testing.T) {

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1465,7 +1465,7 @@ var forEachUserCloudCredentialTests = []struct {
 	env:      forEachUserCloudCredentialEnv,
 	username: "alice@canonical.com",
 	f: func(*dbmodel.CloudCredential) error {
-		return errors.MsgWithCode("test error", errors.Code("test code"))
+		return errors.Codef(errors.Code("test code"), "test error")
 	},
 	expectError:     "test error",
 	expectErrorCode: "test code",
@@ -1740,50 +1740,50 @@ func (s testCloudCredentialAttributeStore) Put(_ context.Context, tag names.Clou
 }
 
 func (s testCloudCredentialAttributeStore) GetControllerCredentials(ctx context.Context, controllerName string) (string, string, error) {
-	return "", "", errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return "", "", errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) PutControllerCredentials(ctx context.Context, controllerName string, username string, password string) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKS(ctx context.Context) (jwk.Set, error) {
-	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return nil, errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKSPrivateKey(ctx context.Context) ([]byte, error) {
-	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return nil, errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) GetJWKSExpiry(ctx context.Context) (time.Time, error) {
-	return time.Now(), errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return time.Now(), errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) PutJWKS(ctx context.Context, jwks jwk.Set) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 func (s testCloudCredentialAttributeStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) CleanupJWKS(ctx context.Context) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) CleanupOAuthSecrets(ctx context.Context) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) GetOAuthSecret(ctx context.Context) ([]byte, error) {
-	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return nil, errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func (s testCloudCredentialAttributeStore) PutOAuthSecret(ctx context.Context, raw []byte) error {
-	return errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 func TestCopyCredential(t *testing.T) {

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1383,7 +1383,7 @@ func TestGetCloudCredential(t *testing.T) {
 
 			tag := names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential-1")
 
-			return u, tag, dbmodel.CloudCredential{}, `cloudcredential "test-cloud/alice@canonical.com/test-credential-1" not found.*`
+			return u, tag, dbmodel.CloudCredential{}, `cloudcredential "test-cloud/alice@canonical.com/test-credential-1" not found`
 		},
 	}}
 	for _, test := range tests {

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -32,7 +32,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 
 	for k := range configs {
 		if k == agentVersionKey {
-			return errors.MsgWithCode(`agent-version cannot have a default value`, errors.CodeBadRequest)
+			return errors.Codef(errors.CodeBadRequest, `agent-version cannot have a default value`)
 		}
 	}
 
@@ -51,7 +51,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 			}
 		}
 		if !found {
-			return errors.MsgWithCode("region not found", errors.CodeNotFound)
+			return errors.Codef(errors.CodeNotFound, "region not found")
 		}
 	}
 	err = j.Database.SetCloudDefaults(ctx, &dbmodel.CloudDefaults{

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -32,7 +32,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 
 	for k := range configs {
 		if k == agentVersionKey {
-			return errors.E(errors.CodeBadRequest, `agent-version cannot have a default value`)
+			return errors.MsgWithCode(`agent-version cannot have a default value`, errors.CodeBadRequest)
 		}
 	}
 
@@ -51,7 +51,7 @@ func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identi
 			}
 		}
 		if !found {
-			return errors.E(errors.CodeNotFound, "region not found")
+			return errors.MsgWithCode("region not found", errors.CodeNotFound)
 		}
 	}
 	err = j.Database.SetCloudDefaults(ctx, &dbmodel.CloudDefaults{

--- a/internal/jimm/juju/clouddefaults_test.go
+++ b/internal/jimm/juju/clouddefaults_test.go
@@ -193,7 +193,7 @@ func TestSetCloudDefaults(t *testing.T) {
 				cloud:         names.NewCloudTag(cloud.Name),
 				region:        cloud.Regions[0].Name,
 				defaults:      defaults,
-				expectedError: `cloud "test-cloud-1" not found`,
+				expectedError: `cloud "test-cloud-1" not found.*`,
 			}
 		},
 	}, {

--- a/internal/jimm/juju/clouddefaults_test.go
+++ b/internal/jimm/juju/clouddefaults_test.go
@@ -193,7 +193,7 @@ func TestSetCloudDefaults(t *testing.T) {
 				cloud:         names.NewCloudTag(cloud.Name),
 				region:        cloud.Regions[0].Name,
 				defaults:      defaults,
-				expectedError: `cloud "test-cloud-1" not found.*`,
+				expectedError: `cloud "test-cloud-1" not found`,
 			}
 		},
 	}, {

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -347,7 +347,7 @@ func newModelImporter(jimm *JujuManager, newOwner string) (modelImporter, error)
 		return modelImporter, nil
 	}
 	if !names.IsValidUser(newOwner) {
-		return modelImporter, errors.MsgWithCode("invalid new username for new model owner", errors.CodeBadRequest)
+		return modelImporter, errors.Codef(errors.CodeBadRequest, "invalid new username for new model owner")
 	}
 	newOwnerTag := names.NewUserTag(newOwner)
 	modelImporter.newOwner = &newOwnerTag
@@ -455,7 +455,7 @@ func (m *modelImporter) setCloudCredential(ctx context.Context) error {
 		return err
 	}
 	if len(allCredentials) == 0 {
-		return errors.MsgWithCode(fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, m.modelInfo.Cloud), errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, m.modelInfo.Cloud)
 	}
 	cloudCredential := allCredentials[0]
 
@@ -571,7 +571,7 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	model := dbmodel.Model{
@@ -583,7 +583,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.MsgWithCode("model not found", errors.CodeModelNotFound)
+			return errors.Codef(errors.CodeModelNotFound, "model not found")
 		}
 		return err
 	}
@@ -594,7 +594,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err = j.Database.GetController(ctx, &targetController)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.MsgWithCode("controller not found", errors.CodeNotFound)
+			return errors.Codef(errors.CodeNotFound, "controller not found")
 		}
 		return err
 	}
@@ -637,31 +637,31 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	}
 	mt, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
-		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return result, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, mt)
 	if err != nil {
-		return result, errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
+		return result, errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 	}
 	if !isAdministrator {
-		return result, errors.ErrWithCode(nil, errors.CodeUnauthorized)
+		return result, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetControllerTag, err := names.ParseControllerTag(spec.TargetInfo.ControllerTag)
 	if err != nil {
-		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return result, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	targetUserTag, err := names.ParseUserTag(spec.TargetInfo.AuthTag)
 	if err != nil {
-		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return result, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	var targetMacaroons []macaroon.Slice
 	if spec.TargetInfo.Macaroons != "" {
 		err = json.Unmarshal([]byte(spec.TargetInfo.Macaroons), &targetMacaroons)
 		if err != nil {
-			return result, errors.ErrWithCode(fmt.Errorf("failed to unmarshal macaroons: %w", err), errors.CodeBadRequest)
+			return result, errors.Codef(errors.CodeBadRequest, "failed to unmarshal macaroons: %w", err)
 		}
 	}
 
@@ -759,7 +759,7 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.MsgWithCode(fmt.Sprintf("migrating model %q not found", modelUUID), errors.CodeNotFound)
+			return ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "migrating model %q not found", modelUUID)
 		}
 		return ControllerConnectionDetails{}, err
 	}
@@ -770,7 +770,7 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.ErrWithCode(fmt.Errorf("missing credentials for controller %q", model.Controller.Name), errors.CodeNotFound)
+		return ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "missing credentials for controller %q", model.Controller.Name)
 	}
 
 	return toControllerConnectionDetails(model.Controller, username, password), nil

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -221,7 +221,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	clouds, err := api.Clouds()
 	if err != nil {
-		return errors.E(err, "failed to fetch controller clouds")
+		return fmt.Errorf("failed to fetch controller clouds: %w", err)
 	}
 
 	dbClouds := convertJujuCloudsToDbClouds(clouds)
@@ -245,12 +245,12 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	err = j.CredentialStore.PutControllerCredentials(ctx, ctl.Name, creds.AdminIdentityName, creds.AdminPassword)
 	if err != nil {
-		return errors.E(err, "failed to store controller credentials")
+		return fmt.Errorf("failed to store controller credentials: %w", err)
 	}
 
 	if err := addControllerTx(ctx, j, dbClouds, ctl); err != nil {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return errors.E(err, fmt.Sprintf("controller %q already exists", ctl.Name))
+			return fmt.Errorf("%s: %w", fmt.Sprintf("controller %q already exists", ctl.Name), err)
 		}
 
 		return fmt.Errorf("failed to add controller: %w", err)
@@ -347,7 +347,7 @@ func newModelImporter(jimm *JujuManager, newOwner string) (modelImporter, error)
 		return modelImporter, nil
 	}
 	if !names.IsValidUser(newOwner) {
-		return modelImporter, errors.E(errors.CodeBadRequest, "invalid new username for new model owner")
+		return modelImporter, errors.MsgWithCode("invalid new username for new model owner", errors.CodeBadRequest)
 	}
 	newOwnerTag := names.NewUserTag(newOwner)
 	modelImporter.newOwner = &newOwnerTag
@@ -362,7 +362,7 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, 
 
 	api, err := m.jimm.dialController(ctx, controller, user)
 	if err != nil {
-		return errors.E("failed to dial the controller", err)
+		return fmt.Errorf("failed to dial the controller: %w", err)
 	}
 	defer api.Close()
 
@@ -455,7 +455,7 @@ func (m *modelImporter) setCloudCredential(ctx context.Context) error {
 		return err
 	}
 	if len(allCredentials) == 0 {
-		return errors.E(errors.CodeNotFound, fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, m.modelInfo.Cloud))
+		return errors.MsgWithCode(fmt.Sprintf("Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, m.modelInfo.Cloud), errors.CodeNotFound)
 	}
 	cloudCredential := allCredentials[0]
 
@@ -484,7 +484,7 @@ func (m *modelImporter) setModelCloud(ctx context.Context) error {
 		m.model.CloudRegion = cr
 	} else {
 		if len(cloud.Regions) != 1 {
-			return errors.E("expected one cloud region, found %d", len(cloud.Regions))
+			return fmt.Errorf("expected one cloud region, found %d", len(cloud.Regions))
 		}
 		// because this cloud only has the one region, we can safely
 		// assume the model deployed to this region.
@@ -571,7 +571,7 @@ func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, contr
 func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	model := dbmodel.Model{
@@ -583,7 +583,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E("model not found", errors.CodeModelNotFound)
+			return errors.MsgWithCode("model not found", errors.CodeModelNotFound)
 		}
 		return err
 	}
@@ -594,7 +594,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	err = j.Database.GetController(ctx, &targetController)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return errors.E("controller not found", errors.CodeNotFound)
+			return errors.MsgWithCode("controller not found", errors.CodeNotFound)
 		}
 		return err
 	}
@@ -637,31 +637,31 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	}
 	mt, err := names.ParseModelTag(spec.ModelTag)
 	if err != nil {
-		return result, errors.E(err, errors.CodeBadRequest)
+		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	isAdministrator, err := openfga.IsAdministrator(ctx, user, mt)
 	if err != nil {
-		return result, errors.E(err, errors.CodeOpenFGARequestFailed)
+		return result, errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
 	}
 	if !isAdministrator {
-		return result, errors.E(errors.CodeUnauthorized)
+		return result, errors.ErrWithCode(nil, errors.CodeUnauthorized)
 	}
 
 	targetControllerTag, err := names.ParseControllerTag(spec.TargetInfo.ControllerTag)
 	if err != nil {
-		return result, errors.E(err, errors.CodeBadRequest)
+		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	targetUserTag, err := names.ParseUserTag(spec.TargetInfo.AuthTag)
 	if err != nil {
-		return result, errors.E(err, errors.CodeBadRequest)
+		return result, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	var targetMacaroons []macaroon.Slice
 	if spec.TargetInfo.Macaroons != "" {
 		err = json.Unmarshal([]byte(spec.TargetInfo.Macaroons), &targetMacaroons)
 		if err != nil {
-			return result, errors.E(err, "failed to unmarshal macaroons", errors.CodeBadRequest)
+			return result, errors.ErrWithCode(fmt.Errorf("failed to unmarshal macaroons: %w", err), errors.CodeBadRequest)
 		}
 	}
 
@@ -701,7 +701,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
 	if err != nil {
 		rollbackMigrationMode()
-		return result, errors.E("failed to dial the controller", err)
+		return result, fmt.Errorf("failed to dial the controller: %w", err)
 	}
 
 	client := newControllerClient(api)
@@ -759,7 +759,7 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	err := j.Database.GetModel(ctx, &model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.MsgWithCode(fmt.Sprintf("migrating model %q not found", modelUUID), errors.CodeNotFound)
 		}
 		return ControllerConnectionDetails{}, err
 	}
@@ -770,7 +770,7 @@ func (j *JujuManager) ControllerDetailsForModel(ctx context.Context, modelUUID s
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", model.Controller.Name))
+		return ControllerConnectionDetails{}, errors.ErrWithCode(fmt.Errorf("missing credentials for controller %q", model.Controller.Name), errors.CodeNotFound)
 	}
 
 	return toControllerConnectionDetails(model.Controller, username, password), nil

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -250,7 +250,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	if err := addControllerTx(ctx, j, dbClouds, ctl); err != nil {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			return fmt.Errorf("%s: %w", fmt.Sprintf("controller %q already exists", ctl.Name), err)
+			return errors.Codef(errors.CodeAlreadyExists, "controller %q already exists", ctl.Name)
 		}
 
 		return fmt.Errorf("failed to add controller: %w", err)
@@ -500,7 +500,7 @@ func (m *modelImporter) save(ctx context.Context) error {
 		err := m.jimm.Database.AddModel(ctx, &m.model)
 		if err != nil {
 			if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-				return fmt.Errorf("model (%s) already exists", m.model.Name)
+				return errors.Codef(errors.CodeAlreadyExists, "model %q already exists", m.model.Name)
 			}
 			return err
 		}
@@ -513,7 +513,7 @@ func (m *modelImporter) save(ctx context.Context) error {
 			}
 			if err := m.jimm.Database.AddApplicationOffer(ctx, &dbOffer); err != nil {
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-					return fmt.Errorf("offer with URL %s already exists", offer.OfferURL)
+					return errors.Codef(errors.CodeAlreadyExists, "offer with URL %s already exists", offer.OfferURL)
 				}
 				return err
 			}

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -661,7 +661,8 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 	if spec.TargetInfo.Macaroons != "" {
 		err = json.Unmarshal([]byte(spec.TargetInfo.Macaroons), &targetMacaroons)
 		if err != nil {
-			return result, errors.Codef(errors.CodeBadRequest, "failed to unmarshal macaroons: %w", err)
+			zapctx.Error(ctx, "failed to unmarshal macaroons", zap.Error(err))
+			return result, errors.Codef(errors.CodeBadRequest, "failed to unmarshal macaroons")
 		}
 	}
 

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -766,7 +766,7 @@ func TestImportModel(t *testing.T) {
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
-			return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+			return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "model not found")
 		},
 		expectedError: "model not found.*",
 	}, {
@@ -990,7 +990,7 @@ func TestImportModel(t *testing.T) {
 							}, nil
 						}
 					}
-					return jujuparams.ConsumeOfferDetails{}, errors.ErrWithCode(nil, errors.CodeNotFound)
+					return jujuparams.ConsumeOfferDetails{}, errors.Codef(errors.CodeNotFound, "not found")
 				},
 			}
 
@@ -1521,7 +1521,7 @@ func (c *testControllerClient) InitiateMigration(spec controller.MigrationSpec, 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.initiateMigrationResults) == 0 {
-		return "", errors.ErrWithCode(nil, errors.CodeNotImplemented)
+		return "", errors.Codef(errors.CodeNotImplemented, "not implemented")
 	}
 	var result result
 	result, c.initiateMigrationResults = c.initiateMigrationResults[0], c.initiateMigrationResults[1:]

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -766,7 +766,7 @@ func TestImportModel(t *testing.T) {
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
 		jimmAdmin:      true,
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
-			return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound, "model not found")
+			return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 		},
 		expectedError: "model not found",
 	}, {
@@ -990,7 +990,7 @@ func TestImportModel(t *testing.T) {
 							}, nil
 						}
 					}
-					return jujuparams.ConsumeOfferDetails{}, errors.E(errors.CodeNotFound)
+					return jujuparams.ConsumeOfferDetails{}, errors.ErrWithCode(nil, errors.CodeNotFound)
 				},
 			}
 
@@ -1433,7 +1433,7 @@ func TestInitiateMigration(t *testing.T) {
 			},
 		},
 		initiateMigrationResults: []result{{}},
-		expectedError:            "failed to unmarshal macaroons",
+		expectedError:            "failed to unmarshal macaroons.*",
 	}}
 
 	for _, test := range tests {
@@ -1521,7 +1521,7 @@ func (c *testControllerClient) InitiateMigration(spec controller.MigrationSpec, 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.initiateMigrationResults) == 0 {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.ErrWithCode(nil, errors.CodeNotImplemented)
 	}
 	var result result
 	result, c.initiateMigrationResults = c.initiateMigrationResults[0], c.initiateMigrationResults[1:]

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -442,7 +442,7 @@ func TestControllerConfig(t *testing.T) {
 	c.Assert(config.SSHServerPort(), qt.Equals, 17022)
 
 	_, err = j.ControllerConfig(ctx, alice, "not-found")
-	c.Assert(err, qt.ErrorMatches, "controller not found.*")
+	c.Assert(err, qt.ErrorMatches, "controller not found")
 }
 
 const testImportModelEnv = `
@@ -768,7 +768,7 @@ func TestImportModel(t *testing.T) {
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
 			return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "model not found")
 		},
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:          "fail import from local user without newOwner flag",
 		user:           "alice@canonical.com",
@@ -1124,14 +1124,14 @@ func TestUpdateMigratedModel(t *testing.T) {
 		about:         "model not found",
 		user:          "alice@canonical.com",
 		model:         names.NewModelTag("unknown-model"),
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 		jimmAdmin:     true,
 	}, {
 		about:            "controller not found",
 		user:             "alice@canonical.com",
 		model:            names.NewModelTag("00000002-0000-0000-0000-000000000002"),
 		targetController: "no-such-controller",
-		expectedError:    "controller not found.*",
+		expectedError:    "controller not found",
 		jimmAdmin:        true,
 	}, {
 		about:            "api returns an error",

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1255,7 +1255,6 @@ func TestInitiateMigration(t *testing.T) {
 	c := qt.New(t)
 
 	mt1 := names.NewModelTag("00000002-0000-0000-0000-000000000003")
-	// mt2 := names.NewModelTag("00000002-0000-0000-0000-000000000004")
 
 	migrationId1 := uuid.New().String()
 
@@ -1316,7 +1315,7 @@ func TestInitiateMigration(t *testing.T) {
 			},
 		},
 		initiateMigrationResults: []result{{}},
-		expectedError:            "unauthorized access",
+		expectedError:            "unauthorized",
 	}, {
 		about: "InitiateMigration call fails",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1356,7 +1355,7 @@ func TestInitiateMigration(t *testing.T) {
 			},
 		},
 		initiateMigrationResults: []result{{}},
-		expectedError:            "unauthorized access",
+		expectedError:            "unauthorized",
 	}, {
 		about: "invalid model tag",
 		user: func(client *openfga.OFGAClient) *openfga.User {

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -442,7 +442,7 @@ func TestControllerConfig(t *testing.T) {
 	c.Assert(config.SSHServerPort(), qt.Equals, 17022)
 
 	_, err = j.ControllerConfig(ctx, alice, "not-found")
-	c.Assert(err, qt.ErrorMatches, "controller not found")
+	c.Assert(err, qt.ErrorMatches, "controller not found.*")
 }
 
 const testImportModelEnv = `
@@ -768,7 +768,7 @@ func TestImportModel(t *testing.T) {
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
 			return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 		},
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:          "fail import from local user without newOwner flag",
 		user:           "alice@canonical.com",
@@ -1124,14 +1124,14 @@ func TestUpdateMigratedModel(t *testing.T) {
 		about:         "model not found",
 		user:          "alice@canonical.com",
 		model:         names.NewModelTag("unknown-model"),
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 		jimmAdmin:     true,
 	}, {
 		about:            "controller not found",
 		user:             "alice@canonical.com",
 		model:            names.NewModelTag("00000002-0000-0000-0000-000000000002"),
 		targetController: "no-such-controller",
-		expectedError:    "controller not found",
+		expectedError:    "controller not found.*",
 		jimmAdmin:        true,
 	}, {
 		about:            "api returns an error",

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1432,7 +1432,7 @@ func TestInitiateMigration(t *testing.T) {
 			},
 		},
 		initiateMigrationResults: []result{{}},
-		expectedError:            "failed to unmarshal macaroons.*",
+		expectedError:            "failed to unmarshal macaroons",
 	}}
 
 	for _, test := range tests {

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -94,7 +94,7 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -135,7 +135,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 			return err
 		}
 		if len(models) > 0 && !force {
-			return errors.E(errors.CodeStillAlive, "controller still has models")
+			return errors.MsgWithCode("controller still has models", errors.CodeStillAlive)
 		}
 
 		// Remove all models associated with the controller. If force is false,
@@ -160,7 +160,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 // FullModelStatus returns the full status of the juju model.
 func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error) {
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	model := dbmodel.Model{
@@ -199,7 +199,7 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return jujuparams.MigrationTargetInfo{}, 0, err
 		}
-		return jujuparams.MigrationTargetInfo{}, 0, errors.E(err, fmt.Errorf("failed to get controller with name %q", controllerName))
+		return jujuparams.MigrationTargetInfo{}, 0, fmt.Errorf("failed to get controller with name %q: %w", controllerName, err)
 	}
 	adminUser, adminPass, err := credStore.GetControllerCredentials(ctx, controllerName)
 	if err != nil {
@@ -382,14 +382,14 @@ func WithOwnerAndModelName(ownerName, modelName string) ModelControllerInfoQuali
 // - WithOwnerAndModelName(owner, name) to specify by owner and model name
 func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var model dbmodel.Model
 	qualifier(&model)
 
 	if !model.UUID.Valid && (model.OwnerIdentityName == "" || model.Name == "") {
-		return nil, errors.E("either model uuid or both model name and owner must be provided", errors.CodeBadRequest)
+		return nil, errors.MsgWithCode("either model uuid or both model name and owner must be provided", errors.CodeBadRequest)
 	}
 
 	err := j.Database.GetModel(ctx, &model)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -94,7 +94,7 @@ func (j *JujuManager) ListControllers(ctx context.Context, user *openfga.User) (
 func (j *JujuManager) SetControllerDeprecated(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Update the local database with the updated cloud definition. We
@@ -135,7 +135,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 			return err
 		}
 		if len(models) > 0 && !force {
-			return errors.MsgWithCode("controller still has models", errors.CodeStillAlive)
+			return errors.Codef(errors.CodeStillAlive, "controller still has models")
 		}
 
 		// Remove all models associated with the controller. If force is false,
@@ -160,7 +160,7 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 // FullModelStatus returns the full status of the juju model.
 func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error) {
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	model := dbmodel.Model{
@@ -382,14 +382,14 @@ func WithOwnerAndModelName(ownerName, modelName string) ModelControllerInfoQuali
 // - WithOwnerAndModelName(owner, name) to specify by owner and model name
 func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var model dbmodel.Model
 	qualifier(&model)
 
 	if !model.UUID.Valid && (model.OwnerIdentityName == "" || model.Name == "") {
-		return nil, errors.MsgWithCode("either model uuid or both model name and owner must be provided", errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "either model uuid or both model name and owner must be provided")
 	}
 
 	err := j.Database.GetModel(ctx, &model)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -197,7 +197,7 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 	err := db.GetController(ctx, &dbController)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return jujuparams.MigrationTargetInfo{}, 0, err
+			return jujuparams.MigrationTargetInfo{}, 0, errors.Codef(errors.CodeNotFound, "controller %q not found", controllerName)
 		}
 		return jujuparams.MigrationTargetInfo{}, 0, fmt.Errorf("failed to get controller with name %q: %w", controllerName, err)
 	}

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -197,7 +197,7 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 	err := db.GetController(ctx, &dbController)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return jujuparams.MigrationTargetInfo{}, 0, errors.Codef(errors.CodeNotFound, "controller %q not found", controllerName)
+			return jujuparams.MigrationTargetInfo{}, 0, errors.Codef(errors.CodeNotFound, "controller not found")
 		}
 		return jujuparams.MigrationTargetInfo{}, 0, fmt.Errorf("failed to get controller with name %q: %w", controllerName, err)
 	}

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -496,7 +496,7 @@ func TestFullModelStatus(t *testing.T) {
 		statusFunc: func(_ context.Context, _ []string) (*jujuparams.FullStatus, error) {
 			return &fullStatus, nil
 		},
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:     "controller returns an error",
 		user:      "alice@canonical.com",
@@ -594,7 +594,7 @@ func TestFillMigrationTarget(t *testing.T) {
 		about:          "controller doesn't exist",
 		userTag:        "alice@canonical.com",
 		controllerName: "controller-2",
-		expectedError:  "controller not found",
+		expectedError:  "controller not found.*",
 	},
 	}
 	for _, test := range tests {
@@ -1060,7 +1060,7 @@ func TestListMigrationTargets(t *testing.T) {
 		about:         "fails to list controllers for missing model",
 		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
 		modelTag:      names.NewModelTag("00000002-0000-0000-0000-000000000002"),
-		expectedError: `model not found`,
+		expectedError: `model not found.*`,
 	}, {
 		about:               "empty list of controllers for too-new model",
 		user:                env.User("alice@canonical.com").DBObject(c, j.Database),
@@ -1187,7 +1187,7 @@ func TestModelControllerInfo(t *testing.T) {
 		jimmAdmin:     true,
 		useModelTag:   true,
 		modelTag:      "00000002-0000-0000-0000-000000000999",
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:       "jimm admin can get model controller info by owner and name",
 		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
@@ -1229,7 +1229,7 @@ func TestModelControllerInfo(t *testing.T) {
 		useModelTag:   false,
 		ownerName:     "alice@canonical.com",
 		modelName:     "non-existent-model",
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:         "jimm admin fails when neither model uuid nor owner/name provided",
 		user:          env.User("alice@canonical.com").DBObject(c, j.Database),

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -81,7 +81,7 @@ func TestControllerInfo(t *testing.T) {
 	c.Assert(ctl.Name, qt.Equals, "test1")
 
 	_, err = j.ControllerInfo(ctx, "does-not-exist")
-	c.Assert(err, qt.ErrorMatches, "controller not found.*")
+	c.Assert(err, qt.ErrorMatches, "controller not found")
 }
 
 func TestListControllers(t *testing.T) {
@@ -337,7 +337,7 @@ func TestRemoveController(t *testing.T) {
 					Name: "test1",
 				}
 				err = j.Database.GetController(ctx, &controller)
-				c.Assert(err, qt.ErrorMatches, "controller not found.*")
+				c.Assert(err, qt.ErrorMatches, "controller not found")
 			}
 		})
 	}
@@ -676,17 +676,17 @@ func TestInitiateInternalMigration(t *testing.T) {
 		about:         "empty controller name",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "alice@canonical.com/model-1", TargetController: ""},
-		expectedError: `failed to get controller with name "".*`,
+		expectedError: `failed to get controller with name "": controller UUID or name must be provided`,
 	}, {
 		about:         "model doesn't exist",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "00000002-0000-0000-0000-000000000002", TargetController: "myController"},
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:         "model doesn't exist",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "00000002-0000-0000-0000-000000000002", TargetController: "myController"},
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:         "a missing model target",
 		user:          "alice@canonical.com",
@@ -788,7 +788,7 @@ func TestPrepareModelMigration_ControllerDoesNotExist(t *testing.T) {
 		targetControllerName,
 		userMapping,
 	)
-	c.Assert(err, qt.ErrorMatches, "failed to add incoming model migration details: controller not found.*")
+	c.Assert(err, qt.ErrorMatches, "failed to add incoming model migration details: controller not found")
 }
 
 func TestPrepareModelMigration_Success(t *testing.T) {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -496,7 +496,7 @@ func TestFullModelStatus(t *testing.T) {
 		statusFunc: func(_ context.Context, _ []string) (*jujuparams.FullStatus, error) {
 			return &fullStatus, nil
 		},
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:     "controller returns an error",
 		user:      "alice@canonical.com",
@@ -594,7 +594,7 @@ func TestFillMigrationTarget(t *testing.T) {
 		about:          "controller doesn't exist",
 		userTag:        "alice@canonical.com",
 		controllerName: "controller-2",
-		expectedError:  "controller not found.*",
+		expectedError:  "controller not found",
 	},
 	}
 	for _, test := range tests {
@@ -1060,7 +1060,7 @@ func TestListMigrationTargets(t *testing.T) {
 		about:         "fails to list controllers for missing model",
 		user:          env.User("alice@canonical.com").DBObject(c, j.Database),
 		modelTag:      names.NewModelTag("00000002-0000-0000-0000-000000000002"),
-		expectedError: `model not found.*`,
+		expectedError: `model not found`,
 	}, {
 		about:               "empty list of controllers for too-new model",
 		user:                env.User("alice@canonical.com").DBObject(c, j.Database),
@@ -1187,7 +1187,7 @@ func TestModelControllerInfo(t *testing.T) {
 		jimmAdmin:     true,
 		useModelTag:   true,
 		modelTag:      "00000002-0000-0000-0000-000000000999",
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:       "jimm admin can get model controller info by owner and name",
 		user:        env.User("alice@canonical.com").DBObject(c, j.Database),
@@ -1229,7 +1229,7 @@ func TestModelControllerInfo(t *testing.T) {
 		useModelTag:   false,
 		ownerName:     "alice@canonical.com",
 		modelName:     "non-existent-model",
-		expectedError: "model not found.*",
+		expectedError: "model not found",
 	}, {
 		about:         "jimm admin fails when neither model uuid nor owner/name provided",
 		user:          env.User("alice@canonical.com").DBObject(c, j.Database),

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -81,7 +81,7 @@ func TestControllerInfo(t *testing.T) {
 	c.Assert(ctl.Name, qt.Equals, "test1")
 
 	_, err = j.ControllerInfo(ctx, "does-not-exist")
-	c.Assert(err, qt.ErrorMatches, "controller not found")
+	c.Assert(err, qt.ErrorMatches, "controller not found.*")
 }
 
 func TestListControllers(t *testing.T) {
@@ -337,7 +337,7 @@ func TestRemoveController(t *testing.T) {
 					Name: "test1",
 				}
 				err = j.Database.GetController(ctx, &controller)
-				c.Assert(err, qt.ErrorMatches, "controller not found")
+				c.Assert(err, qt.ErrorMatches, "controller not found.*")
 			}
 		})
 	}
@@ -676,17 +676,17 @@ func TestInitiateInternalMigration(t *testing.T) {
 		about:         "empty controller name",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "alice@canonical.com/model-1", TargetController: ""},
-		expectedError: `failed to get controller with name ""`,
+		expectedError: `failed to get controller with name "".*`,
 	}, {
 		about:         "model doesn't exist",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "00000002-0000-0000-0000-000000000002", TargetController: "myController"},
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:         "model doesn't exist",
 		user:          "alice@canonical.com",
 		migrateInfo:   params.MigrateModelInfo{TargetModelNameOrUUID: "00000002-0000-0000-0000-000000000002", TargetController: "myController"},
-		expectedError: "model not found",
+		expectedError: "model not found.*",
 	}, {
 		about:         "a missing model target",
 		user:          "alice@canonical.com",
@@ -788,7 +788,7 @@ func TestPrepareModelMigration_ControllerDoesNotExist(t *testing.T) {
 		targetControllerName,
 		userMapping,
 	)
-	c.Assert(err, qt.ErrorMatches, "failed to add incoming model migration details: controller not found")
+	c.Assert(err, qt.ErrorMatches, "failed to add incoming model migration details: controller not found.*")
 }
 
 func TestPrepareModelMigration_Success(t *testing.T) {

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -81,7 +81,7 @@ func NewJujuManager(
 // code of CodeConnectionFailed will be returned.
 func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error) {
 	if j == nil || j.Dialer == nil {
-		return nil, errors.E(errors.CodeConnectionFailed, "no dialer configured")
+		return nil, errors.MsgWithCode("no dialer configured", errors.CodeConnectionFailed)
 	}
 
 	return j.Dialer.Dial(ctx, ctl, modelTag, user)

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -81,7 +81,7 @@ func NewJujuManager(
 // code of CodeConnectionFailed will be returned.
 func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error) {
 	if j == nil || j.Dialer == nil {
-		return nil, errors.MsgWithCode("no dialer configured", errors.CodeConnectionFailed)
+		return nil, errors.Codef(errors.CodeConnectionFailed, "no dialer configured")
 	}
 
 	return j.Dialer.Dial(ctx, ctl, modelTag, user)

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -127,7 +127,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Sprintf("migrating model %q not found", modelUUID))
+			return ControllerConnectionDetails{}, errors.MsgWithCode(fmt.Sprintf("migrating model %q not found", modelUUID), errors.CodeNotFound)
 		}
 		return ControllerConnectionDetails{}, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err)
 	}
@@ -138,7 +138,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name))
+		return ControllerConnectionDetails{}, errors.ErrWithCode(fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name), errors.CodeNotFound)
 	}
 
 	return toControllerConnectionDetails(incomingModel.TargetController, username, password), nil

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -628,7 +628,7 @@ func importFromDescription(ctx context.Context, tx *db.Database, targetControlle
 			}
 			if err := tx.AddApplicationOffer(ctx, &dbOffer); err != nil {
 				if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-					return nil, nil, fmt.Errorf("offer with URL %s already exists", dbOffer.URL)
+					return nil, nil, errors.Codef(errors.CodeAlreadyExists, "offer with URL %s already exists", dbOffer.URL)
 				}
 				return nil, nil, fmt.Errorf("failed to add application offer %q: %w", dbOffer.Name, err)
 			}

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -127,7 +127,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	err := j.Database.GetIncomingModelMigration(ctx, &incomingModel)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			return ControllerConnectionDetails{}, errors.MsgWithCode(fmt.Sprintf("migrating model %q not found", modelUUID), errors.CodeNotFound)
+			return ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "migrating model %q not found", modelUUID)
 		}
 		return ControllerConnectionDetails{}, fmt.Errorf("failed to get controller for model %q: %w", modelUUID, err)
 	}
@@ -138,7 +138,7 @@ func (j *JujuManager) ControllerDetailsForIncomingModel(ctx context.Context, mod
 	}
 
 	if username == "" || password == "" {
-		return ControllerConnectionDetails{}, errors.ErrWithCode(fmt.Errorf("missing credentials for controller %q", incomingModel.TargetController.Name), errors.CodeNotFound)
+		return ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "missing credentials for controller %q", incomingModel.TargetController.Name)
 	}
 
 	return toControllerConnectionDetails(incomingModel.TargetController, username, password), nil

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -110,7 +110,7 @@ func TestAbortMigration_Success(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 
 	// Check the model has been deleted from the database.
 	model := &dbmodel.Model{
@@ -120,7 +120,7 @@ func TestAbortMigration_Success(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(ctx, model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 
 	// Check that permissions for the user have been removed.
 	ok, err := user.IsModelAdmin(ctx, names.NewModelTag(migratingModelUUID))
@@ -144,7 +144,7 @@ func TestAbortMigration_MissingIncomingModel(t *testing.T) {
 	user := openfga.NewUser(&dbUser, nil)
 
 	err := j.AbortMigration(ctx, user, "foo")
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
 func TestCheckMachines_Success(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCheckMachines_MissingIncomingModel(t *testing.T) {
 	user := openfga.NewUser(&dbUser, nil)
 
 	_, err := j.CheckMachines(ctx, user, "foo")
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
 func TestControllerDetailsForIncomingModel(t *testing.T) {
@@ -552,7 +552,7 @@ func TestPrechecks_MissingCloudCredential(t *testing.T) {
 	})
 
 	err := j.Prechecks(ctx, user, toJimmMigratingInfo(c, model, desc))
-	c.Assert(err, qt.ErrorMatches, `^cloudcredential "test/alice@canonical.com/test-cred-not-found" not found.*$`)
+	c.Assert(err, qt.ErrorMatches, `^cloudcredential "test/alice@canonical.com/test-cred-not-found" not found$`)
 }
 
 func TestPrechecks_ControllerUnreachable(t *testing.T) {
@@ -659,7 +659,7 @@ func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
 		CloudRegionName:     "test-region",
 	})
 	err := j.Prechecks(ctx, user, toJimmMigratingInfo(c, model, desc))
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
 func TestAdoptResources_Success(t *testing.T) {
@@ -706,7 +706,7 @@ func TestAdoptResources_NoModel(t *testing.T) {
 	j := newTestJujuManager(c, nil)
 
 	err := j.AdoptResources(ctx, nil, "foo", version.MustParse("3.6.9"))
-	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 }
 
 const testEnvWithIncomingMigrationAndModel = `clouds:
@@ -806,7 +806,7 @@ func TestActivate_Success(t *testing.T) {
 	}
 	// Check the model migration has been removed from the database.
 	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 
 	var count int64
 	err = j.Database.DB.Model(&dbmodel.UserMapping{}).Count(&count).Error
@@ -886,7 +886,7 @@ func TestActivate_NoIncomingModelMigration(t *testing.T) {
 	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	err := j.Activate(ctx, user, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }
 
 type modelDescriptionArgs struct {
@@ -1244,7 +1244,7 @@ func TestImport_MissingCloudCredentialFromJIMMState(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, `.*failed to import model from description: cloudcredential \S+ not found.*$`)
+	c.Assert(err, qt.ErrorMatches, `.*failed to import model from description: cloudcredential \S+ not found$`)
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{
@@ -1407,7 +1407,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 
 	userMapping := dbmodel.UserMapping{
 		ModelUUID:        modelMigration.ModelUUID,
@@ -1415,7 +1415,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		ExternalUserName: "alice@canonical.com",
 	}
 	err = j.Database.GetUserMapping(t.Context(), &userMapping)
-	c.Assert(err, qt.ErrorMatches, `.*user mapping not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*user mapping not found`)
 
 	// Check the model has been deleted.
 	model := &dbmodel.Model{
@@ -1425,7 +1425,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(t.Context(), model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 
 	// Check the third incoming migration has been deleted, with its model.
 	modelMigration = dbmodel.IncomingModelMigration{
@@ -1435,7 +1435,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 
 	model = &dbmodel.Model{
 		UUID: sql.NullString{
@@ -1444,7 +1444,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(t.Context(), model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found`)
 
 	// Check the fourth incoming migration has been deleted.
 	modelMigration = dbmodel.IncomingModelMigration{
@@ -1454,5 +1454,5 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
 }

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -110,7 +110,7 @@ func TestAbortMigration_Success(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 
 	// Check the model has been deleted from the database.
 	model := &dbmodel.Model{
@@ -120,7 +120,7 @@ func TestAbortMigration_Success(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(ctx, model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
 
 	// Check that permissions for the user have been removed.
 	ok, err := user.IsModelAdmin(ctx, names.NewModelTag(migratingModelUUID))
@@ -144,7 +144,7 @@ func TestAbortMigration_MissingIncomingModel(t *testing.T) {
 	user := openfga.NewUser(&dbUser, nil)
 
 	err := j.AbortMigration(ctx, user, "foo")
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 }
 
 func TestCheckMachines_Success(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCheckMachines_MissingIncomingModel(t *testing.T) {
 	user := openfga.NewUser(&dbUser, nil)
 
 	_, err := j.CheckMachines(ctx, user, "foo")
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 }
 
 func TestControllerDetailsForIncomingModel(t *testing.T) {
@@ -552,7 +552,7 @@ func TestPrechecks_MissingCloudCredential(t *testing.T) {
 	})
 
 	err := j.Prechecks(ctx, user, toJimmMigratingInfo(c, model, desc))
-	c.Assert(err, qt.ErrorMatches, `^cloudcredential "test/alice@canonical.com/test-cred-not-found" not found$`)
+	c.Assert(err, qt.ErrorMatches, `^cloudcredential "test/alice@canonical.com/test-cred-not-found" not found.*$`)
 }
 
 func TestPrechecks_ControllerUnreachable(t *testing.T) {
@@ -659,7 +659,7 @@ func TestPrechecks_NoIncomingModelMigration(t *testing.T) {
 		CloudRegionName:     "test-region",
 	})
 	err := j.Prechecks(ctx, user, toJimmMigratingInfo(c, model, desc))
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 }
 
 func TestAdoptResources_Success(t *testing.T) {
@@ -706,7 +706,7 @@ func TestAdoptResources_NoModel(t *testing.T) {
 	j := newTestJujuManager(c, nil)
 
 	err := j.AdoptResources(ctx, nil, "foo", version.MustParse("3.6.9"))
-	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
 }
 
 const testEnvWithIncomingMigrationAndModel = `clouds:
@@ -806,7 +806,7 @@ func TestActivate_Success(t *testing.T) {
 	}
 	// Check the model migration has been removed from the database.
 	err = j.Database.GetIncomingModelMigration(ctx, &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 
 	var count int64
 	err = j.Database.DB.Model(&dbmodel.UserMapping{}).Count(&count).Error
@@ -886,7 +886,7 @@ func TestActivate_NoIncomingModelMigration(t *testing.T) {
 	user := openfga.NewUser(&dbUser, j.OpenFGAClient)
 
 	err := j.Activate(ctx, user, names.NewModelTag("foo"), migration.SourceControllerInfo{}, nil)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 }
 
 type modelDescriptionArgs struct {
@@ -1244,7 +1244,7 @@ func TestImport_MissingCloudCredentialFromJIMMState(t *testing.T) {
 	err = j.Import(ctx, user, params.SerializedModel{
 		Bytes: bytes,
 	})
-	c.Assert(err, qt.ErrorMatches, `.*failed to import model from description: cloudcredential \S+ not found$`)
+	c.Assert(err, qt.ErrorMatches, `.*failed to import model from description: cloudcredential \S+ not found.*$`)
 
 	// Check the model is created in the database with migration mode set to importing.
 	m := &dbmodel.Model{
@@ -1407,7 +1407,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 
 	userMapping := dbmodel.UserMapping{
 		ModelUUID:        modelMigration.ModelUUID,
@@ -1415,7 +1415,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		ExternalUserName: "alice@canonical.com",
 	}
 	err = j.Database.GetUserMapping(t.Context(), &userMapping)
-	c.Assert(err, qt.ErrorMatches, `.*user mapping not found`)
+	c.Assert(err, qt.ErrorMatches, `.*user mapping not found.*`)
 
 	// Check the model has been deleted.
 	model := &dbmodel.Model{
@@ -1425,7 +1425,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(t.Context(), model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
 
 	// Check the third incoming migration has been deleted, with its model.
 	modelMigration = dbmodel.IncomingModelMigration{
@@ -1435,7 +1435,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 
 	model = &dbmodel.Model{
 		UUID: sql.NullString{
@@ -1444,7 +1444,7 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetModel(t.Context(), model)
-	c.Assert(err, qt.ErrorMatches, `.*model not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model not found.*`)
 
 	// Check the fourth incoming migration has been deleted.
 	modelMigration = dbmodel.IncomingModelMigration{
@@ -1454,5 +1454,5 @@ func TestCleanupPartialModelMigrations(t *testing.T) {
 		},
 	}
 	err = j.Database.GetIncomingModelMigration(t.Context(), &modelMigration)
-	c.Assert(err, qt.ErrorMatches, `.*model migration not found`)
+	c.Assert(err, qt.ErrorMatches, `.*model migration not found.*`)
 }

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -68,7 +68,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 
 	// Only JIMM admins are able to add models on behalf of other users.
 	if owner.Name != user.Name && !user.JimmAdmin {
-		return base.ModelInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return base.ModelInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	builder := newModelBuilder(ctx, j)
@@ -211,7 +211,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 	}
 
 	if ok, err := user.IsModelReader(ctx, mt); !ok || err != nil {
-		return jujuclient.ModelInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return jujuclient.ModelInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
@@ -529,7 +529,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 // immediately. The given function should not update the database.
 func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error {
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	errStop := errors.New("stop")
@@ -667,7 +667,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 	if !hasAccess {
 		// If the user doesn't have correct access on the model return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
@@ -685,7 +685,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 // the controller and the local database.
 func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error {
 	if !user.JimmAdmin && user.Tag() != cloudCredentialTag.Owner() {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	credential := dbmodel.CloudCredential{}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -68,7 +68,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 
 	// Only JIMM admins are able to add models on behalf of other users.
 	if owner.Name != user.Name && !user.JimmAdmin {
-		return base.ModelInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return base.ModelInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	builder := newModelBuilder(ctx, j)
@@ -211,7 +211,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 	}
 
 	if ok, err := user.IsModelReader(ctx, mt); !ok || err != nil {
-		return jujuclient.ModelInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return jujuclient.ModelInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
@@ -529,7 +529,7 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 // immediately. The given function should not update the database.
 func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error {
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	errStop := errors.New("stop")
@@ -667,7 +667,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 	if !hasAccess {
 		// If the user doesn't have correct access on the model return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
@@ -685,7 +685,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 // the controller and the local database.
 func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error {
 	if !user.JimmAdmin && user.Tag() != cloudCredentialTag.Owner() {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	credential := dbmodel.CloudCredential{}
@@ -730,13 +730,13 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 	// Get uuids of models the user has access to
 	uuids, err := user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return nil, errors.E(fmt.Sprintf("failed to list user models: %v", err))
+		return nil, errors.New(fmt.Sprintf("failed to list user models: %v", err))
 	}
 
 	// Get the models from the database
 	models, err := j.Database.GetModelsByUUID(ctx, uuids)
 	if err != nil {
-		return nil, errors.E(fmt.Sprintf("failed to get models by uuid: %v", err))
+		return nil, errors.New(fmt.Sprintf("failed to get models by uuid: %v", err))
 	}
 
 	// Create map for lookup later
@@ -785,7 +785,7 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 		return nil
 	})
 	if err != nil {
-		return nil, errors.E(fmt.Sprintf("failed to list models: %v", err))
+		return nil, errors.New(fmt.Sprintf("failed to list models: %v", err))
 	}
 
 	return userModels, nil

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -730,13 +730,13 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 	// Get uuids of models the user has access to
 	uuids, err := user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to list user models: %v", err))
+		return nil, fmt.Errorf("failed to list user models: %v", err)
 	}
 
 	// Get the models from the database
 	models, err := j.Database.GetModelsByUUID(ctx, uuids)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to get models by uuid: %v", err))
+		return nil, fmt.Errorf("failed to get models by uuid: %v", err)
 	}
 
 	// Create map for lookup later
@@ -785,7 +785,7 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 		return nil
 	})
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to list models: %v", err))
+		return nil, fmt.Errorf("failed to list models: %v", err)
 	}
 
 	return userModels, nil

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -75,7 +75,7 @@ func (j *JujuManager) checkModelMigratedInternal(ctx context.Context, errFromAPI
 	// This is the error that Juju controllers return when a model has been migrated.
 	isRedirectErr := errors.ErrorCode(errFromAPI) == params.CodeRedirect
 	if !isRedirectErr {
-		return errors.E(errFromAPI)
+		return errFromAPI
 	}
 
 	// Parse the redirect error to get the new controller details.

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -119,7 +119,7 @@ func TestModelCleanup(t *testing.T) {
 			ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
 				switch model.Id() {
 				case s.env.Models[0].UUID:
-					return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "not found")
 				case s.env.Models[1].UUID:
 					return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
 				case s.env.Models[2].UUID:

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -144,7 +144,7 @@ func TestModelCleanup(t *testing.T) {
 		},
 	}
 	err = s.jujuManager.Database.GetModel(ctx, &model)
-	c.Assert(err, qt.ErrorMatches, "model not found")
+	c.Assert(err, qt.ErrorMatches, "model not found.*")
 
 	model = dbmodel.Model{
 		UUID: sql.NullString{

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -144,7 +144,7 @@ func TestModelCleanup(t *testing.T) {
 		},
 	}
 	err = s.jujuManager.Database.GetModel(ctx, &model)
-	c.Assert(err, qt.ErrorMatches, "model not found.*")
+	c.Assert(err, qt.ErrorMatches, "model not found")
 
 	model = dbmodel.Model{
 		UUID: sql.NullString{

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -119,7 +119,7 @@ func TestModelCleanup(t *testing.T) {
 			ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
 				switch model.Id() {
 				case s.env.Models[0].UUID:
-					return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
 				case s.env.Models[1].UUID:
 					return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
 				case s.env.Models[2].UUID:

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -36,7 +36,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 
 	query, err := gojq.Parse(jqQuery)
 	if err != nil {
-		return results, errors.E("failed to parse jq query", err)
+		return results, fmt.Errorf("failed to parse jq query: %w", err)
 	}
 
 	// Set up a formatterParamsRetriever to handle the heavy lifting
@@ -96,7 +96,7 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 			// both erreoneous and valid query results.
 			if err, ok := v.(error); ok {
 				if stderrors.Is(err, context.DeadlineExceeded) {
-					return results, errors.E(fmt.Sprintf("jq query timed out after %.2f seconds", j.crossModelQueryTimeout.Seconds()), err)
+					return results, fmt.Errorf("jq query timed out after %.2f seconds: %w", j.crossModelQueryTimeout.Seconds(), err)
 				}
 				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())
 				continue

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -792,5 +792,5 @@ func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
 	}
 
 	_, err := j.QueryModelsJq(ctx, modelUUIDs, "range(infinite)")
-	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds")
+	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds: context deadline exceeded")
 }

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -792,5 +792,5 @@ func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
 	}
 
 	_, err := j.QueryModelsJq(ctx, modelUUIDs, "range(infinite)")
-	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds")
+	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds.*")
 }

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -792,5 +792,5 @@ func TestQueryModelsJqInfiniteRangeQueryTimesOut(t *testing.T) {
 	}
 
 	_, err := j.QueryModelsJq(ctx, modelUUIDs, "range(infinite)")
-	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds.*")
+	c.Assert(err, qt.ErrorMatches, "jq query timed out after 0.00 seconds")
 }

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1921,7 +1921,7 @@ func TestModelInfoNotFound(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-					return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "model not found")
 				},
 			},
 		},
@@ -1964,7 +1964,7 @@ func TestModelInfoRedirect(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-					return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "model not found")
 				},
 			},
 		},
@@ -2025,7 +2025,7 @@ func TestModelStatusNotFound(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelStatus_: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
-					return base.ModelStatus{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+					return base.ModelStatus{}, errors.Codef(errors.CodeNotFound, "model not found")
 				},
 			},
 		},

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -692,7 +692,7 @@ users:
 		Cloud:       names.NewCloudTag("test-cloud"),
 		CloudRegion: "test-region-1",
 	},
-	expectError: "model alice@canonical.com/test-model already exists.*",
+	expectError: "model alice@canonical.com/test-model already exists",
 }, {
 	name: "UpdateCredentialError",
 	env: `
@@ -760,7 +760,7 @@ users:
 		Cloud:       names.NewCloudTag("test-cloud"),
 		CloudRegion: "test-region-1",
 	},
-	expectError: "failed to update cloud credential: a silly error.*",
+	expectError: "failed to update cloud credential: a silly error",
 }, {
 	name: "UserWithoutAddModelPermission",
 	env: `
@@ -1671,7 +1671,7 @@ func TestGetModel(t *testing.T) {
 
 	// Get model that doesn't exist
 	_, err = j.GetModel(ctx, "fake-uuid")
-	c.Assert(err, qt.ErrorMatches, "failed to get model: model not found.*")
+	c.Assert(err, qt.ErrorMatches, "failed to get model: model not found")
 }
 
 // Note that this env does not give the everyone user access to the model.
@@ -1819,7 +1819,7 @@ var modelInfoTests = []struct {
 	env:         modelInfoTestEnv,
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000002",
-	expectError: "model not found.*",
+	expectError: "model not found",
 }, {
 	name:             "Access through everyone user",
 	env:              modelInfoTestEnvWithEveryoneAccess,
@@ -2107,7 +2107,7 @@ var modelStatusTests = []struct {
 	name:        "ModelNotFound",
 	username:    "alice@canonical.com",
 	uuid:        "00000001-0000-0000-0000-000000000001",
-	expectError: `model not found.*`,
+	expectError: `model not found`,
 }, {
 	name:        "UnauthorizedUser",
 	env:         modelStatusTestEnv,
@@ -2653,7 +2653,7 @@ var destroyModelTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found.*`,
+	expectError:     `model not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2784,7 +2784,7 @@ var dumpModelTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found.*`,
+	expectError:     `model not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2887,7 +2887,7 @@ var dumpModelDBTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found.*`,
+	expectError:     `model not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2989,7 +2989,7 @@ var validateModelUpgradeTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found.*`,
+	expectError:     `model not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -3224,7 +3224,7 @@ var updateModelCredentialTests = []struct {
 	username:        "alice@canonical.com",
 	credential:      "test-cloud/alice@canonical.com/cred-3",
 	uuid:            "00000002-0000-0000-0000-000000000001",
-	expectError:     `cloudcredential "test-cloud/alice@canonical.com/cred-3" not found.*`,
+	expectError:     `cloudcredential "test-cloud/alice@canonical.com/cred-3" not found`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "update credential returns an error",

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1595,11 +1595,11 @@ func assertConfig(config map[string]interface{}, fnc func(context.Context, *juju
 			return base.ModelInfo{}, errors.New("cloud not specified")
 		}
 		if len(config) != len(args.Config) {
-			return base.ModelInfo{}, errors.E(fmt.Sprintf("expected %d config settings, got %d", len(config), len(args.Config)))
+			return base.ModelInfo{}, errors.New(fmt.Sprintf("expected %d config settings, got %d", len(config), len(args.Config)))
 		}
 		for k, v := range args.Config {
 			if config[k] != v {
-				return base.ModelInfo{}, errors.E(fmt.Sprintf("config value mismatch for key %s: %s -> %s", k, config[k], v))
+				return base.ModelInfo{}, errors.New(fmt.Sprintf("config value mismatch for key %s: %s -> %s", k, config[k], v))
 			}
 		}
 		return fnc(ctx, args)
@@ -1921,7 +1921,7 @@ func TestModelInfoNotFound(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-					return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound, "model not found")
+					return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 				},
 			},
 		},
@@ -1964,7 +1964,7 @@ func TestModelInfoRedirect(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-					return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound, "model not found")
+					return jujuclient.ModelInfo{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 				},
 			},
 		},
@@ -2025,7 +2025,7 @@ func TestModelStatusNotFound(t *testing.T) {
 		Dialer: &jimmtest.Dialer{
 			API: &jimmtest.API{
 				ModelStatus_: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
-					return base.ModelStatus{}, errors.E(errors.CodeNotFound, "model not found")
+					return base.ModelStatus{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 				},
 			},
 		},

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -692,7 +692,7 @@ users:
 		Cloud:       names.NewCloudTag("test-cloud"),
 		CloudRegion: "test-region-1",
 	},
-	expectError: "model alice@canonical.com/test-model already exists",
+	expectError: "model alice@canonical.com/test-model already exists.*",
 }, {
 	name: "UpdateCredentialError",
 	env: `
@@ -760,7 +760,7 @@ users:
 		Cloud:       names.NewCloudTag("test-cloud"),
 		CloudRegion: "test-region-1",
 	},
-	expectError: "failed to update cloud credential: a silly error",
+	expectError: "failed to update cloud credential: a silly error.*",
 }, {
 	name: "UserWithoutAddModelPermission",
 	env: `
@@ -1671,7 +1671,7 @@ func TestGetModel(t *testing.T) {
 
 	// Get model that doesn't exist
 	_, err = j.GetModel(ctx, "fake-uuid")
-	c.Assert(err, qt.ErrorMatches, "failed to get model: model not found")
+	c.Assert(err, qt.ErrorMatches, "failed to get model: model not found.*")
 }
 
 // Note that this env does not give the everyone user access to the model.
@@ -1819,7 +1819,7 @@ var modelInfoTests = []struct {
 	env:         modelInfoTestEnv,
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000002",
-	expectError: "model not found",
+	expectError: "model not found.*",
 }, {
 	name:             "Access through everyone user",
 	env:              modelInfoTestEnvWithEveryoneAccess,
@@ -2107,7 +2107,7 @@ var modelStatusTests = []struct {
 	name:        "ModelNotFound",
 	username:    "alice@canonical.com",
 	uuid:        "00000001-0000-0000-0000-000000000001",
-	expectError: `model not found`,
+	expectError: `model not found.*`,
 }, {
 	name:        "UnauthorizedUser",
 	env:         modelStatusTestEnv,
@@ -2653,7 +2653,7 @@ var destroyModelTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found`,
+	expectError:     `model not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2784,7 +2784,7 @@ var dumpModelTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found`,
+	expectError:     `model not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2887,7 +2887,7 @@ var dumpModelDBTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found`,
+	expectError:     `model not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -2989,7 +2989,7 @@ var validateModelUpgradeTests = []struct {
 	env:             destroyModelTestEnv,
 	username:        "alice@canonical.com",
 	uuid:            "00000002-0000-0000-0000-000000000002",
-	expectError:     `model not found`,
+	expectError:     `model not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name:            "Unauthorized",
@@ -3224,7 +3224,7 @@ var updateModelCredentialTests = []struct {
 	username:        "alice@canonical.com",
 	credential:      "test-cloud/alice@canonical.com/cred-3",
 	uuid:            "00000002-0000-0000-0000-000000000001",
-	expectError:     `cloudcredential "test-cloud/alice@canonical.com/cred-3" not found`,
+	expectError:     `cloudcredential "test-cloud/alice@canonical.com/cred-3" not found.*`,
 	expectErrorCode: errors.CodeNotFound,
 }, {
 	name: "update credential returns an error",

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -162,16 +162,16 @@ func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
 	}
 	err := b.jujuManager.Database.GetController(b.ctx, &targetController)
 	if err != nil {
-		b.err = errors.E(err, fmt.Sprintf("controller %q not found", controllerName))
+		b.err = fmt.Errorf("%s: %w", fmt.Sprintf("controller %q not found", controllerName), err)
 		return b
 	}
 	ok, err := b.ofgaUser.IsAllowedAddModelToController(b.ctx, targetController.ResourceTag())
 	if err != nil {
-		b.err = errors.E(err, "failed to verify permissions for adding model to controller")
+		b.err = fmt.Errorf("failed to verify permissions for adding model to controller: %w", err)
 		return b
 	}
 	if !ok {
-		b.err = errors.E(errors.CodeUnauthorized, fmt.Sprintf("not authorized to add model to controller %q", controllerName))
+		b.err = errors.MsgWithCode(fmt.Sprintf("not authorized to add model to controller %q", controllerName), errors.CodeUnauthorized)
 		return b
 	}
 	b.candidates = append(b.candidates, candidateController{
@@ -249,11 +249,11 @@ func (b *modelBuilder) WithCloud(user *openfga.User, cloud names.CloudTag) *mode
 	}
 	ok, err := b.ofgaUser.IsAllowedAddModelToCloud(b.ctx, c.ResourceTag())
 	if err != nil {
-		b.err = errors.E(err, "failed to verify permissions for adding model to cloud")
+		b.err = fmt.Errorf("failed to verify permissions for adding model to cloud: %w", err)
 		return b
 	}
 	if !ok {
-		b.err = errors.E(errors.CodeUnauthorized, fmt.Sprintf("not authorized to add model to cloud %q", cloud.Id()))
+		b.err = errors.MsgWithCode(fmt.Sprintf("not authorized to add model to cloud %q", cloud.Id()), errors.CodeUnauthorized)
 		return b
 	}
 	b.cloud = &c
@@ -337,7 +337,7 @@ func (b *modelBuilder) WithCloudRegion(region string) *modelBuilder {
 	// If there is no such region we will get a zero valued object below.
 	cloudRegion := b.cloud.Region(region)
 	if cloudRegion.Name == "" {
-		b.err = errors.E(errors.CodeNotFound, fmt.Sprintf("cloud region %q not found in cloud %q", region, b.cloud.Name))
+		b.err = errors.MsgWithCode(fmt.Sprintf("cloud region %q not found in cloud %q", region, b.cloud.Name), errors.CodeNotFound)
 		return b
 	}
 	b.cloudRegion = region
@@ -368,7 +368,7 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 
 	// Verify ownership of cloud credential
 	if b.owner == nil || b.owner.Name != credentialTag.Owner().Id() {
-		b.err = errors.E("model owner doesn't match cloud-credential owner", errors.CodeUnauthorized)
+		b.err = errors.MsgWithCode("model owner doesn't match cloud-credential owner", errors.CodeUnauthorized)
 		return b
 	}
 
@@ -379,7 +379,7 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 	}
 	err := b.jujuManager.Database.GetCloudCredential(b.ctx, &credential)
 	if err != nil {
-		b.err = errors.E(err, fmt.Sprintf("failed to fetch cloud credentials %s", credential.Path()))
+		b.err = fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch cloud credentials %s", credential.Path()), err)
 	}
 	b.credential = &credential
 
@@ -434,7 +434,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 	err := b.jujuManager.Database.AddModel(b.ctx, b.model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			b.err = errors.E(err, fmt.Sprintf("model %s/%s already exists", b.owner.Name, b.name))
+			b.err = fmt.Errorf("%s: %w", fmt.Sprintf("model %s/%s already exists", b.owner.Name, b.name), err)
 			return b
 		} else {
 			b.err = fmt.Errorf("failed to store model information: %w", err)
@@ -469,7 +469,7 @@ func (b *modelBuilder) UpdateDatabaseModel() *modelBuilder {
 	}
 	err := b.model.FromJujuModelInfo(b.modelInfo)
 	if err != nil {
-		b.err = errors.E(err, "failed to convert model info")
+		b.err = fmt.Errorf("failed to convert model info: %w", err)
 		return b
 	}
 	b.model.ControllerID = b.controller.ID
@@ -483,7 +483,7 @@ func (b *modelBuilder) UpdateDatabaseModel() *modelBuilder {
 
 	err = b.jujuManager.Database.UpdateModel(b.ctx, b.model)
 	if err != nil {
-		b.err = errors.E(err, "failed to store model information")
+		b.err = fmt.Errorf("failed to store model information: %w", err)
 		return b
 	}
 	return b
@@ -516,7 +516,7 @@ func (b *modelBuilder) selectCloudCredentials() error {
 	}
 	credentials, err := b.jujuManager.Database.GetIdentityCloudCredentials(b.ctx, b.owner, b.cloud.Name)
 	if err != nil {
-		return errors.E(err, "failed to fetch user cloud credentials")
+		return fmt.Errorf("failed to fetch user cloud credentials: %w", err)
 	}
 	for _, credential := range credentials {
 		// skip any credentials known to be invalid.
@@ -550,7 +550,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 
 	if b.credential != nil {
 		if err := b.updateCredential(b.ctx, api, b.credential); err != nil {
-			b.err = errors.E(fmt.Sprintf("failed to update cloud credential: %s", err), err)
+			b.err = fmt.Errorf("%s: %w", fmt.Sprintf("failed to update cloud credential: %s", err), err)
 			return b
 		}
 	}
@@ -574,14 +574,14 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 			// the operation to delete a model isn't synchronous even
 			// for empty models. We could also have a worker that deletes
 			// empty models that don't appear in the database.
-			b.err = errors.E(err, errors.CodeAlreadyExists, "model name in use")
+			b.err = errors.ErrWithCode(fmt.Errorf("model name in use: %w", err), errors.CodeAlreadyExists)
 		case jujuparams.CodeUpgradeInProgress:
-			b.err = errors.E(err, "upgrade in progress")
+			b.err = fmt.Errorf("upgrade in progress: %w", err)
 		default:
 			// The model couldn't be created because of an
 			// error in the request, don't try another
 			// controller.
-			b.err = errors.E(err, errors.CodeBadRequest)
+			b.err = errors.ErrWithCode(err, errors.CodeBadRequest)
 		}
 		return b
 	}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -162,7 +162,7 @@ func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
 	}
 	err := b.jujuManager.Database.GetController(b.ctx, &targetController)
 	if err != nil {
-		b.err = fmt.Errorf("%s: %w", fmt.Sprintf("controller %q not found", controllerName), err)
+		b.err = fmt.Errorf("controller %q not found: %w", controllerName, err)
 		return b
 	}
 	ok, err := b.ofgaUser.IsAllowedAddModelToController(b.ctx, targetController.ResourceTag())
@@ -379,7 +379,7 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 	}
 	err := b.jujuManager.Database.GetCloudCredential(b.ctx, &credential)
 	if err != nil {
-		b.err = fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch cloud credentials %s", credential.Path()), err)
+		b.err = fmt.Errorf("failed to fetch cloud credentials %s: %w", credential.Path(), err)
 	}
 	b.credential = &credential
 

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -171,7 +171,7 @@ func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
 		return b
 	}
 	if !ok {
-		b.err = errors.MsgWithCode(fmt.Sprintf("not authorized to add model to controller %q", controllerName), errors.CodeUnauthorized)
+		b.err = errors.Codef(errors.CodeUnauthorized, "not authorized to add model to controller %q", controllerName)
 		return b
 	}
 	b.candidates = append(b.candidates, candidateController{
@@ -253,7 +253,7 @@ func (b *modelBuilder) WithCloud(user *openfga.User, cloud names.CloudTag) *mode
 		return b
 	}
 	if !ok {
-		b.err = errors.MsgWithCode(fmt.Sprintf("not authorized to add model to cloud %q", cloud.Id()), errors.CodeUnauthorized)
+		b.err = errors.Codef(errors.CodeUnauthorized, "not authorized to add model to cloud %q", cloud.Id())
 		return b
 	}
 	b.cloud = &c
@@ -337,7 +337,7 @@ func (b *modelBuilder) WithCloudRegion(region string) *modelBuilder {
 	// If there is no such region we will get a zero valued object below.
 	cloudRegion := b.cloud.Region(region)
 	if cloudRegion.Name == "" {
-		b.err = errors.MsgWithCode(fmt.Sprintf("cloud region %q not found in cloud %q", region, b.cloud.Name), errors.CodeNotFound)
+		b.err = errors.Codef(errors.CodeNotFound, "cloud region %q not found in cloud %q", region, b.cloud.Name)
 		return b
 	}
 	b.cloudRegion = region
@@ -368,7 +368,7 @@ func (b *modelBuilder) WithCloudCredential(credentialTag names.CloudCredentialTa
 
 	// Verify ownership of cloud credential
 	if b.owner == nil || b.owner.Name != credentialTag.Owner().Id() {
-		b.err = errors.MsgWithCode("model owner doesn't match cloud-credential owner", errors.CodeUnauthorized)
+		b.err = errors.Codef(errors.CodeUnauthorized, "model owner doesn't match cloud-credential owner")
 		return b
 	}
 
@@ -574,14 +574,14 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 			// the operation to delete a model isn't synchronous even
 			// for empty models. We could also have a worker that deletes
 			// empty models that don't appear in the database.
-			b.err = errors.ErrWithCode(fmt.Errorf("model name in use: %w", err), errors.CodeAlreadyExists)
+			b.err = errors.Codef(errors.CodeAlreadyExists, "model name in use: %w", err)
 		case jujuparams.CodeUpgradeInProgress:
 			b.err = fmt.Errorf("upgrade in progress: %w", err)
 		default:
 			// The model couldn't be created because of an
 			// error in the request, don't try another
 			// controller.
-			b.err = errors.ErrWithCode(err, errors.CodeBadRequest)
+			b.err = errors.Codef(errors.CodeBadRequest, "%w", err)
 		}
 		return b
 	}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -550,7 +550,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 
 	if b.credential != nil {
 		if err := b.updateCredential(b.ctx, api, b.credential); err != nil {
-			b.err = fmt.Errorf("%s: %w", fmt.Sprintf("failed to update cloud credential: %s", err), err)
+			b.err = fmt.Errorf("failed to update cloud credential: %w", err)
 			return b
 		}
 	}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -434,7 +434,7 @@ func (b *modelBuilder) CreateDatabaseModel() *modelBuilder {
 	err := b.jujuManager.Database.AddModel(b.ctx, b.model)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeAlreadyExists {
-			b.err = fmt.Errorf("%s: %w", fmt.Sprintf("model %s/%s already exists", b.owner.Name, b.name), err)
+			b.err = errors.Codef(errors.CodeAlreadyExists, "model %s/%s already exists", b.owner.Name, b.name)
 			return b
 		} else {
 			b.err = fmt.Errorf("failed to store model information: %w", err)

--- a/internal/jimm/juju/supportedversions.go
+++ b/internal/jimm/juju/supportedversions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-github/v69/github"
 	"github.com/juju/version/v2"
 
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
 
@@ -52,7 +51,7 @@ func (j *JujuManager) SupportedVersions(ctx context.Context, minVersion *string)
 
 	releases, err := fetchReleasesFromGitHub(ctx, client, parsedMinVersion)
 	if err != nil {
-		return params.SupportedJujuVersionsResponse{}, errors.E(err)
+		return params.SupportedJujuVersionsResponse{}, err
 	}
 	return params.SupportedJujuVersionsResponse{Versions: releases}, nil
 }

--- a/internal/jimm/juju/utils.go
+++ b/internal/jimm/juju/utils.go
@@ -29,7 +29,7 @@ func (j *JujuManager) everyoneUser() *openfga.User {
 // checkJimmAdmin checks if the user is a JIMM admin.
 func (j *JujuManager) checkJimmAdmin(user *openfga.User) error {
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func (j *JujuManager) checkControllerAdminAccess(ctx context.Context, user *open
 		return err
 	}
 	if !isAdministrator {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	return nil
 }
@@ -55,7 +55,7 @@ func (j *JujuManager) getControllerByName(ctx context.Context, controllerName st
 	controller := dbmodel.Controller{Name: controllerName}
 	err := j.Database.GetController(ctx, &controller)
 	if err != nil {
-		return nil, errors.MsgWithCode("controller not found", errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "controller not found")
 	}
 	return &controller, nil
 }

--- a/internal/jimm/juju/utils.go
+++ b/internal/jimm/juju/utils.go
@@ -29,7 +29,7 @@ func (j *JujuManager) everyoneUser() *openfga.User {
 // checkJimmAdmin checks if the user is a JIMM admin.
 func (j *JujuManager) checkJimmAdmin(user *openfga.User) error {
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func (j *JujuManager) checkControllerAdminAccess(ctx context.Context, user *open
 		return err
 	}
 	if !isAdministrator {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	return nil
 }
@@ -55,7 +55,7 @@ func (j *JujuManager) getControllerByName(ctx context.Context, controllerName st
 	controller := dbmodel.Controller{Name: controllerName}
 	err := j.Database.GetController(ctx, &controller)
 	if err != nil {
-		return nil, errors.E(errors.CodeNotFound, "controller not found")
+		return nil, errors.MsgWithCode("controller not found", errors.CodeNotFound)
 	}
 	return &controller, nil
 }

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -136,7 +136,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	defer api.Close()
 
 	if !api.SupportsModelSummaryWatcher() {
-		return errors.ErrWithCode(nil, errors.CodeNotSupported)
+		return errors.Codef(errors.CodeNotSupported, "not supported")
 	}
 
 	// start the model summary watcher

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -135,7 +136,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	defer api.Close()
 
 	if !api.SupportsModelSummaryWatcher() {
-		return errors.E(errors.CodeNotSupported)
+		return errors.ErrWithCode(nil, errors.CodeNotSupported)
 	}
 
 	// start the model summary watcher
@@ -152,7 +153,7 @@ func (w *Watcher) watchAllModelSummaries(ctx context.Context, ctl *dbmodel.Contr
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.E(ctx.Err(), "context cancelled")
+			return fmt.Errorf("context cancelled: %w", ctx.Err())
 		default:
 		}
 		// wait for updates from the all model summary watcher.

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -180,7 +180,7 @@ func TestModelSummaryWatcher(t *testing.T) {
 							case "00000002-0000-0000-0000-000000000002":
 							case "00000002-0000-0000-0000-000000000003":
 							}
-							return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
+							return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "not found")
 						},
 					},
 				},
@@ -292,7 +292,7 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 					case "00000002-0000-0000-0000-000000000002":
 					case "00000002-0000-0000-0000-000000000003":
 					}
-					return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "not found")
 				},
 				WatchAllModelSummaries_: func(ctx context.Context) (jujuclient.SummaryWatcher, error) {
 					return mockWatcher, nil

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -180,7 +180,7 @@ func TestModelSummaryWatcher(t *testing.T) {
 							case "00000002-0000-0000-0000-000000000002":
 							case "00000002-0000-0000-0000-000000000003":
 							}
-							return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound)
+							return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
 						},
 					},
 				},
@@ -292,7 +292,7 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 					case "00000002-0000-0000-0000-000000000002":
 					case "00000002-0000-0000-0000-000000000003":
 					}
-					return jujuclient.ModelInfo{}, errors.E(errors.CodeNotFound)
+					return jujuclient.ModelInfo{}, errors.ErrWithCode(nil, errors.CodeNotFound)
 				},
 				WatchAllModelSummaries_: func(ctx context.Context) (jujuclient.SummaryWatcher, error) {
 					return mockWatcher, nil

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -111,7 +111,7 @@ func (j *LoginManager) LoginDevice(ctx context.Context) (*oauth2.DeviceAuthRespo
 
 	if err != nil {
 		zapctx.Error(ctx, "oauth device login failed", zap.Error(err))
-		return nil, errors.E(errors.CodeFatalLoginError, "oauth device login failed, check JIMM's log.")
+		return nil, errors.MsgWithCode("oauth device login failed, check JIMM's log.", errors.CodeFatalLoginError)
 	}
 	return resp, nil
 }
@@ -159,18 +159,18 @@ func (j *LoginManager) LoginClientCredentials(ctx context.Context, clientID stri
 	// TODO(Kian): Consider inlining the function below and removing the dependency on jimmnames.
 	clientIdWithDomain, err := jimmnames.EnsureValidServiceAccountId(clientID)
 	if err != nil {
-		return nil, errors.E(errors.CodeFatalLoginError, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
 	}
 
 	err = j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.E(errors.CodeFatalLoginError, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
 	}
 	user, err := j.UserLogin(ctx, clientIdWithDomain)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.E(errors.CodeFatalLoginError, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
 	}
 	logger.LogSuccessfulLogin(ctx, clientIdWithDomain)
 	return user, nil
@@ -185,14 +185,14 @@ func (j *LoginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 			return nil, err
 		}
 		logger.LogFailedLogin(ctx, "unknown session token")
-		return nil, errors.E(errors.CodeFatalLoginError, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
 	}
 
 	email := jwtToken.Subject()
 	user, err := j.UserLogin(ctx, email)
 	if err != nil {
 		logger.LogFailedLogin(ctx, email)
-		return nil, errors.E(errors.CodeFatalLoginError, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
 	}
 	logger.LogSuccessfulLogin(ctx, email)
 	return user, nil
@@ -226,7 +226,7 @@ func (j *LoginManager) UserLogin(ctx context.Context, identifier string) (*openf
 
 	ofgaUser, err := j.GetOrCreateIdentity(ctx, identifier)
 	if err != nil {
-		return nil, errors.E(err, errors.CodeUnauthorized)
+		return nil, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 	err = j.updateLastLogin(ctx, ofgaUser.Identity)
 	if err != nil {

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -111,7 +111,7 @@ func (j *LoginManager) LoginDevice(ctx context.Context) (*oauth2.DeviceAuthRespo
 
 	if err != nil {
 		zapctx.Error(ctx, "oauth device login failed", zap.Error(err))
-		return nil, errors.MsgWithCode("oauth device login failed, check JIMM's log.", errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "oauth device login failed, check JIMM's log.")
 	}
 	return resp, nil
 }
@@ -159,18 +159,18 @@ func (j *LoginManager) LoginClientCredentials(ctx context.Context, clientID stri
 	// TODO(Kian): Consider inlining the function below and removing the dependency on jimmnames.
 	clientIdWithDomain, err := jimmnames.EnsureValidServiceAccountId(clientID)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 
 	err = j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 	user, err := j.UserLogin(ctx, clientIdWithDomain)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
-		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 	logger.LogSuccessfulLogin(ctx, clientIdWithDomain)
 	return user, nil
@@ -185,14 +185,14 @@ func (j *LoginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 			return nil, err
 		}
 		logger.LogFailedLogin(ctx, "unknown session token")
-		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 
 	email := jwtToken.Subject()
 	user, err := j.UserLogin(ctx, email)
 	if err != nil {
 		logger.LogFailedLogin(ctx, email)
-		return nil, errors.ErrWithCode(err, errors.CodeFatalLoginError)
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 	logger.LogSuccessfulLogin(ctx, email)
 	return user, nil
@@ -226,7 +226,7 @@ func (j *LoginManager) UserLogin(ctx context.Context, identifier string) (*openf
 
 	ofgaUser, err := j.GetOrCreateIdentity(ctx, identifier)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 	err = j.updateLastLogin(ctx, ofgaUser.Identity)
 	if err != nil {

--- a/internal/jimm/login/login_test.go
+++ b/internal/jimm/login/login_test.go
@@ -105,11 +105,11 @@ func (s *loginManagerSuite) Init(c *qt.C) {
 	mockAuthenticator.EXPECT().VerifySessionToken(gomock.Any()).DoAndReturn(func(token string) (jwt.Token, error) {
 		decodedToken, err := base64.StdEncoding.DecodeString(token)
 		if err != nil {
-			return nil, errors.MsgWithCode("failed to decode token", errors.CodeSessionTokenInvalid)
+			return nil, errors.Codef(errors.CodeSessionTokenInvalid, "failed to decode token")
 		}
 		parsedToken, err := jwt.ParseInsecure(decodedToken)
 		if err != nil {
-			return nil, errors.MsgWithCode("failed to parse token", errors.CodeSessionTokenInvalid)
+			return nil, errors.Codef(errors.CodeSessionTokenInvalid, "failed to parse token")
 		}
 		return parsedToken, nil
 	}).AnyTimes()

--- a/internal/jimm/login/login_test.go
+++ b/internal/jimm/login/login_test.go
@@ -105,11 +105,11 @@ func (s *loginManagerSuite) Init(c *qt.C) {
 	mockAuthenticator.EXPECT().VerifySessionToken(gomock.Any()).DoAndReturn(func(token string) (jwt.Token, error) {
 		decodedToken, err := base64.StdEncoding.DecodeString(token)
 		if err != nil {
-			return nil, errors.E(errors.CodeSessionTokenInvalid, "failed to decode token")
+			return nil, errors.MsgWithCode("failed to decode token", errors.CodeSessionTokenInvalid)
 		}
 		parsedToken, err := jwt.ParseInsecure(decodedToken)
 		if err != nil {
-			return nil, errors.E(errors.CodeSessionTokenInvalid, "failed to parse token")
+			return nil, errors.MsgWithCode("failed to parse token", errors.CodeSessionTokenInvalid)
 		}
 		return parsedToken, nil
 	}).AnyTimes()

--- a/internal/jimm/offer/authorizer_test.go
+++ b/internal/jimm/offer/authorizer_test.go
@@ -137,7 +137,7 @@ func TestIsUserConsumerForOffer(t *testing.T) {
 			userTag:             names.NewLocalUserTag("alice"),
 			applicationOfferTag: names.NewApplicationOfferTag(deps.offerUUID),
 			allowed:             false,
-			expectedError:       "user mapping not found",
+			expectedError:       "user mapping not found.*",
 		},
 		{
 			name:                "not-existing application offer local user",

--- a/internal/jimm/offer/authorizer_test.go
+++ b/internal/jimm/offer/authorizer_test.go
@@ -137,7 +137,7 @@ func TestIsUserConsumerForOffer(t *testing.T) {
 			userTag:             names.NewLocalUserTag("alice"),
 			applicationOfferTag: names.NewApplicationOfferTag(deps.offerUUID),
 			allowed:             false,
-			expectedError:       "user mapping not found.*",
+			expectedError:       "user mapping not found",
 		},
 		{
 			name:                "not-existing application offer local user",

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -148,7 +148,7 @@ func (j *PermissionManager) GrantAuditLogAccess(ctx context.Context, user *openf
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -170,7 +170,7 @@ func (j *PermissionManager) RevokeAuditLogAccess(ctx context.Context, user *open
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -238,7 +238,7 @@ func (j *PermissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Only JIMM administrators are allowed to see the access
 	// level of somebody else.
 	if !user.JimmAdmin {
-		return "", errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return "", errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var targetUser dbmodel.Identity
@@ -272,7 +272,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -282,7 +282,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -340,7 +340,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -350,7 +350,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -418,7 +418,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
 	}
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
@@ -426,7 +426,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 		return err
 	}
 	if !modelAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -490,7 +490,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
 	}
 
 	requiredAccess := ofganames.AdministratorRelation
@@ -504,7 +504,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 		return err
 	}
 	if !modelAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -586,7 +586,7 @@ func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)
@@ -656,7 +656,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -205,7 +205,7 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 			}
 			relation, err := ofganames.ConvertJujuRelation(stringVal)
 			if err != nil {
-				return cachedPerms, fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse relation %s", stringVal), err)
+				return cachedPerms, fmt.Errorf("failed to parse relation %s: %w", stringVal, err)
 			}
 			check, err := openfga.CheckRelation(ctx, user, tag, relation)
 			if err != nil {

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -197,11 +197,11 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 		if _, ok := cachedPerms[key]; !ok {
 			stringVal, ok := val.(string)
 			if !ok {
-				return nil, errors.New(fmt.Sprintf("failed to get permission assertion: expected %T, got %T", stringVal, val))
+				return nil, fmt.Errorf("failed to get permission assertion: expected %T, got %T", stringVal, val)
 			}
 			tag, err := names.ParseTag(key)
 			if err != nil {
-				return cachedPerms, errors.New(fmt.Sprintf("failed to parse tag %s", key))
+				return cachedPerms, fmt.Errorf("failed to parse tag %s", key)
 			}
 			relation, err := ofganames.ConvertJujuRelation(stringVal)
 			if err != nil {
@@ -212,7 +212,7 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 				return cachedPerms, err
 			}
 			if !check {
-				return cachedPerms, errors.New(fmt.Sprintf("Missing permission for %s:%s", key, val))
+				return cachedPerms, fmt.Errorf("Missing permission for %s:%s", key, val)
 			}
 			cachedPerms[key] = stringVal
 		}

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -272,7 +272,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q", access)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -340,7 +340,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q", access)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -418,7 +418,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q", access)
 	}
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
@@ -490,7 +490,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q: %w", access, err)
+		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q", access)
 	}
 
 	requiredAccess := ofganames.AdministratorRelation

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -212,7 +212,7 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 				return cachedPerms, err
 			}
 			if !check {
-				return cachedPerms, fmt.Errorf("Missing permission for %s:%s", key, val)
+				return cachedPerms, fmt.Errorf("missing permission for %s:%s", key, val)
 			}
 			cachedPerms[key] = stringVal
 		}

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -148,7 +148,7 @@ func (j *PermissionManager) GrantAuditLogAccess(ctx context.Context, user *openf
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -170,7 +170,7 @@ func (j *PermissionManager) RevokeAuditLogAccess(ctx context.Context, user *open
 
 	access := user.GetControllerAccess(ctx, j.jimmTag)
 	if access != ofganames.AdministratorRelation {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -197,22 +197,22 @@ func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.U
 		if _, ok := cachedPerms[key]; !ok {
 			stringVal, ok := val.(string)
 			if !ok {
-				return nil, errors.E(fmt.Sprintf("failed to get permission assertion: expected %T, got %T", stringVal, val))
+				return nil, errors.New(fmt.Sprintf("failed to get permission assertion: expected %T, got %T", stringVal, val))
 			}
 			tag, err := names.ParseTag(key)
 			if err != nil {
-				return cachedPerms, errors.E(fmt.Sprintf("failed to parse tag %s", key))
+				return cachedPerms, errors.New(fmt.Sprintf("failed to parse tag %s", key))
 			}
 			relation, err := ofganames.ConvertJujuRelation(stringVal)
 			if err != nil {
-				return cachedPerms, errors.E(fmt.Sprintf("failed to parse relation %s", stringVal), err)
+				return cachedPerms, fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse relation %s", stringVal), err)
 			}
 			check, err := openfga.CheckRelation(ctx, user, tag, relation)
 			if err != nil {
 				return cachedPerms, err
 			}
 			if !check {
-				return cachedPerms, errors.E(fmt.Sprintf("Missing permission for %s:%s", key, val))
+				return cachedPerms, errors.New(fmt.Sprintf("Missing permission for %s:%s", key, val))
 			}
 			cachedPerms[key] = stringVal
 		}
@@ -238,7 +238,7 @@ func (j *PermissionManager) GetJimmControllerAccess(ctx context.Context, user *o
 	// Only JIMM administrators are allowed to see the access
 	// level of somebody else.
 	if !user.JimmAdmin {
-		return "", errors.E(errors.CodeUnauthorized, "unauthorized")
+		return "", errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var targetUser dbmodel.Identity
@@ -272,7 +272,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -282,7 +282,7 @@ func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -340,7 +340,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
 	}
 
 	isCloudAdministrator, err := openfga.IsAdministrator(ctx, user, ct)
@@ -350,7 +350,7 @@ func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga
 	if !isCloudAdministrator {
 		// If the user doesn't have admin access on the cloud return
 		// an unauthorized error.
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -418,7 +418,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
 	}
 
 	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
@@ -426,7 +426,7 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 		return err
 	}
 	if !modelAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -490,7 +490,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 			zaputil.Error(err),
 			zap.String("access", string(access)),
 		)
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to recognize given access: %q", access), err)
+		return errors.ErrWithCode(fmt.Errorf("failed to recognize given access: %q: %w", access, err), errors.CodeBadRequest)
 	}
 
 	requiredAccess := ofganames.AdministratorRelation
@@ -504,7 +504,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 		return err
 	}
 	if !modelAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := &dbmodel.Identity{}
@@ -586,7 +586,7 @@ func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)
@@ -656,7 +656,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 		return err
 	}
 	if !isOfferAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	targetUser := openfga.NewUser(identity, j.authSvc)
@@ -666,7 +666,7 @@ func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga
 	}
 	err = targetUser.UnsetApplicationOfferAccess(ctx, offer.ResourceTag(), targetRelation)
 	if err != nil {
-		return errors.E(err, "failed to unset given access")
+		return fmt.Errorf("failed to unset given access: %w", err)
 	}
 
 	// Checking if the target user still has the given access to the

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -299,7 +299,7 @@ var grantModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access"`,
+	expectError:    `failed to recognize given access: "some-unknown-access".*`,
 }}
 
 func TestGrantModelAccess(t *testing.T) {
@@ -992,7 +992,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access"`,
+	expectError:    `failed to recognize given access: "some-unknown-access".*`,
 }}
 
 //nolint:gocognit
@@ -1282,7 +1282,7 @@ func TestRevokeOfferAccess(t *testing.T) {
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
 			return env.User("fred@canonical.com").DBObject(c, db), env.User("fred@canonical.com").DBObject(c, db), "no-such-offer", jujuparams.OfferReadAccess
 		},
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}, {
 		about: "admin revokes another user (who is direct admin+consumer) their consume access)",
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
@@ -1448,7 +1448,7 @@ func TestGrantOfferAccess(t *testing.T) {
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
 			return env.User("alice@canonical.com").DBObject(c, db), env.User("fred@canonical.com").DBObject(c, db), "no-such-offer", jujuparams.OfferReadAccess
 		},
-		expectedError: "application offer not found",
+		expectedError: "application offer not found.*",
 	}, {
 		about: "user with consume rights cannot grant any rights",
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
@@ -1606,7 +1606,7 @@ var grantCloudAccessTests = []struct {
 	cloud:          "test",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access"`,
+	expectError:    `failed to recognize given access: "some-unknown-access".*`,
 }}
 
 func TestGrantCloudAccess(t *testing.T) {
@@ -1882,7 +1882,7 @@ var revokeCloudAccessTests = []struct {
 	cloud:          "test",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access"`,
+	expectError:    `failed to recognize given access: "some-unknown-access".*`,
 }}
 
 //nolint:gocognit

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -299,7 +299,7 @@ var grantModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access".*`,
+	expectError:    `failed to recognize given access: "some-unknown-access"`,
 }}
 
 func TestGrantModelAccess(t *testing.T) {
@@ -992,7 +992,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access".*`,
+	expectError:    `failed to recognize given access: "some-unknown-access"`,
 }}
 
 //nolint:gocognit
@@ -1282,7 +1282,7 @@ func TestRevokeOfferAccess(t *testing.T) {
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
 			return env.User("fred@canonical.com").DBObject(c, db), env.User("fred@canonical.com").DBObject(c, db), "no-such-offer", jujuparams.OfferReadAccess
 		},
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}, {
 		about: "admin revokes another user (who is direct admin+consumer) their consume access)",
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
@@ -1448,7 +1448,7 @@ func TestGrantOfferAccess(t *testing.T) {
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
 			return env.User("alice@canonical.com").DBObject(c, db), env.User("fred@canonical.com").DBObject(c, db), "no-such-offer", jujuparams.OfferReadAccess
 		},
-		expectedError: "application offer not found.*",
+		expectedError: "application offer not found",
 	}, {
 		about: "user with consume rights cannot grant any rights",
 		parameterFunc: func(env *jimmtest.Environment, db *db.Database) (dbmodel.Identity, dbmodel.Identity, string, jujuparams.OfferAccessPermission) {
@@ -1606,7 +1606,7 @@ var grantCloudAccessTests = []struct {
 	cloud:          "test",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access".*`,
+	expectError:    `failed to recognize given access: "some-unknown-access"`,
 }}
 
 func TestGrantCloudAccess(t *testing.T) {
@@ -1882,7 +1882,7 @@ var revokeCloudAccessTests = []struct {
 	cloud:          "test",
 	targetUsername: "bob@canonical.com",
 	access:         "some-unknown-access",
-	expectError:    `failed to recognize given access: "some-unknown-access".*`,
+	expectError:    `failed to recognize given access: "some-unknown-access"`,
 }}
 
 //nolint:gocognit

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -30,7 +30,7 @@ const BATCH_SIZE_OPENFGA = 100
 func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
@@ -45,7 +45,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 
 		err = j.authSvc.AddRelation(ctx, batch...)
 		if err != nil {
-			return errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
+			return errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -57,7 +57,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
@@ -72,7 +72,7 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 
 		err = j.authSvc.RemoveRelation(ctx, batch...)
 		if err != nil {
-			return errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
+			return errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -91,12 +91,12 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
 	// Admins can check any relation, non-admins can only check their own.
 	if !user.JimmAdmin && !userCheckingSelf {
-		return allowed, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return allowed, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace)
 	if err != nil {
-		return allowed, errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
+		return allowed, errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 	}
 	return allowed, nil
 }
@@ -125,7 +125,7 @@ func (j *PermissionManager) CheckRelations(ctx context.Context, user *openfga.Us
 func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, pageSize int32, continuationToken string) ([]openfga.Tuple, string, error) {
 
 	if !user.JimmAdmin {
-		return nil, "", errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, "", errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	// if targetObject is not specified returns all tuples.
 	parsedTuple := &openfga.Tuple{}
@@ -136,7 +136,7 @@ func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *op
 			return nil, "", err
 		}
 	} else if tuple.Object != "" {
-		return nil, "", errors.MsgWithCode("it is invalid to pass an object without a target object.", errors.CodeBadRequest)
+		return nil, "", errors.Codef(errors.CodeBadRequest, "it is invalid to pass an object without a target object.")
 	}
 
 	responseTuples, ct, err := j.authSvc.ReadRelatedObjects(ctx, *parsedTuple, pageSize, continuationToken)
@@ -154,7 +154,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 
 	var e pagination.EntitlementToken
 	if !user.JimmAdmin {
-		return nil, e, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, e, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	responseTuples, nextToken, err := j.getObjectRelationsPage(ctx, object, pageSize, entitlementToken)
 	if err != nil {
@@ -177,7 +177,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 func (j *PermissionManager) ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	return j.store.ListResources(ctx, filter.Limit(), filter.Offset(), namePrefixFilter, typeFilter)
@@ -243,7 +243,7 @@ func (j *PermissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 
 	relation, err := ofganames.ParseRelation(tuple.Relation)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	t := openfga.Tuple{
 		Relation: relation,
@@ -254,11 +254,11 @@ func (j *PermissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 	// to be specific to the erroneous offender.
 	parseTagError := func(msg string, key string, err error) error {
 		zapctx.Debug(ctx, msg, zap.String("key", key), zap.Error(err))
-		return errors.MsgWithCode(fmt.Sprintf("%s %s: %s", msg, key, err.Error()), errors.CodeFailedToParseTupleKey)
+		return errors.Codef(errors.CodeFailedToParseTupleKey, "%s %s: %s", msg, key, err.Error())
 	}
 
 	if tuple.TargetObject == "" {
-		return nil, errors.MsgWithCode("target object not specified", errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "target object not specified")
 	}
 	t.Target, err = j.parseAndValidateTag(ctx, tuple.TargetObject)
 	if err != nil {

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -30,7 +30,7 @@ const BATCH_SIZE_OPENFGA = 100
 func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
@@ -45,7 +45,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 
 		err = j.authSvc.AddRelation(ctx, batch...)
 		if err != nil {
-			return errors.E(errors.CodeOpenFGARequestFailed, err)
+			return errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -57,7 +57,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
@@ -72,7 +72,7 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 
 		err = j.authSvc.RemoveRelation(ctx, batch...)
 		if err != nil {
-			return errors.E(errors.CodeOpenFGARequestFailed, err)
+			return errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
 		}
 		j.logUserUpdates(ctx, user, batch, true)
 	}
@@ -91,12 +91,12 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
 	// Admins can check any relation, non-admins can only check their own.
 	if !user.JimmAdmin && !userCheckingSelf {
-		return allowed, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return allowed, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace)
 	if err != nil {
-		return allowed, errors.E(errors.CodeOpenFGARequestFailed, err)
+		return allowed, errors.ErrWithCode(err, errors.CodeOpenFGARequestFailed)
 	}
 	return allowed, nil
 }
@@ -125,7 +125,7 @@ func (j *PermissionManager) CheckRelations(ctx context.Context, user *openfga.Us
 func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, pageSize int32, continuationToken string) ([]openfga.Tuple, string, error) {
 
 	if !user.JimmAdmin {
-		return nil, "", errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, "", errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	// if targetObject is not specified returns all tuples.
 	parsedTuple := &openfga.Tuple{}
@@ -136,7 +136,7 @@ func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *op
 			return nil, "", err
 		}
 	} else if tuple.Object != "" {
-		return nil, "", errors.E(errors.CodeBadRequest, "it is invalid to pass an object without a target object.")
+		return nil, "", errors.MsgWithCode("it is invalid to pass an object without a target object.", errors.CodeBadRequest)
 	}
 
 	responseTuples, ct, err := j.authSvc.ReadRelatedObjects(ctx, *parsedTuple, pageSize, continuationToken)
@@ -154,7 +154,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 
 	var e pagination.EntitlementToken
 	if !user.JimmAdmin {
-		return nil, e, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, e, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	responseTuples, nextToken, err := j.getObjectRelationsPage(ctx, object, pageSize, entitlementToken)
 	if err != nil {
@@ -164,7 +164,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 	if len(responseTuples) == int(pageSize) && nextToken.String() != "" {
 		responseTuples, _, err := j.getObjectRelationsPage(ctx, object, 1, nextToken)
 		if err != nil {
-			return nil, e, errors.E("error getting next page to verify it cointains something", err)
+			return nil, e, fmt.Errorf("error getting next page to verify it cointains something: %w", err)
 		}
 		if len(responseTuples) == 0 {
 			nextToken = pagination.EntitlementToken{}
@@ -177,7 +177,7 @@ func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openf
 func (j *PermissionManager) ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error) {
 
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	return j.store.ListResources(ctx, filter.Limit(), filter.Offset(), namePrefixFilter, typeFilter)
@@ -243,7 +243,7 @@ func (j *PermissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 
 	relation, err := ofganames.ParseRelation(tuple.Relation)
 	if err != nil {
-		return nil, errors.E(err, errors.CodeBadRequest)
+		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	t := openfga.Tuple{
 		Relation: relation,
@@ -254,11 +254,11 @@ func (j *PermissionManager) parseTuple(ctx context.Context, tuple apiparams.Rela
 	// to be specific to the erroneous offender.
 	parseTagError := func(msg string, key string, err error) error {
 		zapctx.Debug(ctx, msg, zap.String("key", key), zap.Error(err))
-		return errors.E(errors.CodeFailedToParseTupleKey, fmt.Sprintf("%s %s: %s", msg, key, err.Error()))
+		return errors.MsgWithCode(fmt.Sprintf("%s %s: %s", msg, key, err.Error()), errors.CodeFailedToParseTupleKey)
 	}
 
 	if tuple.TargetObject == "" {
-		return nil, errors.E(errors.CodeBadRequest, "target object not specified")
+		return nil, errors.MsgWithCode("target object not specified", errors.CodeBadRequest)
 	}
 	t.Target, err = j.parseAndValidateTag(ctx, tuple.TargetObject)
 	if err != nil {

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -144,7 +144,7 @@ type tagResolver struct {
 func newTagResolver(tag string) (*tagResolver, string, error) {
 	matches := jujuURIMatcher.FindStringSubmatch(tag)
 	if len(matches) != 4 {
-		return nil, "", errors.MsgWithCode("tag is not properly formatted", errors.CodeBadRequest)
+		return nil, "", errors.Codef(errors.CodeBadRequest, "tag is not properly formatted")
 	}
 	tagKind := matches[1]
 	resourceUUID := ""
@@ -160,7 +160,7 @@ func newTagResolver(tag string) (*tagResolver, string, error) {
 
 	relation, err := ofganames.ParseRelation(matches[3])
 	if err != nil {
-		return nil, "", errors.MsgWithCode("failed to parse relation", errors.CodeBadRequest)
+		return nil, "", errors.Codef(errors.CodeBadRequest, "failed to parse relation")
 	}
 	return &tagResolver{
 		resourceUUID: resourceUUID,
@@ -337,7 +337,7 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 	case names.CloudTagKind:
 		return resolver.cloudTag(ctx, db)
 	}
-	return nil, errors.MsgWithCode(fmt.Sprintf("failed to map tag, unknown kind: %s", tagKind), errors.CodeBadRequest)
+	return nil, errors.Codef(errors.CodeBadRequest, "failed to map tag, unknown kind: %s", tagKind)
 }
 
 // parseAndValidateTag attempts to parse the provided key into a tag whilst additionally
@@ -349,7 +349,7 @@ func (j *PermissionManager) parseAndValidateTag(ctx context.Context, key string)
 	if len(tupleKeySplit) == 1 {
 		tag, err := ofganames.BlankKindTag(tupleKeySplit[0])
 		if err != nil {
-			return nil, errors.ErrWithCode(err, errors.CodeFailedToParseTupleKey)
+			return nil, errors.Codef(errors.CodeFailedToParseTupleKey, "%w", err)
 		}
 		return tag, nil
 	}
@@ -357,7 +357,7 @@ func (j *PermissionManager) parseAndValidateTag(ctx context.Context, key string)
 	tag, err := resolveTag(j.jimmUUID, j.store, tagString)
 	if err != nil {
 		zapctx.Debug(ctx, "failed to resolve tuple object", zap.Error(err))
-		return nil, errors.ErrWithCode(err, errors.CodeFailedToResolveTupleResource)
+		return nil, errors.Codef(errors.CodeFailedToResolveTupleResource, "%w", err)
 	}
 	zapctx.Debug(ctx, "resolved JIMM tag", zap.String("tag", tag.String()))
 

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -78,7 +78,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetController(ctx, &controller)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch controller information: %s", controller.UUID), err)
+			return "", fmt.Errorf("failed to fetch controller information: %s: %w", controller.UUID, err)
 		}
 		return tagToString(names.ControllerTagKind, controller.Name), nil
 	case names.ModelTagKind:
@@ -90,7 +90,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetModel(ctx, &model)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch model information: %s", model.UUID.String), err)
+			return "", fmt.Errorf("failed to fetch model information: %s: %w", model.UUID.String, err)
 		}
 		modelUserID := model.OwnerIdentityName + "/" + model.Name
 		return tagToString(names.ModelTagKind, modelUserID), nil
@@ -100,7 +100,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetApplicationOffer(ctx, &ao)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch application offer information: %s", ao.UUID), err)
+			return "", fmt.Errorf("failed to fetch application offer information: %s: %w", ao.UUID, err)
 		}
 		return tagToString(names.ApplicationOfferTagKind, ao.URL), nil
 	case jimmnames.GroupTagKind:
@@ -109,7 +109,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetGroup(ctx, &group)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch group information: %s", group.UUID), err)
+			return "", fmt.Errorf("failed to fetch group information: %s: %w", group.UUID, err)
 		}
 		return tagToString(jimmnames.GroupTagKind, group.Name), nil
 	case jimmnames.RoleTagKind:
@@ -118,7 +118,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetRole(ctx, &role)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch role information: %s", role.UUID), err)
+			return "", fmt.Errorf("failed to fetch role information: %s: %w", role.UUID, err)
 		}
 		return tagToString(jimmnames.RoleTagKind, role.Name), nil
 	case names.CloudTagKind:
@@ -127,7 +127,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetCloud(ctx, &cloud)
 		if err != nil {
-			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch cloud information: %s", cloud.Name), err)
+			return "", fmt.Errorf("failed to fetch cloud information: %s: %w", cloud.Name, err)
 		}
 		return tagToString(names.CloudTagKind, cloud.Name), nil
 	default:

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -78,7 +78,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetController(ctx, &controller)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch controller information: %s", controller.UUID))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch controller information: %s", controller.UUID), err)
 		}
 		return tagToString(names.ControllerTagKind, controller.Name), nil
 	case names.ModelTagKind:
@@ -90,7 +90,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetModel(ctx, &model)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch model information: %s", model.UUID.String))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch model information: %s", model.UUID.String), err)
 		}
 		modelUserID := model.OwnerIdentityName + "/" + model.Name
 		return tagToString(names.ModelTagKind, modelUserID), nil
@@ -100,7 +100,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetApplicationOffer(ctx, &ao)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch application offer information: %s", ao.UUID))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch application offer information: %s", ao.UUID), err)
 		}
 		return tagToString(names.ApplicationOfferTagKind, ao.URL), nil
 	case jimmnames.GroupTagKind:
@@ -109,7 +109,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetGroup(ctx, &group)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch group information: %s", group.UUID))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch group information: %s", group.UUID), err)
 		}
 		return tagToString(jimmnames.GroupTagKind, group.Name), nil
 	case jimmnames.RoleTagKind:
@@ -118,7 +118,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetRole(ctx, &role)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch role information: %s", role.UUID))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch role information: %s", role.UUID), err)
 		}
 		return tagToString(jimmnames.RoleTagKind, role.Name), nil
 	case names.CloudTagKind:
@@ -127,11 +127,11 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		err := j.store.GetCloud(ctx, &cloud)
 		if err != nil {
-			return "", errors.E(err, fmt.Sprintf("failed to fetch cloud information: %s", cloud.Name))
+			return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to fetch cloud information: %s", cloud.Name), err)
 		}
 		return tagToString(names.CloudTagKind, cloud.Name), nil
 	default:
-		return "", errors.E(fmt.Sprintf("unexpected tag kind: %v", tag.Kind))
+		return "", errors.New(fmt.Sprintf("unexpected tag kind: %v", tag.Kind))
 	}
 }
 
@@ -144,7 +144,7 @@ type tagResolver struct {
 func newTagResolver(tag string) (*tagResolver, string, error) {
 	matches := jujuURIMatcher.FindStringSubmatch(tag)
 	if len(matches) != 4 {
-		return nil, "", errors.E("tag is not properly formatted", errors.CodeBadRequest)
+		return nil, "", errors.MsgWithCode("tag is not properly formatted", errors.CodeBadRequest)
 	}
 	tagKind := matches[1]
 	resourceUUID := ""
@@ -160,7 +160,7 @@ func newTagResolver(tag string) (*tagResolver, string, error) {
 
 	relation, err := ofganames.ParseRelation(matches[3])
 	if err != nil {
-		return nil, "", errors.E("failed to parse relation", errors.CodeBadRequest)
+		return nil, "", errors.MsgWithCode("failed to parse relation", errors.CodeBadRequest)
 	}
 	return &tagResolver{
 		resourceUUID: resourceUUID,
@@ -197,7 +197,7 @@ func (t *tagResolver) groupTag(ctx context.Context, db *db.Database) (*ofga.Enti
 
 	err := db.GetGroup(ctx, &entry)
 	if err != nil {
-		return nil, errors.E(fmt.Sprintf("group %s not found", t.trailer))
+		return nil, errors.New(fmt.Sprintf("group %s not found", t.trailer))
 	}
 
 	return ofganames.ConvertTagWithRelation(entry.ResourceTag(), t.relation), nil
@@ -237,7 +237,7 @@ func (t *tagResolver) roleTag(ctx context.Context, db *db.Database) (*ofga.Entit
 
 	err := db.GetRole(ctx, &entry)
 	if err != nil {
-		return nil, errors.E(fmt.Sprintf("role %s not found", t.trailer))
+		return nil, errors.New(fmt.Sprintf("role %s not found", t.trailer))
 	}
 
 	return ofganames.ConvertTagWithRelation(entry.ResourceTag(), t.relation), nil
@@ -337,7 +337,7 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 	case names.CloudTagKind:
 		return resolver.cloudTag(ctx, db)
 	}
-	return nil, errors.E(errors.CodeBadRequest, fmt.Sprintf("failed to map tag, unknown kind: %s", tagKind))
+	return nil, errors.MsgWithCode(fmt.Sprintf("failed to map tag, unknown kind: %s", tagKind), errors.CodeBadRequest)
 }
 
 // parseAndValidateTag attempts to parse the provided key into a tag whilst additionally
@@ -349,7 +349,7 @@ func (j *PermissionManager) parseAndValidateTag(ctx context.Context, key string)
 	if len(tupleKeySplit) == 1 {
 		tag, err := ofganames.BlankKindTag(tupleKeySplit[0])
 		if err != nil {
-			return nil, errors.E(errors.CodeFailedToParseTupleKey, err)
+			return nil, errors.ErrWithCode(err, errors.CodeFailedToParseTupleKey)
 		}
 		return tag, nil
 	}
@@ -357,7 +357,7 @@ func (j *PermissionManager) parseAndValidateTag(ctx context.Context, key string)
 	tag, err := resolveTag(j.jimmUUID, j.store, tagString)
 	if err != nil {
 		zapctx.Debug(ctx, "failed to resolve tuple object", zap.Error(err))
-		return nil, errors.E(errors.CodeFailedToResolveTupleResource, err)
+		return nil, errors.ErrWithCode(err, errors.CodeFailedToResolveTupleResource)
 	}
 	zapctx.Debug(ctx, "resolved JIMM tag", zap.String("tag", tag.String()))
 

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -131,7 +131,7 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 		}
 		return tagToString(names.CloudTagKind, cloud.Name), nil
 	default:
-		return "", errors.New(fmt.Sprintf("unexpected tag kind: %v", tag.Kind))
+		return "", fmt.Errorf("unexpected tag kind: %v", tag.Kind)
 	}
 }
 
@@ -197,7 +197,7 @@ func (t *tagResolver) groupTag(ctx context.Context, db *db.Database) (*ofga.Enti
 
 	err := db.GetGroup(ctx, &entry)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("group %s not found", t.trailer))
+		return nil, fmt.Errorf("group %s not found", t.trailer)
 	}
 
 	return ofganames.ConvertTagWithRelation(entry.ResourceTag(), t.relation), nil
@@ -237,7 +237,7 @@ func (t *tagResolver) roleTag(ctx context.Context, db *db.Database) (*ofga.Entit
 
 	err := db.GetRole(ctx, &entry)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("role %s not found", t.trailer))
+		return nil, fmt.Errorf("role %s not found", t.trailer)
 	}
 
 	return ofganames.ConvertTagWithRelation(entry.ResourceTag(), t.relation), nil

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -32,7 +32,7 @@ func NewRoleManager(store *db.Database, authSvc *openfga.OFGAClient) (*RoleManag
 // AddRole adds a role to JIMM.
 func (rm *RoleManager) AddRole(ctx context.Context, user *openfga.User, roleName string) (*dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	re, err := rm.store.AddRole(ctx, roleName)
@@ -55,7 +55,7 @@ func (rm *RoleManager) GetRoleByName(ctx context.Context, user *openfga.User, na
 // RemoveRole removes the role from JIMM in both the store and authorisation store.
 func (rm *RoleManager) RemoveRole(ctx context.Context, user *openfga.User, roleName string) error {
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	re := &dbmodel.RoleEntry{
@@ -83,7 +83,7 @@ func (rm *RoleManager) RemoveRole(ctx context.Context, user *openfga.User, roleN
 // RenameRole renames a role in JIMM's DB.
 func (rm *RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldName, newName string) error {
 	if !user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	err := rm.store.UpdateRoleName(ctx, oldName, newName)
@@ -98,7 +98,7 @@ func (rm *RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldNa
 // `match` will filter the list fuzzy matching role's name or uuid.
 func (rm *RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	res, err := rm.store.ListRoles(ctx, pagination.Limit(), pagination.Offset(), match)
@@ -111,7 +111,7 @@ func (rm *RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagina
 // CountRoles returns the number of roles that exist.
 func (rm *RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int, error) {
 	if !user.JimmAdmin {
-		return 0, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	count, err := rm.store.CountRoles(ctx)
 	if err != nil {
@@ -123,7 +123,7 @@ func (rm *RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int,
 // getRole returns a role based on the provided UUID or name.
 func (rm *RoleManager) getRole(ctx context.Context, user *openfga.User, role *dbmodel.RoleEntry) (*dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	if err := rm.store.GetRole(ctx, role); err != nil {

--- a/internal/jimm/role/role.go
+++ b/internal/jimm/role/role.go
@@ -32,7 +32,7 @@ func NewRoleManager(store *db.Database, authSvc *openfga.OFGAClient) (*RoleManag
 // AddRole adds a role to JIMM.
 func (rm *RoleManager) AddRole(ctx context.Context, user *openfga.User, roleName string) (*dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	re, err := rm.store.AddRole(ctx, roleName)
@@ -55,7 +55,7 @@ func (rm *RoleManager) GetRoleByName(ctx context.Context, user *openfga.User, na
 // RemoveRole removes the role from JIMM in both the store and authorisation store.
 func (rm *RoleManager) RemoveRole(ctx context.Context, user *openfga.User, roleName string) error {
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	re := &dbmodel.RoleEntry{
@@ -83,7 +83,7 @@ func (rm *RoleManager) RemoveRole(ctx context.Context, user *openfga.User, roleN
 // RenameRole renames a role in JIMM's DB.
 func (rm *RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldName, newName string) error {
 	if !user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := rm.store.UpdateRoleName(ctx, oldName, newName)
@@ -98,7 +98,7 @@ func (rm *RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldNa
 // `match` will filter the list fuzzy matching role's name or uuid.
 func (rm *RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	res, err := rm.store.ListRoles(ctx, pagination.Limit(), pagination.Offset(), match)
@@ -111,7 +111,7 @@ func (rm *RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagina
 // CountRoles returns the number of roles that exist.
 func (rm *RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int, error) {
 	if !user.JimmAdmin {
-		return 0, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return 0, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	count, err := rm.store.CountRoles(ctx)
 	if err != nil {
@@ -123,7 +123,7 @@ func (rm *RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int,
 // getRole returns a role based on the provided UUID or name.
 func (rm *RoleManager) getRole(ctx context.Context, user *openfga.User, role *dbmodel.RoleEntry) (*dbmodel.RoleEntry, error) {
 	if !user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	if err := rm.store.GetRole(ctx, role); err != nil {

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -144,7 +144,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 
 	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, user, model.Controller.Name)
 	if err != nil {
-		return DialInfo{}, errors.E(err, "cannot get controller config")
+		return DialInfo{}, fmt.Errorf("cannot get controller config: %w", err)
 	}
 
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -31,7 +31,7 @@ func NewSSHKeyManager(store *db.Database) (*SSHKeyManager, error) {
 func (sm *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey PublicKey) error {
 
 	if ok, reason := publicKey.valid(); !ok {
-		return errors.MsgWithCode(reason, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%s", reason)
 	}
 
 	k := dbmodel.SSHKey{

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -31,7 +31,7 @@ func NewSSHKeyManager(store *db.Database) (*SSHKeyManager, error) {
 func (sm *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey PublicKey) error {
 
 	if ok, reason := publicKey.valid(); !ok {
-		return errors.E(errors.CodeBadRequest, reason)
+		return errors.MsgWithCode(reason, errors.CodeBadRequest)
 	}
 
 	k := dbmodel.SSHKey{

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -93,12 +93,12 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 	// Forbid a zero target version as this complicates checking for whether
 	// the upgrade was successful.
 	if targetVersion == version.Zero {
-		return errors.MsgWithCode("target version cannot be zero", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "target version cannot be zero")
 	}
 
 	model := &dbmodel.Model{UUID: sql.NullString{Valid: true, String: modelUUID}}
 	if err := u.store.GetModel(ctx, model); err != nil {
-		return errors.ErrWithCode(fmt.Errorf("model not found: %w", err), errors.CodeNotFound)
+		return errors.Codef(errors.CodeNotFound, "model not found: %w", err)
 	}
 
 	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
@@ -158,7 +158,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 // This currently only works with non-kubernetes clouds.
 func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string) (int64, error) {
 	if !names.IsValidModel(modelUUID) {
-		return 0, errors.MsgWithCode("invalid model UUID", errors.CodeBadRequest)
+		return 0, errors.Codef(errors.CodeBadRequest, "invalid model UUID")
 	}
 	mt := names.NewModelTag(modelUUID)
 
@@ -176,7 +176,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		}
 	}
 	if targetController == nil {
-		return 0, errors.MsgWithCode(fmt.Sprintf("target controller %s is not a valid migration target for this model", targetControllerName), errors.CodeBadRequest)
+		return 0, errors.Codef(errors.CodeBadRequest, "target controller %s is not a valid migration target for this model", targetControllerName)
 	}
 
 	targetVersion, err := version.Parse(targetController.AgentVersion)
@@ -195,7 +195,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 	}
 
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.MsgWithCode("an upgrade job for this model is already in progress", errors.CodeInProgress)
+		return 0, errors.Codef(errors.CodeInProgress, "an upgrade job for this model is already in progress")
 	}
 
 	return job.Job.ID, nil
@@ -208,7 +208,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 	ctx = zapctx.WithFields(ctx, zap.String("model_uuid", modelUUID), zap.String("target_controller_name", targetControllerName))
 
 	if !names.IsValidModel(modelUUID) {
-		return errors.MsgWithCode("invalid model UUID", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid model UUID")
 	}
 
 	// Fetch the model info to refresh current controller.

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -93,12 +93,12 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 	// Forbid a zero target version as this complicates checking for whether
 	// the upgrade was successful.
 	if targetVersion == version.Zero {
-		return errors.E(errors.CodeBadRequest, "target version cannot be zero")
+		return errors.MsgWithCode("target version cannot be zero", errors.CodeBadRequest)
 	}
 
 	model := &dbmodel.Model{UUID: sql.NullString{Valid: true, String: modelUUID}}
 	if err := u.store.GetModel(ctx, model); err != nil {
-		return errors.E(errors.CodeNotFound, err, "model not found")
+		return errors.ErrWithCode(fmt.Errorf("model not found: %w", err), errors.CodeNotFound)
 	}
 
 	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
@@ -158,7 +158,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 // This currently only works with non-kubernetes clouds.
 func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string) (int64, error) {
 	if !names.IsValidModel(modelUUID) {
-		return 0, errors.E(errors.CodeBadRequest, "invalid model UUID")
+		return 0, errors.MsgWithCode("invalid model UUID", errors.CodeBadRequest)
 	}
 	mt := names.NewModelTag(modelUUID)
 
@@ -176,7 +176,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		}
 	}
 	if targetController == nil {
-		return 0, errors.E(errors.CodeBadRequest, fmt.Sprintf("target controller %s is not a valid migration target for this model", targetControllerName))
+		return 0, errors.MsgWithCode(fmt.Sprintf("target controller %s is not a valid migration target for this model", targetControllerName), errors.CodeBadRequest)
 	}
 
 	targetVersion, err := version.Parse(targetController.AgentVersion)
@@ -195,7 +195,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 	}
 
 	if job.UniqueSkippedAsDuplicate {
-		return 0, errors.E("an upgrade job for this model is already in progress", errors.CodeInProgress)
+		return 0, errors.MsgWithCode("an upgrade job for this model is already in progress", errors.CodeInProgress)
 	}
 
 	return job.Job.ID, nil
@@ -208,7 +208,7 @@ func (u *UpgradeManager) MigrateModel(ctx context.Context, user *openfga.User, m
 	ctx = zapctx.WithFields(ctx, zap.String("model_uuid", modelUUID), zap.String("target_controller_name", targetControllerName))
 
 	if !names.IsValidModel(modelUUID) {
-		return errors.E(errors.CodeBadRequest, "invalid model UUID")
+		return errors.MsgWithCode("invalid model UUID", errors.CodeBadRequest)
 	}
 
 	// Fetch the model info to refresh current controller.

--- a/internal/jimmhttp/httpproxy_handler.go
+++ b/internal/jimmhttp/httpproxy_handler.go
@@ -69,13 +69,13 @@ func (hph *HTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http.Request)
 	modelUUID := chi.URLParam(req, "uuid")
 	if modelUUID == "" {
 		msg := "cannot parse model UUID from path"
-		writeError(ctx, w, http.StatusBadRequest, errors.E(msg), msg)
+		writeError(ctx, w, http.StatusBadRequest, errors.New(msg), msg)
 		return
 	}
 
 	if !names.IsValidModel(modelUUID) {
 		msg := "invalid model UUID format"
-		writeError(ctx, w, http.StatusBadRequest, errors.E(msg), msg)
+		writeError(ctx, w, http.StatusBadRequest, errors.New(msg), msg)
 		return
 	}
 

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -80,7 +80,7 @@ func TestHTTPProxyHandler(t *testing.T) {
 	ctrlService := mocks.ControllerService{
 		ControllerDetailsForModel_: func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 			if modelUUID != model.UUID.String {
-				return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, "model not found")
+				return juju.ControllerConnectionDetails{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 			}
 			return juju.ControllerConnectionDetails{
 				PublicAddress: fakeController.URL,

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -80,7 +80,7 @@ func TestHTTPProxyHandler(t *testing.T) {
 	ctrlService := mocks.ControllerService{
 		ControllerDetailsForModel_: func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 			if modelUUID != model.UUID.String {
-				return juju.ControllerConnectionDetails{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+				return juju.ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "model not found")
 			}
 			return juju.ControllerConnectionDetails{
 				PublicAddress: fakeController.URL,

--- a/internal/jimmhttp/migrationproxy_handler.go
+++ b/internal/jimmhttp/migrationproxy_handler.go
@@ -66,7 +66,7 @@ func (hph *MigrationHTTPProxyHandler) ProxyHTTP(w http.ResponseWriter, req *http
 	modelUUID := req.Header.Get(jujuparams.MigrationModelHTTPHeader)
 	if modelUUID == "" {
 		errMsg := fmt.Sprintf("missing %s header value", jujuparams.MigrationModelHTTPHeader)
-		writeError(ctx, w, http.StatusBadRequest, errors.E(errMsg), errMsg)
+		writeError(ctx, w, http.StatusBadRequest, errors.New(errMsg), errMsg)
 		return
 	}
 

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -72,7 +72,7 @@ func TestMigrationHTTPProxyHandler(t *testing.T) {
 	ctrlService := mocks.ControllerService{
 		ControllerDetailsForIncomingModel_: func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 			if modelUUID != incomingModel.ModelUUID.String {
-				return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotFound, "model not found")
+				return juju.ControllerConnectionDetails{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
 			}
 			return juju.ControllerConnectionDetails{
 				PublicAddress: fakeController.URL,

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -72,7 +72,7 @@ func TestMigrationHTTPProxyHandler(t *testing.T) {
 	ctrlService := mocks.ControllerService{
 		ControllerDetailsForIncomingModel_: func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 			if modelUUID != incomingModel.ModelUUID.String {
-				return juju.ControllerConnectionDetails{}, errors.MsgWithCode("model not found", errors.CodeNotFound)
+				return juju.ControllerConnectionDetails{}, errors.Codef(errors.CodeNotFound, "model not found")
 			}
 			return juju.ControllerConnectionDetails{
 				PublicAddress: fakeController.URL,

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -315,7 +315,7 @@ func TestGetGroupRoles(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*group doesn't exist")
 	getGroupErr = nil
 
-	getRoleErr = jimmerr.E("role doesn't exist", jimmerr.CodeNotFound)
+	getRoleErr = jimmerr.MsgWithCode("role doesn't exist", jimmerr.CodeNotFound)
 	_, err = groupSvc.GetGroupRoles(ctx, newUUID.String(), &resources.GetGroupsItemRolesParams{})
 	c.Assert(err, qt.IsNil)
 	getRoleErr = nil

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -315,7 +315,7 @@ func TestGetGroupRoles(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*group doesn't exist")
 	getGroupErr = nil
 
-	getRoleErr = jimmerr.MsgWithCode("role doesn't exist", jimmerr.CodeNotFound)
+	getRoleErr = jimmerr.Codef(jimmerr.CodeNotFound, "role doesn't exist")
 	_, err = groupSvc.GetGroupRoles(ctx, newUUID.String(), &resources.GetGroupsItemRolesParams{})
 	c.Assert(err, qt.IsNil)
 	getRoleErr = nil

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -4,7 +4,6 @@ package rebac_admin_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/canonical/ofga"
@@ -16,7 +15,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/common/pagination"
 	"github.com/canonical/jimm/v3/internal/common/utils"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	jimmm_errors "github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -33,7 +32,7 @@ func TestGetIdentity(t *testing.T) {
 			if username == "bob@canonical.com" {
 				return openfga.NewUser(&dbmodel.Identity{Name: "bob@canonical.com"}, nil), nil
 			}
-			return nil, jimmm_errors.ErrWithCode(nil, jimmm_errors.CodeNotFound)
+			return nil, errors.Codef(errors.CodeNotFound, "not found")
 		},
 	}
 	jimm := jimmtest.JIMM{

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -33,7 +33,7 @@ func TestGetIdentity(t *testing.T) {
 			if username == "bob@canonical.com" {
 				return openfga.NewUser(&dbmodel.Identity{Name: "bob@canonical.com"}, nil), nil
 			}
-			return nil, jimmm_errors.E(jimmm_errors.CodeNotFound)
+			return nil, jimmm_errors.ErrWithCode(nil, jimmm_errors.CodeNotFound)
 		},
 	}
 	jimm := jimmtest.JIMM{

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -69,7 +69,7 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	if err != nil && errors.ErrorCode(err) == errors.CodeNotFound {
 		w.WriteHeader(http.StatusNotFound)
 		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", fmt.Errorf("JWKS does not exist yet: %w", err)))
-		render.JSON(w, r, errors.Codef(errors.CodeNotFound, "JWKS does not exist yet"))
+		render.JSON(w, r, errors.Error{Code: errors.CodeNotFound, Message: "JWKS does not exist yet"})
 		return
 	}
 
@@ -84,7 +84,7 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", fmt.Errorf("failed to retrieve JWKS expiry: %w", err)))
-		render.JSON(w, r, errors.Codef(errors.CodeJWKSRetrievalFailed, "something went wrong..."))
+		render.JSON(w, r, errors.Error{Code: errors.CodeJWKSRetrievalFailed, Message: "something went wrong..."})
 		return
 	}
 

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -61,30 +61,30 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	if wkh == nil || wkh.CredentialStore == nil {
 		zapctx.Error(ctx, "nil reference in JWKS handler")
 		w.WriteHeader(http.StatusInternalServerError)
-		render.JSON(w, r, errors.MsgWithCode("JWKS does not exist", errors.CodeJWKSRetrievalFailed))
+		render.JSON(w, r, errors.Codef(errors.CodeJWKSRetrievalFailed, "JWKS does not exist"))
 		return
 	}
 	ks, err := wkh.CredentialStore.GetJWKS(ctx)
 
 	if err != nil && errors.ErrorCode(err) == errors.CodeNotFound {
 		w.WriteHeader(http.StatusNotFound)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("JWKS does not exist yet: %w", err), errors.CodeJWKSRetrievalFailed)))
-		render.JSON(w, r, errors.MsgWithCode("JWKS does not exist yet", errors.CodeNotFound))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", fmt.Errorf("JWKS does not exist yet: %w", err)))
+		render.JSON(w, r, errors.Codef(errors.CodeNotFound, "JWKS does not exist yet"))
 		return
 	}
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("failed to retrieve JWKS: %w", err), errors.CodeJWKSRetrievalFailed)))
-		render.JSON(w, r, errors.MsgWithCode("failed to retrieve JWKS", errors.CodeJWKSRetrievalFailed))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", fmt.Errorf("failed to retrieve JWKS: %w", err)))
+		render.JSON(w, r, errors.Codef(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS"))
 		return
 	}
 
 	expiry, err := wkh.CredentialStore.GetJWKSExpiry(ctx)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("failed to retrieve JWKS expiry: %w", err), errors.CodeJWKSRetrievalFailed)))
-		render.JSON(w, r, errors.MsgWithCode("something went wrong...", errors.CodeJWKSRetrievalFailed))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", fmt.Errorf("failed to retrieve JWKS expiry: %w", err)))
+		render.JSON(w, r, errors.Codef(errors.CodeJWKSRetrievalFailed, "something went wrong..."))
 		return
 	}
 

--- a/internal/jimmhttp/wellknown_handler.go
+++ b/internal/jimmhttp/wellknown_handler.go
@@ -61,30 +61,30 @@ func (wkh *WellKnownHandler) JWKS(w http.ResponseWriter, r *http.Request) {
 	if wkh == nil || wkh.CredentialStore == nil {
 		zapctx.Error(ctx, "nil reference in JWKS handler")
 		w.WriteHeader(http.StatusInternalServerError)
-		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "JWKS does not exist"))
+		render.JSON(w, r, errors.MsgWithCode("JWKS does not exist", errors.CodeJWKSRetrievalFailed))
 		return
 	}
 	ks, err := wkh.CredentialStore.GetJWKS(ctx)
 
 	if err != nil && errors.ErrorCode(err) == errors.CodeNotFound {
 		w.WriteHeader(http.StatusNotFound)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "JWKS does not exist yet", err)))
-		render.JSON(w, r, errors.E(errors.CodeNotFound, "JWKS does not exist yet"))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("JWKS does not exist yet: %w", err), errors.CodeJWKSRetrievalFailed)))
+		render.JSON(w, r, errors.MsgWithCode("JWKS does not exist yet", errors.CodeNotFound))
 		return
 	}
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS", err)))
-		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS"))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("failed to retrieve JWKS: %w", err), errors.CodeJWKSRetrievalFailed)))
+		render.JSON(w, r, errors.MsgWithCode("failed to retrieve JWKS", errors.CodeJWKSRetrievalFailed))
 		return
 	}
 
 	expiry, err := wkh.CredentialStore.GetJWKSExpiry(ctx)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.E(errors.CodeJWKSRetrievalFailed, "failed to retrieve JWKS expiry", err)))
-		render.JSON(w, r, errors.E(errors.CodeJWKSRetrievalFailed, "something went wrong..."))
+		zapctx.Error(ctx, "HTTP error", zap.NamedError("/jwks.json", errors.ErrWithCode(fmt.Errorf("failed to retrieve JWKS expiry: %w", err), errors.CodeJWKSRetrievalFailed)))
+		render.JSON(w, r, errors.MsgWithCode("something went wrong...", errors.CodeJWKSRetrievalFailed))
 		return
 	}
 

--- a/internal/jujuapi/accesscontrol.go
+++ b/internal/jujuapi/accesscontrol.go
@@ -30,7 +30,7 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 	resp := apiparams.AddGroupResponse{}
 
 	if !jimmnames.IsValidGroupName(req.Name) {
-		return resp, errors.E(errors.CodeBadRequest, "invalid group name")
+		return resp, errors.MsgWithCode("invalid group name", errors.CodeBadRequest)
 	}
 
 	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
@@ -54,13 +54,13 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Group{}, errors.E(errors.CodeBadRequest, "only one of UUID or Name should be provided")
+		return apiparams.Group{}, errors.MsgWithCode("only one of UUID or Name should be provided", errors.CodeBadRequest)
 	case req.UUID != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Group{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
+		return apiparams.Group{}, errors.MsgWithCode("no UUID or Name provided", errors.CodeBadRequest)
 	}
 	if err != nil {
 		return apiparams.Group{}, fmt.Errorf("failed to get group: %w", err)
@@ -78,7 +78,7 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGroupRequest) error {
 
 	if !jimmnames.IsValidGroupName(req.NewName) {
-		return errors.E(errors.CodeBadRequest, "invalid group name")
+		return errors.MsgWithCode("invalid group name", errors.CodeBadRequest)
 	}
 
 	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {

--- a/internal/jujuapi/accesscontrol.go
+++ b/internal/jujuapi/accesscontrol.go
@@ -30,7 +30,7 @@ func (r *controllerRoot) AddGroup(ctx context.Context, req apiparams.AddGroupReq
 	resp := apiparams.AddGroupResponse{}
 
 	if !jimmnames.IsValidGroupName(req.Name) {
-		return resp, errors.MsgWithCode("invalid group name", errors.CodeBadRequest)
+		return resp, errors.Codef(errors.CodeBadRequest, "invalid group name")
 	}
 
 	groupEntry, err := r.jimm.GroupManager().AddGroup(ctx, r.user, req.Name)
@@ -54,13 +54,13 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Group{}, errors.MsgWithCode("only one of UUID or Name should be provided", errors.CodeBadRequest)
+		return apiparams.Group{}, errors.Codef(errors.CodeBadRequest, "only one of UUID or Name should be provided")
 	case req.UUID != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		groupEntry, err = r.jimm.GroupManager().GetGroupByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Group{}, errors.MsgWithCode("no UUID or Name provided", errors.CodeBadRequest)
+		return apiparams.Group{}, errors.Codef(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
 		return apiparams.Group{}, fmt.Errorf("failed to get group: %w", err)
@@ -78,7 +78,7 @@ func (r *controllerRoot) GetGroup(ctx context.Context, req apiparams.GetGroupReq
 func (r *controllerRoot) RenameGroup(ctx context.Context, req apiparams.RenameGroupRequest) error {
 
 	if !jimmnames.IsValidGroupName(req.NewName) {
-		return errors.MsgWithCode("invalid group name", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid group name")
 	}
 
 	if err := r.jimm.GroupManager().RenameGroup(ctx, r.user, req.Name, req.NewName); err != nil {

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -19,10 +19,7 @@ import (
 // unsupportedLogin returns an appropriate error for login attempts using
 // old version of the Admin facade.
 func unsupportedLogin() error {
-	return errors.E(
-		errors.CodeNotSupported,
-		"JIMM does not support login from old clients",
-	)
+	return errors.MsgWithCode("JIMM does not support login from old clients", errors.CodeNotSupported)
 }
 
 // unsupportedLoginWithInfo is a version of unsupportedLogin that logs the
@@ -73,7 +70,7 @@ func (r *controllerRoot) GetDeviceSessionToken(ctx context.Context) (params.GetD
 
 	token, err := r.jimm.LoginManager().GetDeviceSessionToken(ctx, r.deviceOAuthResponse)
 	if err != nil {
-		return response, errors.E(err, errors.CodeUnauthorized)
+		return response, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 
 	response.SessionToken = token
@@ -90,7 +87,7 @@ func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams
 
 	user, err := r.jimm.LoginManager().LoginWithSessionCookie(ctx, r.identityId)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(err, errors.CodeUnauthorized)
+		return jujuparams.LoginResult{}, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 
 	r.mu.Lock()
@@ -152,7 +149,7 @@ func (r *controllerRoot) LoginWithClientCredentials(ctx context.Context, req par
 
 	user, err := r.jimm.LoginManager().LoginClientCredentials(ctx, req.ClientID, req.ClientSecret)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.E(err, errors.CodeUnauthorized)
+		return jujuparams.LoginResult{}, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 
 	r.mu.Lock()

--- a/internal/jujuapi/admin.go
+++ b/internal/jujuapi/admin.go
@@ -19,7 +19,7 @@ import (
 // unsupportedLogin returns an appropriate error for login attempts using
 // old version of the Admin facade.
 func unsupportedLogin() error {
-	return errors.MsgWithCode("JIMM does not support login from old clients", errors.CodeNotSupported)
+	return errors.Codef(errors.CodeNotSupported, "JIMM does not support login from old clients")
 }
 
 // unsupportedLoginWithInfo is a version of unsupportedLogin that logs the
@@ -70,7 +70,7 @@ func (r *controllerRoot) GetDeviceSessionToken(ctx context.Context) (params.GetD
 
 	token, err := r.jimm.LoginManager().GetDeviceSessionToken(ctx, r.deviceOAuthResponse)
 	if err != nil {
-		return response, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return response, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 
 	response.SessionToken = token
@@ -87,7 +87,7 @@ func (r *controllerRoot) LoginWithSessionCookie(ctx context.Context) (jujuparams
 
 	user, err := r.jimm.LoginManager().LoginWithSessionCookie(ctx, r.identityId)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return jujuparams.LoginResult{}, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 
 	r.mu.Lock()
@@ -149,7 +149,7 @@ func (r *controllerRoot) LoginWithClientCredentials(ctx context.Context, req par
 
 	user, err := r.jimm.LoginManager().LoginClientCredentials(ctx, req.ClientID, req.ClientSecret)
 	if err != nil {
-		return jujuparams.LoginResult{}, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return jujuparams.LoginResult{}, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 
 	r.mu.Lock()

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -55,11 +55,11 @@ func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicati
 
 	mt, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.E(errors.CodeBadRequest, err)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	offerOwnerTag, err := names.ParseUserTag(args.OwnerTag)
 	if err != nil {
-		return errors.E(errors.CodeBadRequest, err)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	err = r.jimm.JujuManager().Offer(ctx, r.user, juju.AddApplicationOfferParams{
 		ModelTag:               mt,
@@ -103,7 +103,7 @@ func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.Us
 
 	ourl, err := crossmodel.ParseOfferURL(offerURL)
 	if err != nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.E("cannot parse offer URL", errors.CodeBadRequest, err)
+		return jujuparams.ConsumeOfferDetails{}, errors.ErrWithCode(fmt.Errorf("cannot parse offer URL: %w", err), errors.CodeBadRequest)
 	}
 
 	// Ensure the path is normalised.
@@ -171,7 +171,7 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 
 	ut, err := parseUserTag(change.UserTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
@@ -185,7 +185,7 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 		}
 		return nil
 	default:
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("unknown action %q", change.Action))
+		return errors.MsgWithCode(fmt.Sprintf("unknown action %q", change.Action), errors.CodeBadRequest)
 	}
 }
 

--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -4,7 +4,6 @@ package jujuapi
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/juju/core/crossmodel"
@@ -55,11 +54,11 @@ func (r *controllerRoot) offer(ctx context.Context, args jujuparams.AddApplicati
 
 	mt, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	offerOwnerTag, err := names.ParseUserTag(args.OwnerTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	err = r.jimm.JujuManager().Offer(ctx, r.user, juju.AddApplicationOfferParams{
 		ModelTag:               mt,
@@ -103,7 +102,7 @@ func (r *controllerRoot) getConsumeDetails(ctx context.Context, user *openfga.Us
 
 	ourl, err := crossmodel.ParseOfferURL(offerURL)
 	if err != nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.ErrWithCode(fmt.Errorf("cannot parse offer URL: %w", err), errors.CodeBadRequest)
+		return jujuparams.ConsumeOfferDetails{}, errors.Codef(errors.CodeBadRequest, "cannot parse offer URL: %w", err)
 	}
 
 	// Ensure the path is normalised.
@@ -171,7 +170,7 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 
 	ut, err := parseUserTag(change.UserTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	switch change.Action {
 	case jujuparams.GrantOfferAccess:
@@ -185,7 +184,7 @@ func (r *controllerRoot) modifyOfferAccess(ctx context.Context, change jujuparam
 		}
 		return nil
 	default:
-		return errors.MsgWithCode(fmt.Sprintf("unknown action %q", change.Action), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "unknown action %q", change.Action)
 	}
 }
 

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -303,7 +303,7 @@ func TestApplicationOffers(t *testing.T) {
 	jujuManager := mocks.JujuManager{
 		GetApplicationOffer_: func(ctx context.Context, user *openfga.User, offerURL string) (*crossmodel.ApplicationOfferDetails, error) {
 			if offerURL == "owner@canonical.com/test-model.missing" {
-				return nil, errors.E(errors.CodeNotFound, "application offer not found")
+				return nil, errors.MsgWithCode("application offer not found", errors.CodeNotFound)
 			}
 			return &crossmodel.ApplicationOfferDetails{
 				OfferName:              "test-offer",

--- a/internal/jujuapi/applicationoffers_test.go
+++ b/internal/jujuapi/applicationoffers_test.go
@@ -303,7 +303,7 @@ func TestApplicationOffers(t *testing.T) {
 	jujuManager := mocks.JujuManager{
 		GetApplicationOffer_: func(ctx context.Context, user *openfga.User, offerURL string) (*crossmodel.ApplicationOfferDetails, error) {
 			if offerURL == "owner@canonical.com/test-model.missing" {
-				return nil, errors.MsgWithCode("application offer not found", errors.CodeNotFound)
+				return nil, errors.Codef(errors.CodeNotFound, "application offer not found")
 			}
 			return &crossmodel.ApplicationOfferDetails{
 				OfferName:              "test-offer",

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -62,7 +62,7 @@ func init() {
 // DefaultCloud implements the DefaultCloud method of the Cloud facade.
 // It returns a default cloud if there is only one cloud available.
 func (r *controllerRoot) DefaultCloud(ctx context.Context) (jujuparams.StringResult, error) {
-	return jujuparams.StringResult{}, errors.E(errors.CodeNotFound, "no default cloud")
+	return jujuparams.StringResult{}, errors.MsgWithCode("no default cloud", errors.CodeNotFound)
 }
 
 // Cloud implements the Cloud method of the Cloud facade.
@@ -72,7 +72,7 @@ func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (j
 	for i, ent := range ents.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			cloudResults[i].Error = r.mapError(ctx, errors.E(errors.CodeBadRequest, err))
+			cloudResults[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
@@ -116,7 +116,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 		}
 		cld, err := names.ParseCloudTag(ent.CloudTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		err = r.jimm.JujuManager().ForEachUserCloudCredential(ctx, user.Identity, cld, func(c *dbmodel.CloudCredential) error {
@@ -152,7 +152,7 @@ func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, _ boo
 
 	ct, err := names.ParseCloudCredentialTag(tag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct); err != nil {
 		return err
@@ -181,7 +181,7 @@ func (r *controllerRoot) credential(ctx context.Context, cloudCredentialTag stri
 
 	cct, err := names.ParseCloudCredentialTag(cloudCredentialTag)
 	if err != nil {
-		return nil, errors.E(err, errors.CodeBadRequest)
+		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	cred, err := r.jimm.JujuManager().GetCloudCredential(ctx, r.user, cct)
@@ -382,7 +382,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 	}
 	ct, err := names.ParseCloudTag(change.CloudTag)
 	if err != nil {
-		return errors.E(errors.CodeBadRequest, err)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	var modifyf func(context.Context, *openfga.User, names.CloudTag, names.UserTag, string) error
@@ -392,7 +392,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 	case jujuparams.RevokeCloudAccess:
 		modifyf = r.jimm.PermissionManager().RevokeCloudAccess
 	default:
-		return errors.E(errors.CodeBadRequest, fmt.Sprintf("unsupported modify cloud action %q", change.Action))
+		return errors.MsgWithCode(fmt.Sprintf("unsupported modify cloud action %q", change.Action), errors.CodeBadRequest)
 	}
 	if err := modifyf(ctx, r.user, ct, ut, change.Access); err != nil {
 		return err
@@ -428,7 +428,7 @@ func (r *controllerRoot) updateCredentials(ctx context.Context, args []jujuparam
 func (r *controllerRoot) updateCredential(ctx context.Context, cred jujuparams.TaggedCredential, skipCheck, skipUpdate bool) ([]jujuparams.UpdateCredentialModelResult, error) {
 	tag, err := names.ParseCloudCredentialTag(cred.Tag)
 	if err != nil {
-		return nil, errors.E(err, errors.CodeBadRequest)
+		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	return r.jimm.JujuManager().UpdateCloudCredential(ctx, r.user, juju.UpdateCloudCredentialArgs{
 		CredentialTag: tag,
@@ -455,7 +455,7 @@ func (r *controllerRoot) UpdateCloud(ctx context.Context, args jujuparams.Update
 func (r *controllerRoot) updateCloud() error {
 	// TODO(mhilton) work out how to support updating clouds, for now
 	// tell everyone they're not allowed.
-	return errors.E(errors.CodeForbidden, "permission denied")
+	return errors.MsgWithCode("permission denied", errors.CodeForbidden)
 }
 
 // CloudInfo implements the cloud facades CloudInfo method.
@@ -465,7 +465,7 @@ func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities
 	for i, ent := range args.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -62,7 +62,7 @@ func init() {
 // DefaultCloud implements the DefaultCloud method of the Cloud facade.
 // It returns a default cloud if there is only one cloud available.
 func (r *controllerRoot) DefaultCloud(ctx context.Context) (jujuparams.StringResult, error) {
-	return jujuparams.StringResult{}, errors.MsgWithCode("no default cloud", errors.CodeNotFound)
+	return jujuparams.StringResult{}, errors.Codef(errors.CodeNotFound, "no default cloud")
 }
 
 // Cloud implements the Cloud method of the Cloud facade.
@@ -72,7 +72,7 @@ func (r *controllerRoot) Cloud(ctx context.Context, ents jujuparams.Entities) (j
 	for i, ent := range ents.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			cloudResults[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			cloudResults[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)
@@ -116,7 +116,7 @@ func (r *controllerRoot) UserCredentials(ctx context.Context, userclouds jujupar
 		}
 		cld, err := names.ParseCloudTag(ent.CloudTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		err = r.jimm.JujuManager().ForEachUserCloudCredential(ctx, user.Identity, cld, func(c *dbmodel.CloudCredential) error {
@@ -152,7 +152,7 @@ func (r *controllerRoot) revokeCredential(ctx context.Context, tag string, _ boo
 
 	ct, err := names.ParseCloudCredentialTag(tag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if err := r.jimm.JujuManager().RevokeCloudCredential(ctx, r.user.Identity, ct); err != nil {
 		return err
@@ -181,7 +181,7 @@ func (r *controllerRoot) credential(ctx context.Context, cloudCredentialTag stri
 
 	cct, err := names.ParseCloudCredentialTag(cloudCredentialTag)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	cred, err := r.jimm.JujuManager().GetCloudCredential(ctx, r.user, cct)
@@ -382,7 +382,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 	}
 	ct, err := names.ParseCloudTag(change.CloudTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	var modifyf func(context.Context, *openfga.User, names.CloudTag, names.UserTag, string) error
@@ -392,7 +392,7 @@ func (r *controllerRoot) modifyCloudAccess(ctx context.Context, change jujuparam
 	case jujuparams.RevokeCloudAccess:
 		modifyf = r.jimm.PermissionManager().RevokeCloudAccess
 	default:
-		return errors.MsgWithCode(fmt.Sprintf("unsupported modify cloud action %q", change.Action), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "unsupported modify cloud action %q", change.Action)
 	}
 	if err := modifyf(ctx, r.user, ct, ut, change.Access); err != nil {
 		return err
@@ -428,7 +428,7 @@ func (r *controllerRoot) updateCredentials(ctx context.Context, args []jujuparam
 func (r *controllerRoot) updateCredential(ctx context.Context, cred jujuparams.TaggedCredential, skipCheck, skipUpdate bool) ([]jujuparams.UpdateCredentialModelResult, error) {
 	tag, err := names.ParseCloudCredentialTag(cred.Tag)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	return r.jimm.JujuManager().UpdateCloudCredential(ctx, r.user, juju.UpdateCloudCredentialArgs{
 		CredentialTag: tag,
@@ -455,7 +455,7 @@ func (r *controllerRoot) UpdateCloud(ctx context.Context, args jujuparams.Update
 func (r *controllerRoot) updateCloud() error {
 	// TODO(mhilton) work out how to support updating clouds, for now
 	// tell everyone they're not allowed.
-	return errors.MsgWithCode("permission denied", errors.CodeForbidden)
+	return errors.Codef(errors.CodeForbidden, "permission denied")
 }
 
 // CloudInfo implements the cloud facades CloudInfo method.
@@ -465,7 +465,7 @@ func (r *controllerRoot) CloudInfo(ctx context.Context, args jujuparams.Entities
 	for i, ent := range args.Entities {
 		tag, err := names.ParseCloudTag(ent.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		cloud, err := r.jimm.JujuManager().GetCloud(ctx, r.user, tag)

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -75,14 +75,14 @@ type ControllerService interface {
 // settings. Only some settings can be changed after bootstrap.
 // JIMM does not support changing settings via ConfigSet.
 func (r *controllerRoot) ConfigSet(ctx context.Context, args jujuparams.ControllerConfigSet) error {
-	return errors.ErrWithCode(nil, errors.CodeNotSupported)
+	return errors.Codef(errors.CodeNotSupported, "not supported")
 }
 
 // MongoVersion allows the introspection of the mongo version per
 // controller. This returns a not-supported error as JIMM does not use
 // mongodb for a database.
 func (r *controllerRoot) MongoVersion(ctx context.Context) (jujuparams.StringResult, error) {
-	return jujuparams.StringResult{}, errors.ErrWithCode(nil, errors.CodeNotSupported)
+	return jujuparams.StringResult{}, errors.Codef(errors.CodeNotSupported, "not supported")
 }
 
 // IdentityProviderURL returns the URL of the configured external identity
@@ -145,7 +145,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams.SummaryWatcherID, error) {
 
 	if !r.user.JimmAdmin {
-		return jujuparams.SummaryWatcherID{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return jujuparams.SummaryWatcherID{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := r.setupUUIDGenerator()
@@ -211,7 +211,7 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 	for i, arg := range args.Entities {
 		mt, err := names.ParseModelTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		status, err := r.jimm.JujuManager().ModelStatus(ctx, r.user, mt)
@@ -252,7 +252,7 @@ func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparam
 	for i, arg := range args.Entities {
 		tag, err := names.ParseUserTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		access, err := r.jimm.PermissionManager().GetJimmControllerAccess(ctx, r.user, tag)

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -75,14 +75,14 @@ type ControllerService interface {
 // settings. Only some settings can be changed after bootstrap.
 // JIMM does not support changing settings via ConfigSet.
 func (r *controllerRoot) ConfigSet(ctx context.Context, args jujuparams.ControllerConfigSet) error {
-	return errors.E(errors.CodeNotSupported)
+	return errors.ErrWithCode(nil, errors.CodeNotSupported)
 }
 
 // MongoVersion allows the introspection of the mongo version per
 // controller. This returns a not-supported error as JIMM does not use
 // mongodb for a database.
 func (r *controllerRoot) MongoVersion(ctx context.Context) (jujuparams.StringResult, error) {
-	return jujuparams.StringResult{}, errors.E(errors.CodeNotSupported)
+	return jujuparams.StringResult{}, errors.ErrWithCode(nil, errors.CodeNotSupported)
 }
 
 // IdentityProviderURL returns the URL of the configured external identity
@@ -145,7 +145,7 @@ func (r *controllerRoot) WatchModelSummaries(ctx context.Context) (jujuparams.Su
 func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams.SummaryWatcherID, error) {
 
 	if !r.user.JimmAdmin {
-		return jujuparams.SummaryWatcherID{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return jujuparams.SummaryWatcherID{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	err := r.setupUUIDGenerator()
@@ -211,7 +211,7 @@ func (r *controllerRoot) ModelStatus(ctx context.Context, args jujuparams.Entiti
 	for i, arg := range args.Entities {
 		mt, err := names.ParseModelTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		status, err := r.jimm.JujuManager().ModelStatus(ctx, r.user, mt)
@@ -252,7 +252,7 @@ func (r *controllerRoot) GetControllerAccess(ctx context.Context, args jujuparam
 	for i, arg := range args.Entities {
 		tag, err := names.ParseUserTag(arg.Tag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		access, err := r.jimm.PermissionManager().GetJimmControllerAccess(ctx, r.user, tag)

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -4,7 +4,6 @@ package jujuapi
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/juju/names/v5"
@@ -79,14 +78,14 @@ func newControllerRoot(j JIMM, p Params, identityId string) *controllerRoot {
 func (r *controllerRoot) masquerade(ctx context.Context, userTag string) (*openfga.User, error) {
 	ut, err := parseUserTag(userTag)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if r.user.Tag() == ut {
 		// allow anyone to masquarade as themselves.
 		return r.user, nil
 	}
 	if !r.user.JimmAdmin {
-		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	user, err := r.jimm.LoginManager().UserLogin(ctx, ut.Id())
 	if err != nil {
@@ -100,10 +99,10 @@ func (r *controllerRoot) masquerade(ctx context.Context, userTag string) (*openf
 func parseUserTag(tag string) (names.UserTag, error) {
 	ut, err := names.ParseUserTag(tag)
 	if err != nil {
-		return names.UserTag{}, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return names.UserTag{}, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if ut.IsLocal() {
-		return names.UserTag{}, errors.MsgWithCode(fmt.Sprintf("unsupported local user; if this is a service account add @%s domain", jimmnames.ServiceAccountDomain), errors.CodeBadRequest)
+		return names.UserTag{}, errors.Codef(errors.CodeBadRequest, "unsupported local user; if this is a service account add @%s domain", jimmnames.ServiceAccountDomain)
 	}
 	return ut, nil
 }

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -79,14 +79,14 @@ func newControllerRoot(j JIMM, p Params, identityId string) *controllerRoot {
 func (r *controllerRoot) masquerade(ctx context.Context, userTag string) (*openfga.User, error) {
 	ut, err := parseUserTag(userTag)
 	if err != nil {
-		return nil, errors.E(errors.CodeBadRequest, err)
+		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if r.user.Tag() == ut {
 		// allow anyone to masquarade as themselves.
 		return r.user, nil
 	}
 	if !r.user.JimmAdmin {
-		return nil, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return nil, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	user, err := r.jimm.LoginManager().UserLogin(ctx, ut.Id())
 	if err != nil {
@@ -100,10 +100,10 @@ func (r *controllerRoot) masquerade(ctx context.Context, userTag string) (*openf
 func parseUserTag(tag string) (names.UserTag, error) {
 	ut, err := names.ParseUserTag(tag)
 	if err != nil {
-		return names.UserTag{}, errors.E(errors.CodeBadRequest, err)
+		return names.UserTag{}, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if ut.IsLocal() {
-		return names.UserTag{}, errors.E(errors.CodeBadRequest, fmt.Sprintf("unsupported local user; if this is a service account add @%s domain", jimmnames.ServiceAccountDomain))
+		return names.UserTag{}, errors.MsgWithCode(fmt.Sprintf("unsupported local user; if this is a service account add @%s domain", jimmnames.ServiceAccountDomain), errors.CodeBadRequest)
 	}
 	return ut, nil
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -142,7 +142,7 @@ func init() {
 func (r *controllerRoot) DisableControllerUUIDMasking(ctx context.Context) error {
 
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	r.controllerUUIDMasking = false
 	return nil
@@ -220,28 +220,28 @@ func (r *controllerRoot) AddModelToController(ctx context.Context, req apiparams
 // available to JIMM.
 func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddControllerRequest) (apiparams.ControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.ControllerInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	if req.Name == jimmControllerName {
-		return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("cannot add a controller with name %q", jimmControllerName), errors.CodeBadRequest)
+		return apiparams.ControllerInfo{}, errors.Codef(errors.CodeBadRequest, "cannot add a controller with name %q", jimmControllerName)
 	}
 	if req.PublicAddress != "" {
 		host, port, err := net.SplitHostPort(req.PublicAddress)
 		if err != nil {
-			return apiparams.ControllerInfo{}, errors.ErrWithCode(err, errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.Codef(errors.CodeBadRequest, "%w", err)
 		}
 		if host == "" {
-			return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("address %s: host not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.Codef(errors.CodeBadRequest, "address %s: host not specified in public address", req.PublicAddress)
 		}
 		if port == "" {
-			return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("address %s: port not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.Codef(errors.CodeBadRequest, "address %s: port not specified in public address", req.PublicAddress)
 		}
 	}
 
 	nphps, err := network.ParseProviderHostPorts(req.APIAddresses...)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return apiparams.ControllerInfo{}, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	for i := range nphps {
 		// Mark all the unknown scopes public.
@@ -289,7 +289,7 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 // RemoveController removes a controller.
 func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.RemoveControllerRequest) (apiparams.ControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.ControllerInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
@@ -331,19 +331,19 @@ func auditParamsToFilter(req apiparams.FindAuditEventsRequest) (db.AuditLogFilte
 	if req.After != "" {
 		filter.Start, err = time.Parse(time.RFC3339, req.After)
 		if err != nil {
-			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "after" filter: %w`, err), errors.CodeBadRequest)
+			return filter, errors.Codef(errors.CodeBadRequest, `invalid "after" filter: %w`, err)
 		}
 	}
 	if req.Before != "" {
 		filter.End, err = time.Parse(time.RFC3339, req.Before)
 		if err != nil {
-			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "before" filter: %w`, err), errors.CodeBadRequest)
+			return filter, errors.Codef(errors.CodeBadRequest, `invalid "before" filter: %w`, err)
 		}
 	}
 	if req.UserTag != "" {
 		tag, err := names.ParseUserTag(req.UserTag)
 		if err != nil {
-			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "user-tag" filter: %w`, err), errors.CodeBadRequest)
+			return filter, errors.Codef(errors.CodeBadRequest, `invalid "user-tag" filter: %w`, err)
 		}
 		filter.IdentityTag = tag.String()
 	}
@@ -392,7 +392,7 @@ func (r *controllerRoot) GrantAuditLogAccess(ctx context.Context, req apiparams.
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	err = r.jimm.PermissionManager().GrantAuditLogAccess(ctx, r.user, ut)
@@ -409,7 +409,7 @@ func (r *controllerRoot) RevokeAuditLogAccess(ctx context.Context, req apiparams
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	err = r.jimm.PermissionManager().RevokeAuditLogAccess(ctx, r.user, ut)
@@ -424,7 +424,7 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return jujuparams.FullStatus{}, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return jujuparams.FullStatus{}, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	status, err := r.jimm.JujuManager().FullModelStatus(ctx, r.user, mt, req.Patterns)
@@ -440,12 +440,12 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.UpdateMigratedModelRequest) error {
 
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	err = r.jimm.JujuManager().UpdateMigratedModel(ctx, r.user, mt, req.TargetController)
 	if err != nil {
@@ -460,7 +460,7 @@ func (r *controllerRoot) ImportModel(ctx context.Context, req apiparams.ImportMo
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	err = r.jimm.JujuManager().ImportModel(ctx, r.user, req.Controller, mt, req.Owner)
@@ -475,7 +475,7 @@ func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apip
 
 	ct, err := names.ParseCloudTag(req.CloudTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if err := r.jimm.JujuManager().RemoveCloudFromController(ctx, r.user, req.ControllerName, ct); err != nil {
 		return err
@@ -490,16 +490,16 @@ func (r *controllerRoot) CrossModelQuery(ctx context.Context, req apiparams.Cros
 
 	modelUUIDs, err := r.user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return apiparams.CrossModelQueryResponse{}, errors.ErrWithCode(nil, errors.Code("failed to list user's model access"))
+		return apiparams.CrossModelQueryResponse{}, fmt.Errorf("failed to list user's model access: %w", err)
 	}
 
 	switch strings.TrimSpace(strings.ToLower(req.Type)) {
 	case "jq":
 		return r.jimm.JujuManager().QueryModelsJq(ctx, modelUUIDs, req.Query)
 	case "jimmsql":
-		return apiparams.CrossModelQueryResponse{}, errors.ErrWithCode(nil, errors.CodeNotImplemented)
+		return apiparams.CrossModelQueryResponse{}, errors.Codef(errors.CodeNotImplemented, "not implemented")
 	default:
-		return apiparams.CrossModelQueryResponse{}, errors.MsgWithCode("unable to query models", errors.Code("invalid query type"))
+		return apiparams.CrossModelQueryResponse{}, errors.New("unable to query models: invalid query type")
 	}
 }
 
@@ -550,7 +550,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	resp := apiparams.PrepareModelMigrationResponse{}
 
 	if !r.user.JimmAdmin {
-		return resp, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return resp, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(args.ModelTag)
@@ -592,12 +592,12 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 // cloud region and version, but excludes the controller the model is already on.
 func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams.ListMigrationTargetsRequest) (apiparams.ListControllersResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ListControllersResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.ListControllersResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return apiparams.ListControllersResponse{}, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 
 	dbControllers, err := r.jimm.JujuManager().ListMigrationTargets(ctx, r.user, mt)
@@ -619,12 +619,12 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 func (r *controllerRoot) GetBootstrapInfo(ctx context.Context, req apiparams.GetBootstrapInfoRequest) (apiparams.GetBootstrapInfoResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.GetBootstrapInfoResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return apiparams.GetBootstrapInfoResponse{}, errors.Codef(errors.CodeBadRequest, "invalid job ID: %s", req.JobID)
 	}
 
 	return r.jimm.BootstrapManager().GetJobInfo(ctx, r.user, jobID, req.Watermark)
@@ -634,12 +634,12 @@ func (r *controllerRoot) GetBootstrapInfo(ctx context.Context, req apiparams.Get
 func (r *controllerRoot) StopBootstrap(ctx context.Context, req apiparams.StopBootstrapRequest) error {
 
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid job ID: %s", req.JobID)
 	}
 
 	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
@@ -655,7 +655,7 @@ var builtInClouds = []string{"microk8s", "localhost"}
 func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.BootstrapParams) (apiparams.StartBootstrapResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.StartBootstrapResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	// Validate request is not for a built in cloud.
@@ -663,7 +663,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 	// function requires providers to be registered in the environs global.
 	if slices.Contains(builtInClouds, req.CloudName) {
 		return apiparams.StartBootstrapResponse{},
-			errors.ErrWithCode(fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName), errors.CodeIncompatibleClouds)
+			errors.Codef(errors.CodeIncompatibleClouds, "bootstrap via JIMM does not support built-in clouds like %q", req.CloudName)
 	}
 
 	cloudNameAndRegion := req.CloudName
@@ -702,7 +702,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 func (r *controllerRoot) StartDestroyController(ctx context.Context, req apiparams.DestroyControllerRequest) (apiparams.StartBootstrapResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.StartBootstrapResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.ControllerName)
@@ -711,7 +711,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 	}
 
 	if len(ctrl.Models) != 0 {
-		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("cannot destroy controller with models", errors.CodeBadRequest)
+		return apiparams.StartBootstrapResponse{}, errors.Codef(errors.CodeBadRequest, "cannot destroy controller with models")
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartDestroyControllerJob(ctx, r.user, bootstrap.DestroyControllerParams{
@@ -737,17 +737,17 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 // at the requested version and migrating the model to it (phase 1 automated upgrade).
 func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToRequest) (apiparams.UpgradeToResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.UpgradeToResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.ErrWithCode(fmt.Errorf("invalid model tag %q: %w", req.ModelTag, err), errors.CodeBadRequest)
+		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeBadRequest, "invalid model tag %q: %w", req.ModelTag, err)
 	}
 
 	_, err = r.jimm.UpgradeManager().UpgradeTo(ctx, r.user, mt.Id(), req.TargetControllerName)
 	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.ErrWithCode(fmt.Errorf("failed to run upgrade to: %w", err), errors.CodeBadRequest)
+		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeBadRequest, "failed to run upgrade to: %w", err)
 	}
 
 	return apiparams.UpgradeToResponse{
@@ -758,14 +758,14 @@ func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToR
 // ListUserClouds lists the clouds accessible to the user.
 func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListUserCloudsRequest) (jujuparams.CloudsResult, error) {
 	if !r.user.JimmAdmin && r.user.ResourceTag().String() != req.UserTag {
-		return jujuparams.CloudsResult{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return jujuparams.CloudsResult{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	user := r.user
 	if r.user.ResourceTag().String() != req.UserTag {
 		ut, err := names.ParseUserTag(req.UserTag)
 		if err != nil {
-			return jujuparams.CloudsResult{}, errors.ErrWithCode(fmt.Errorf("invalid user tag: %w", err), errors.CodeBadRequest)
+			return jujuparams.CloudsResult{}, errors.Codef(errors.CodeBadRequest, "invalid user tag: %w", err)
 		}
 		u, err := r.jimm.IdentityManager().FetchIdentity(ctx, ut.Id())
 		if err != nil {
@@ -792,7 +792,7 @@ func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListU
 // or by the combination of ownerName and modelName parameters.
 func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.ModelControllerInfoRequest) (apiparams.ModelControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ModelControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.ModelControllerInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	var qualifier juju.ModelControllerInfoQualifier
@@ -803,7 +803,7 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 	} else {
 		modelUUID, err := uuid.Parse(req.ModelQualifier)
 		if err != nil {
-			return apiparams.ModelControllerInfo{}, errors.ErrWithCode(fmt.Errorf("invalid model UUID: %w", err), errors.CodeBadRequest)
+			return apiparams.ModelControllerInfo{}, errors.Codef(errors.CodeBadRequest, "invalid model UUID: %w", err)
 		}
 		qualifier = juju.WithModelUUID(modelUUID.String())
 	}
@@ -819,12 +819,12 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 // JobInfo returns information about a job given its ID.
 func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoRequest) (apiparams.JobInfoResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.JobInfoResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.JobInfoResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return apiparams.JobInfoResponse{}, errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return apiparams.JobInfoResponse{}, errors.Codef(errors.CodeBadRequest, "invalid job ID: %s", req.JobID)
 	}
 
 	jobInfo, err := r.jimm.JobManager().GetJobInfo(ctx, jobID)
@@ -838,7 +838,7 @@ func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoReque
 // ListJobs returns the list of all jobs matching the given filter.
 func (r *controllerRoot) ListJobs(ctx context.Context, req apiparams.ListJobsRequest) (apiparams.ListJobsResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ListJobsResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return apiparams.ListJobsResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	return r.jimm.JobManager().ListJobs(ctx, req)

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -565,7 +565,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	// Check each key is a valid local user and each value is a valid user and has a domain
 	for local, external := range args.UserMapping {
 		if !names.IsValidUserName(local) {
-			return resp, errors.New(fmt.Sprintf("%s is not a valid local user name", local))
+			return resp, fmt.Errorf("%s is not a valid local user name", local)
 		}
 
 		if external == "" {
@@ -575,7 +575,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 		}
 
 		if !names.IsValidUser(external) || !strings.Contains(external, "@") {
-			return resp, errors.New(fmt.Sprintf("%s is not a valid external user name", external))
+			return resp, fmt.Errorf("%s is not a valid external user name", external)
 		}
 	}
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -142,7 +142,7 @@ func init() {
 func (r *controllerRoot) DisableControllerUUIDMasking(ctx context.Context) error {
 
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 	r.controllerUUIDMasking = false
 	return nil
@@ -220,28 +220,28 @@ func (r *controllerRoot) AddModelToController(ctx context.Context, req apiparams
 // available to JIMM.
 func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddControllerRequest) (apiparams.ControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ControllerInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.ControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	if req.Name == jimmControllerName {
-		return apiparams.ControllerInfo{}, errors.E(errors.CodeBadRequest, fmt.Sprintf("cannot add a controller with name %q", jimmControllerName))
+		return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("cannot add a controller with name %q", jimmControllerName), errors.CodeBadRequest)
 	}
 	if req.PublicAddress != "" {
 		host, port, err := net.SplitHostPort(req.PublicAddress)
 		if err != nil {
-			return apiparams.ControllerInfo{}, errors.E(err, errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.ErrWithCode(err, errors.CodeBadRequest)
 		}
 		if host == "" {
-			return apiparams.ControllerInfo{}, errors.E(fmt.Sprintf("address %s: host not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("address %s: host not specified in public address", req.PublicAddress), errors.CodeBadRequest)
 		}
 		if port == "" {
-			return apiparams.ControllerInfo{}, errors.E(fmt.Sprintf("address %s: port not specified in public address", req.PublicAddress), errors.CodeBadRequest)
+			return apiparams.ControllerInfo{}, errors.MsgWithCode(fmt.Sprintf("address %s: port not specified in public address", req.PublicAddress), errors.CodeBadRequest)
 		}
 	}
 
 	nphps, err := network.ParseProviderHostPorts(req.APIAddresses...)
 	if err != nil {
-		return apiparams.ControllerInfo{}, errors.E(errors.CodeBadRequest, err)
+		return apiparams.ControllerInfo{}, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	for i := range nphps {
 		// Mark all the unknown scopes public.
@@ -289,7 +289,7 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 // RemoveController removes a controller.
 func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.RemoveControllerRequest) (apiparams.ControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ControllerInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.ControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
@@ -331,19 +331,19 @@ func auditParamsToFilter(req apiparams.FindAuditEventsRequest) (db.AuditLogFilte
 	if req.After != "" {
 		filter.Start, err = time.Parse(time.RFC3339, req.After)
 		if err != nil {
-			return filter, errors.E(err, errors.CodeBadRequest, `invalid "after" filter`)
+			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "after" filter: %w`, err), errors.CodeBadRequest)
 		}
 	}
 	if req.Before != "" {
 		filter.End, err = time.Parse(time.RFC3339, req.Before)
 		if err != nil {
-			return filter, errors.E(err, errors.CodeBadRequest, `invalid "before" filter`)
+			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "before" filter: %w`, err), errors.CodeBadRequest)
 		}
 	}
 	if req.UserTag != "" {
 		tag, err := names.ParseUserTag(req.UserTag)
 		if err != nil {
-			return filter, errors.E(err, errors.CodeBadRequest, `invalid "user-tag" filter`)
+			return filter, errors.ErrWithCode(fmt.Errorf(`invalid "user-tag" filter: %w`, err), errors.CodeBadRequest)
 		}
 		filter.IdentityTag = tag.String()
 	}
@@ -392,7 +392,7 @@ func (r *controllerRoot) GrantAuditLogAccess(ctx context.Context, req apiparams.
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.PermissionManager().GrantAuditLogAccess(ctx, r.user, ut)
@@ -409,7 +409,7 @@ func (r *controllerRoot) RevokeAuditLogAccess(ctx context.Context, req apiparams
 
 	ut, err := parseUserTag(req.UserTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.PermissionManager().RevokeAuditLogAccess(ctx, r.user, ut)
@@ -424,7 +424,7 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return jujuparams.FullStatus{}, errors.E(err, errors.CodeBadRequest)
+		return jujuparams.FullStatus{}, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	status, err := r.jimm.JujuManager().FullModelStatus(ctx, r.user, mt, req.Patterns)
@@ -440,12 +440,12 @@ func (r *controllerRoot) FullModelStatus(ctx context.Context, req apiparams.Full
 func (r *controllerRoot) UpdateMigratedModel(ctx context.Context, req apiparams.UpdateMigratedModelRequest) error {
 
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	err = r.jimm.JujuManager().UpdateMigratedModel(ctx, r.user, mt, req.TargetController)
 	if err != nil {
@@ -460,7 +460,7 @@ func (r *controllerRoot) ImportModel(ctx context.Context, req apiparams.ImportMo
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	err = r.jimm.JujuManager().ImportModel(ctx, r.user, req.Controller, mt, req.Owner)
@@ -475,7 +475,7 @@ func (r *controllerRoot) RemoveCloudFromController(ctx context.Context, req apip
 
 	ct, err := names.ParseCloudTag(req.CloudTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().RemoveCloudFromController(ctx, r.user, req.ControllerName, ct); err != nil {
 		return err
@@ -490,16 +490,16 @@ func (r *controllerRoot) CrossModelQuery(ctx context.Context, req apiparams.Cros
 
 	modelUUIDs, err := r.user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return apiparams.CrossModelQueryResponse{}, errors.E(errors.Code("failed to list user's model access"))
+		return apiparams.CrossModelQueryResponse{}, errors.ErrWithCode(nil, errors.Code("failed to list user's model access"))
 	}
 
 	switch strings.TrimSpace(strings.ToLower(req.Type)) {
 	case "jq":
 		return r.jimm.JujuManager().QueryModelsJq(ctx, modelUUIDs, req.Query)
 	case "jimmsql":
-		return apiparams.CrossModelQueryResponse{}, errors.E(errors.CodeNotImplemented)
+		return apiparams.CrossModelQueryResponse{}, errors.ErrWithCode(nil, errors.CodeNotImplemented)
 	default:
-		return apiparams.CrossModelQueryResponse{}, errors.E(errors.Code("invalid query type"), "unable to query models")
+		return apiparams.CrossModelQueryResponse{}, errors.MsgWithCode("unable to query models", errors.Code("invalid query type"))
 	}
 }
 
@@ -550,12 +550,12 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	resp := apiparams.PrepareModelMigrationResponse{}
 
 	if !r.user.JimmAdmin {
-		return resp, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return resp, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	mt, err := names.ParseModelTag(args.ModelTag)
 	if err != nil {
-		return resp, errors.E("invalid model tag", err)
+		return resp, fmt.Errorf("invalid model tag: %w", err)
 	}
 
 	if !names.IsValidControllerName(args.BackingControllerName) {
@@ -565,7 +565,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 	// Check each key is a valid local user and each value is a valid user and has a domain
 	for local, external := range args.UserMapping {
 		if !names.IsValidUserName(local) {
-			return resp, errors.E(fmt.Sprintf("%s is not a valid local user name", local))
+			return resp, errors.New(fmt.Sprintf("%s is not a valid local user name", local))
 		}
 
 		if external == "" {
@@ -575,7 +575,7 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 		}
 
 		if !names.IsValidUser(external) || !strings.Contains(external, "@") {
-			return resp, errors.E(fmt.Sprintf("%s is not a valid external user name", external))
+			return resp, errors.New(fmt.Sprintf("%s is not a valid external user name", external))
 		}
 	}
 
@@ -592,12 +592,12 @@ func (r *controllerRoot) PrepareModelMigration(ctx context.Context, args apipara
 // cloud region and version, but excludes the controller the model is already on.
 func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams.ListMigrationTargetsRequest) (apiparams.ListControllersResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ListControllersResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.ListControllersResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return apiparams.ListControllersResponse{}, errors.E(err, errors.CodeBadRequest)
+		return apiparams.ListControllersResponse{}, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 
 	dbControllers, err := r.jimm.JujuManager().ListMigrationTargets(ctx, r.user, mt)
@@ -619,12 +619,12 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 func (r *controllerRoot) GetBootstrapInfo(ctx context.Context, req apiparams.GetBootstrapInfoRequest) (apiparams.GetBootstrapInfoResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.GetBootstrapInfoResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return apiparams.GetBootstrapInfoResponse{}, errors.E(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
 	}
 
 	return r.jimm.BootstrapManager().GetJobInfo(ctx, r.user, jobID, req.Watermark)
@@ -634,12 +634,12 @@ func (r *controllerRoot) GetBootstrapInfo(ctx context.Context, req apiparams.Get
 func (r *controllerRoot) StopBootstrap(ctx context.Context, req apiparams.StopBootstrapRequest) error {
 
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return errors.E(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
 	}
 
 	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
@@ -655,7 +655,7 @@ var builtInClouds = []string{"microk8s", "localhost"}
 func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.BootstrapParams) (apiparams.StartBootstrapResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartBootstrapResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	// Validate request is not for a built in cloud.
@@ -663,7 +663,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 	// function requires providers to be registered in the environs global.
 	if slices.Contains(builtInClouds, req.CloudName) {
 		return apiparams.StartBootstrapResponse{},
-			errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
+			errors.ErrWithCode(fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName), errors.CodeIncompatibleClouds)
 	}
 
 	cloudNameAndRegion := req.CloudName
@@ -702,7 +702,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 func (r *controllerRoot) StartDestroyController(ctx context.Context, req apiparams.DestroyControllerRequest) (apiparams.StartBootstrapResponse, error) {
 
 	if !r.user.JimmAdmin {
-		return apiparams.StartBootstrapResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.ControllerName)
@@ -711,7 +711,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 	}
 
 	if len(ctrl.Models) != 0 {
-		return apiparams.StartBootstrapResponse{}, errors.E(errors.CodeBadRequest, "cannot destroy controller with models")
+		return apiparams.StartBootstrapResponse{}, errors.MsgWithCode("cannot destroy controller with models", errors.CodeBadRequest)
 	}
 
 	jobID, err := r.jimm.BootstrapManager().StartDestroyControllerJob(ctx, r.user, bootstrap.DestroyControllerParams{
@@ -737,17 +737,17 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 // at the requested version and migrating the model to it (phase 1 automated upgrade).
 func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToRequest) (apiparams.UpgradeToResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.UpgradeToResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.UpgradeToResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	mt, err := names.ParseModelTag(req.ModelTag)
 	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.E(errors.CodeBadRequest, fmt.Errorf("invalid model tag %q: %w", req.ModelTag, err))
+		return apiparams.UpgradeToResponse{}, errors.ErrWithCode(fmt.Errorf("invalid model tag %q: %w", req.ModelTag, err), errors.CodeBadRequest)
 	}
 
 	_, err = r.jimm.UpgradeManager().UpgradeTo(ctx, r.user, mt.Id(), req.TargetControllerName)
 	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.E(errors.CodeBadRequest, fmt.Errorf("failed to run upgrade to: %w", err))
+		return apiparams.UpgradeToResponse{}, errors.ErrWithCode(fmt.Errorf("failed to run upgrade to: %w", err), errors.CodeBadRequest)
 	}
 
 	return apiparams.UpgradeToResponse{
@@ -758,14 +758,14 @@ func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToR
 // ListUserClouds lists the clouds accessible to the user.
 func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListUserCloudsRequest) (jujuparams.CloudsResult, error) {
 	if !r.user.JimmAdmin && r.user.ResourceTag().String() != req.UserTag {
-		return jujuparams.CloudsResult{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return jujuparams.CloudsResult{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	user := r.user
 	if r.user.ResourceTag().String() != req.UserTag {
 		ut, err := names.ParseUserTag(req.UserTag)
 		if err != nil {
-			return jujuparams.CloudsResult{}, errors.E(err, errors.CodeBadRequest, "invalid user tag")
+			return jujuparams.CloudsResult{}, errors.ErrWithCode(fmt.Errorf("invalid user tag: %w", err), errors.CodeBadRequest)
 		}
 		u, err := r.jimm.IdentityManager().FetchIdentity(ctx, ut.Id())
 		if err != nil {
@@ -792,7 +792,7 @@ func (r *controllerRoot) ListUserClouds(ctx context.Context, req apiparams.ListU
 // or by the combination of ownerName and modelName parameters.
 func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.ModelControllerInfoRequest) (apiparams.ModelControllerInfo, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ModelControllerInfo{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.ModelControllerInfo{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	var qualifier juju.ModelControllerInfoQualifier
@@ -803,7 +803,7 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 	} else {
 		modelUUID, err := uuid.Parse(req.ModelQualifier)
 		if err != nil {
-			return apiparams.ModelControllerInfo{}, errors.E(fmt.Errorf("invalid model UUID: %w", err), errors.CodeBadRequest)
+			return apiparams.ModelControllerInfo{}, errors.ErrWithCode(fmt.Errorf("invalid model UUID: %w", err), errors.CodeBadRequest)
 		}
 		qualifier = juju.WithModelUUID(modelUUID.String())
 	}
@@ -819,12 +819,12 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 // JobInfo returns information about a job given its ID.
 func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoRequest) (apiparams.JobInfoResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.JobInfoResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.JobInfoResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	jobID, err := strconv.ParseInt(req.JobID, 10, 64)
 	if err != nil {
-		return apiparams.JobInfoResponse{}, errors.E(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
+		return apiparams.JobInfoResponse{}, errors.MsgWithCode(fmt.Sprintf("invalid job ID: %s", req.JobID), errors.CodeBadRequest)
 	}
 
 	jobInfo, err := r.jimm.JobManager().GetJobInfo(ctx, jobID)
@@ -838,7 +838,7 @@ func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoReque
 // ListJobs returns the list of all jobs matching the given filter.
 func (r *controllerRoot) ListJobs(ctx context.Context, req apiparams.ListJobsRequest) (apiparams.ListJobsResponse, error) {
 	if !r.user.JimmAdmin {
-		return apiparams.ListJobsResponse{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return apiparams.ListJobsResponse{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	return r.jimm.JobManager().ListJobs(ctx, req)

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -196,7 +196,7 @@ func TestPrepareModelMigration_InvalidModelTag(t *testing.T) {
 		ModelTag: "blah",
 	})
 
-	c.Assert(err, qt.ErrorMatches, "invalid model tag")
+	c.Assert(err, qt.ErrorMatches, "invalid model tag.*")
 }
 
 func TestPrepareModelMigration_InvalidControllerName(t *testing.T) {
@@ -291,7 +291,7 @@ func TestBootstrapStatus(t *testing.T) {
 			return &mocks.BootstapManager{
 				GetJobInfo_: func(ctx context.Context, user *openfga.User, jobId int64, offset int) (apiparams.GetBootstrapInfoResponse, error) {
 					if jobId != expectedJobID {
-						return apiparams.GetBootstrapInfoResponse{}, errors.E(errors.CodeNotFound, "job not found")
+						return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode("job not found", errors.CodeNotFound)
 					}
 					return apiparams.GetBootstrapInfoResponse{
 						Status: "running",
@@ -406,7 +406,7 @@ func TestBootstrapStop(t *testing.T) {
 			return &mocks.BootstapManager{
 				StopJob_: func(ctx context.Context, user *openfga.User, jobId int64) error {
 					if jobId != expectedJobID {
-						return errors.E(errors.CodeNotFound, "job not found")
+						return errors.MsgWithCode("job not found", errors.CodeNotFound)
 					}
 					return nil
 				},
@@ -743,7 +743,7 @@ func TestJobInfo(t *testing.T) {
 			return &mocks.JobManager{
 				GetJobInfo_: func(ctx context.Context, jobID int64) (jobs.JobInfo, error) {
 					if jobID != int64(1) {
-						return jobs.JobInfo{}, errors.E(errors.CodeNotFound, "job not found")
+						return jobs.JobInfo{}, errors.MsgWithCode("job not found", errors.CodeNotFound)
 					}
 					c.Check(jobID, qt.Equals, int64(1))
 					return jobs.JobInfo{
@@ -848,7 +848,7 @@ func TestListJobs(t *testing.T) {
 		JobManager_: func() jujuapi.JobManager {
 			return &mocks.JobManager{
 				ListJobs_: func(ctx context.Context, params apiparams.ListJobsRequest) (apiparams.ListJobsResponse, error) {
-					return apiparams.ListJobsResponse{}, errors.E(errors.CodeNotFound, "no jobs found")
+					return apiparams.ListJobsResponse{}, errors.MsgWithCode("no jobs found", errors.CodeNotFound)
 				},
 			}
 		},

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -196,7 +196,7 @@ func TestPrepareModelMigration_InvalidModelTag(t *testing.T) {
 		ModelTag: "blah",
 	})
 
-	c.Assert(err, qt.ErrorMatches, "invalid model tag.*")
+	c.Assert(err, qt.ErrorMatches, `invalid model tag: "blah" is not a valid tag`)
 }
 
 func TestPrepareModelMigration_InvalidControllerName(t *testing.T) {

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -291,7 +291,7 @@ func TestBootstrapStatus(t *testing.T) {
 			return &mocks.BootstapManager{
 				GetJobInfo_: func(ctx context.Context, user *openfga.User, jobId int64, offset int) (apiparams.GetBootstrapInfoResponse, error) {
 					if jobId != expectedJobID {
-						return apiparams.GetBootstrapInfoResponse{}, errors.MsgWithCode("job not found", errors.CodeNotFound)
+						return apiparams.GetBootstrapInfoResponse{}, errors.Codef(errors.CodeNotFound, "job not found")
 					}
 					return apiparams.GetBootstrapInfoResponse{
 						Status: "running",
@@ -406,7 +406,7 @@ func TestBootstrapStop(t *testing.T) {
 			return &mocks.BootstapManager{
 				StopJob_: func(ctx context.Context, user *openfga.User, jobId int64) error {
 					if jobId != expectedJobID {
-						return errors.MsgWithCode("job not found", errors.CodeNotFound)
+						return errors.Codef(errors.CodeNotFound, "job not found")
 					}
 					return nil
 				},
@@ -743,7 +743,7 @@ func TestJobInfo(t *testing.T) {
 			return &mocks.JobManager{
 				GetJobInfo_: func(ctx context.Context, jobID int64) (jobs.JobInfo, error) {
 					if jobID != int64(1) {
-						return jobs.JobInfo{}, errors.MsgWithCode("job not found", errors.CodeNotFound)
+						return jobs.JobInfo{}, errors.Codef(errors.CodeNotFound, "job not found")
 					}
 					c.Check(jobID, qt.Equals, int64(1))
 					return jobs.JobInfo{
@@ -848,7 +848,7 @@ func TestListJobs(t *testing.T) {
 		JobManager_: func() jujuapi.JobManager {
 			return &mocks.JobManager{
 				ListJobs_: func(ctx context.Context, params apiparams.ListJobsRequest) (apiparams.ListJobsResponse, error) {
-					return apiparams.ListJobsResponse{}, errors.MsgWithCode("no jobs found", errors.CodeNotFound)
+					return apiparams.ListJobsResponse{}, errors.Codef(errors.CodeNotFound, "no jobs found")
 				},
 			}
 		},

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -73,7 +73,7 @@ func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 
 func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.ModelArgs) (jujuparams.ErrorResults, error) {
 	if !r.user.JimmAdmin {
-		return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -100,7 +100,7 @@ func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.Mode
 // It is used by the source Juju controller to abort a model migration.
 func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -117,7 +117,7 @@ func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) e
 // is destroyed after the model is migrated away.
 func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.AdoptResourcesArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -132,7 +132,7 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.Ado
 // latest log record it has seen.
 func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.ModelArgs) (time.Time, error) {
 	if !r.user.JimmAdmin {
-		return time.Time{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return time.Time{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -151,7 +151,7 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfo) error {
 
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	ownerTag, err := names.ParseUserTag(args.OwnerTag)
@@ -177,7 +177,7 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 // Activate is the implementation of the Activate method of the MigrationTarget facade.
 func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateModelArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -215,7 +215,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 // It imports resources into JIMM and proxies the import request to the target Juju controller.
 func (r *controllerRoot) Import(ctx context.Context, serialized jujuparams.SerializedModel) error {
 	if !r.user.JimmAdmin {
-		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
 	err := r.jimm.JujuManager().Import(ctx, r.user, serialized)

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -73,7 +73,7 @@ func (r *controllerRoot) CACert() (jujuparams.BytesResult, error) {
 
 func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.ModelArgs) (jujuparams.ErrorResults, error) {
 	if !r.user.JimmAdmin {
-		return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -100,7 +100,7 @@ func (r *controllerRoot) CheckMachines(ctx context.Context, args jujuparams.Mode
 // It is used by the source Juju controller to abort a model migration.
 func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -117,7 +117,7 @@ func (r *controllerRoot) Abort(ctx context.Context, args jujuparams.ModelArgs) e
 // is destroyed after the model is migrated away.
 func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.AdoptResourcesArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -132,7 +132,7 @@ func (r *controllerRoot) AdoptResources(ctx context.Context, args jujuparams.Ado
 // latest log record it has seen.
 func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.ModelArgs) (time.Time, error) {
 	if !r.user.JimmAdmin {
-		return time.Time{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+		return time.Time{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -151,7 +151,7 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfo) error {
 
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	ownerTag, err := names.ParseUserTag(args.OwnerTag)
@@ -177,7 +177,7 @@ func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.Migratio
 // Activate is the implementation of the Activate method of the MigrationTarget facade.
 func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateModelArgs) error {
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	modelTag, err := names.ParseModelTag(args.ModelTag)
@@ -215,7 +215,7 @@ func (r *controllerRoot) Activate(ctx context.Context, args jujuparams.ActivateM
 // It imports resources into JIMM and proxies the import request to the target Juju controller.
 func (r *controllerRoot) Import(ctx context.Context, serialized jujuparams.SerializedModel) error {
 	if !r.user.JimmAdmin {
-		return errors.E(errors.CodeUnauthorized, "unauthorized")
+		return errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 	}
 
 	err := r.jimm.JujuManager().Import(ctx, r.user, serialized)

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -106,7 +106,7 @@ func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpMod
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 		}
 		modelDump, err := r.jimm.JujuManager().DumpModel(ctx, r.user, mt, args.Simplified)
 		if err != nil {
@@ -180,7 +180,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 		mt, err := names.ParseModelTag(arg.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 
@@ -189,7 +189,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				// Map not-found errors to unauthorized, this is what juju
 				// does.
-				err = errors.E(errors.CodeUnauthorized, "unauthorized")
+				err = errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 			}
 			results[i].Error = r.mapError(ctx, err)
 			continue
@@ -241,7 +241,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 		mt, err := names.ParseModelTag(model.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 
@@ -269,12 +269,12 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		mt, err := names.ParseModelTag(change.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		user, err := parseUserTag(change.UserTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		switch change.Action {
@@ -283,10 +283,10 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		case jujuparams.RevokeModelAccess:
 			err = r.jimm.PermissionManager().RevokeModelAccess(ctx, r.user, mt, user, change.Access)
 		default:
-			err = errors.E(errors.CodeBadRequest, fmt.Sprintf("invalid action %q", change.Action))
+			err = errors.MsgWithCode(fmt.Sprintf("invalid action %q", change.Action), errors.CodeBadRequest)
 		}
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			err = errors.E(errors.CodeUnauthorized, "unauthorized")
+			err = errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 		}
 		results[i].Error = r.mapError(ctx, err)
 	}
@@ -307,7 +307,7 @@ func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entit
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModelDB(ctx, r.user, mt)
 		if err != nil {
@@ -339,11 +339,11 @@ func (r *controllerRoot) changeModelCredential(ctx context.Context, arg jujupara
 	mt, err := names.ParseModelTag(arg.ModelTag)
 	ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	cct, err := names.ParseCloudCredentialTag(arg.CloudCredentialTag)
 	if err != nil {
-		return errors.E(err, errors.CodeBadRequest)
+		return errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if err := r.jimm.JujuManager().ChangeModelCredential(ctx, r.user, mt, cct); err != nil {
 		return err
@@ -363,7 +363,7 @@ func (r *controllerRoot) ValidateModelUpgrades(ctx context.Context, args jujupar
 		modelTag, err := names.ParseModelTag(arg.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", modelTag.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.E(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
 			continue
 		}
 		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().ValidateModelUpgrade(ctx, r.user, modelTag, args.Force))

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -106,7 +106,7 @@ func (r *controllerRoot) DumpModels(ctx context.Context, args jujuparams.DumpMod
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 		}
 		modelDump, err := r.jimm.JujuManager().DumpModel(ctx, r.user, mt, args.Simplified)
 		if err != nil {
@@ -180,7 +180,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 		mt, err := names.ParseModelTag(arg.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 
@@ -189,7 +189,7 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 			if errors.ErrorCode(err) == errors.CodeNotFound {
 				// Map not-found errors to unauthorized, this is what juju
 				// does.
-				err = errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+				err = errors.Codef(errors.CodeUnauthorized, "unauthorized")
 			}
 			results[i].Error = r.mapError(ctx, err)
 			continue
@@ -241,7 +241,7 @@ func (r *controllerRoot) DestroyModels(ctx context.Context, args jujuparams.Dest
 		mt, err := names.ParseModelTag(model.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 
@@ -269,12 +269,12 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		mt, err := names.ParseModelTag(change.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		user, err := parseUserTag(change.UserTag)
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		switch change.Action {
@@ -283,10 +283,10 @@ func (r *controllerRoot) ModifyModelAccess(ctx context.Context, args jujuparams.
 		case jujuparams.RevokeModelAccess:
 			err = r.jimm.PermissionManager().RevokeModelAccess(ctx, r.user, mt, user, change.Access)
 		default:
-			err = errors.MsgWithCode(fmt.Sprintf("invalid action %q", change.Action), errors.CodeBadRequest)
+			err = errors.Codef(errors.CodeBadRequest, "invalid action %q", change.Action)
 		}
 		if errors.ErrorCode(err) == errors.CodeNotFound {
-			err = errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+			err = errors.Codef(errors.CodeUnauthorized, "unauthorized")
 		}
 		results[i].Error = r.mapError(ctx, err)
 	}
@@ -307,7 +307,7 @@ func (r *controllerRoot) DumpModelsDB(ctx context.Context, args jujuparams.Entit
 		mt, err := names.ParseModelTag(ent.Tag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 		}
 		results[i].Result, err = r.jimm.JujuManager().DumpModelDB(ctx, r.user, mt)
 		if err != nil {
@@ -339,11 +339,11 @@ func (r *controllerRoot) changeModelCredential(ctx context.Context, arg jujupara
 	mt, err := names.ParseModelTag(arg.ModelTag)
 	ctx = zapctx.WithFields(ctx, zap.String("entity", mt.String()))
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	cct, err := names.ParseCloudCredentialTag(arg.CloudCredentialTag)
 	if err != nil {
-		return errors.ErrWithCode(err, errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if err := r.jimm.JujuManager().ChangeModelCredential(ctx, r.user, mt, cct); err != nil {
 		return err
@@ -363,7 +363,7 @@ func (r *controllerRoot) ValidateModelUpgrades(ctx context.Context, args jujupar
 		modelTag, err := names.ParseModelTag(arg.ModelTag)
 		ctx = zapctx.WithFields(ctx, zap.String("entity", modelTag.String()))
 		if err != nil {
-			results[i].Error = r.mapError(ctx, errors.ErrWithCode(err, errors.CodeBadRequest))
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "%w", err))
 			continue
 		}
 		results[i].Error = r.mapError(ctx, r.jimm.JujuManager().ValidateModelUpgrade(ctx, r.user, modelTag, args.Force))

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -93,7 +93,7 @@ func (r *watcherRegistry) get(id string) (*modelSummaryWatcher, error) {
 
 	w, ok := r.watchers[id]
 	if !ok {
-		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "not found")
 	}
 	return w, nil
 }

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -93,7 +93,7 @@ func (r *watcherRegistry) get(id string) (*modelSummaryWatcher, error) {
 
 	w, ok := r.watchers[id]
 	if !ok {
-		return nil, errors.E(errors.CodeNotFound)
+		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 	return w, nil
 }

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -20,7 +20,7 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 	resp := apiparams.AddRoleResponse{}
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return resp, errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
+		return resp, errors.Codef(errors.CodeBadRequest, "invalid role name")
 	}
 
 	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
@@ -44,15 +44,15 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Role{}, errors.MsgWithCode("only one of UUID or Name should be provided", errors.CodeBadRequest)
+		return apiparams.Role{}, errors.Codef(errors.CodeBadRequest, "only one of UUID or Name should be provided")
 	case req.Name != "" && !jimmnames.IsValidRoleName(req.Name):
-		return apiparams.Role{}, errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
+		return apiparams.Role{}, errors.Codef(errors.CodeBadRequest, "invalid role name")
 	case req.UUID != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Role{}, errors.MsgWithCode("no UUID or Name provided", errors.CodeBadRequest)
+		return apiparams.Role{}, errors.Codef(errors.CodeBadRequest, "no UUID or Name provided")
 	}
 	if err != nil {
 		return apiparams.Role{}, fmt.Errorf("failed to get role: %w", err)
@@ -70,7 +70,7 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRoleRequest) error {
 
 	if !jimmnames.IsValidRoleName(req.NewName) {
-		return errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid role name")
 	}
 
 	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
@@ -83,7 +83,7 @@ func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRol
 func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRoleRequest) error {
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
+		return errors.Codef(errors.CodeBadRequest, "invalid role name")
 	}
 
 	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {

--- a/internal/jujuapi/role.go
+++ b/internal/jujuapi/role.go
@@ -20,7 +20,7 @@ func (r *controllerRoot) AddRole(ctx context.Context, req apiparams.AddRoleReque
 	resp := apiparams.AddRoleResponse{}
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return resp, errors.E(errors.CodeBadRequest, "invalid role name")
+		return resp, errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
 	}
 
 	roleEntry, err := r.jimm.RoleManager().AddRole(ctx, r.user, req.Name)
@@ -44,15 +44,15 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 	var err error
 	switch {
 	case req.UUID != "" && req.Name != "":
-		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "only one of UUID or Name should be provided")
+		return apiparams.Role{}, errors.MsgWithCode("only one of UUID or Name should be provided", errors.CodeBadRequest)
 	case req.Name != "" && !jimmnames.IsValidRoleName(req.Name):
-		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "invalid role name")
+		return apiparams.Role{}, errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
 	case req.UUID != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByUUID(ctx, r.user, req.UUID)
 	case req.Name != "":
 		roleEntry, err = r.jimm.RoleManager().GetRoleByName(ctx, r.user, req.Name)
 	default:
-		return apiparams.Role{}, errors.E(errors.CodeBadRequest, "no UUID or Name provided")
+		return apiparams.Role{}, errors.MsgWithCode("no UUID or Name provided", errors.CodeBadRequest)
 	}
 	if err != nil {
 		return apiparams.Role{}, fmt.Errorf("failed to get role: %w", err)
@@ -70,7 +70,7 @@ func (r *controllerRoot) GetRole(ctx context.Context, req apiparams.GetRoleReque
 func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRoleRequest) error {
 
 	if !jimmnames.IsValidRoleName(req.NewName) {
-		return errors.E(errors.CodeBadRequest, "invalid role name")
+		return errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
 	}
 
 	if err := r.jimm.RoleManager().RenameRole(ctx, r.user, req.Name, req.NewName); err != nil {
@@ -83,7 +83,7 @@ func (r *controllerRoot) RenameRole(ctx context.Context, req apiparams.RenameRol
 func (r *controllerRoot) RemoveRole(ctx context.Context, req apiparams.RemoveRoleRequest) error {
 
 	if !jimmnames.IsValidRoleName(req.Name) {
-		return errors.E(errors.CodeBadRequest, "invalid role name")
+		return errors.MsgWithCode("invalid role name", errors.CodeBadRequest)
 	}
 
 	if err := r.jimm.RoleManager().RemoveRole(ctx, r.user, req.Name); err != nil {

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -39,11 +39,11 @@ type streamControllerProxier struct {
 func (s streamControllerProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	_, password, ok := req.BasicAuth()
 	if !ok {
-		return ctx, errors.E(errors.CodeUnauthorized, "authentication missing")
+		return ctx, errors.MsgWithCode("authentication missing", errors.CodeUnauthorized)
 	}
 	jwtToken, err := s.jimm.OAuthAuthenticator.VerifySessionToken(password)
 	if err != nil {
-		return ctx, errors.E(errors.CodeUnauthorized, err)
+		return ctx, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 	email := jwtToken.Subject()
 	ctx = auth.ContextWithSessionIdentity(ctx, email)

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -39,11 +39,11 @@ type streamControllerProxier struct {
 func (s streamControllerProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	_, password, ok := req.BasicAuth()
 	if !ok {
-		return ctx, errors.MsgWithCode("authentication missing", errors.CodeUnauthorized)
+		return ctx, errors.Codef(errors.CodeUnauthorized, "authentication missing")
 	}
 	jwtToken, err := s.jimm.OAuthAuthenticator.VerifySessionToken(password)
 	if err != nil {
-		return ctx, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 	email := jwtToken.Subject()
 	ctx = auth.ContextWithSessionIdentity(ctx, email)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -34,11 +34,11 @@ type streamModelProxier struct {
 func (s streamModelProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	_, password, ok := req.BasicAuth()
 	if !ok {
-		return ctx, errors.MsgWithCode("authentication missing", errors.CodeUnauthorized)
+		return ctx, errors.Codef(errors.CodeUnauthorized, "authentication missing")
 	}
 	jwtToken, err := s.jimm.OAuthAuthenticator.VerifySessionToken(password)
 	if err != nil {
-		return ctx, errors.ErrWithCode(err, errors.CodeUnauthorized)
+		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
 	email := jwtToken.Subject()
 	ctx = auth.ContextWithSessionIdentity(ctx, email)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -34,11 +34,11 @@ type streamModelProxier struct {
 func (s streamModelProxier) Authenticate(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	_, password, ok := req.BasicAuth()
 	if !ok {
-		return ctx, errors.E(errors.CodeUnauthorized, "authentication missing")
+		return ctx, errors.MsgWithCode("authentication missing", errors.CodeUnauthorized)
 	}
 	jwtToken, err := s.jimm.OAuthAuthenticator.VerifySessionToken(password)
 	if err != nil {
-		return ctx, errors.E(errors.CodeUnauthorized, err)
+		return ctx, errors.ErrWithCode(err, errors.CodeUnauthorized)
 	}
 	email := jwtToken.Subject()
 	ctx = auth.ContextWithSessionIdentity(ctx, email)
@@ -121,6 +121,6 @@ func checkPermission(ctx context.Context, path string, u *openfga.User, mt names
 	case "log":
 		return u.IsModelReader(ctx, mt)
 	default:
-		return false, errors.E("unknown endpoint " + path)
+		return false, errors.New("unknown endpoint " + path)
 	}
 }

--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -68,7 +68,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	if args.CloudTag != "" {
 		ct, err := names.ParseCloudTag(args.CloudTag)
 		if err != nil {
-			return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+			return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 		}
 		a.Cloud = ct
 	}
@@ -76,7 +76,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	if args.OwnerTag != "" {
 		ot, err := names.ParseUserTag(args.OwnerTag)
 		if err != nil {
-			return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+			return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 		}
 		a.Owner = ot
 	} else {

--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -3,6 +3,8 @@
 package jujuapi
 
 import (
+	"fmt"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/cloud"
 	jujuparams "github.com/juju/juju/rpc/params"
@@ -66,7 +68,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	if args.CloudTag != "" {
 		ct, err := names.ParseCloudTag(args.CloudTag)
 		if err != nil {
-			return nil, errors.E(err, errors.CodeBadRequest)
+			return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 		}
 		a.Cloud = ct
 	}
@@ -74,7 +76,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	if args.OwnerTag != "" {
 		ot, err := names.ParseUserTag(args.OwnerTag)
 		if err != nil {
-			return nil, errors.E(err, errors.CodeBadRequest)
+			return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 		}
 		a.Owner = ot
 	} else {
@@ -84,7 +86,7 @@ func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.Use
 	if args.CloudCredentialTag != "" {
 		ct, err := names.ParseCloudCredentialTag(args.CloudCredentialTag)
 		if err != nil {
-			return nil, errors.E(err, "invalid cloud credential tag")
+			return nil, fmt.Errorf("invalid cloud credential tag: %w", err)
 		}
 		if a.Cloud.Id() != "" && ct.Cloud().Id() != a.Cloud.Id() {
 			return nil, errors.New("cloud credential cloud mismatch")

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -78,7 +78,7 @@ func TestModelCreateArgs(t *testing.T) {
 			CloudTag:           names.NewCloudTag("test-cloud").String(),
 			CloudCredentialTag: "test-credential-1",
 		},
-		expectedError: "invalid cloud credential tag",
+		expectedError: `invalid cloud credential tag: "test-credential-1" is not a valid tag`,
 	}, {
 		about: "cloud does not match cloud credential cloud",
 		args: jujuparams.ModelCreateArgs{
@@ -119,7 +119,7 @@ func TestModelCreateArgs(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(a, qt.CmpEquals(opts...), test.expectedArgs)
 			} else {
-				c.Assert(err, qt.ErrorMatches, test.expectedError+".*")
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
 			}
 		})
 	}

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -325,7 +325,7 @@ func TestToFullModelInfo(t *testing.T) {
 			NumSecrets: 7,
 			Status:     "available",
 			Message:    "ready",
-			Error:      errors.MsgWithCode("backend warning", errors.CodeBadRequest),
+			Error:      errors.Codef(errors.CodeBadRequest, "backend warning"),
 		}},
 	}
 

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -119,7 +119,7 @@ func TestModelCreateArgs(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(a, qt.CmpEquals(opts...), test.expectedArgs)
 			} else {
-				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				c.Assert(err, qt.ErrorMatches, test.expectedError+".*")
 			}
 		})
 	}
@@ -325,7 +325,7 @@ func TestToFullModelInfo(t *testing.T) {
 			NumSecrets: 7,
 			Status:     "available",
 			Message:    "ready",
-			Error:      errors.E("backend warning", errors.CodeBadRequest),
+			Error:      errors.MsgWithCode("backend warning", errors.CodeBadRequest),
 		}},
 	}
 
@@ -417,7 +417,7 @@ func TestToFullModelInfoNonNilSecretBackendError(t *testing.T) {
 				Name:        "vault",
 				BackendType: "vault",
 			},
-			Error: errors.E("an error", errors.CodeNotFound, map[string]any{"detail": "not found"}),
+			Error: &errors.Error{Code: errors.CodeNotFound, Message: "an error", Info: map[string]any{"detail": "not found"}},
 		}},
 	}
 

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -37,27 +37,27 @@ func init() {
 
 // AddUser implements the UserManager facade's AddUser method.
 func (r *controllerRoot) AddUser(args jujuparams.AddUsers) (jujuparams.AddUserResults, error) {
-	return jujuparams.AddUserResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.AddUserResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }
 
 // RemoveUser implements the UserManager facade's RemoveUser method.
 func (r *controllerRoot) RemoveUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }
 
 // EnableUser implements the UserManager facade's EnableUser method.
 func (r *controllerRoot) EnableUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }
 
 // DisableUser implements the UserManager facade's DisableUser method.
 func (r *controllerRoot) DisableUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }
 
 // ModelUserInfo returns information on all users in the model.
 func (r *controllerRoot) ModelUserInfo(args jujuparams.Entities) (jujuparams.ModelUserInfoResults, error) {
-	return jujuparams.ModelUserInfoResults{}, errors.E(errors.CodeNotImplemented, "not implements")
+	return jujuparams.ModelUserInfoResults{}, errors.MsgWithCode("not implements", errors.CodeNotImplemented)
 }
 
 // UserInfo implements the UserManager facade's UserInfo method.
@@ -80,10 +80,10 @@ func (r *controllerRoot) userInfo(entity string) (*jujuparams.UserInfo, error) {
 
 	user, err := parseUserTag(entity)
 	if err != nil {
-		return nil, errors.E(err, errors.CodeBadRequest)
+		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
 	}
 	if r.user.Name != user.Id() {
-		return nil, errors.E(errors.CodeUnauthorized)
+		return nil, errors.ErrWithCode(nil, errors.CodeUnauthorized)
 	}
 	ui := r.user.ToJujuUserInfo()
 	return &ui, nil
@@ -91,11 +91,11 @@ func (r *controllerRoot) userInfo(entity string) (*jujuparams.UserInfo, error) {
 
 // SetPassword implements the UserManager facade's SetPassword method.
 func (r *controllerRoot) SetPassword(jujuparams.EntityPasswords) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }
 
 // ResetPassword implements the UserManager facade's ResetPassword method.
 func (r *controllerRoot) ResetPassword(jujuparams.Entities) (jujuparams.ErrorResults, error) {
 	// JIMM does not support resetting user's password.
-	return jujuparams.ErrorResults{}, errors.E(errors.CodeUnauthorized, "unauthorized")
+	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
 }

--- a/internal/jujuapi/usermanager.go
+++ b/internal/jujuapi/usermanager.go
@@ -37,27 +37,27 @@ func init() {
 
 // AddUser implements the UserManager facade's AddUser method.
 func (r *controllerRoot) AddUser(args jujuparams.AddUsers) (jujuparams.AddUserResults, error) {
-	return jujuparams.AddUserResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.AddUserResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }
 
 // RemoveUser implements the UserManager facade's RemoveUser method.
 func (r *controllerRoot) RemoveUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }
 
 // EnableUser implements the UserManager facade's EnableUser method.
 func (r *controllerRoot) EnableUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }
 
 // DisableUser implements the UserManager facade's DisableUser method.
 func (r *controllerRoot) DisableUser(jujuparams.Entities) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }
 
 // ModelUserInfo returns information on all users in the model.
 func (r *controllerRoot) ModelUserInfo(args jujuparams.Entities) (jujuparams.ModelUserInfoResults, error) {
-	return jujuparams.ModelUserInfoResults{}, errors.MsgWithCode("not implements", errors.CodeNotImplemented)
+	return jujuparams.ModelUserInfoResults{}, errors.Codef(errors.CodeNotImplemented, "not implements")
 }
 
 // UserInfo implements the UserManager facade's UserInfo method.
@@ -80,10 +80,10 @@ func (r *controllerRoot) userInfo(entity string) (*jujuparams.UserInfo, error) {
 
 	user, err := parseUserTag(entity)
 	if err != nil {
-		return nil, errors.ErrWithCode(err, errors.CodeBadRequest)
+		return nil, errors.Codef(errors.CodeBadRequest, "%w", err)
 	}
 	if r.user.Name != user.Id() {
-		return nil, errors.ErrWithCode(nil, errors.CodeUnauthorized)
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	ui := r.user.ToJujuUserInfo()
 	return &ui, nil
@@ -91,11 +91,11 @@ func (r *controllerRoot) userInfo(entity string) (*jujuparams.UserInfo, error) {
 
 // SetPassword implements the UserManager facade's SetPassword method.
 func (r *controllerRoot) SetPassword(jujuparams.EntityPasswords) (jujuparams.ErrorResults, error) {
-	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }
 
 // ResetPassword implements the UserManager facade's ResetPassword method.
 func (r *controllerRoot) ResetPassword(jujuparams.Entities) (jujuparams.ErrorResults, error) {
 	// JIMM does not support resetting user's password.
-	return jujuparams.ErrorResults{}, errors.MsgWithCode("unauthorized", errors.CodeUnauthorized)
+	return jujuparams.ErrorResults{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -223,7 +223,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 			},
 		}
 		if err := s.jimm.Database.GetModel(context.Background(), &m); err != nil {
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.E(fmt.Errorf("failed to find model: %w", err), errors.CodeNotFound)
+			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.ErrWithCode(fmt.Errorf("failed to find model: %w", err), errors.CodeNotFound)
 		}
 		jwtGenerator.SetTags(m.ResourceTag(), m.Controller.ResourceTag())
 		mt := m.ResourceTag()

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -223,7 +223,7 @@ func controllerConnectionFunc(s apiModelProxier, jwtGenerator *jujuauth.LoginTok
 			},
 		}
 		if err := s.jimm.Database.GetModel(context.Background(), &m); err != nil {
-			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.ErrWithCode(fmt.Errorf("failed to find model: %w", err), errors.CodeNotFound)
+			return rpcproxy.WebsocketConnectionWithMetadata{}, errors.Codef(errors.CodeNotFound, "failed to find model: %w", err)
 		}
 		jwtGenerator.SetTags(m.ResourceTag(), m.Controller.ResourceTag())
 		mt := m.ResourceTag()

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -90,7 +90,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 		return nil, err
 	}
 	if conn == nil {
-		return nil, errors.ErrWithCode(err, errors.CodeConnectionFailed)
+		return nil, errors.Codef(errors.CodeConnectionFailed, "%w", err)
 	}
 	client := rpc.NewClient(conn)
 
@@ -107,7 +107,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	var res jujuparams.LoginResult
 	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
 		client.Close()
-		return nil, errors.ErrWithCode(err, errors.CodeConnectionFailed)
+		return nil, errors.Codef(errors.CodeConnectionFailed, "%w", err)
 	}
 
 	ct, err := names.ParseControllerTag(res.ControllerTag)
@@ -273,7 +273,7 @@ func (c *Connection) ModelTag() (names.ModelTag, bool) {
 // to make HTTP requests to the API. URLs passed to the client
 // will be made relative to the API host and the current model.
 func (c *Connection) HTTPClient() (*httprequest.Client, error) {
-	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
+	return nil, errors.Codef(errors.CodeNotImplemented, "not implemented")
 }
 
 // BakeryClientWrapper wraps an httpbakery.Client to implement

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -254,7 +254,7 @@ func (c *Connection) CallHighestFacadeVersion(ctx context.Context, facade string
 			return c.Call(ctx, facade, version, id, method, args, resp)
 		}
 	}
-	return errors.New(fmt.Sprintf("facade %v version %v not supported", facade, versions))
+	return fmt.Errorf("facade %v version %v not supported", facade, versions)
 }
 
 // BestFacadeVersion returns the newest version of 'objType' that this

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -90,7 +90,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 		return nil, err
 	}
 	if conn == nil {
-		return nil, errors.E(errors.CodeConnectionFailed, err)
+		return nil, errors.ErrWithCode(err, errors.CodeConnectionFailed)
 	}
 	client := rpc.NewClient(conn)
 
@@ -107,7 +107,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	var res jujuparams.LoginResult
 	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
 		client.Close()
-		return nil, errors.E(errors.CodeConnectionFailed, err)
+		return nil, errors.ErrWithCode(err, errors.CodeConnectionFailed)
 	}
 
 	ct, err := names.ParseControllerTag(res.ControllerTag)
@@ -254,7 +254,7 @@ func (c *Connection) CallHighestFacadeVersion(ctx context.Context, facade string
 			return c.Call(ctx, facade, version, id, method, args, resp)
 		}
 	}
-	return errors.E(fmt.Sprintf("facade %v version %v not supported", facade, versions))
+	return errors.New(fmt.Sprintf("facade %v version %v not supported", facade, versions))
 }
 
 // BestFacadeVersion returns the newest version of 'objType' that this
@@ -273,7 +273,7 @@ func (c *Connection) ModelTag() (names.ModelTag, bool) {
 // to make HTTP requests to the API. URLs passed to the client
 // will be made relative to the API host and the current model.
 func (c *Connection) HTTPClient() (*httprequest.Client, error) {
-	return nil, errors.E(errors.CodeNotImplemented)
+	return nil, errors.ErrWithCode(nil, errors.CodeNotImplemented)
 }
 
 // BakeryClientWrapper wraps an httpbakery.Client to implement

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -87,7 +87,7 @@ func (c Connection) ModelInfo(ctx context.Context, model names.ModelTag) (ModelI
 		return ModelInfo{}, err
 	}
 	if res[0].Error != nil {
-		return ModelInfo{}, errors.E(res[0].Error)
+		return ModelInfo{}, res[0].Error
 	}
 	return convertParamsModelInfo(*res[0].Result)
 }

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -140,7 +140,7 @@ func TestAuthenticateViaBasicAuth(t *testing.T) {
 	loginManager := mocks.LoginManager{
 		LoginWithSessionToken_: func(ctx context.Context, sessionToken string) (*openfga.User, error) {
 			if sessionToken != "good" {
-				return nil, jimm_errors.E(jimm_errors.CodeSessionTokenInvalid)
+					return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeSessionTokenInvalid)
 			}
 			user := dbmodel.Identity{Name: testUser}
 			return &openfga.User{Identity: &user, JimmAdmin: true}, nil
@@ -213,7 +213,7 @@ func TestAuthenticateViaBasicAuthServiceAccount(t *testing.T) {
 				}
 				return &openfga.User{Identity: &user}, nil
 			}
-			return nil, jimm_errors.E(jimm_errors.CodeUnauthorized)
+			return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeUnauthorized)
 		},
 	}
 	tests := []struct {

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -4,7 +4,6 @@ package middleware_test
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +15,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	jimm_errors "github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/middleware"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
@@ -140,7 +139,7 @@ func TestAuthenticateViaBasicAuth(t *testing.T) {
 	loginManager := mocks.LoginManager{
 		LoginWithSessionToken_: func(ctx context.Context, sessionToken string) (*openfga.User, error) {
 			if sessionToken != "good" {
-				return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeSessionTokenInvalid)
+				return nil, errors.Codef(errors.CodeSessionTokenInvalid, "session token invalid")
 			}
 			user := dbmodel.Identity{Name: testUser}
 			return &openfga.User{Identity: &user, JimmAdmin: true}, nil
@@ -213,7 +212,7 @@ func TestAuthenticateViaBasicAuthServiceAccount(t *testing.T) {
 				}
 				return &openfga.User{Identity: &user}, nil
 			}
-			return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeUnauthorized)
+			return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 		},
 	}
 	tests := []struct {

--- a/internal/middleware/authn_test.go
+++ b/internal/middleware/authn_test.go
@@ -140,7 +140,7 @@ func TestAuthenticateViaBasicAuth(t *testing.T) {
 	loginManager := mocks.LoginManager{
 		LoginWithSessionToken_: func(ctx context.Context, sessionToken string) (*openfga.User, error) {
 			if sessionToken != "good" {
-					return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeSessionTokenInvalid)
+				return nil, jimm_errors.ErrWithCode(nil, jimm_errors.CodeSessionTokenInvalid)
 			}
 			user := dbmodel.Identity{Name: testUser}
 			return &openfga.User{Identity: &user, JimmAdmin: true}, nil

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -171,7 +171,7 @@ func ParseRelation(relationString string) (cofga.Relation, error) {
 	case AssigneeRelation.String():
 		return AssigneeRelation, nil
 	default:
-		return cofga.Relation(""), errors.E(fmt.Sprintf("unknown relation %s", relationString))
+		return cofga.Relation(""), errors.New(fmt.Sprintf("unknown relation %s", relationString))
 
 	}
 }

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -171,7 +171,7 @@ func ParseRelation(relationString string) (cofga.Relation, error) {
 	case AssigneeRelation.String():
 		return AssigneeRelation, nil
 	default:
-		return cofga.Relation(""), errors.New(fmt.Sprintf("unknown relation %s", relationString))
+		return cofga.Relation(""), fmt.Errorf("unknown relation %s", relationString)
 
 	}
 }

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -294,7 +294,7 @@ func (u *User) ListApplicationOffers(ctx context.Context, relation ofga.Relation
 // CheckPermission returns an Unauthorized error if user is not allowed specified permission to the resource.
 func (u *User) CheckPermission(ctx context.Context, resourceTag string, permission string) error {
 	if u.client == nil {
-		return errors.MsgWithCode("cannot check permission", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "cannot check permission")
 	}
 	resource, err := names.ParseTag(resourceTag)
 	if err != nil {
@@ -329,7 +329,7 @@ func (u *User) CheckPermission(ctx context.Context, resourceTag string, permissi
 	}
 
 	if !allowed {
-		return errors.MsgWithCode(fmt.Sprintf("user %q not allowed %q to %q", u.Name, permission, resourceTag), errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "user %q not allowed %q to %q", u.Name, permission, resourceTag)
 	}
 	return nil
 }

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -294,7 +294,7 @@ func (u *User) ListApplicationOffers(ctx context.Context, relation ofga.Relation
 // CheckPermission returns an Unauthorized error if user is not allowed specified permission to the resource.
 func (u *User) CheckPermission(ctx context.Context, resourceTag string, permission string) error {
 	if u.client == nil {
-		return errors.E(errors.CodeUnauthorized, "cannot check permission")
+		return errors.MsgWithCode("cannot check permission", errors.CodeUnauthorized)
 	}
 	resource, err := names.ParseTag(resourceTag)
 	if err != nil {
@@ -329,7 +329,7 @@ func (u *User) CheckPermission(ctx context.Context, resourceTag string, permissi
 	}
 
 	if !allowed {
-		return errors.E(errors.CodeUnauthorized, fmt.Sprintf("user %q not allowed %q to %q", u.Name, permission, resourceTag))
+		return errors.MsgWithCode(fmt.Sprintf("user %q not allowed %q to %q", u.Name, permission, resourceTag), errors.CodeUnauthorized)
 	}
 	return nil
 }
@@ -426,7 +426,7 @@ func unsetMultipleResourceAccesses[T ofganames.ResourceTagger](ctx context.Conte
 		}, pageSize, lastContinuationToken)
 
 		if err != nil {
-			return errors.E(err, "failed to retrieve existing relations")
+			return fmt.Errorf("failed to retrieve existing relations: %w", err)
 		}
 
 		for _, timestampedTuple := range timestampedTuples {
@@ -453,7 +453,7 @@ func unsetMultipleResourceAccesses[T ofganames.ResourceTagger](ctx context.Conte
 
 	err := user.client.RemoveRelation(ctx, tuplesToRemove...)
 	if err != nil {
-		return errors.E(err, "failed to remove relations")
+		return fmt.Errorf("failed to remove relations: %w", err)
 	}
 	return nil
 }

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -220,7 +220,7 @@ func (c *Client) Call(ctx context.Context, facade string, version int, id, metho
 		defer c.mu.Unlock()
 		return c.err
 	case <-ctx.Done():
-		return errors.E(ctx.Err())
+		return ctx.Err()
 	}
 }
 
@@ -242,7 +242,7 @@ func (c *Client) Close() error {
 	c.closing = true
 	cm := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
 	if err := c.conn.WriteControl(websocket.CloseMessage, cm, time.Time{}); err != nil {
-		c.err = errors.E("error closing connection", err)
+		c.err = fmt.Errorf("error closing connection: %w", err)
 		// If sending the close message failed then tear down the
 		// connection. Note that we don't need to clear up any
 		// outstanding messages here as the receiver will error and

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -335,7 +335,7 @@ func (p *modelProxy) auditLogMessage(msg *message, isResponse bool) error {
 		allErrors.Results = append(allErrors.Results, singleError)
 		jsonErr, err := json.Marshal(allErrors)
 		if err != nil {
-			return errors.E(err, "failed to marshal all errors")
+			return fmt.Errorf("failed to marshal all errors: %w", err)
 		}
 		ale.Errors = jsonErr
 	} else {
@@ -613,11 +613,11 @@ func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any
 func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]any) error {
 
 	if p.anonymousLogin {
-		return errors.E(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
+		return errors.MsgWithCode("Anonymous login does not support re-authentication", errors.CodeUnauthorized)
 	}
 	loginMsg := p.msgs.getLoginMessage()
 	if loginMsg == nil {
-		return errors.E(errors.CodeUnauthorized, "Haven't received login yet")
+		return errors.MsgWithCode("Haven't received login yet", errors.CodeUnauthorized)
 	}
 	err := addJWT(ctx, loginMsg, permissions, p.tokenGen)
 	if err != nil {
@@ -813,7 +813,7 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 			// return the client's login message verbatim to the controller.
 			return msg, nil
 		}
-		return nil, errors.E("JIMM does not support login from old clients", errors.CodeNotSupported)
+		return nil, errors.MsgWithCode("JIMM does not support login from old clients", errors.CodeNotSupported)
 	case names.ModelTag, names.MachineTag, names.UnitTag:
 		zapctx.Debug(ctx, "Legacy login request from agent", zap.String("tag", tag.String()))
 
@@ -828,11 +828,11 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 			Servers: redirectInfo.Addresses,
 			CACert:  redirectInfo.CACert,
 		}.AsMap()
-		errRedirect := errors.E(
-			errors.CodeRedirect,
-			"redirection to alternative server required",
-			info,
-		)
+		errRedirect := &errors.Error{
+			Code:    errors.CodeRedirect,
+			Message: "redirection to alternative server required",
+			Info:    info,
+		}
 
 		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Addresses))
 		return nil, errRedirect

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -613,11 +613,11 @@ func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any
 func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]any) error {
 
 	if p.anonymousLogin {
-		return errors.MsgWithCode("Anonymous login does not support re-authentication", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
 	}
 	loginMsg := p.msgs.getLoginMessage()
 	if loginMsg == nil {
-		return errors.MsgWithCode("Haven't received login yet", errors.CodeUnauthorized)
+		return errors.Codef(errors.CodeUnauthorized, "Haven't received login yet")
 	}
 	err := addJWT(ctx, loginMsg, permissions, p.tokenGen)
 	if err != nil {
@@ -813,7 +813,7 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 			// return the client's login message verbatim to the controller.
 			return msg, nil
 		}
-		return nil, errors.MsgWithCode("JIMM does not support login from old clients", errors.CodeNotSupported)
+		return nil, errors.Codef(errors.CodeNotSupported, "JIMM does not support login from old clients")
 	case names.ModelTag, names.MachineTag, names.UnitTag:
 		zapctx.Debug(ctx, "Legacy login request from agent", zap.String("tag", tag.String()))
 

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -140,7 +140,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
 	}, {
 		about: "login with client credentials - a login message is sent to the controller",
 		messageToSend: rpcproxy.Message{
@@ -171,7 +171,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
 	}, {
 		about: "login with username/password fails",
 		messageToSend: rpcproxy.Message{
@@ -310,7 +310,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
 	}, {
 		about: "connection to controller fails",
 		expectedClientResponse: &rpcproxy.Message{

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -137,7 +137,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		},
 		expectedClientResponse: &rpcproxy.Message{
 			RequestID: 1,
-			Error:     "unauthorized access",
+			Error:     "unauthorized",
 			ErrorCode: "unauthorized access",
 		},
 		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
@@ -168,7 +168,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		},
 		expectedClientResponse: &rpcproxy.Message{
 			RequestID: 1,
-			Error:     "unauthorized access",
+			Error:     "unauthorized",
 			ErrorCode: "unauthorized access",
 		},
 		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
@@ -307,7 +307,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		},
 		expectedClientResponse: &rpcproxy.Message{
 			RequestID: 1,
-			Error:     "unauthorized access",
+			Error:     "unauthorized",
 			ErrorCode: "unauthorized access",
 		},
 		oauthAuthenticatorError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -140,7 +140,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.E(errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
 	}, {
 		about: "login with client credentials - a login message is sent to the controller",
 		messageToSend: rpcproxy.Message{
@@ -171,7 +171,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.E(errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
 	}, {
 		about: "login with username/password fails",
 		messageToSend: rpcproxy.Message{
@@ -310,7 +310,7 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 			Error:     "unauthorized access",
 			ErrorCode: "unauthorized access",
 		},
-		oauthAuthenticatorError: errors.E(errors.CodeUnauthorized),
+		oauthAuthenticatorError: errors.ErrWithCode(nil, errors.CodeUnauthorized),
 	}, {
 		about: "connection to controller fails",
 		expectedClientResponse: &rpcproxy.Message{

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -105,7 +105,7 @@ func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt na
 	if d, ok := m[mt.Id()]; ok {
 		return d.Dial(ctx, ctl, mt, u)
 	}
-	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
+	return nil, errors.New(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }
 
 // A DialerMap implements a juju.Dialer that uses a different Dialer for
@@ -117,7 +117,7 @@ func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.M
 	if d, ok := m[ctl.Name]; ok {
 		return d.Dial(ctx, ctl, mt, u)
 	}
-	return nil, errors.E(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
+	return nil, errors.New(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
 }
 
 // API is a default implementation of the juju.API interface. Every method

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -105,7 +105,7 @@ func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt na
 	if d, ok := m[mt.Id()]; ok {
 		return d.Dial(ctx, ctl, mt, u)
 	}
-	return nil, errors.New(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
 
 // A DialerMap implements a juju.Dialer that uses a different Dialer for
@@ -117,7 +117,7 @@ func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.M
 	if d, ok := m[ctl.Name]; ok {
 		return d.Dial(ctx, ctl, mt, u)
 	}
-	return nil, errors.New(fmt.Sprintf("dialer not configured for controller %s", ctl.Name))
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
 
 // API is a default implementation of the juju.API interface. Every method

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -176,7 +176,7 @@ type API struct {
 
 func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
 	if a.Activate_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.Activate_(modelUUID, sourceInfo, relatedModels)
 }
@@ -184,35 +184,35 @@ func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControll
 // Abort aborts the current operation on the controller.
 func (a *API) Abort(modelUUID string) error {
 	if a.Abort_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.Abort_(modelUUID)
 }
 
 func (a *API) AddCloud(tag names.CloudTag, cld jujucloud.Cloud, force bool) error {
 	if a.AddCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.AddCloud_(tag, cld, force)
 }
 
 func (a *API) AdoptResources(modelUUID string, controllerVersion version.Number) error {
 	if a.AdoptResources_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.AdoptResources_(modelUUID, controllerVersion)
 }
 
 func (a *API) CheckCredentialModels(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 	if a.CheckCredentialModels_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.CheckCredentialModels_(ctx, cred)
 }
 
 func (a *API) CheckMachines(modelUUID string) ([]error, error) {
 	if a.CheckMachines_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.CheckMachines_(modelUUID)
 }
@@ -226,91 +226,91 @@ func (a *API) Close() error {
 
 func (a *API) Cloud(tag names.CloudTag) (jujucloud.Cloud, error) {
 	if a.Cloud_ == nil {
-		return jujucloud.Cloud{}, errors.E(errors.CodeNotImplemented)
+		return jujucloud.Cloud{}, errors.New("not implemented")
 	}
 	return a.Cloud_(tag)
 }
 
 func (a *API) Clouds() (map[names.CloudTag]jujucloud.Cloud, error) {
 	if a.Clouds_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.Clouds_()
 }
 
 func (a *API) CloudSpec(ctx context.Context) (cloudspec.CloudSpec, error) {
 	if a.CloudSpec_ == nil {
-		return cloudspec.CloudSpec{}, errors.E(errors.CodeNotImplemented)
+		return cloudspec.CloudSpec{}, errors.New("not implemented")
 	}
 	return a.CloudSpec_(ctx)
 }
 
 func (a *API) ControllerConfig(ctx context.Context) (jujucontroller.Config, error) {
 	if a.ControllerConfig_ == nil {
-		return jujucontroller.Config{}, errors.E(errors.CodeNotImplemented)
+		return jujucontroller.Config{}, errors.New("not implemented")
 	}
 	return a.ControllerConfig_(ctx)
 }
 
 func (a *API) CreateModel(ctx context.Context, args *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 	if a.CreateModel_ == nil {
-		return base.ModelInfo{}, errors.E(errors.CodeNotImplemented)
+		return base.ModelInfo{}, errors.New("not implemented")
 	}
 	return a.CreateModel_(ctx, args)
 }
 
 func (a *API) DestroyApplicationOffer(ctx context.Context, offerURL string, force bool) error {
 	if a.DestroyApplicationOffer_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.DestroyApplicationOffer_(ctx, offerURL, force)
 }
 
 func (a *API) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStorage *bool, force *bool, maxWait, timeout *time.Duration) error {
 	if a.DestroyModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.DestroyModel_(ctx, tag, destroyStorage, force, maxWait, timeout)
 }
 
 func (a *API) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
 	if a.DumpModel_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.DumpModel_(ctx, tag, simplified)
 }
 
 func (a *API) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
 	if a.DumpModelDB_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.DumpModelDB_(ctx, tag)
 }
 
 func (a *API) FindApplicationOffers(ctx context.Context, f []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	if a.FindApplicationOffers_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.FindApplicationOffers_(ctx, f)
 }
 
 func (a *API) GetApplicationOffer(ctx context.Context, urlStr string) (*crossmodel.ApplicationOfferDetails, error) {
 	if a.GetApplicationOffer_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.GetApplicationOffer_(ctx, urlStr)
 }
 
 func (a *API) GetApplicationOfferConsumeDetails(ctx context.Context, url string) (jujuparams.ConsumeOfferDetails, error) {
 	if a.GetApplicationOfferConsumeDetails_ == nil {
-		return jujuparams.ConsumeOfferDetails{}, errors.E(errors.CodeNotImplemented)
+		return jujuparams.ConsumeOfferDetails{}, errors.New("not implemented")
 	}
 	return a.GetApplicationOfferConsumeDetails_(ctx, url)
 }
 
 func (a *API) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
 	if a.GrantJIMMModelAdmin_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.GrantJIMMModelAdmin_(ctx, tag)
 }
@@ -321,42 +321,42 @@ func (a *API) IsBroken() bool {
 
 func (a *API) ListApplicationOffers(ctx context.Context, f []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	if a.ListApplicationOffers_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListApplicationOffers_(ctx, f)
 }
 
 func (a *API) ModelInfo(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
 	if a.ModelInfo_ == nil {
-		return jujuclient.ModelInfo{}, errors.E(errors.CodeNotImplemented)
+		return jujuclient.ModelInfo{}, errors.New("not implemented")
 	}
 	return a.ModelInfo_(ctx, model)
 }
 
 func (a *API) ModelStatus(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
 	if a.ModelStatus_ == nil {
-		return base.ModelStatus{}, errors.E(errors.CodeNotImplemented)
+		return base.ModelStatus{}, errors.New("not implemented")
 	}
 	return a.ModelStatus_(ctx, modelTag)
 }
 
 func (a *API) LatestLogTime(modelUUID string) (time.Time, error) {
 	if a.LatestLogTime_ == nil {
-		return time.Time{}, errors.E(errors.CodeNotImplemented)
+		return time.Time{}, errors.New("not implemented")
 	}
 	return a.LatestLogTime_(modelUUID)
 }
 
 func (a *API) ListModelSummaries(ctx context.Context, ms jujuparams.ModelSummariesRequest) ([]base.UserModelSummary, error) {
 	if a.ListModelSummaries_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListModelSummaries_(ctx, ms)
 }
 
 func (a *API) Offer(ctx context.Context, offer jujuclient.OfferParams) error {
 	if a.Offer_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.Offer_(ctx, offer)
 }
@@ -370,21 +370,21 @@ func (a *API) Ping(ctx context.Context) error {
 
 func (a *API) Prechecks(model jujuparams.MigrationModelInfo) error {
 	if a.Prechecks_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.Prechecks_(model)
 }
 
 func (a *API) RemoveCloud(tag names.CloudTag) error {
 	if a.RemoveCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.RemoveCloud_(tag)
 }
 
 func (a *API) RevokeCredential(ctx context.Context, tag names.CloudCredentialTag) error {
 	if a.RevokeCredential_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.RevokeCredential_(ctx, tag)
 }
@@ -395,91 +395,91 @@ func (a *API) SupportsModelSummaryWatcher() bool {
 
 func (a *API) Status(ctx context.Context, patterns []string) (*jujuparams.FullStatus, error) {
 	if a.Status_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.Status_(ctx, patterns)
 }
 
 func (a *API) UpdateCloud(tag names.CloudTag, cloud jujucloud.Cloud) error {
 	if a.UpdateCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.UpdateCloud_(tag, cloud)
 }
 
 func (a *API) UpdateCloudsCredentialForce(ctx context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
 	if a.UpdateCloudsCredentialForce_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.UpdateCloudsCredentialForce_(ctx, cred)
 }
 
 func (a *API) ValidateModelUpgrade(ctx context.Context, model names.ModelTag, force bool) error {
 	if a.ValidateModelUpgrade_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.ValidateModelUpgrade_(ctx, model, force)
 }
 
 func (a *API) WatchAllModelSummaries(ctx context.Context) (jujuclient.SummaryWatcher, error) {
 	if a.WatchAllModelSummaries_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.WatchAllModelSummaries_(ctx)
 }
 
 func (a *API) ChangeModelCredential(ctx context.Context, model names.ModelTag, credential names.CloudCredentialTag) error {
 	if a.ChangeModelCredential_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.ChangeModelCredential_(ctx, model, credential)
 }
 
 func (a *API) ListFilesystems(ctx context.Context, machines []string) ([]jujuparams.FilesystemDetailsListResult, error) {
 	if a.ListFilesystems_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListFilesystems_(ctx, machines)
 }
 
 func (a *API) ListVolumes(ctx context.Context, machines []string) ([]jujuparams.VolumeDetailsListResult, error) {
 	if a.ListVolumes_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListVolumes_(ctx, machines)
 }
 
 func (a *API) ListStorageDetails(ctx context.Context) ([]jujuparams.StorageDetails, error) {
 	if a.ListStorageDetails_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListStorageDetails_(ctx)
 }
 
 func (a *API) ListModels(ctx context.Context) ([]base.UserModel, error) {
 	if a.ListModels_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.ListModels_(ctx)
 }
 
 func (a *API) Import(bytes []byte) error {
 	if a.Import_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return a.Import_(bytes)
 }
 
 func (a *API) CredentialContents(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error) {
 	if a.CredentialContents_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return a.CredentialContents(cloud, credential, withSecrets)
 }
 
 func (a *API) UpgradeModel(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
 	if a.UpgradeModel_ == nil {
-		return version.Number{}, errors.E(errors.CodeNotImplemented)
+		return version.Number{}, errors.New("not implemented")
 	}
 	return a.UpgradeModel_(modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
 }

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -120,7 +120,7 @@ func (m *mockOAuthAuthenticator) DeviceAccessToken(ctx context.Context, res *oau
 // Notice the use of jwt.ParseInsecure to skip JWT signature verification.
 func (m *mockOAuthAuthenticator) VerifySessionToken(token string) (jwt.Token, error) {
 	errorFn := func(err error) error {
-		return jimmerrors.ErrWithCode(err, jimmerrors.CodeSessionTokenInvalid)
+		return jimmerrors.Codef(jimmerrors.CodeSessionTokenInvalid, "%w", err)
 	}
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -120,7 +120,7 @@ func (m *mockOAuthAuthenticator) DeviceAccessToken(ctx context.Context, res *oau
 // Notice the use of jwt.ParseInsecure to skip JWT signature verification.
 func (m *mockOAuthAuthenticator) VerifySessionToken(token string) (jwt.Token, error) {
 	errorFn := func(err error) error {
-		return jimmerrors.E(err, jimmerrors.CodeSessionTokenInvalid)
+		return jimmerrors.ErrWithCode(err, jimmerrors.CodeSessionTokenInvalid)
 	}
 	decodedToken, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-
-	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 // These constants are based on the `docker-compose.yaml` and `local/keycloak/jimm-realm.json` content.
@@ -105,7 +103,7 @@ func getAdminCLIAccessToken() (string, error) {
 		return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for admin CLI login (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.New(fmt.Sprintf("failed to login with keycloak admin CLI user (status-code: %d): %q", resp.StatusCode, string(body)))
+		return "", fmt.Errorf("failed to login with keycloak admin CLI user (status-code: %d): %q", resp.StatusCode, string(body))
 	}
 
 	m := map[string]any{}
@@ -149,7 +147,7 @@ func getKeycloakUsersMap(adminCLIToken string) (map[string]string, error) {
 		return nil, fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for list of users (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf("failed to get users from keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
+		return nil, fmt.Errorf("failed to get users from keycloak (status-code: %d): %q", resp.StatusCode, string(body))
 	}
 
 	var raw []struct {
@@ -175,7 +173,7 @@ func getKeycloakUserId(adminCLIToken, username string) (string, error) {
 	}
 
 	if id, ok := m[username]; !ok {
-		return "", errors.New(fmt.Sprintf("keycloak user not found: %q", username))
+		return "", fmt.Errorf("keycloak user not found: %q", username)
 	} else {
 		return id, nil
 	}
@@ -221,7 +219,7 @@ func addKeycloakUser(adminCLIToken, email, username string) error {
 		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to add user (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return errors.New(fmt.Sprintf("failed to add user to keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
+		return fmt.Errorf("failed to add user to keycloak (status-code: %d): %q", resp.StatusCode, string(body))
 	}
 	return nil
 }
@@ -264,7 +262,7 @@ func setKeycloakUserPassword(adminCLIToken, id, password string) error {
 		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to set user password (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusNoContent {
-		return errors.New(fmt.Sprintf("failed to set keycloak user password (status-code: %d): %q", resp.StatusCode, string(body)))
+		return fmt.Errorf("failed to set keycloak user password (status-code: %d): %q", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -100,7 +100,7 @@ func getAdminCLIAccessToken() (string, error) {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for admin CLI login (status-code: %d)", resp.StatusCode), err)
+		return "", fmt.Errorf("failed to read keycloak response for admin CLI login (status-code: %d): %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("failed to login with keycloak admin CLI user (status-code: %d): %q", resp.StatusCode, string(body))
@@ -108,14 +108,14 @@ func getAdminCLIAccessToken() (string, error) {
 
 	m := map[string]any{}
 	if err := json.Unmarshal(body, &m); err != nil {
-		return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse keycloak response for admin CLI login: %q", string(body)), err)
+		return "", fmt.Errorf("failed to parse keycloak response for admin CLI login: %q: %w", string(body), err)
 	}
 
 	if _, ok := m["access_token"]; !ok {
-		return "", fmt.Errorf("%s: %w", fmt.Sprintf("cannot find access token in keycloak response: %q", string(body)), err)
+		return "", fmt.Errorf("cannot find access token in keycloak response: %q: %w", string(body), err)
 	}
 	if token, ok := m["access_token"].(string); !ok {
-		return "", fmt.Errorf("%s: %w", fmt.Sprintf("received token is not string: %v", m["access_token"]), err)
+		return "", fmt.Errorf("received token is not string: %v: %w", m["access_token"], err)
 	} else {
 		return token, nil
 	}
@@ -144,7 +144,7 @@ func getKeycloakUsersMap(adminCLIToken string) (map[string]string, error) {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for list of users (status-code: %d)", resp.StatusCode), err)
+		return nil, fmt.Errorf("failed to read keycloak response for list of users (status-code: %d): %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get users from keycloak (status-code: %d): %q", resp.StatusCode, string(body))
@@ -155,7 +155,7 @@ func getKeycloakUsersMap(adminCLIToken string) (map[string]string, error) {
 		Username string `json:"username"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse keycloak response for list of users: %q", string(body)), err)
+		return nil, fmt.Errorf("failed to parse keycloak response for list of users: %q: %w", string(body), err)
 	}
 
 	result := map[string]string{}
@@ -216,7 +216,7 @@ func addKeycloakUser(adminCLIToken, email, username string) error {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to add user (status-code: %d)", resp.StatusCode), err)
+		return fmt.Errorf("failed to read keycloak response to add user (status-code: %d): %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to add user to keycloak (status-code: %d): %q", resp.StatusCode, string(body))
@@ -259,7 +259,7 @@ func setKeycloakUserPassword(adminCLIToken, id, password string) error {
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to set user password (status-code: %d)", resp.StatusCode), err)
+		return fmt.Errorf("failed to read keycloak response to set user password (status-code: %d): %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("failed to set keycloak user password (status-code: %d): %q", resp.StatusCode, string(body))

--- a/internal/testutils/jimmtest/keycloak.go
+++ b/internal/testutils/jimmtest/keycloak.go
@@ -96,28 +96,28 @@ func getAdminCLIAccessToken() (string, error) {
 		strings.NewReader(reqBody.Encode()),
 	)
 	if err != nil {
-		return "", errors.E(err, "failed to login with keycloak admin CLI user")
+		return "", fmt.Errorf("failed to login with keycloak admin CLI user: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.E(err, fmt.Sprintf("failed to read keycloak response for admin CLI login (status-code: %d)", resp.StatusCode))
+		return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for admin CLI login (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.E(fmt.Sprintf("failed to login with keycloak admin CLI user (status-code: %d): %q", resp.StatusCode, string(body)))
+		return "", errors.New(fmt.Sprintf("failed to login with keycloak admin CLI user (status-code: %d): %q", resp.StatusCode, string(body)))
 	}
 
 	m := map[string]any{}
 	if err := json.Unmarshal(body, &m); err != nil {
-		return "", errors.E(err, fmt.Sprintf("failed to parse keycloak response for admin CLI login: %q", string(body)))
+		return "", fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse keycloak response for admin CLI login: %q", string(body)), err)
 	}
 
 	if _, ok := m["access_token"]; !ok {
-		return "", errors.E(err, fmt.Sprintf("cannot find access token in keycloak response: %q", string(body)))
+		return "", fmt.Errorf("%s: %w", fmt.Sprintf("cannot find access token in keycloak response: %q", string(body)), err)
 	}
 	if token, ok := m["access_token"].(string); !ok {
-		return "", errors.E(err, fmt.Sprintf("received token is not string: %v", m["access_token"]))
+		return "", fmt.Errorf("%s: %w", fmt.Sprintf("received token is not string: %v", m["access_token"]), err)
 	} else {
 		return token, nil
 	}
@@ -140,16 +140,16 @@ func getKeycloakUsersMap(adminCLIToken string) (map[string]string, error) {
 	req.Header.Add("Content-Type", "application/json")
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, errors.E(err, "failed to get users from keycloak")
+		return nil, fmt.Errorf("failed to get users from keycloak: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.E(err, fmt.Sprintf("failed to read keycloak response for list of users (status-code: %d)", resp.StatusCode))
+		return nil, fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response for list of users (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.E(fmt.Sprintf("failed to get users from keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
+		return nil, errors.New(fmt.Sprintf("failed to get users from keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
 	}
 
 	var raw []struct {
@@ -157,7 +157,7 @@ func getKeycloakUsersMap(adminCLIToken string) (map[string]string, error) {
 		Username string `json:"username"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, errors.E(err, fmt.Sprintf("failed to parse keycloak response for list of users: %q", string(body)))
+		return nil, fmt.Errorf("%s: %w", fmt.Sprintf("failed to parse keycloak response for list of users: %q", string(body)), err)
 	}
 
 	result := map[string]string{}
@@ -175,7 +175,7 @@ func getKeycloakUserId(adminCLIToken, username string) (string, error) {
 	}
 
 	if id, ok := m[username]; !ok {
-		return "", errors.E(fmt.Sprintf("keycloak user not found: %q", username))
+		return "", errors.New(fmt.Sprintf("keycloak user not found: %q", username))
 	} else {
 		return id, nil
 	}
@@ -212,16 +212,16 @@ func addKeycloakUser(adminCLIToken, email, username string) error {
 	req.Header.Add("Content-Type", "application/json")
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return errors.E(err, "failed to add user to keycloak")
+		return fmt.Errorf("failed to add user to keycloak: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.E(err, fmt.Sprintf("failed to read keycloak response to add user (status-code: %d)", resp.StatusCode))
+		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to add user (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return errors.E(fmt.Sprintf("failed to add user to keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
+		return errors.New(fmt.Sprintf("failed to add user to keycloak (status-code: %d): %q", resp.StatusCode, string(body)))
 	}
 	return nil
 }
@@ -255,16 +255,16 @@ func setKeycloakUserPassword(adminCLIToken, id, password string) error {
 	req.Header.Add("Content-Type", "application/json")
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return errors.E(err, "failed to set keycloak user password")
+		return fmt.Errorf("failed to set keycloak user password: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.E(err, fmt.Sprintf("failed to read keycloak response to set user password (status-code: %d)", resp.StatusCode))
+		return fmt.Errorf("%s: %w", fmt.Sprintf("failed to read keycloak response to set user password (status-code: %d)", resp.StatusCode), err)
 	}
 	if resp.StatusCode != http.StatusNoContent {
-		return errors.E(fmt.Sprintf("failed to set keycloak user password (status-code: %d): %q", resp.StatusCode, string(body)))
+		return errors.New(fmt.Sprintf("failed to set keycloak user password (status-code: %d): %q", resp.StatusCode, string(body)))
 	}
 	return nil
 }

--- a/internal/testutils/jimmtest/mocks/jimm_auditlog_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_auditlog_mock.go
@@ -26,13 +26,13 @@ func (j *AuditLogManager) AddAuditLogEntry(ale *dbmodel.AuditLogEntry) {
 }
 func (j *AuditLogManager) FindAuditEvents(ctx context.Context, user *openfga.User, filter db.AuditLogFilter) ([]dbmodel.AuditLogEntry, error) {
 	if j.FindAuditEvents_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.FindAuditEvents_(ctx, user, filter)
 }
 func (j *AuditLogManager) PurgeLogs(ctx context.Context, user *openfga.User, before time.Time) (int64, error) {
 	if j.PurgeLogs_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return j.PurgeLogs_(ctx, user, before)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_bootstrap_mock.go
@@ -23,49 +23,49 @@ type BootstapManager struct {
 
 func (b *BootstapManager) GetJobInfo(ctx context.Context, user *openfga.User, jobId int64, offset int) (params.GetBootstrapInfoResponse, error) {
 	if b.GetJobInfo_ == nil {
-		return params.GetBootstrapInfoResponse{}, errors.E(errors.CodeNotImplemented)
+		return params.GetBootstrapInfoResponse{}, errors.New("not implemented")
 	}
 	return b.GetJobInfo_(ctx, user, jobId, offset)
 }
 
 func (b *BootstapManager) StopJob(ctx context.Context, user *openfga.User, jobId int64) error {
 	if b.StopJob_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return b.StopJob_(ctx, user, jobId)
 }
 
 func (b *BootstapManager) StartBootstrapJob(ctx context.Context, user *openfga.User, params bootstrap.BootstrapParams) (int64, error) {
 	if b.StartBootstrapJob_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return b.StartBootstrapJob_(ctx, user, params)
 }
 
 func (b *BootstapManager) StartDestroyControllerJob(ctx context.Context, user *openfga.User, params bootstrap.DestroyControllerParams) (int64, error) {
 	if b.StartDestroyControllerJob_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return b.StartDestroyControllerJob_(ctx, user, params)
 }
 
 func (b *BootstapManager) WaitForJobCompletion(ctx context.Context, jobId int64, config bootstrap.WaitConfig) error {
 	if b.WaitForJobCompletion_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return b.WaitForJobCompletion_(ctx, jobId, config)
 }
 
 func (b *BootstapManager) BootstrapController(ctx context.Context, p bootstrap.RunBootstrapArgs, cmdFactory bootstrap.CommandFactory, user *openfga.User) error {
 	if b.BootstrapController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return b.BootstrapController_(ctx, p, cmdFactory, user)
 }
 
 func (b *BootstapManager) DestroyController(ctx context.Context, p bootstrap.RunDestroyControllerArgs, cmdFactory bootstrap.CommandFactory, user *openfga.User) error {
 	if b.DestroyController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return b.DestroyController_(ctx, p, cmdFactory, user)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_group_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_group_mock.go
@@ -29,49 +29,49 @@ type GroupManager struct {
 
 func (j *GroupManager) AddGroup(ctx context.Context, u *openfga.User, name string) (*dbmodel.GroupEntry, error) {
 	if j.AddGroup_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.AddGroup_(ctx, u, name)
 }
 
 func (j *GroupManager) CountGroups(ctx context.Context, user *openfga.User) (int, error) {
 	if j.CountGroups_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return j.CountGroups_(ctx, user)
 }
 
 func (j *GroupManager) GetGroupByUUID(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error) {
 	if j.GetGroupByUUID_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetGroupByUUID_(ctx, user, uuid)
 }
 
 func (j *GroupManager) GetGroupByName(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
 	if j.GetGroupByName_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetGroupByName_(ctx, user, name)
 }
 
 func (j *GroupManager) ListGroups(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.GroupEntry, error) {
 	if j.ListGroups_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListGroups_(ctx, user, pagination, match)
 }
 
 func (j *GroupManager) RemoveGroup(ctx context.Context, user *openfga.User, name string) error {
 	if j.RemoveGroup_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveGroup_(ctx, user, name)
 }
 
 func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error {
 	if j.RenameGroup_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RenameGroup_(ctx, user, oldName, newName)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_identity_mock.go
@@ -19,19 +19,19 @@ type IdentityManager struct {
 
 func (i *IdentityManager) FetchIdentity(ctx context.Context, id string) (*openfga.User, error) {
 	if i.FetchIdentity_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return i.FetchIdentity_(ctx, id)
 }
 func (i *IdentityManager) ListIdentities(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 	if i.ListIdentities_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return i.ListIdentities_(ctx, user, pagination, match)
 }
 func (i *IdentityManager) CountIdentities(ctx context.Context, user *openfga.User) (int, error) {
 	if i.CountIdentities_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return i.CountIdentities_(ctx, user)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
@@ -17,14 +17,14 @@ type JobManager struct {
 
 func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error) {
 	if j.GetJobInfo_ == nil {
-		return jobs.JobInfo{}, errors.E(errors.CodeNotImplemented)
+		return jobs.JobInfo{}, errors.New("not implemented")
 	}
 	return j.GetJobInfo_(ctx, jobID)
 }
 
 func (j *JobManager) ListJobs(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error) {
 	if j.ListJobs_ == nil {
-		return params.ListJobsResponse{}, errors.E(errors.CodeNotImplemented)
+		return params.ListJobsResponse{}, errors.New("not implemented")
 	}
 	return j.ListJobs_(ctx, req)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -29,63 +29,63 @@ type ControllerService struct {
 
 func (j *ControllerService) AddController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error {
 	if j.AddController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AddController_(ctx, u, ctl, creds)
 }
 
 func (j *ControllerService) ControllerDetailsForModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 	if j.ControllerDetailsForModel_ == nil {
-		return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotImplemented)
+		return juju.ControllerConnectionDetails{}, errors.New("not implemented")
 	}
 	return j.ControllerDetailsForModel_(ctx, modelUUID)
 }
 
 func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error) {
 	if j.ControllerDetailsForIncomingModel_ == nil {
-		return juju.ControllerConnectionDetails{}, errors.E(errors.CodeNotImplemented)
+		return juju.ControllerConnectionDetails{}, errors.New("not implemented")
 	}
 	return j.ControllerDetailsForIncomingModel_(ctx, modelUUID)
 }
 
 func (j *ControllerService) ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error) {
 	if j.ControllerInfo_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ControllerInfo_(ctx, name)
 }
 
 func (j *ControllerService) EarliestControllerVersion(ctx context.Context) (version.Number, error) {
 	if j.EarliestControllerVersion_ == nil {
-		return version.Number{}, errors.E(errors.CodeNotImplemented)
+		return version.Number{}, errors.New("not implemented")
 	}
 	return j.EarliestControllerVersion_(ctx)
 }
 
 func (j *ControllerService) ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error) {
 	if j.ListControllers_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListControllers_(ctx, user)
 }
 
 func (j *ControllerService) RemoveController(ctx context.Context, user *openfga.User, controllerName string, force bool) error {
 	if j.RemoveController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveController_(ctx, user, controllerName, force)
 }
 
 func (j *ControllerService) SetControllerDeprecated(ctx context.Context, user *openfga.User, controllerName string, deprecated bool) error {
 	if j.SetControllerDeprecated_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.SetControllerDeprecated_(ctx, user, controllerName, deprecated)
 }
 
 func (j *ControllerService) ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error) {
 	if j.ControllerConfig_ == nil {
-		return jujucontroller.Config{}, errors.E(errors.CodeNotImplemented)
+		return jujucontroller.Config{}, errors.New("not implemented")
 	}
 	return j.ControllerConfig_(ctx, user, controllerName)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_migration_mock.go
@@ -29,56 +29,56 @@ type MigrationMocks struct {
 
 func (j *MigrationMocks) AbortMigration(ctx context.Context, user *openfga.User, modelUUID string) error {
 	if j.AbortMigration_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AbortMigration_(ctx, user, modelUUID)
 }
 
 func (j *MigrationMocks) Prechecks(ctx context.Context, user *openfga.User, model juju.MigratingModelInfo) error {
 	if j.Prechecks_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.Prechecks_(ctx, user, model)
 }
 
 func (j *MigrationMocks) AdoptResources(ctx context.Context, user *openfga.User, modelUUID string, sourceControllerVersion version.Number) error {
 	if j.AdoptResources_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AdoptResources_(ctx, user, modelUUID, sourceControllerVersion)
 }
 
 func (j *MigrationMocks) Activate(ctx context.Context, user *openfga.User, modelTag names.ModelTag, sourceControllerInfo migration.SourceControllerInfo, relatedModels []string) error {
 	if j.Activate_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.Activate_(ctx, user, modelTag, sourceControllerInfo, relatedModels)
 }
 
 func (j *MigrationMocks) CheckMachines(ctx context.Context, user *openfga.User, modelUUID string) ([]error, error) {
 	if j.CheckMachines_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.CheckMachines_(ctx, user, modelUUID)
 }
 
 func (j *MigrationMocks) LatestLogTime(ctx context.Context, user *openfga.User, modelUUID string) (time.Time, error) {
 	if j.LatestLogTime_ == nil {
-		return time.Time{}, errors.E(errors.CodeNotImplemented)
+		return time.Time{}, errors.New("not implemented")
 	}
 	return j.LatestLogTime_(ctx, user, modelUUID)
 }
 
 func (j *MigrationMocks) Import(ctx context.Context, user *openfga.User, serialized jujuparams.SerializedModel) error {
 	if j.Import_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.Import_(ctx, user, serialized)
 }
 
 func (j *MigrationMocks) ListMigrationTargets(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error) {
 	if j.ListMigrationTargets_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListMigrationTargets_(ctx, user, modelTag)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -77,87 +77,87 @@ func (j *JujuManager) AddAuditLogEntry(ale *dbmodel.AuditLogEntry) {
 }
 func (j *JujuManager) AddCloudToController(ctx context.Context, user *openfga.User, controllerName string, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error {
 	if j.AddCloudToController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AddCloudToController_(ctx, user, controllerName, tag, cloud, force)
 }
 func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) error {
 	if j.AddHostedCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AddHostedCloud_(ctx, user, tag, cloud, force)
 }
 func (j *JujuManager) CopyCredential(ctx context.Context, originalUser *openfga.User, newUser *openfga.User, cred names.CloudCredentialTag) (names.CloudCredentialTag, []jujuparams.UpdateCredentialModelResult, error) {
 	if j.CopyCredential_ == nil {
-		return names.CloudCredentialTag{}, nil, errors.E(errors.CodeNotImplemented)
+		return names.CloudCredentialTag{}, nil, errors.New("not implemented")
 	}
 	return j.CopyCredential_(ctx, originalUser, newUser, cred)
 }
 func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offerURL string, force bool) error {
 	if j.DestroyOffer_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.DestroyOffer_(ctx, user, offerURL, force)
 }
 func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	if j.FindApplicationOffers_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.FindApplicationOffers_(ctx, user, filters...)
 }
 func (j *JujuManager) FindAuditEvents(ctx context.Context, user *openfga.User, filter db.AuditLogFilter) ([]dbmodel.AuditLogEntry, error) {
 	if j.FindAuditEvents_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.FindAuditEvents_(ctx, user, filter)
 }
 func (j *JujuManager) ForEachCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
 	if j.ForEachCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ForEachCloud_(ctx, user, f)
 }
 
 func (j *JujuManager) ForEachUserCloud(ctx context.Context, user *openfga.User, f func(*dbmodel.Cloud) error) error {
 	if j.ForEachUserCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ForEachUserCloud_(ctx, user, f)
 }
 func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel.Identity, ct names.CloudTag, f func(cred *dbmodel.CloudCredential) error) error {
 	if j.ForEachUserCloudCredential_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ForEachUserCloudCredential_(ctx, u, ct, f)
 }
 
 func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.User, offerURL string) (*crossmodel.ApplicationOfferDetails, error) {
 	if j.GetApplicationOffer_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetApplicationOffer_(ctx, user, offerURL)
 }
 func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, user *openfga.User, details *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
 	if j.GetApplicationOfferConsumeDetails_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GetApplicationOfferConsumeDetails_(ctx, user, details, v)
 }
 func (j *JujuManager) GetCloud(ctx context.Context, u *openfga.User, tag names.CloudTag) (dbmodel.Cloud, error) {
 	if j.GetCloud_ == nil {
-		return dbmodel.Cloud{}, errors.E(errors.CodeNotImplemented)
+		return dbmodel.Cloud{}, errors.New("not implemented")
 	}
 	return j.GetCloud_(ctx, u, tag)
 }
 func (j *JujuManager) GetCloudCredential(ctx context.Context, user *openfga.User, tag names.CloudCredentialTag) (*dbmodel.CloudCredential, error) {
 	if j.GetCloudCredential_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetCloudCredential_(ctx, user, tag)
 }
 func (j *JujuManager) GetCloudCredentialAttributes(ctx context.Context, u *openfga.User, cred *dbmodel.CloudCredential, hidden bool) (attrs map[string]string, redacted []string, err error) {
 	if j.GetCloudCredentialAttributes_ == nil {
-		return nil, nil, errors.E(errors.CodeNotImplemented)
+		return nil, nil, errors.New("not implemented")
 	}
 	return j.GetCloudCredentialAttributes_(ctx, u, cred, hidden)
 }
@@ -171,79 +171,79 @@ func (j *JujuManager) GetCredentialStore() jimmcreds.CredentialStore {
 
 func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {
 	if j.InitiateMigration_ == nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(errors.CodeNotImplemented)
+		return jujuparams.InitiateMigrationResult{}, errors.New("not implemented")
 	}
 	return j.InitiateMigration_(ctx, user, spec)
 }
 func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error) {
 	if j.InitiateInternalMigration_ == nil {
-		return jujuparams.InitiateMigrationResult{}, errors.E(errors.CodeNotImplemented)
+		return jujuparams.InitiateMigrationResult{}, errors.New("not implemented")
 	}
 	return j.InitiateInternalMigration_(ctx, user, modelNameOrUUID, targetController)
 }
 func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
 	if j.ListApplicationOffers_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListApplicationOffers_(ctx, user, filters...)
 }
 func (j *JujuManager) ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error) {
 	if j.ListResources_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListResources_(ctx, user, filter, namePrefixFilter, typeFilter)
 }
 func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer juju.AddApplicationOfferParams) error {
 	if j.Offer_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.Offer_(ctx, user, offer)
 }
 func (j *JujuManager) PurgeLogs(ctx context.Context, user *openfga.User, before time.Time) (int64, error) {
 	if j.PurgeLogs_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return j.PurgeLogs_(ctx, user, before)
 }
 func (j *JujuManager) RemoveCloud(ctx context.Context, u *openfga.User, ct names.CloudTag) error {
 	if j.RemoveCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveCloud_(ctx, u, ct)
 }
 func (j *JujuManager) RemoveCloudFromController(ctx context.Context, u *openfga.User, controllerName string, ct names.CloudTag) error {
 	if j.RemoveCloudFromController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveCloudFromController_(ctx, u, controllerName, ct)
 }
 func (j *JujuManager) RevokeCloudCredential(ctx context.Context, user *dbmodel.Identity, tag names.CloudCredentialTag) error {
 	if j.RevokeCloudCredential_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeCloudCredential_(ctx, user, tag)
 }
 func (j *JujuManager) UpdateApplicationOffer(ctx context.Context, controller *dbmodel.Controller, offerUUID string, removed bool) error {
 	if j.UpdateApplicationOffer_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.UpdateApplicationOffer_(ctx, controller, offerUUID, removed)
 }
 func (j *JujuManager) UpdateCloud(ctx context.Context, u *openfga.User, ct names.CloudTag, cloud jujucloud.Cloud) error {
 	if j.UpdateCloud_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.UpdateCloud_(ctx, u, ct, cloud)
 }
 func (j *JujuManager) UpdateCloudCredential(ctx context.Context, u *openfga.User, args juju.UpdateCloudCredentialArgs) ([]jujuparams.UpdateCredentialModelResult, error) {
 	if j.UpdateCloudCredential_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.UpdateCloudCredential_(ctx, u, args)
 }
 func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]base.UserModel, error) {
 	if j.ListModels_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListModels_(ctx, user)
 }
@@ -255,28 +255,28 @@ func (j *JujuManager) UpdateMetrics(ctx context.Context) {
 }
 func (j *JujuManager) PollModels(ctx context.Context) error {
 	if j.PollModels_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.PollModels_(ctx)
 }
 
 func (j *JujuManager) GrantOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
 	if j.GrantOfferAccessOnController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GrantOfferAccessOnController_(ctx, user, ut, offerURL, access)
 }
 
 func (j *JujuManager) RevokeOfferAccessOnController(ctx context.Context, user *openfga.User, ut names.UserTag, offerURL string, access jujuparams.OfferAccessPermission) error {
 	if j.RevokeOfferAccessOnController_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeOfferAccessOnController_(ctx, user, ut, offerURL, access)
 }
 
 func (j *JujuManager) PrepareModelMigration(ctx context.Context, user *openfga.User, modelUUID string, targetControllerName string, userMapping map[string]string) (string, error) {
 	if j.PrepareModelMigration_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.PrepareModelMigration_(ctx, user, modelUUID, targetControllerName, userMapping)
 }
@@ -290,7 +290,7 @@ func (j *JujuManager) CleanupPartialModelMigrations(ctx context.Context) error {
 
 func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error) {
 	if j.ModelControllerInfo_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ModelControllerInfo_(ctx, user, qualifier)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -297,7 +297,7 @@ func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.Use
 
 func (j *JujuManager) SupportedVersions(ctx context.Context, minVersion *string) (params.SupportedJujuVersionsResponse, error) {
 	if j.SupportedVersions_ == nil {
-		return params.SupportedJujuVersionsResponse{}, errors.E(errors.CodeNotImplemented)
+		return params.SupportedJujuVersionsResponse{}, errors.New("not implemented")
 	}
 	return j.SupportedVersions_(ctx, minVersion)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
@@ -45,142 +45,142 @@ type ModelManager struct {
 
 func (j *ModelManager) AddModel(ctx context.Context, u *openfga.User, args *juju.ModelCreateArgs) (_ base.ModelInfo, err error) {
 	if j.AddModel_ == nil {
-		return base.ModelInfo{}, errors.E(errors.CodeNotImplemented)
+		return base.ModelInfo{}, errors.New("not implemented")
 	}
 	return j.AddModel_(ctx, u, args)
 }
 
 func (j *ModelManager) ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error {
 	if j.ChangeModelCredential_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ChangeModelCredential_(ctx, user, modelTag, cloudCredentialTag)
 }
 
 func (j *ModelManager) DestroyModel(ctx context.Context, u *openfga.User, mt names.ModelTag, destroyStorage *bool, force *bool, maxWait *time.Duration, timeout *time.Duration) error {
 	if j.DestroyModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.DestroyModel_(ctx, u, mt, destroyStorage, force, maxWait, timeout)
 }
 
 func (j *ModelManager) DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]interface{}, error) {
 	if j.DumpModel_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.DumpModel_(ctx, u, mt, simplified)
 }
 func (j *ModelManager) DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]interface{}, error) {
 	if j.DumpModelDB_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.DumpModelDB_(ctx, u, mt)
 }
 
 func (j *ModelManager) ForEachModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error {
 	if j.ForEachModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ForEachModel_(ctx, u, f)
 }
 
 func (j *ModelManager) ForEachUserModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, string) error) error {
 	if j.ForEachUserModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ForEachUserModel_(ctx, u, f)
 }
 
 func (j *ModelManager) FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error) {
 	if j.FullModelStatus_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.FullModelStatus_(ctx, user, modelTag, patterns)
 }
 
 func (j *ModelManager) GetModel(ctx context.Context, uuid string) (dbmodel.Model, error) {
 	if j.GetModel_ == nil {
-		return dbmodel.Model{}, errors.E(errors.CodeNotImplemented)
+		return dbmodel.Model{}, errors.New("not implemented")
 	}
 	return j.GetModel_(ctx, uuid)
 }
 
 func (j *ModelManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
 	if j.ImportModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ImportModel_(ctx, user, controllerName, modelTag, newOwner)
 }
 
 func (j *ModelManager) ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error) {
 	if j.ModelDefaultsForCloud_ == nil {
-		return jujuparams.ModelDefaultsResult{}, errors.E(errors.CodeNotImplemented)
+		return jujuparams.ModelDefaultsResult{}, errors.New("not implemented")
 	}
 	return j.ModelDefaultsForCloud_(ctx, user, cloudTag)
 }
 
 func (j *ModelManager) ModelInfo(ctx context.Context, u *openfga.User, mt names.ModelTag) (jujuclient.ModelInfo, error) {
 	if j.ModelInfo_ == nil {
-		return jujuclient.ModelInfo{}, errors.E(errors.CodeNotImplemented)
+		return jujuclient.ModelInfo{}, errors.New("not implemented")
 	}
 	return j.ModelInfo_(ctx, u, mt)
 }
 func (j *ModelManager) ModelStatus(ctx context.Context, u *openfga.User, mt names.ModelTag) (base.ModelStatus, error) {
 	if j.ModelStatus_ == nil {
-		return base.ModelStatus{}, errors.E(errors.CodeNotImplemented)
+		return base.ModelStatus{}, errors.New("not implemented")
 	}
 	return j.ModelStatus_(ctx, u, mt)
 }
 
 func (j *ModelManager) ListModelSummaries(ctx context.Context, u *openfga.User, maskingControllerUUID string) ([]base.UserModelSummary, error) {
 	if j.ListModelSummaries_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListModelSummaries_(ctx, u, maskingControllerUUID)
 }
 
 func (j *ModelManager) QueryModelsJq(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error) {
 	if j.QueryModelsJq_ == nil {
-		return params.CrossModelQueryResponse{}, errors.E(errors.CodeNotImplemented)
+		return params.CrossModelQueryResponse{}, errors.New("not implemented")
 	}
 	return j.QueryModelsJq_(ctx, models, jqQuery)
 }
 
 func (j *ModelManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error {
 	if j.SetModelDefaults_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.SetModelDefaults_(ctx, user, cloudTag, region, configs)
 }
 
 func (j *ModelManager) UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error {
 	if j.UnsetModelDefaults_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.UnsetModelDefaults_(ctx, user, cloudTag, region, keys)
 }
 
 func (j *ModelManager) UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error {
 	if j.UpdateMigratedModel_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.UpdateMigratedModel_(ctx, user, modelTag, targetControllerName)
 }
 func (j *ModelManager) IdentityModelDefaults(ctx context.Context, user *dbmodel.Identity) (map[string]interface{}, error) {
 	if j.IdentityModelDefaults_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.IdentityModelDefaults_(ctx, user)
 }
 func (j *ModelManager) ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error {
 	if j.ValidateModelUpgrade_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.ValidateModelUpgrade_(ctx, u, mt, force)
 }
 func (j *ModelManager) WatchAllModelSummaries(ctx context.Context, controller *dbmodel.Controller) (_ func() error, err error) {
 	if j.WatchAllModelSummaries_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.WatchAllModelSummaries_(ctx, controller)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_login_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_login_mock.go
@@ -23,49 +23,49 @@ type LoginManager struct {
 
 func (j *LoginManager) AuthenticateBrowserSession(ctx context.Context, w http.ResponseWriter, req *http.Request) (context.Context, error) {
 	if j.AuthenticateBrowserSession_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.AuthenticateBrowserSession_(ctx, w, req)
 }
 
 func (j *LoginManager) LoginDevice(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
 	if j.LoginDevice_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.LoginDevice_(ctx)
 }
 
 func (j *LoginManager) GetDeviceSessionToken(ctx context.Context, deviceOAuthResponse *oauth2.DeviceAuthResponse) (string, error) {
 	if j.GetDeviceSessionToken_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.GetDeviceSessionToken_(ctx, deviceOAuthResponse)
 }
 
 func (j *LoginManager) LoginClientCredentials(ctx context.Context, clientID string, clientSecret string) (*openfga.User, error) {
 	if j.LoginClientCredentials_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.LoginClientCredentials_(ctx, clientID, clientSecret)
 }
 
 func (j *LoginManager) LoginWithSessionToken(ctx context.Context, sessionToken string) (*openfga.User, error) {
 	if j.LoginWithSessionToken_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.LoginWithSessionToken_(ctx, sessionToken)
 }
 
 func (j *LoginManager) LoginWithSessionCookie(ctx context.Context, identityID string) (*openfga.User, error) {
 	if j.LoginWithSessionCookie_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.LoginWithSessionCookie_(ctx, identityID)
 }
 
 func (j *LoginManager) UserLogin(ctx context.Context, identityName string) (*openfga.User, error) {
 	if j.UserLogin_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.UserLogin_(ctx, identityName)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_relation_mock.go
@@ -48,147 +48,147 @@ type PermissionManager struct {
 
 func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 	if j.AddRelation_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AddRelation_(ctx, user, tuples)
 }
 
 func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 	if j.RemoveRelation_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveRelation_(ctx, user, tuples)
 }
 
 func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, trace bool) (_ bool, err error) {
 	if j.CheckRelation_ == nil {
-		return false, errors.E(errors.CodeNotImplemented)
+		return false, errors.New("not implemented")
 	}
 	return j.CheckRelation_(ctx, user, tuple, trace)
 }
 
 func (j *PermissionManager) CheckRelations(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) ([]openfga.CheckResult, error) {
 	if j.CheckRelations_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.CheckRelations_(ctx, user, tuples)
 }
 
 func (j *PermissionManager) ListRelationshipTuples(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, pageSize int32, continuationToken string) ([]openfga.Tuple, string, error) {
 	if j.ListRelationshipTuples_ == nil {
-		return []openfga.Tuple{}, "", errors.E(errors.CodeNotImplemented)
+		return []openfga.Tuple{}, "", errors.New("not implemented")
 	}
 	return j.ListRelationshipTuples_(ctx, user, tuple, pageSize, continuationToken)
 }
 
 func (j *PermissionManager) ListObjectRelations(ctx context.Context, user *openfga.User, object string, pageSize int32, entitlementToken pagination.EntitlementToken) ([]openfga.Tuple, pagination.EntitlementToken, error) {
 	if j.ListObjectRelations_ == nil {
-		return []openfga.Tuple{}, pagination.EntitlementToken{}, errors.E(errors.CodeNotImplemented)
+		return []openfga.Tuple{}, pagination.EntitlementToken{}, errors.New("not implemented")
 	}
 	return j.ListObjectRelations_(ctx, user, object, pageSize, entitlementToken)
 }
 
 func (j *PermissionManager) ListResources(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error) {
 	if j.ListResources_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListResources_(ctx, user, filter, namePrefixFilter, typeFilter)
 }
 
 func (j *PermissionManager) GetJimmControllerAccess(ctx context.Context, user *openfga.User, tag names.UserTag) (string, error) {
 	if j.GetJimmControllerAccess_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.GetJimmControllerAccess_(ctx, user, tag)
 }
 
 func (j *PermissionManager) GetUserCloudAccess(ctx context.Context, user *openfga.User, cloud names.CloudTag) (string, error) {
 	if j.GetUserCloudAccess_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.GetUserCloudAccess_(ctx, user, cloud)
 }
 
 func (j *PermissionManager) GetUserControllerAccess(ctx context.Context, user *openfga.User, controller names.ControllerTag) (string, error) {
 	if j.GetUserControllerAccess_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.GetUserControllerAccess_(ctx, user, controller)
 }
 
 func (j *PermissionManager) GetUserModelAccess(ctx context.Context, user *openfga.User, model names.ModelTag) (string, error) {
 	if j.GetUserModelAccess_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.GetUserModelAccess_(ctx, user, model)
 }
 
 func (j *PermissionManager) GrantAuditLogAccess(ctx context.Context, user *openfga.User, targetUserTag names.UserTag) error {
 	if j.GrantAuditLogAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GrantAuditLogAccess_(ctx, user, targetUserTag)
 }
 
 func (j *PermissionManager) GrantCloudAccess(ctx context.Context, user *openfga.User, ct names.CloudTag, ut names.UserTag, access string) error {
 	if j.GrantCloudAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GrantCloudAccess_(ctx, user, ct, ut, access)
 }
 
 func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error {
 	if j.GrantModelAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GrantModelAccess_(ctx, user, mt, ut, access)
 }
 
 func (j *PermissionManager) GrantOfferAccess(ctx context.Context, user *openfga.User, offerURL string, ut names.UserTag, access jujuparams.OfferAccessPermission) error {
 	if j.GrantOfferAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.GrantOfferAccess_(ctx, user, offerURL, ut, access)
 }
 
 func (j *PermissionManager) RevokeAuditLogAccess(ctx context.Context, user *openfga.User, targetUserTag names.UserTag) error {
 	if j.RevokeAuditLogAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeAuditLogAccess_(ctx, user, targetUserTag)
 }
 
 func (j *PermissionManager) RevokeCloudAccess(ctx context.Context, user *openfga.User, ct names.CloudTag, ut names.UserTag, access string) error {
 	if j.RevokeCloudAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeCloudAccess_(ctx, user, ct, ut, access)
 }
 
 func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error {
 	if j.RevokeModelAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeModelAccess_(ctx, user, mt, ut, access)
 }
 
 func (j *PermissionManager) RevokeOfferAccess(ctx context.Context, user *openfga.User, offerURL string, ut names.UserTag, access jujuparams.OfferAccessPermission) (err error) {
 	if j.RevokeOfferAccess_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RevokeOfferAccess_(ctx, user, offerURL, ut, access)
 }
 
 func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, resolveUUIDs bool) (string, error) {
 	if j.ToJAASTag_ == nil {
-		return "", errors.E(errors.CodeNotImplemented)
+		return "", errors.New("not implemented")
 	}
 	return j.ToJAASTag_(ctx, tag, resolveUUIDs)
 }
 
 func (j *PermissionManager) OpenFGACleanup(ctx context.Context) error {
 	if j.OpenFGACleanup_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.OpenFGACleanup_(ctx)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_role_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_role_mock.go
@@ -24,49 +24,49 @@ type RoleManager struct {
 
 func (j RoleManager) AddRole(ctx context.Context, u *openfga.User, name string) (*dbmodel.RoleEntry, error) {
 	if j.AddRole_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.AddRole_(ctx, u, name)
 }
 
 func (j RoleManager) CountRoles(ctx context.Context, user *openfga.User) (int, error) {
 	if j.CountRoles_ == nil {
-		return 0, errors.E(errors.CodeNotImplemented)
+		return 0, errors.New("not implemented")
 	}
 	return j.CountRoles_(ctx, user)
 }
 
 func (j RoleManager) GetRoleByUUID(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.RoleEntry, error) {
 	if j.GetRoleByUUID_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetRoleByUUID_(ctx, user, uuid)
 }
 
 func (j RoleManager) GetRoleByName(ctx context.Context, user *openfga.User, name string) (*dbmodel.RoleEntry, error) {
 	if j.GetRoleByName_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.GetRoleByName_(ctx, user, name)
 }
 
 func (j RoleManager) ListRoles(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]dbmodel.RoleEntry, error) {
 	if j.ListRoles_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListRoles_(ctx, user, pagination, match)
 }
 
 func (j RoleManager) RemoveRole(ctx context.Context, user *openfga.User, name string) error {
 	if j.RemoveRole_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveRole_(ctx, user, name)
 }
 
 func (j RoleManager) RenameRole(ctx context.Context, user *openfga.User, oldName, newName string) error {
 	if j.RenameRole_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RenameRole_(ctx, user, oldName, newName)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -21,21 +21,21 @@ type SSHManager struct {
 
 func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	if j.PublicKeyHandler_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
 func (j SSHManager) DialController(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error) {
 	if j.DialController_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.DialController_(ctx, ctrlInfo, user)
 }
 
 func (j SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error) {
 	if j.DialInfo_ == nil {
-		return ssh.DialInfo{}, errors.E(errors.CodeNotImplemented)
+		return ssh.DialInfo{}, errors.New("not implemented")
 	}
 	return j.DialInfo_(ctx, modelUUID, user)
 }

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -21,35 +21,35 @@ type SSHKeyManager struct {
 
 func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error {
 	if j.AddUserPublicKey_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.AddUserPublicKey_(ctx, user, model, publicKey)
 }
 
 func (j *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
 	if j.ListUserPublicKeys_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.ListUserPublicKeys_(ctx, user, model)
 }
 
 func (j *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
 	if j.RemoveUserKeyByComment_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveUserKeyByComment_(ctx, user, model, comment)
 }
 
 func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
 	if j.RemoveUserKeyByFingerprint_ == nil {
-		return errors.E(errors.CodeNotImplemented)
+		return errors.New("not implemented")
 	}
 	return j.RemoveUserKeyByFingerprint_(ctx, user, model, fingerprint)
 }
 
 func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {
 	if j.VerifyPublicKey_ == nil {
-		return false, errors.E(errors.CodeNotImplemented)
+		return false, errors.New("not implemented")
 	}
 	return j.VerifyPublicKey_(ctx, claimUser, publicKey)
 }

--- a/internal/testutils/jimmtest/mocks/jwt_service_mock.go
+++ b/internal/testutils/jimmtest/mocks/jwt_service_mock.go
@@ -14,7 +14,7 @@ type JWTService struct {
 
 func (j JWTService) NewJWT(ctx context.Context, params jimmjwx.JWTParams) ([]byte, error) {
 	if j.NewJWT_ == nil {
-		return nil, errors.E(errors.CodeNotImplemented)
+		return nil, errors.New("not implemented")
 	}
 	return j.NewJWT_(ctx, params)
 }

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -48,7 +48,7 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, credTag names.CloudCr
 
 	attrs, ok := s.cloudCredentialAttributes[credTag.String()]
 	if !ok {
-		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "not found")
 	}
 	attrsCopy := make(map[string]string, len(attrs))
 	for k, v := range attrs {
@@ -82,7 +82,7 @@ func (s *InMemoryCredentialStore) GetControllerCredentials(ctx context.Context, 
 
 	cc, ok := s.controllerCredentials[controllerName]
 	if !ok {
-		return "", "", errors.ErrWithCode(nil, errors.CodeNotFound)
+		return "", "", errors.Codef(errors.CodeNotFound, "not found")
 	}
 	return cc.username, cc.password, nil
 }
@@ -127,7 +127,7 @@ func (s *InMemoryCredentialStore) GetJWKS(ctx context.Context) (jwk.Set, error) 
 	defer s.mu.RUnlock()
 
 	if s.jwks == nil {
-		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "not found")
 	}
 	jwks := s.jwks
 	return jwks, nil
@@ -139,7 +139,7 @@ func (s *InMemoryCredentialStore) GetJWKSPrivateKey(ctx context.Context) ([]byte
 	defer s.mu.RUnlock()
 
 	if len(s.privateKey) == 0 {
-		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "not found")
 	}
 
 	pk := make([]byte, len(s.privateKey))
@@ -154,7 +154,7 @@ func (s *InMemoryCredentialStore) GetJWKSExpiry(ctx context.Context) (time.Time,
 	defer s.mu.RUnlock()
 
 	if s.expiry.IsZero() {
-		return time.Time{}, errors.ErrWithCode(nil, errors.CodeNotFound)
+		return time.Time{}, errors.Codef(errors.CodeNotFound, "not found")
 	}
 
 	return s.expiry, nil

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -48,7 +48,7 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, credTag names.CloudCr
 
 	attrs, ok := s.cloudCredentialAttributes[credTag.String()]
 	if !ok {
-		return nil, errors.E(errors.CodeNotFound)
+		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 	attrsCopy := make(map[string]string, len(attrs))
 	for k, v := range attrs {
@@ -82,7 +82,7 @@ func (s *InMemoryCredentialStore) GetControllerCredentials(ctx context.Context, 
 
 	cc, ok := s.controllerCredentials[controllerName]
 	if !ok {
-		return "", "", errors.E(errors.CodeNotFound)
+		return "", "", errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 	return cc.username, cc.password, nil
 }
@@ -127,7 +127,7 @@ func (s *InMemoryCredentialStore) GetJWKS(ctx context.Context) (jwk.Set, error) 
 	defer s.mu.RUnlock()
 
 	if s.jwks == nil {
-		return nil, errors.E(errors.CodeNotFound)
+		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 	jwks := s.jwks
 	return jwks, nil
@@ -139,7 +139,7 @@ func (s *InMemoryCredentialStore) GetJWKSPrivateKey(ctx context.Context) ([]byte
 	defer s.mu.RUnlock()
 
 	if len(s.privateKey) == 0 {
-		return nil, errors.E(errors.CodeNotFound)
+		return nil, errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 
 	pk := make([]byte, len(s.privateKey))
@@ -154,7 +154,7 @@ func (s *InMemoryCredentialStore) GetJWKSExpiry(ctx context.Context) (time.Time,
 	defer s.mu.RUnlock()
 
 	if s.expiry.IsZero() {
-		return time.Time{}, errors.E(errors.CodeNotFound)
+		return time.Time{}, errors.ErrWithCode(nil, errors.CodeNotFound)
 	}
 
 	return s.expiry, nil

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -22,7 +22,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/db"
-	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/logger"
 )
 
@@ -216,17 +215,17 @@ func DeleteDatabase(databaseName string) (err error) {
 
 	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		return errors.New(fmt.Sprintf("error opening database: %s", err))
+		return fmt.Errorf("error opening database: %s", err)
 	}
 	db, err := gdb.DB()
 	if err != nil {
-		return errors.New(fmt.Sprintf("error getting db: %s", err))
+		return fmt.Errorf("error getting db: %s", err)
 	}
 	defer func() { err = db.Close() }()
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return errors.New(fmt.Sprintf("failed to delete database (%s): %s", databaseName, err))
+		return fmt.Errorf("failed to delete database (%s): %s", databaseName, err)
 	}
 	return nil
 }

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -172,7 +172,7 @@ func createDatabaseFromTemplate(suggestedName string, templateName string) (stri
 
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", errors.E("error parsing DSN as a URI: %s", err)
+		return "", "", fmt.Errorf("error parsing DSN as a URI: %s", err)
 	}
 
 	createDatabaseMutex.Lock()
@@ -180,25 +180,25 @@ func createDatabaseFromTemplate(suggestedName string, templateName string) (stri
 
 	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		return "", "", errors.E(err, "error opening database")
+		return "", "", fmt.Errorf("error opening database: %w", err)
 	}
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return "", "", errors.E(err, fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName))
+		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName), err)
 	}
 
 	createDatabaseCommand := fmt.Sprintf(`CREATE DATABASE "%s" TEMPLATE "%s"`, databaseName, templateName)
 	if err := gdb.Exec(createDatabaseCommand).Error; err != nil {
-		return "", "", errors.E(err, fmt.Sprintf("error creating database: (%s)", databaseName))
+		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error creating database: (%s)", databaseName), err)
 	}
 
 	sqlDB, err := gdb.DB()
 	if err != nil {
-		return "", "", errors.E(err, "failed to get the internal DB object")
+		return "", "", fmt.Errorf("failed to get the internal DB object: %w", err)
 	}
 	if err := sqlDB.Close(); err != nil {
-		return "", "", errors.E(err, "failed to close database connection")
+		return "", "", fmt.Errorf("failed to close database connection: %w", err)
 	}
 
 	u.Path = databaseName
@@ -216,17 +216,17 @@ func DeleteDatabase(databaseName string) (err error) {
 
 	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		return errors.E(fmt.Sprintf("error opening database: %s", err))
+		return errors.New(fmt.Sprintf("error opening database: %s", err))
 	}
 	db, err := gdb.DB()
 	if err != nil {
-		return errors.E(fmt.Sprintf("error getting db: %s", err))
+		return errors.New(fmt.Sprintf("error getting db: %s", err))
 	}
 	defer func() { err = db.Close() }()
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return errors.E(fmt.Sprintf("failed to delete database (%s): %s", databaseName, err))
+		return errors.New(fmt.Sprintf("failed to delete database (%s): %s", databaseName, err))
 	}
 	return nil
 }
@@ -245,7 +245,7 @@ func createEmptyDatabase(suggestedName string) (string, string, error) {
 
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", errors.E("error parsing DSN as a URI: %s", err)
+		return "", "", fmt.Errorf("error parsing DSN as a URI: %s", err)
 	}
 
 	createDatabaseMutex.Lock()
@@ -253,25 +253,25 @@ func createEmptyDatabase(suggestedName string) (string, string, error) {
 
 	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		return "", "", errors.E(err, "error opening database")
+		return "", "", fmt.Errorf("error opening database: %w", err)
 	}
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return "", "", errors.E(err, fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName))
+		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName), err)
 	}
 
 	createDatabaseCommand := fmt.Sprintf(`CREATE DATABASE "%s"`, databaseName)
 	if err := gdb.Exec(createDatabaseCommand).Error; err != nil {
-		return "", "", errors.E(err, fmt.Sprintf("error creating database: (%s)", databaseName))
+		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error creating database: (%s)", databaseName), err)
 	}
 
 	sqlDB, err := gdb.DB()
 	if err != nil {
-		return "", "", errors.E(err, "failed to get the internal DB object")
+		return "", "", fmt.Errorf("failed to get the internal DB object: %w", err)
 	}
 	if err := sqlDB.Close(); err != nil {
-		return "", "", errors.E(err, "failed to close database connection")
+		return "", "", fmt.Errorf("failed to close database connection: %w", err)
 	}
 
 	u.Path = databaseName
@@ -284,26 +284,26 @@ func createTemplateDatabase() (string, string, error) {
 	suggestedName := fmt.Sprintf("jimm_template_%s", uuid.New().String()[0:8])
 	templateName, templateDSN, err := createEmptyDatabase(suggestedName)
 	if err != nil {
-		return "", "", errors.E(err, "failed to create the template database")
+		return "", "", fmt.Errorf("failed to create the template database: %w", err)
 	}
 
 	gdb, err := gorm.Open(postgres.Open(templateDSN), &gorm.Config{})
 	if err != nil {
-		return "", "", errors.E(err, "error opening template database")
+		return "", "", fmt.Errorf("error opening template database: %w", err)
 	}
 
 	database := db.Database{
 		DB: gdb,
 	}
 	if err := database.Migrate(context.Background()); err != nil {
-		return "", "", errors.E(err, "error applying migrations on template database")
+		return "", "", fmt.Errorf("error applying migrations on template database: %w", err)
 	}
 	sqlDB, err := gdb.DB()
 	if err != nil {
-		return "", "", errors.E(err, "failed to get the internal DB object")
+		return "", "", fmt.Errorf("failed to get the internal DB object: %w", err)
 	}
 	if err := sqlDB.Close(); err != nil {
-		return "", "", errors.E(err, "failed to close template database connection")
+		return "", "", fmt.Errorf("failed to close template database connection: %w", err)
 	}
 	return templateName, templateDSN, nil
 }

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -184,12 +184,12 @@ func createDatabaseFromTemplate(suggestedName string, templateName string) (stri
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName), err)
+		return "", "", fmt.Errorf("error dropping existing database (maybe there's an active connection like psql client): %s: %w", databaseName, err)
 	}
 
 	createDatabaseCommand := fmt.Sprintf(`CREATE DATABASE "%s" TEMPLATE "%s"`, databaseName, templateName)
 	if err := gdb.Exec(createDatabaseCommand).Error; err != nil {
-		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error creating database: (%s)", databaseName), err)
+		return "", "", fmt.Errorf("error creating database %q: %w)", databaseName, err)
 	}
 
 	sqlDB, err := gdb.DB()
@@ -257,12 +257,12 @@ func createEmptyDatabase(suggestedName string) (string, string, error) {
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error dropping existing database (maybe there's an active connection like psql client): %s", databaseName), err)
+		return "", "", fmt.Errorf("error dropping existing database %q (maybe there's an active connection like psql client): %w", databaseName, err)
 	}
 
 	createDatabaseCommand := fmt.Sprintf(`CREATE DATABASE "%s"`, databaseName)
 	if err := gdb.Exec(createDatabaseCommand).Error; err != nil {
-		return "", "", fmt.Errorf("%s: %w", fmt.Sprintf("error creating database: (%s)", databaseName), err)
+		return "", "", fmt.Errorf("error creating database %q: %w)", databaseName, err)
 	}
 
 	sqlDB, err := gdb.DB()

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -255,7 +255,7 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.MsgWithCode(msg, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "%s", msg)
 	}
 
 	jsonString, ok := secret.Data[jwksKey].(string)
@@ -292,7 +292,7 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS private key exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.MsgWithCode(msg, errors.CodeNotFound)
+		return nil, errors.Codef(errors.CodeNotFound, "%s", msg)
 	}
 
 	keyPemB64 := secret.Data[jwksPrivateKey].(string)
@@ -327,7 +327,7 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS expiry exists yet."
 		zapctx.Debug(ctx, msg)
-		return now, errors.MsgWithCode(msg, errors.CodeNotFound)
+		return now, errors.Codef(errors.CodeNotFound, "%s", msg)
 	}
 
 	expiry, ok := secret.Data[jwksExpiryKey].(string)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -255,7 +255,7 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.E(errors.CodeNotFound, msg)
+		return nil, errors.MsgWithCode(msg, errors.CodeNotFound)
 	}
 
 	jsonString, ok := secret.Data[jwksKey].(string)
@@ -292,7 +292,7 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS private key exists yet."
 		zapctx.Debug(ctx, msg)
-		return nil, errors.E(errors.CodeNotFound, msg)
+		return nil, errors.MsgWithCode(msg, errors.CodeNotFound)
 	}
 
 	keyPemB64 := secret.Data[jwksPrivateKey].(string)
@@ -327,7 +327,7 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 	if secret == nil || secret.Data == nil {
 		msg := "no JWKS expiry exists yet."
 		zapctx.Debug(ctx, msg)
-		return now, errors.E(errors.CodeNotFound, msg)
+		return now, errors.MsgWithCode(msg, errors.CodeNotFound)
 	}
 
 	expiry, ok := secret.Data[jwksExpiryKey].(string)

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -1016,7 +1016,7 @@ func TestListRelationshipTuplesWithMissingGroups(t *testing.T) {
 	tupleWithoutDBEntry.TargetObject = "group:" + group.UUID
 	// first tuples are created during setup test
 	c.Assert(response.Tuples[initialTupleCount], qt.Equals, tupleWithoutDBEntry)
-	c.Assert(response.Errors, qt.DeepEquals, []string{"failed to parse target: failed to fetch group information: " + group.UUID})
+	c.Assert(response.Errors, qt.DeepEquals, []string{"failed to parse target: failed to fetch group information: " + group.UUID + ": record not found"})
 }
 
 func TestCheckRelationAsNonAdmin(t *testing.T) {

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -901,7 +901,7 @@ func TestCrossModelQuery(t *testing.T) {
 		Type:  "some-type-not-supported",
 		Query: ".",
 	})
-	c.Assert(err, qt.ErrorMatches, `unable to query models \(invalid query type\)`)
+	c.Assert(err, qt.ErrorMatches, `unable to query models: invalid query type`)
 
 	_, err = client.CrossModelQuery(&apiparams.CrossModelQueryRequest{
 		Type:  "jimmsql",
@@ -991,7 +991,7 @@ func TestJimmModelMigrationNonSuperuser(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(res.Results, qt.HasLen, 1)
 	item := res.Results[0]
-	c.Assert(item.Error.Message, qt.Matches, "unauthorized access")
+	c.Assert(item.Error.Message, qt.Matches, "unauthorized")
 }
 
 func TestVersion(t *testing.T) {

--- a/testing/usermanager_test.go
+++ b/testing/usermanager_test.go
@@ -104,7 +104,7 @@ func TestUserInfoSpecifiedUsers(t *testing.T) {
 
 	client := usermanager.NewClient(conn)
 	users, err := client.UserInfo([]string{"alice@canonical.com", "bob@canonical.com"}, usermanager.AllUsers)
-	c.Assert(err, qt.ErrorMatches, "bob@canonical.com: unauthorized access")
+	c.Assert(err, qt.ErrorMatches, "bob@canonical.com: unauthorized")
 	c.Assert(users, qt.HasLen, 0)
 }
 


### PR DESCRIPTION
## Description
Another attempt at removing `errors.E`. The difference between this PR and https://github.com/canonical/jimm/pull/1903 is that this one offers a much simpler alternative for error handling. <s>
2 new error functions are introduced to replace `errors.E` namely,
- `ErrWithCode(err error, code Code) error` this function takes an error and a code and returns an error that has the specified code.
- `MsgWithCode(msg string, code Code) error` this function takes a string and a code and returns an error that has the specified code.
</s>

1 new error function has been introduced to replace `errors.E`,
- `Codef(code Code, format code Code, format string, args ...any) error`

This calls `fmt.Errorf` underneath and returns an error with the appropriate code. It turns out this was all we needed to cover all our error use cases. The only caveat is that if you want to carry an error's code through the stack but replace its message you need to either know the code and do something like,
```
errors.Codef(errors.CodeNotFound, "resource %q not found", resourceName)
```
Or one can extract the error code beforehand with `errors.ErrorCode(err)`. 

In many cases where we were checking the error code e.g. in the DB we often check the gorm error and if it was NotFound error we mask the underlying DB's "record not found" error and just return "<resource> was not found". That's cleanly done with the above pattern.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
