### PR TITLE
feat: add additional flags to jaas bootstrap command

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -143,8 +143,8 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 	f.StringVar(&c.credentialName, "credential", "", "The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud.")
-	f.StringVar(&c.bootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
-	f.Var(&c.bootstrapCons, "bootstrap-constraints", "Specify bootstrap machine constraints")
+	f.StringVar(&c.bootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine.")
+	f.Var(&c.bootstrapCons, "bootstrap-constraints", "Specify bootstrap machine constraints.")
 	f.Var(&c.constraints, "constraints", "Set model constraints")
 	f.Var(&c.config, "config",
 		"Specify a configuration file, or one or more configuration options.\n    (`--config config.yaml [--config key=value ...])`")

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -427,6 +427,7 @@ func parseConstraintFlag(ctxt *cmd.Context, values []string, flagName string) (m
 	if len(values) == 0 {
 		return nil, nil
 	}
+	// ParseWithAliases requires only spaces and name=value pairs.
 	joined := strings.Join(values, " ")
 	_, aliases, err := constraints.ParseWithAliases(joined)
 	common.WarnConstraintAliases(ctxt, aliases)

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -12,6 +12,8 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/modelcmd"
+	corebase "github.com/juju/juju/core/base"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/jujuclient"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
@@ -46,10 +48,11 @@ file contents.
 These config options must match the config options supported by the Juju CLI
 for the version of Juju being bootstrapped. See the Juju documentation for
 the version specified for the full list of supported bootstrap config
-options.
+options. Additional bootstrap settings can be supplied with --bootstrap-base,
+--bootstrap-constraints, --constraints, --model-default, and --storage-pool,
+these align with the corresponding Juju CLI options.
 
-Note that some config options may not be specified as they will automatically
-be set.
+Note that some config options will be automatically set but can be overriden.
 These are:
 
 - login-token-refresh-url
@@ -73,6 +76,8 @@ Note that JIMM will internally do the following:
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --config controller-service-type=loadbalancer
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --bootstrap-base ubuntu@24.04 --bootstrap-constraints mem=8G --constraints arch=amd64
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --storage-pool name=controller-pool --storage-pool type=ebs --config audit-log-enabled=true
 `
 )
 
@@ -90,7 +95,12 @@ type bootstrapCommand struct {
 
 	credentialName string
 	detach         bool
+	bootstrapBase  string
+	constraints    common.ConstraintsFlag
+	bootstrapCons  common.BootstrapConstraintsFlag
 	config         common.ConfigFlag
+	modelDefaults  common.ConfigFlag
+	storagePool    common.ConfigFlag
 }
 
 // NewBootstrapStartCommand returns a command to start a job
@@ -106,6 +116,11 @@ func NewBootstrapStartCommand() cmd.Command {
 func (c *bootstrapCommand) Init(args []string) error {
 	if len(args) < 3 {
 		return fmt.Errorf("expected at least 3 arguments, got %d", len(args))
+	}
+	if c.bootstrapBase != "" {
+		if _, err := corebase.ParseBaseFromString(c.bootstrapBase); err != nil {
+			return fmt.Errorf("invalid bootstrap base %q: %w", c.bootstrapBase, err)
+		}
 	}
 	c.cloud = args[0]
 	if i := strings.IndexRune(c.cloud, '/'); i > 0 {
@@ -128,8 +143,15 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 	f.StringVar(&c.credentialName, "credential", "", "The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud.")
+	f.StringVar(&c.bootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
+	f.Var(&c.bootstrapCons, "bootstrap-constraints", "Specify bootstrap machine constraints")
+	f.Var(&c.constraints, "constraints", "Set model constraints")
 	f.Var(&c.config, "config",
 		"Specify a configuration file, or one or more configuration options.\n    (`--config config.yaml [--config key=value ...])`")
+	f.Var(&c.modelDefaults, "model-default",
+		"Specify a configuration file, or one or more configuration options to be set for all models, unless otherwise specified.\n    (`--model-default config.yaml [--model-default key=value ...])`")
+	f.Var(&c.storagePool, "storage-pool",
+		"Specify options for an initial storage pool. 'name' and 'type' are required, plus any additional attributes.\n    (`--storage-pool pool-config.yaml [--storage-pool key=value ...])`")
 	f.BoolVar(&c.detach, "detach", false, "If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete.")
 }
 
@@ -199,18 +221,9 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return fmt.Errorf("multiple credentials found for cloud %q, please set a default or specify one using --credential", c.cloud)
 	}
 
-	configValues, err := c.config.ReadAttrs(ctxt)
+	bootstrapOptions, err := c.bootstrapOptions(ctxt)
 	if err != nil {
-		return fmt.Errorf("failed to read config values: %v", err)
-	}
-
-	stringConfigValues := make(map[string]string, len(configValues))
-	for k, v := range configValues {
-		strVal, ok := v.(string)
-		if !ok {
-			return fmt.Errorf("config value for %q must be a string, got %T", k, v)
-		}
-		stringConfigValues[k] = strVal
+		return err
 	}
 
 	req := apiparams.BootstrapParams{
@@ -221,9 +234,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 			Attributes: bootstrapCred.Attributes(),
 			AuthType:   string(bootstrapCred.AuthType()),
 		},
-		BootstrapOptions: apiparams.BootstrapOptions{
-			BootstrapConfig: stringConfigValues,
-		},
+		BootstrapOptions: bootstrapOptions,
 	}
 
 	client, err := c.getJIMMAPI()
@@ -309,4 +320,146 @@ func cloudToParams(cloudName, regionName string, cloud *jujucloud.Cloud) apipara
 		}
 	}
 	return paramsCloud
+}
+
+func (c *bootstrapCommand) bootstrapOptions(ctxt *cmd.Context) (apiparams.BootstrapOptions, error) {
+	bootstrapConfig, err := readStringMapFlag(ctxt, &c.config, "config")
+	if err != nil {
+		return apiparams.BootstrapOptions{}, err
+	}
+	modelDefault, err := readStringMapFlag(ctxt, &c.modelDefaults, "model-default")
+	if err != nil {
+		return apiparams.BootstrapOptions{}, err
+	}
+	bootstrapConstraints, err := parseConstraintFlag(ctxt, []string(c.bootstrapCons), "bootstrap-constraints")
+	if err != nil {
+		return apiparams.BootstrapOptions{}, err
+	}
+	modelConstraints, err := parseConstraintFlag(ctxt, []string(c.constraints), "constraints")
+	if err != nil {
+		return apiparams.BootstrapOptions{}, err
+	}
+	storagePool, err := readStoragePoolFlag(ctxt, &c.storagePool)
+	if err != nil {
+		return apiparams.BootstrapOptions{}, err
+	}
+
+	return apiparams.BootstrapOptions{
+		BootstrapBase:        c.bootstrapBase,
+		BootstrapConstraints: bootstrapConstraints,
+		ModelConstraints:     modelConstraints,
+		ModelDefault:         modelDefault,
+		StoragePool:          storagePool,
+		// The CLI intentionally keeps Juju's single --config entrypoint.
+		// StartBootstrap splits bootstrap, controller, and controller-model config,
+		// but JIMM merges those maps again when it shells out to juju bootstrap.
+		BootstrapConfig: bootstrapConfig,
+	}, nil
+}
+
+func readStoragePoolFlag(ctxt *cmd.Context, flag *common.ConfigFlag) (*apiparams.BootstrapStoragePool, error) {
+	attrs, err := flag.ReadAttrs(ctxt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read storage pool values: %w", err)
+	}
+	if len(attrs) == 0 {
+		return nil, nil
+	}
+	values, err := stringifyMapValues(attrs, "storage-pool")
+	if err != nil {
+		return nil, err
+	}
+	pool := &apiparams.BootstrapStoragePool{
+		Name: values["name"],
+		Type: values["type"],
+	}
+	delete(values, "name")
+	delete(values, "type")
+	if pool.Name == "" || pool.Type == "" {
+		return nil, fmt.Errorf("storage-pool requires both name and type")
+	}
+	if len(values) > 0 {
+		pool.Attributes = values
+	}
+	return pool, nil
+}
+
+func readStringMapFlag(ctxt *cmd.Context, flag *common.ConfigFlag, flagName string) (map[string]string, error) {
+	attrs, err := flag.ReadAttrs(ctxt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s values: %w", flagName, err)
+	}
+	return stringifyMapValues(attrs, flagName)
+}
+
+func stringifyMapValues(attrs map[string]interface{}, flagName string) (map[string]string, error) {
+	if len(attrs) == 0 {
+		return nil, nil
+	}
+	values := make(map[string]string, len(attrs))
+	for key, value := range attrs {
+		strValue, err := stringifyScalar(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s value for %q must be a scalar, got %T", flagName, key, value)
+		}
+		values[key] = strValue
+	}
+	return values, nil
+}
+
+func stringifyScalar(value interface{}) (string, error) {
+	if value == nil {
+		return "", fmt.Errorf("nil value")
+	}
+	switch value.(type) {
+	case string,
+		bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return fmt.Sprint(value), nil
+	default:
+		return "", fmt.Errorf("unsupported type %T", value)
+	}
+}
+
+func parseConstraintFlag(ctxt *cmd.Context, values []string, flagName string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	joined := strings.Join(values, " ")
+	_, aliases, err := constraints.ParseWithAliases(joined)
+	common.WarnConstraintAliases(ctxt, aliases)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", flagName, err)
+	}
+	parsedValues := splitEscapedFields(joined)
+	result := make(map[string]string, len(parsedValues))
+	for _, value := range parsedValues {
+		keyValue := strings.SplitN(value, "=", 2)
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("failed to parse %s: invalid constraint %q", flagName, value)
+		}
+		key := keyValue[0]
+		if canonical, ok := aliases[key]; ok {
+			key = canonical
+		}
+		result[key] = keyValue[1]
+	}
+	return result, nil
+}
+
+// splitEscapedFields splits a whitespace-delimited constraint string while
+// preserving spaces that were escaped as `\ ` inside an individual field.
+func splitEscapedFields(value string) []string {
+	if value == "" {
+		return nil
+	}
+	normalized := strings.ReplaceAll(value, `\ `, "\x00")
+	rawFields := strings.Fields(normalized)
+	fields := make([]string, 0, len(rawFields))
+	for _, field := range rawFields {
+		fields = append(fields, strings.ReplaceAll(field, "\x00", " "))
+	}
+	return fields
 }

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -195,8 +195,9 @@ func TestBootstrapApiParams(t *testing.T) {
 			BootstrapOptions: params.BootstrapOptions{
 				BootstrapBase: "ubuntu@24.04",
 				BootstrapConstraints: map[string]string{
-					"mem":   "8G",
-					"cores": "2",
+					"mem":       "8G",
+					"cores":     "2",
+					"root-disk": "10G",
 				},
 				ModelConstraints: map[string]string{
 					"arch": "amd64",
@@ -243,7 +244,7 @@ func TestBootstrapApiParams(t *testing.T) {
 		"--detach",
 		"--bootstrap-base", "ubuntu@24.04",
 		"--bootstrap-constraints", "mem=8G",
-		"--bootstrap-constraints", "cores=2",
+		"--bootstrap-constraints", "cores=2 root-disk=10G",
 		"--constraints", "arch=amd64",
 		"--model-default", "logging-config=<root>=INFO",
 		"--storage-pool", "name=controller-pool",

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -57,6 +57,32 @@ func TestBootstrapArgParsing(t *testing.T) {
 				c.Check(command.detach, qt.Equals, true)
 			},
 		}, {
+			name: "bootstrap-option-flags",
+			args: []string{
+				"test-cloud/region",
+				"controller-name",
+				"controller-version",
+				"--bootstrap-base", "ubuntu@24.04",
+				"--bootstrap-constraints", "mem=8G",
+				"--constraints", "arch=amd64",
+				"--model-default", "logging-config=<root>=INFO",
+				"--storage-pool", "name=controller-pool",
+				"--storage-pool", "type=ebs",
+				"--config", "audit-log-enabled=true",
+				"--config", "image-stream=released",
+			},
+			checkFlags: func(c *qt.C, command *bootstrapCommand) {
+				c.Check(command.cloud, qt.Equals, "test-cloud")
+				c.Check(command.region, qt.Equals, "region")
+				c.Check(command.bootstrapBase, qt.Equals, "ubuntu@24.04")
+				c.Check([]string(command.bootstrapCons), qt.DeepEquals, []string{"mem=8G"})
+				c.Check([]string(command.constraints), qt.DeepEquals, []string{"arch=amd64"})
+			},
+		}, {
+			name:     "invalid-bootstrap-base",
+			args:     []string{"test-cloud/region", "controller-name", "controller-version", "--bootstrap-base", "not-a-base"},
+			errMatch: `invalid bootstrap base "not-a-base": .*`,
+		}, {
 			name:     "too-few-args",
 			args:     []string{"test-cloud/region"},
 			errMatch: "expected at least 3 arguments, got 1",
@@ -167,8 +193,28 @@ func TestBootstrapApiParams(t *testing.T) {
 				Attributes: map[string]string{},
 			},
 			BootstrapOptions: params.BootstrapOptions{
+				BootstrapBase: "ubuntu@24.04",
+				BootstrapConstraints: map[string]string{
+					"mem":   "8G",
+					"cores": "2",
+				},
+				ModelConstraints: map[string]string{
+					"arch": "amd64",
+				},
+				ModelDefault: map[string]string{
+					"logging-config": "<root>=INFO",
+				},
+				StoragePool: &params.BootstrapStoragePool{
+					Name: "controller-pool",
+					Type: "ebs",
+					Attributes: map[string]string{
+						"volume-type": "gp3",
+					},
+				},
 				BootstrapConfig: map[string]string{
+					"audit-log-enabled": "true",
 					"bootstrap-timeout": "60",
+					"image-stream":      "released",
 					"string-option":     "value",
 				},
 			},
@@ -195,7 +241,17 @@ func TestBootstrapApiParams(t *testing.T) {
 		"controller-name",
 		"controller-version",
 		"--detach",
+		"--bootstrap-base", "ubuntu@24.04",
+		"--bootstrap-constraints", "mem=8G",
+		"--bootstrap-constraints", "cores=2",
+		"--constraints", "arch=amd64",
+		"--model-default", "logging-config=<root>=INFO",
+		"--storage-pool", "name=controller-pool",
+		"--storage-pool", "type=ebs",
+		"--storage-pool", "volume-type=gp3",
+		"--config", "audit-log-enabled=true",
 		"--config", "bootstrap-timeout=60",
+		"--config", "image-stream=released",
 		"--config", "string-option=value",
 	)
 
@@ -411,4 +467,88 @@ func TestBootstrapSpecifiedCredentialWithDefault(t *testing.T) {
 	mcmd := modelcmd.WrapBase(command)
 	err := mcmd.Run(ctx)
 	c.Assert(err, qt.ErrorMatches, `no credential found with name "cred-3"`)
+}
+
+func TestSplitEscapedFields(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		value    string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			value:    "",
+			expected: nil,
+		},
+		{
+			name:     "plain fields",
+			value:    "mem=8G arch=amd64",
+			expected: []string{"mem=8G", "arch=amd64"},
+		},
+		{
+			name:     "escaped spaces",
+			value:    `tags=prod\ blue zones=us-east-1a`,
+			expected: []string{"tags=prod blue", "zones=us-east-1a"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c.Check(splitEscapedFields(test.value), qt.DeepEquals, test.expected)
+		})
+	}
+}
+
+func TestStringifyScalar(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+		errMatch string
+	}{
+		{
+			name:     "string",
+			value:    "value",
+			expected: "value",
+		},
+		{
+			name:     "bool",
+			value:    true,
+			expected: "true",
+		},
+		{
+			name:     "integer",
+			value:    42,
+			expected: "42",
+		},
+		{
+			name:     "float",
+			value:    3.5,
+			expected: "3.5",
+		},
+		{
+			name:     "nil",
+			value:    nil,
+			errMatch: "nil value",
+		},
+		{
+			name:     "non scalar",
+			value:    []string{"nope"},
+			errMatch: `unsupported type \[\]string`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, err := stringifyScalar(test.value)
+			if test.errMatch != "" {
+				c.Assert(err, qt.ErrorMatches, test.errMatch)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Check(value, qt.Equals, test.expected)
+		})
+	}
 }

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -236,17 +236,24 @@ Bootstrap a Juju controller via JIMM
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--bootstrap-base` |  | Specify the base of the bootstrap machine |
+| `--bootstrap-constraints` | [] | Specify bootstrap machine constraints |
 | `--config` |  | Specify a configuration file, or one or more configuration options.     (`--config config.yaml [--config key=value ...])` |
+| `--constraints` | [] | Set model constraints |
 | `--credential` |  | The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud. |
 | `--detach` | false | If set, the command will start the bootstrap job and return immediately with the job ID, without waiting for the job to complete. |
 | `--format` | json | Specify output format (json&#x7c;yaml) |
+| `--model-default` |  | Specify a configuration file, or one or more configuration options to be set for all models, unless otherwise specified.     (`--model-default config.yaml [--model-default key=value ...])` |
 | `-o`, `--output` |  | Specify an output file |
+| `--storage-pool` |  | Specify options for an initial storage pool. 'name' and 'type' are required, plus any additional attributes.     (`--storage-pool pool-config.yaml [--storage-pool key=value ...])` |
 
 ## Examples
 
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --config controller-service-type=loadbalancer
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --bootstrap-base ubuntu@24.04 --bootstrap-constraints mem=8G --constraints arch=amd64
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --storage-pool name=controller-pool --storage-pool type=ebs --config audit-log-enabled=true
 
 
 ## Details
@@ -276,10 +283,11 @@ file contents.
 These config options must match the config options supported by the Juju CLI
 for the version of Juju being bootstrapped. See the Juju documentation for
 the version specified for the full list of supported bootstrap config
-options.
+options. Additional bootstrap settings can be supplied with --bootstrap-base,
+--bootstrap-constraints, --constraints, --model-default, and --storage-pool,
+these align with the corresponding Juju CLI options.
 
-Note that some config options may not be specified as they will automatically
-be set.
+Note that some config options will be automatically set but can be overriden.
 These are:
 
 - login-token-refresh-url

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -236,8 +236,8 @@ Bootstrap a Juju controller via JIMM
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
-| `--bootstrap-base` |  | Specify the base of the bootstrap machine |
-| `--bootstrap-constraints` | [] | Specify bootstrap machine constraints |
+| `--bootstrap-base` |  | Specify the base of the bootstrap machine. |
+| `--bootstrap-constraints` | [] | Specify bootstrap machine constraints. |
 | `--config` |  | Specify a configuration file, or one or more configuration options.     (`--config config.yaml [--config key=value ...])` |
 | `--constraints` | [] | Set model constraints |
 | `--credential` |  | The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud. |

--- a/internal/jujuapi/types.go
+++ b/internal/jujuapi/types.go
@@ -54,6 +54,7 @@ func cloudFromParams(cloudName string, p jujuparams.Cloud) cloud.Cloud {
 	}
 }
 
+// bootstrapCloudFromParams converts the bootstrap cloud params into a cloud.Cloud.
 func bootstrapCloudFromParams(p params.BootstrapCloud) cloud.Cloud {
 	authTypes := make([]cloud.AuthType, len(p.AuthTypes))
 	for i, authType := range p.AuthTypes {

--- a/tests/bootstrap/bootstrap-k8s.sh
+++ b/tests/bootstrap/bootstrap-k8s.sh
@@ -14,7 +14,10 @@ sudo microk8s config | juju add-k8s testk8s --cluster-name=microk8s-cluster --cl
 
 echo
 echo "Bootstrapping controller on microk8s"
-$JAAS bootstrap testk8s test-controller 3.6.9 --config controller-service-type=loadbalancer
+$JAAS bootstrap testk8s test-controller 3.6.9 \
+  --config controller-service-type=loadbalancer \
+  --bootstrap-constraints cores=2 \
+  --model-default logging-config=<root>=INFO
 
 CERT=$(sudo microk8s config | yq '.users[0].user."client-certificate-data"')
 KEY=$(sudo microk8s config | yq '.users[0].user."client-key-data"' )

--- a/tests/bootstrap/bootstrap-k8s.sh
+++ b/tests/bootstrap/bootstrap-k8s.sh
@@ -17,7 +17,7 @@ echo "Bootstrapping controller on microk8s"
 $JAAS bootstrap testk8s test-controller 3.6.9 \
   --config controller-service-type=loadbalancer \
   --bootstrap-constraints cores=2 \
-  --model-default logging-config=<root>=INFO
+  --model-default 'logging-config=<root>=INFO'
 
 CERT=$(sudo microk8s config | yq '.users[0].user."client-certificate-data"')
 KEY=$(sudo microk8s config | yq '.users[0].user."client-key-data"' )


### PR DESCRIPTION
## Description
This change adds additional flags to the `jaas bootstrap` command to give it similar capabilities to `juju bootstrap`, allowing a user to specify the bootstrap base, bootstrap constraints, model constraints, model defaults, storage-pool, config.

The constraint parsing logic was largely lifted from the Juju codebase.

Fixes: [JUJU-9427](https://warthogs.atlassian.net/browse/JUJU-9427)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

[JUJU-9427]: https://warthogs.atlassian.net/browse/JUJU-9427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ