### PR TITLE
fix(context): t.Context() can't be used in t.Cleanup()

### DIFF
--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -333,7 +333,7 @@ func (s *JimmWithControllers) OpenNoAssert(c *qt.C, d LoginDetails, modelTag *na
 		dialOpts.DialWebsocket = d.DialWebsocket
 	}
 
-	return api.Open(c.Context(), &inf, dialOpts)
+	return api.Open(context.Background(), &inf, dialOpts)
 }
 
 func (s *JimmWithControllers) Open(c *qt.C, info *api.Info, username string, modelTag *names.ModelTag) api.Connection {

--- a/testing/caasmodelmanager_test.go
+++ b/testing/caasmodelmanager_test.go
@@ -3,6 +3,7 @@
 package testing
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func SetupCaasModelTest(c *qt.C) caasModelManagerDeps {
 		conn := s.Open(c, nil, "bob@canonical.com", nil)
 		defer conn.Close()
 		cloudclient := cloudapi.NewClient(conn)
-		err := cloudclient.RemoveCloud(c.Context(), deps.cloudName)
+		err := cloudclient.RemoveCloud(context.Background(), deps.cloudName)
 		c.Check(err, qt.Equals, nil)
 	})
 


### PR DESCRIPTION
# Description

t.Context() is cancelled before calling t.Cleanup(), so we need to use context.Background() instead.

```
// Context returns a context that is canceled just before
// Cleanup-registered functions are called.
//
// Cleanup functions can wait for any resources
// that shut down on [context.Context.Done] before the test or benchmark completes.
func (c *common) Context() context.Context {
	c.checkFuzzFn("Context")
	return c.ctx
}
```

# QA

No e2e test in caas-modelmanager_test.go should fail.