### PR TITLE
fix(remove-cloud-spec): remove CloudSpec in favor of ControllerModelSummary

### DIFF
--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -211,13 +211,13 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 	}
 	defer api.Close()
 
-	cloudSpec, err := api.CloudSpec(ctx)
+	modelSummary, err := api.ControllerModelSummary(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get model summary: %v", err)
 	}
 
-	ctl.CloudName = cloudSpec.Name
-	ctl.CloudRegion = cloudSpec.Region
+	ctl.CloudName = modelSummary.Cloud
+	ctl.CloudRegion = modelSummary.CloudRegion
 	// TODO(mhilton) add the controller model?
 
 	clouds, err := api.Clouds(ctx)
@@ -260,7 +260,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 	for _, cloud := range dbClouds {
 		// If this cloud is the one used by the controller model then
 		// it is available to all users. Other clouds require `juju grant-cloud` to add permissions.
-		if cloud.Name == cloudSpec.Name {
+		if cloud.Name == modelSummary.Cloud {
 			if err := j.everyoneUser().SetCloudAccess(ctx, cloud.ResourceTag(), ofganames.CanAddModelRelation); err != nil {
 				zapctx.Error(ctx, "failed to grant everyone add-model access", zap.Error(err))
 			}

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs/cloudspec"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
 	"gopkg.in/macaroon.v2"
@@ -86,12 +85,11 @@ func TestAddController(t *testing.T) {
 			}
 			return clouds, nil
 		},
-		CloudSpec_: func(ctx context.Context) (cloudspec.CloudSpec, error) {
-			cs := cloudspec.CloudSpec{}
-			cs.Name = "aws"
-			cs.Type = "iaas"
-			cs.Region = "eu-west-1"
-			return cs, nil
+		ControllerModelSummary_: func(ctx context.Context) (base.UserModelSummary, error) {
+			ms := base.UserModelSummary{}
+			ms.Cloud = "aws"
+			ms.CloudRegion = "eu-west-1"
+			return ms, nil
 		},
 	}
 
@@ -157,11 +155,10 @@ func TestAddControllerWithCloudWithoutRegions(t *testing.T) {
 			}
 			return clouds, nil
 		},
-		CloudSpec_: func(ctx context.Context) (cloudspec.CloudSpec, error) {
-			cs := cloudspec.CloudSpec{}
-			cs.Name = "k8s"
-			cs.Type = "iaas"
-			return cs, nil
+		ControllerModelSummary_: func(ctx context.Context) (base.UserModelSummary, error) {
+			ms := base.UserModelSummary{}
+			ms.Cloud = "k8s"
+			return ms, nil
 		},
 	}
 
@@ -272,12 +269,11 @@ func TestAddControllerWithVault(t *testing.T) {
 			}
 			return clouds, nil
 		},
-		CloudSpec_: func(ctx context.Context) (cloudspec.CloudSpec, error) {
-			cs := cloudspec.CloudSpec{}
-			cs.Name = "aws"
-			cs.Type = "iaas"
-			cs.Region = "eu-west-1"
-			return cs, nil
+		ControllerModelSummary_: func(ctx context.Context) (base.UserModelSummary, error) {
+			ms := base.UserModelSummary{}
+			ms.Cloud = "aws"
+			ms.CloudRegion = "eu-west-1"
+			return ms, nil
 		},
 	}
 

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/semversion"
-	"github.com/juju/juju/environs/cloudspec"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
 
@@ -76,8 +75,9 @@ type API interface {
 	// Clouds returns the set of clouds supported by the controller.
 	Clouds(context.Context) (map[names.CloudTag]jujucloud.Cloud, error)
 
-	// CloudSpec fetches the cloud spec of the model connected to.
-	CloudSpec(context.Context) (cloudspec.CloudSpec, error)
+	// ControllerModelSummary fetches the model summary of the model on the
+	// controller that hosts the controller machines.
+	ControllerModelSummary(context.Context) (base.UserModelSummary, error)
 
 	// ControllerConfig fetches the controller configuration.
 	ControllerConfig(context.Context) (jujucontroller.Config, error)

--- a/internal/jimm/upgrade/mocks/api.go
+++ b/internal/jimm/upgrade/mocks/api.go
@@ -23,7 +23,6 @@ import (
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	migration "github.com/juju/juju/core/migration"
 	semversion "github.com/juju/juju/core/semversion"
-	cloudspec "github.com/juju/juju/environs/cloudspec"
 	params "github.com/juju/juju/rpc/params"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
@@ -513,45 +512,6 @@ func (c *MockAPICloudCall) DoAndReturn(f func(context.Context, names.CloudTag) (
 	return c
 }
 
-// CloudSpec mocks base method.
-func (m *MockAPI) CloudSpec(arg0 context.Context) (cloudspec.CloudSpec, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudSpec", arg0)
-	ret0, _ := ret[0].(cloudspec.CloudSpec)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CloudSpec indicates an expected call of CloudSpec.
-func (mr *MockAPIMockRecorder) CloudSpec(arg0 any) *MockAPICloudSpecCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockAPI)(nil).CloudSpec), arg0)
-	return &MockAPICloudSpecCall{Call: call}
-}
-
-// MockAPICloudSpecCall wrap *gomock.Call
-type MockAPICloudSpecCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockAPICloudSpecCall) Return(arg0 cloudspec.CloudSpec, arg1 error) *MockAPICloudSpecCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockAPICloudSpecCall) Do(f func(context.Context) (cloudspec.CloudSpec, error)) *MockAPICloudSpecCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICloudSpecCall) DoAndReturn(f func(context.Context) (cloudspec.CloudSpec, error)) *MockAPICloudSpecCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Clouds mocks base method.
 func (m *MockAPI) Clouds(arg0 context.Context) (map[names.CloudTag]cloud.Cloud, error) {
 	m.ctrl.T.Helper()
@@ -704,6 +664,45 @@ func (c *MockAPIControllerConfigCall) Do(f func(context.Context) (controller.Con
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockAPIControllerConfigCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ControllerModelSummary mocks base method.
+func (m *MockAPI) ControllerModelSummary(arg0 context.Context) (base.UserModelSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerModelSummary", arg0)
+	ret0, _ := ret[0].(base.UserModelSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerModelSummary indicates an expected call of ControllerModelSummary.
+func (mr *MockAPIMockRecorder) ControllerModelSummary(arg0 any) *MockAPIControllerModelSummaryCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerModelSummary", reflect.TypeOf((*MockAPI)(nil).ControllerModelSummary), arg0)
+	return &MockAPIControllerModelSummaryCall{Call: call}
+}
+
+// MockAPIControllerModelSummaryCall wrap *gomock.Call
+type MockAPIControllerModelSummaryCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAPIControllerModelSummaryCall) Return(arg0 base.UserModelSummary, arg1 error) *MockAPIControllerModelSummaryCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAPIControllerModelSummaryCall) Do(f func(context.Context) (base.UserModelSummary, error)) *MockAPIControllerModelSummaryCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAPIControllerModelSummaryCall) DoAndReturn(f func(context.Context) (base.UserModelSummary, error)) *MockAPIControllerModelSummaryCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jujuclient/controller.go
+++ b/internal/jujuclient/controller.go
@@ -5,32 +5,11 @@ package jujuclient
 import (
 	"context"
 
-	"github.com/juju/juju/api/client/modelconfig"
 	"github.com/juju/juju/api/controller/controller"
 	jujucontroller "github.com/juju/juju/controller"
-	"github.com/juju/juju/environs/cloudspec"
-	"github.com/juju/juju/environs/config"
-	"github.com/juju/names/v6"
 )
 
 // ControllerConfig retrieves the controller configuration.
 func (c Connection) ControllerConfig(ctx context.Context) (jujucontroller.Config, error) {
 	return controller.NewClient(&c).ControllerConfig(ctx)
-}
-
-// CloudSpec retrieves the cloud spec of the model connected to.
-func (c Connection) CloudSpec(ctx context.Context) (cloudspec.CloudSpec, error) {
-	modelCfgClient := modelconfig.NewClient(&c)
-	attrs, err := modelCfgClient.ModelGet(ctx)
-	if err != nil {
-		return cloudspec.CloudSpec{}, err
-	}
-
-	cfg, err := config.New(config.NoDefaults, attrs)
-	if err != nil {
-		return cloudspec.CloudSpec{}, err
-	}
-
-	controllerClient := controller.NewClient(&c)
-	return controllerClient.CloudSpec(ctx, names.NewModelTag(cfg.UUID()))
 }

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -116,6 +116,22 @@ func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[st
 	return modelmanager.NewClient(&c).DumpModelDB(ctx, tag)
 }
 
+// ControllerModelSummary retrieves the ModelSummary for the controller
+// model. ControllerModelSummary uses the ListModelSummaries procedure on
+// the ModelManager facade.
+func (c Connection) ControllerModelSummary(ctx context.Context) (base.UserModelSummary, error) {
+	modelSummaries, err := modelmanager.NewClient(&c).ListModelSummaries(ctx, c.user.ResourceTag().String(), true)
+	if err != nil {
+		return base.UserModelSummary{}, err
+	}
+	for _, r := range modelSummaries {
+		if r.IsController {
+			return r, nil
+		}
+	}
+	return base.UserModelSummary{}, errors.E("controller model not found", errors.CodeNotFound)
+}
+
 // ListModelSummaries retrieves the list of model summaries from the controler
 func (c Connection) ListModelSummaries(ctx context.Context, ms jujuparams.ModelSummariesRequest) ([]base.UserModelSummary, error) {
 	return modelmanager.NewClient(&c).ListModelSummaries(ctx, c.user.ResourceTag().String(), ms.All)

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -15,7 +15,6 @@ import (
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
-	"github.com/juju/juju/environs/cloudspec"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
 
@@ -137,7 +136,7 @@ type API struct {
 	Close_                             func() error
 	Cloud_                             func(context.Context, names.CloudTag) (jujucloud.Cloud, error)
 	Clouds_                            func(context.Context) (map[names.CloudTag]jujucloud.Cloud, error)
-	CloudSpec_                         func(context.Context) (cloudspec.CloudSpec, error)
+	ControllerModelSummary_            func(context.Context) (base.UserModelSummary, error)
 	ControllerConfig_                  func(context.Context) (jujucontroller.Config, error)
 	CreateModel_                       func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error)
 	DestroyApplicationOffer_           func(context.Context, string, bool) error
@@ -238,11 +237,11 @@ func (a *API) Clouds(ctx context.Context) (map[names.CloudTag]jujucloud.Cloud, e
 	return a.Clouds_(ctx)
 }
 
-func (a *API) CloudSpec(ctx context.Context) (cloudspec.CloudSpec, error) {
-	if a.CloudSpec_ == nil {
-		return cloudspec.CloudSpec{}, errors.E(errors.CodeNotImplemented)
+func (a *API) ControllerModelSummary(ctx context.Context) (base.UserModelSummary, error) {
+	if a.ControllerModelSummary_ == nil {
+		return base.UserModelSummary{}, errors.E(errors.CodeNotImplemented)
 	}
-	return a.CloudSpec_(ctx)
+	return a.ControllerModelSummary_(ctx)
 }
 
 func (a *API) ControllerConfig(ctx context.Context) (jujucontroller.Config, error) {

--- a/local/jimm/Dockerfile
+++ b/local/jimm/Dockerfile
@@ -1,6 +1,6 @@
 # Installing delve in the image to avoid running go install in running containers.
 # Installing air to avoid breakages when we update our Go version before a new air image is available.
-FROM golang:1.25 AS dev
+FROM golang:1.26 AS dev
 
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.1
 RUN go install github.com/air-verse/air@v1.63.1
@@ -8,7 +8,7 @@ RUN go install github.com/air-verse/air@v1.63.1
 ENTRYPOINT [ "air" ]
 
 # Create a target without air that we use in smoke tests.
-FROM golang:1.25-bookworm AS smoke
+FROM golang:1.26-bookworm AS smoke
 
 COPY entrypoint.sh     /entry/entrypoint.sh
 


### PR DESCRIPTION
# Description

implement ControllerModelSummary by querying all models and taking only the controller. In this way we can avoid using CloudSpec in JIMM, since it's causing troubles.

And now we can do `make qa-lxd` againt the `4.0` branch in juju.

> fly-by update delve

# QA

`git checkout 4.0` in juju

in jimm `make qa-lxd`, and it should work.