### PR TITLE
refactor: adjust bootstrap cloud shape

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -276,7 +276,7 @@ Should you cancel this process, you can track the progress via bootstrap-status 
 	return poller.watchBootstrapLogs()
 }
 
-// cloudToParams converts a jujucloud.Cloud to the embedded bootstrap request cloud shape.
+// cloudToParams converts a jujucloud.Cloud to the bootstrap request cloud shape.
 func cloudToParams(cloudName, regionName string, cloud *jujucloud.Cloud) apiparams.BootstrapCloud {
 	paramsCloud := apiparams.BootstrapCloud{
 		Name: cloudName,
@@ -307,9 +307,6 @@ func cloudToParams(cloudName, regionName string, cloud *jujucloud.Cloud) apipara
 			}
 			break
 		}
-	}
-	if paramsCloud.Region.Name == "" {
-		paramsCloud.Region.Name = regionName
 	}
 	return paramsCloud
 }

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -214,11 +214,9 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	req := apiparams.BootstrapParams{
-		CloudName:         c.cloud,
-		RegionName:        c.region,
 		ControllerName:    c.controllerName,
 		ControllerVersion: c.controllerVersion,
-		Cloud:             cloudToParams(bootstrapCloud),
+		Cloud:             cloudToParams(c.cloud, c.region, bootstrapCloud),
 		Credential: jujuparams.CloudCredential{
 			Attributes: bootstrapCred.Attributes(),
 			AuthType:   string(bootstrapCred.AuthType()),
@@ -278,44 +276,40 @@ Should you cancel this process, you can track the progress via bootstrap-status 
 	return poller.watchBootstrapLogs()
 }
 
-// CloudToParams converts a jujucloud.Cloud to a jujuparams.Cloud.
-// Copied from api/client/cloud/cloud.go.
-func cloudToParams(cloud *jujucloud.Cloud) jujuparams.Cloud {
+// cloudToParams converts a jujucloud.Cloud to the embedded bootstrap request cloud shape.
+func cloudToParams(cloudName, regionName string, cloud *jujucloud.Cloud) apiparams.BootstrapCloud {
+	paramsCloud := apiparams.BootstrapCloud{
+		Name: cloudName,
+		Region: apiparams.BootstrapCloudRegion{
+			Name: regionName,
+		},
+	}
 	if cloud == nil {
-		return jujuparams.Cloud{}
+		return paramsCloud
 	}
 	authTypes := make([]string, len(cloud.AuthTypes))
 	for i, authType := range cloud.AuthTypes {
 		authTypes[i] = string(authType)
 	}
-	regions := make([]jujuparams.CloudRegion, len(cloud.Regions))
-	for i, region := range cloud.Regions {
-		regions[i] = jujuparams.CloudRegion{
-			Name:             region.Name,
-			Endpoint:         region.Endpoint,
-			IdentityEndpoint: region.IdentityEndpoint,
-			StorageEndpoint:  region.StorageEndpoint,
+	paramsCloud.Type = cloud.Type
+	paramsCloud.AuthTypes = authTypes
+	paramsCloud.Endpoint = cloud.Endpoint
+	paramsCloud.CACertificates = cloud.CACertificates
+	paramsCloud.HostCloudRegion = cloud.HostCloudRegion
+	paramsCloud.Config = cloud.Config
+	for _, region := range cloud.Regions {
+		if region.Name == regionName {
+			paramsCloud.Region = apiparams.BootstrapCloudRegion{
+				Name:             region.Name,
+				Endpoint:         region.Endpoint,
+				IdentityEndpoint: region.IdentityEndpoint,
+				StorageEndpoint:  region.StorageEndpoint,
+			}
+			break
 		}
 	}
-	var regionConfig map[string]map[string]interface{}
-	for r, attr := range cloud.RegionConfig {
-		if regionConfig == nil {
-			regionConfig = make(map[string]map[string]interface{})
-		}
-		regionConfig[r] = attr
+	if paramsCloud.Region.Name == "" {
+		paramsCloud.Region.Name = regionName
 	}
-	return jujuparams.Cloud{
-		Type:              cloud.Type,
-		HostCloudRegion:   cloud.HostCloudRegion,
-		AuthTypes:         authTypes,
-		Endpoint:          cloud.Endpoint,
-		IdentityEndpoint:  cloud.IdentityEndpoint,
-		StorageEndpoint:   cloud.StorageEndpoint,
-		Regions:           regions,
-		CACertificates:    cloud.CACertificates,
-		SkipTLSVerify:     cloud.SkipTLSVerify,
-		Config:            cloud.Config,
-		RegionConfig:      regionConfig,
-		IsControllerCloud: cloud.IsControllerCloud,
-	}
+	return paramsCloud
 }

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -92,8 +92,6 @@ func TestBootstrapWithPublicCloud(t *testing.T) {
 	}, nil)
 
 	s.client.EXPECT().StartBootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartBootstrapResponse, error) {
-		// Public clouds still omit provider metadata, but the request must carry
-		// the selected cloud name and region inside the embedded cloud object.
 		c.Check(bsp.Cloud, qt.DeepEquals, params.BootstrapCloud{
 			Name: cloudName,
 			Region: params.BootstrapCloudRegion{

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -92,8 +92,14 @@ func TestBootstrapWithPublicCloud(t *testing.T) {
 	}, nil)
 
 	s.client.EXPECT().StartBootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartBootstrapResponse, error) {
-		// If the cloud is public, the Cloud field should be empty.
-		c.Check(bsp.Cloud, qt.DeepEquals, jujuparams.Cloud{})
+		// Public clouds still omit provider metadata, but the request must carry
+		// the selected cloud name and region inside the embedded cloud object.
+		c.Check(bsp.Cloud, qt.DeepEquals, params.BootstrapCloud{
+			Name: cloudName,
+			Region: params.BootstrapCloudRegion{
+				Name: "region",
+			},
+		})
 		return &params.StartBootstrapResponse{JobID: "test-job-id"}, nil
 	})
 	s.client.EXPECT().Close().Return(nil)
@@ -149,13 +155,14 @@ func TestBootstrapApiParams(t *testing.T) {
 	s.client.EXPECT().StartBootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartBootstrapResponse, error) {
 		expected := &params.BootstrapParams{
 			ControllerName: "controller-name",
-			CloudName:      cloudName,
-			RegionName:     "region",
-			Cloud: jujuparams.Cloud{
+			Cloud: params.BootstrapCloud{
+				Name:      cloudName,
 				Type:      "openstack",
 				AuthTypes: []string{string(jujucloud.UserPassAuthType)},
 				Endpoint:  "some-endpoint",
-				Regions:   []jujuparams.CloudRegion{},
+				Region: params.BootstrapCloudRegion{
+					Name: "region",
+				},
 			},
 			Credential: jujuparams.CloudCredential{
 				AuthType:   string(jujucloud.UserPassAuthType),
@@ -170,8 +177,6 @@ func TestBootstrapApiParams(t *testing.T) {
 			ControllerVersion: "controller-version",
 		}
 		c.Check(bsp.ControllerName, qt.Equals, expected.ControllerName)
-		c.Check(bsp.CloudName, qt.Equals, expected.CloudName)
-		c.Check(bsp.RegionName, qt.Equals, expected.RegionName)
 		c.Check(bsp.Cloud, qt.DeepEquals, expected.Cloud)
 		c.Check(bsp.Credential, qt.DeepEquals, expected.Credential)
 		c.Check(bsp.BootstrapOptions, qt.DeepEquals, expected.BootstrapOptions)

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -167,7 +167,7 @@ func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.Cont
 		Version:     profile.Version,
 		CreatedAt:   profile.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:   profile.UpdatedAt.Format(time.RFC3339),
-		Cloud: apiparams.ControllerProfileCloud{
+		Cloud: apiparams.BootstrapCloud{
 			Name:            profile.Cloud.Name,
 			Type:            profile.Cloud.Type,
 			AuthTypes:       []string(profile.Cloud.AuthTypes),
@@ -175,7 +175,7 @@ func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.Cont
 			Config:          map[string]interface{}(profile.Cloud.Config),
 			Endpoint:        profile.Cloud.Endpoint,
 			HostCloudRegion: profile.Cloud.HostCloudRegion,
-			Region: apiparams.ControllerProfileCloudRegion{
+			Region: apiparams.BootstrapCloudRegion{
 				Name:             profile.Cloud.Region.Name,
 				Endpoint:         profile.Cloud.Region.Endpoint,
 				IdentityEndpoint: profile.Cloud.Region.IdentityEndpoint,

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -667,15 +667,15 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 	// Validate request is not for a built in cloud.
 	// Using a fixed slice over `juju/cmd/juju/common.BuiltInClouds()` as that
 	// function requires providers to be registered in the environs global.
-	if slices.Contains(builtInClouds, req.CloudName) {
+	if slices.Contains(builtInClouds, req.Cloud.Name) {
 		return apiparams.StartBootstrapResponse{},
-			errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.CloudName))
+			errors.E(errors.CodeIncompatibleClouds, fmt.Errorf("bootstrap via JIMM does not support built-in clouds like %q", req.Cloud.Name))
 	}
 
-	cloudNameAndRegion := req.CloudName
+	cloudNameAndRegion := req.Cloud.Name
 
-	if req.RegionName != "" {
-		cloudNameAndRegion = fmt.Sprintf("%s/%s", req.CloudName, req.RegionName)
+	if req.Cloud.Region.Name != "" {
+		cloudNameAndRegion = fmt.Sprintf("%s/%s", req.Cloud.Name, req.Cloud.Region.Name)
 	}
 
 	params := bootstrap.BootstrapParams{
@@ -684,7 +684,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 		CloudNameAndRegion: cloudNameAndRegion,
 		ControllerName:     req.ControllerName,
 
-		Cloud: cloudFromParams(req.CloudName, req.Cloud),
+		Cloud: bootstrapCloudFromParams(req.Cloud),
 		CloudCred: cloud.NewNamedCredential(
 			"bootstrap-credential",
 			cloud.AuthType(req.Credential.AuthType),

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -341,7 +341,9 @@ func TestBootstrapStart_RejectsBuiltinClouds(t *testing.T) {
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
 
 	params := apiparams.BootstrapParams{
-		CloudName: "localhost",
+		Cloud: apiparams.BootstrapCloud{
+			Name: "localhost",
+		},
 	}
 
 	_, err := root.StartBootstrap(ctx, params)
@@ -372,8 +374,12 @@ func TestBootstrapStart(t *testing.T) {
 
 	params := apiparams.BootstrapParams{
 		ControllerName: "controller",
-		CloudName:      "cloud",
-		RegionName:     "region",
+		Cloud: apiparams.BootstrapCloud{
+			Name: "cloud",
+			Region: apiparams.BootstrapCloudRegion{
+				Name: "region",
+			},
+		},
 		BootstrapOptions: apiparams.BootstrapOptions{
 			BootstrapBase:        "ubuntu@24.04",
 			BootstrapConstraints: map[string]string{"mem": "8G"},
@@ -388,7 +394,6 @@ func TestBootstrapStart(t *testing.T) {
 			ControllerConfig:      map[string]string{"audit-log-enabled": "true"},
 			ControllerModelConfig: map[string]string{"image-stream": "released"},
 		},
-		Cloud:             jujuparams.Cloud{},
 		Credential:        jujuparams.CloudCredential{},
 		ControllerVersion: "3.6.9",
 	}

--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -54,6 +54,32 @@ func cloudFromParams(cloudName string, p jujuparams.Cloud) cloud.Cloud {
 	}
 }
 
+func bootstrapCloudFromParams(p params.BootstrapCloud) cloud.Cloud {
+	authTypes := make([]cloud.AuthType, len(p.AuthTypes))
+	for i, authType := range p.AuthTypes {
+		authTypes[i] = cloud.AuthType(authType)
+	}
+	regions := []cloud.Region{{
+		Name:             p.Region.Name,
+		Endpoint:         p.Region.Endpoint,
+		IdentityEndpoint: p.Region.IdentityEndpoint,
+		StorageEndpoint:  p.Region.StorageEndpoint,
+	}}
+	if p.Region == (params.BootstrapCloudRegion{}) {
+		regions = nil
+	}
+	return cloud.Cloud{
+		Name:            p.Name,
+		Type:            p.Type,
+		AuthTypes:       authTypes,
+		Endpoint:        p.Endpoint,
+		Regions:         regions,
+		CACertificates:  p.CACertificates,
+		HostCloudRegion: p.HostCloudRegion,
+		Config:          p.Config,
+	}
+}
+
 func toAddModelArgs(args jujuparams.ModelCreateArgs, authenticatedUser names.UserTag) (*juju.ModelCreateArgs, error) {
 	// FromJujuModelCreateArgs converts jujuparams.ModelCreateArgs into AddModelArgs.
 	var a juju.ModelCreateArgs

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -261,7 +261,7 @@ type ControllerProfile struct {
 	// UpdatedAt is the time the profile was last updated.
 	UpdatedAt string `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
 	// Cloud stores the cloud definition for the profile.
-	Cloud ControllerProfileCloud `json:"cloud" yaml:"cloud"`
+	Cloud BootstrapCloud `json:"cloud" yaml:"cloud"`
 	// BootstrapOptions holds the reusable bootstrap settings saved in the profile.
 	BootstrapOptions BootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
 }
@@ -278,8 +278,8 @@ type ControllerProfileSummary struct {
 	UpdatedAt string `json:"updated-at,omitempty" yaml:"updated-at,omitempty"`
 }
 
-// ControllerProfileCloud stores the cloud definition persisted in a controller profile.
-type ControllerProfileCloud struct {
+// BootstrapCloud stores the cloud definition used for controller bootstrap.
+type BootstrapCloud struct {
 	// Name is the cloud's name, e.g. "aws", "azure", "gcp", "localhost", etc.
 	Name string `json:"name" yaml:"name"`
 	// Type is the cloud's type, e.g. "ec2", "azure", "openstack", etc.
@@ -294,12 +294,12 @@ type ControllerProfileCloud struct {
 	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	// HostCloudRegion contains the host cloud region for the cloud, if any.
 	HostCloudRegion string `json:"host-cloud-region,omitempty" yaml:"host-cloud-region,omitempty"`
-	// Region contains the cloud region definition for the profile's bootstrap region.
-	Region ControllerProfileCloudRegion `json:"region" yaml:"region"`
+	// Region contains the cloud region definition for the controller.
+	Region BootstrapCloudRegion `json:"region" yaml:"region"`
 }
 
-// ControllerProfileCloudRegion stores the single bootstrap region definition for a profile.
-type ControllerProfileCloudRegion struct {
+// BootstrapCloudRegion stores the single bootstrap region definition for controller bootstrap.
+type BootstrapCloudRegion struct {
 	// Name is the region's name, e.g. "us-east-1".
 	Name string `json:"name" yaml:"name"`
 	// Endpoint contains the region-specific cloud API endpoint, if needed.
@@ -776,23 +776,20 @@ type StartBootstrapResponse struct {
 // BootstrapParams holds parameters for starting
 // a controller bootstrap job.
 type BootstrapParams struct {
-	// CloudName specifies the target cloud for the controller.
-	CloudName string `json:"cloud-name"`
-	// RegionName specifies the target region for the controller.
-	RegionName string `json:"region-name"`
 	// Cloud holds the cloud definition that will be used to bootstrap the controller.
-	Cloud jujuparams.Cloud `json:"cloud,omitempty"`
+	// The cloud name and bootstrap region are carried inside this object.
+	Cloud BootstrapCloud `json:"cloud" yaml:"cloud"`
 	// Credential contains the cloud credential and its tag, this credential will be used against the
 	// the cloud provided to bootstrap the controller.
-	Credential jujuparams.CloudCredential `json:"credential"`
+	Credential jujuparams.CloudCredential `json:"credential" yaml:"credential"`
 
 	// ControllerName specifies the name of the controller as recorded in JIMM.
-	ControllerName string `json:"controller-name"`
+	ControllerName string `json:"controller-name" yaml:"controller-name"`
 	// BootstrapOptions holds the supported bootstrap settings for the job.
-	BootstrapOptions BootstrapOptions `json:"bootstrap-options"`
+	BootstrapOptions BootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
 
 	// ControllerVersion is the version of the controller to be bootstrapped.
-	ControllerVersion string `json:"controller-version"`
+	ControllerVersion string `json:"controller-version" yaml:"controller-version"`
 }
 
 // DestroyControllerRequest holds the name of

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -18,14 +18,14 @@ func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRe
 			Name:        name,
 			Description: "Reusable bootstrap settings",
 			JujuVersion: "3.6",
-			Cloud: apiparams.ControllerProfileCloud{
+			Cloud: apiparams.BootstrapCloud{
 				Name:           "aws",
 				Type:           "ec2",
 				AuthTypes:      []string{"access-key"},
 				CACertificates: []string{"ca-cert"},
 				Config:         map[string]interface{}{"default-base": "ubuntu@24.04"},
 				Endpoint:       "https://aws.example.com",
-				Region: apiparams.ControllerProfileCloudRegion{
+				Region: apiparams.BootstrapCloudRegion{
 					Name:             "eu-west-1",
 					Endpoint:         "https://region.example.com",
 					IdentityEndpoint: "https://identity.example.com",


### PR DESCRIPTION
## Description
This change updates the shape of the cloud parameter used by the bootstrap/controller-profile API. Previously `StartBootstrap` accepted a cloud object of the shape `jujuparams.Cloud`. Now we define our own shape that is more suited to our needs. The main adjustment is that the name of the cloud is stored within the object and we limit the number of regions to 1.

Partially addresses [JUJU-9427](https://warthogs.atlassian.net/browse/JUJU-9427)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


[JUJU-9427]: https://warthogs.atlassian.net/browse/JUJU-9427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ