### PR TITLE
fix(e2e-tests): fix controller facade e2e testing

### DIFF
--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -108,10 +108,10 @@ func TestIdentityProviderURL(t *testing.T) {
 	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 
-	var result jujuparams.StringResult
-	err := conn.APICall(t.Context(), "Controller", 12, "", "IdentityProviderURL", nil, &result)
+	client := controllerapi.NewClient(conn)
+	res, err := client.IdentityProviderURL(t.Context())
 	c.Assert(err, qt.IsNil)
-	c.Assert(result.Result, qt.Matches, ``)
+	c.Assert(res, qt.Matches, ``)
 }
 
 func TestControllerVersion(t *testing.T) {
@@ -121,11 +121,11 @@ func TestControllerVersion(t *testing.T) {
 	conn := s.Open(c, nil, "test", nil)
 	defer conn.Close()
 
-	var result jujuparams.ControllerVersionResults
-	err := conn.APICall(t.Context(), "Controller", 12, "", "ControllerVersion", nil, &result)
+	client := controllerapi.NewClient(conn)
+	result, err := client.ControllerVersion(t.Context())
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, qt.DeepEquals, jujuparams.ControllerVersionResults{
-		Version:   "3.6.19",
+	c.Assert(result, qt.DeepEquals, controllerapi.ControllerVersion{
+		Version:   "3.6.20",
 		GitCommit: jimmversion.VersionInfo.GitCommit,
 	})
 }
@@ -278,18 +278,14 @@ func TestWatchAllModelSummaries(t *testing.T) {
 	conn := s.Open(c, nil, "alice", nil)
 	defer conn.Close()
 
-	var watcherID jujuparams.SummaryWatcherID
-	err := conn.APICall(t.Context(), "Controller", 12, "", "WatchAllModelSummaries", nil, &watcherID)
+	client := controllerapi.NewClient(conn)
+	w, err := client.WatchAllModelSummaries(t.Context())
 	c.Assert(err, qt.IsNil)
 
-	var summaries jujuparams.SummaryWatcherNextResults
-	err = conn.APICall(t.Context(), "ModelSummaryWatcher", 1, watcherID.WatcherID, "Next", nil, &summaries)
+	models, err := w.Next(t.Context())
 	c.Assert(err, qt.IsNil)
-	c.Assert(summaries.Models, qt.DeepEquals, expectedModels)
+	c.Assert(models, qt.DeepEquals, expectedModels)
 
-	err = conn.APICall(t.Context(), "ModelSummaryWatcher", 1, watcherID.WatcherID, "Stop", nil, nil)
+	err = w.Stop(t.Context())
 	c.Assert(err, qt.IsNil)
-
-	err = conn.APICall(t.Context(), "ModelSummaryWatcher", 1, "unknown-id", "Next", nil, &summaries)
-	c.Assert(err, qt.ErrorMatches, `not found \(not found\)`)
 }

--- a/testing/controllerroot_test.go
+++ b/testing/controllerroot_test.go
@@ -7,8 +7,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/core/semversion"
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
@@ -27,7 +27,7 @@ func TestServerVersion(t *testing.T) {
 
 	v, ok := conn.ServerVersion()
 	c.Assert(ok, qt.Equals, true)
-	c.Assert(v, qt.DeepEquals, version.MustParse("1.2.3"))
+	c.Assert(v, qt.DeepEquals, semversion.MustParse("1.2.3"))
 }
 
 func TestUnimplementedMethodFails(t *testing.T) {
@@ -53,5 +53,5 @@ func TestUnimplementedRootFails(t *testing.T) {
 	defer conn.Close()
 	var resp jujuparams.RedirectInfoResult
 	err := conn.APICall(t.Context(), "NoSuch", 1, "", "Method", nil, &resp)
-	c.Assert(err, qt.ErrorMatches, `(?s).*no such request - method NoSuch\(1\).Method is not implemented \(not implemented\).*`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*unknown method "Method" at version 1 for facade type "NoSuch" \(not implemented\).*`)
 }


### PR DESCRIPTION
## Description

fix by using the controller client instead of raw facade calls, and reformat not-implement messages

# QA
no tests in controller_test.go or controlerroot_test.go should fail.