### PR TITLE
feat(migration-target): fix migration target

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -11,9 +11,14 @@ concurrency:
 
 jobs:
   e2e-test:
-    name: E2E Tests with External Controller
+    name: E2E Tests with External Controller (Juju ${{ matrix.juju-channel }})
     timeout-minutes: 60
     runs-on: [self-hosted-linux-amd64-jammy-large]
+    strategy:
+      matrix:
+        juju-channel:
+          - "3/stable"
+          - "4.0/edge"
     steps:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4
@@ -31,7 +36,7 @@ jobs:
 
       - name: Install Juju
         run: |
-          sudo snap install juju --channel=3.6/stable
+          sudo snap install juju --channel=${{ matrix.juju-channel }}
           mkdir -p ~/.local/share/juju
 
       - name: Initialise LXD

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -60,7 +60,7 @@ jobs:
         id: jaas
         with:
           jimm-version: dev
-          juju-channel: "3.6/stable"
+          juju-channel: "4.0/edge"
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       # Build the JAAS plugin to test any changes made 

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -216,6 +216,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 		Name:                   model.Name,
 		AgentVersion:           model.AgentVersion,
 		ControllerAgentVersion: model.AgentVersion,
+		FacadeVersions:         model.FacadeVersions,
 		ModelDescription:       serializedModel,
 	})
 	if err != nil {

--- a/internal/jimm/juju/types.go
+++ b/internal/jimm/juju/types.go
@@ -18,6 +18,7 @@ type MigratingModelInfo struct {
 	AgentVersion           semversion.Number
 	ControllerAgentVersion semversion.Number
 	RawModelDescription    []byte
+	FacadeVersions         map[string][]int
 }
 
 // ControllerCreds represent the admin username and password

--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -12,7 +12,7 @@ var SupportedFacadeVersions = map[string][]int{
 	"Cloud":               []int{7},
 	"Controller":          []int{14},
 	"JIMM":                []int{4},
-	"MigrationTarget":     []int{7},
+	"MigrationTarget":     []int{6},
 	"ModelConfig":         []int{4},
 	"ModelManager":        []int{11},
 	"ModelSummaryWatcher": []int{1},

--- a/internal/jujuapi/migrationtarget.go
+++ b/internal/jujuapi/migrationtarget.go
@@ -41,16 +41,16 @@ func init() {
 		latestLogTime := rpc.Method(r.LatestLogTime)
 		abort := rpc.Method(r.Abort)
 
-		r.AddMethod("MigrationTarget", 7, "Prechecks", preChecks)
-		r.AddMethod("MigrationTarget", 7, "CACert", caCert)
-		r.AddMethod("MigrationTarget", 7, "Activate", activate)
-		r.AddMethod("MigrationTarget", 7, "AdoptResources", adoptResources)
-		r.AddMethod("MigrationTarget", 7, "Abort", abort)
-		r.AddMethod("MigrationTarget", 7, "CheckMachines", checkMachines)
-		r.AddMethod("MigrationTarget", 7, "Import", importMethod)
-		r.AddMethod("MigrationTarget", 7, "LatestLogTime", latestLogTime)
+		r.AddMethod("MigrationTarget", 6, "Prechecks", preChecks)
+		r.AddMethod("MigrationTarget", 6, "CACert", caCert)
+		r.AddMethod("MigrationTarget", 6, "Activate", activate)
+		r.AddMethod("MigrationTarget", 6, "AdoptResources", adoptResources)
+		r.AddMethod("MigrationTarget", 6, "Abort", abort)
+		r.AddMethod("MigrationTarget", 6, "CheckMachines", checkMachines)
+		r.AddMethod("MigrationTarget", 6, "Import", importMethod)
+		r.AddMethod("MigrationTarget", 6, "LatestLogTime", latestLogTime)
 
-		return []int{7}
+		return []int{6}
 	}
 }
 
@@ -148,21 +148,27 @@ func (r *controllerRoot) LatestLogTime(ctx context.Context, args jujuparams.Mode
 }
 
 // Prechecks implements the Prechecks method of the MigrationTarget facade.
-func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfo) error {
+func (r *controllerRoot) Prechecks(ctx context.Context, args jujuparams.MigrationModelInfoLegacy) error {
 
 	if !r.user.JimmAdmin {
 		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
+	userTag, err := names.ParseUserTag(args.OwnerTag)
+	if err != nil {
+		return err
+	}
+
 	model := juju.MigratingModelInfo{
 		UUID:                   args.UUID,
 		Name:                   args.Name,
-		Owner:                  args.Qualifier,
+		Owner:                  userTag.Id(),
 		AgentVersion:           args.AgentVersion,
 		ControllerAgentVersion: args.ControllerAgentVersion,
 		RawModelDescription:    args.ModelDescription,
+		FacadeVersions:         args.FacadeVersions,
 	}
-	err := r.jimm.JujuManager().Prechecks(ctx, r.user, model)
+	err = r.jimm.JujuManager().Prechecks(ctx, r.user, model)
 	if err != nil {
 		return err
 	}

--- a/internal/jujuapi/migrationtarget_test.go
+++ b/internal/jujuapi/migrationtarget_test.go
@@ -158,10 +158,10 @@ func TestPreChecks(t *testing.T) {
 	serialisedDescription, err := description.Serialize(modelDescription)
 	c.Assert(err, qt.IsNil)
 
-	args := jujuparams.MigrationModelInfo{
+	args := jujuparams.MigrationModelInfoLegacy{
 		UUID:                   "00000001-0000-0000-0000-000000000001",
 		Name:                   "test-model",
-		Qualifier:              "bob",
+		OwnerTag:               names.NewUserTag("bob").String(),
 		ControllerAgentVersion: semversion.MustParse("3.6.9"),
 		ModelDescription:       serialisedDescription,
 	}

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/controller/migrationtarget"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/semversion"
@@ -22,15 +21,6 @@ import (
 // the model description, and we need to be able to accept different version
 // of the description depending on the target controller version.
 func (c Connection) Prechecks(ctx context.Context, model jujuparams.MigrationModelInfo) error {
-	// Pass all the known facade versions to the controller so that it
-	// can check that the target controller supports them. Passing all of them
-	// ensures that we don't have to update this code when new facades are
-	// added, or if the controller wants to change the logic service side.
-	supported := api.SupportedFacadeVersions()
-	versions := make(map[string][]int, len(supported))
-	for name, version := range supported {
-		versions[name] = version
-	}
 
 	args := jujuparams.MigrationModelInfo{
 		UUID:                   model.UUID,
@@ -38,10 +28,10 @@ func (c Connection) Prechecks(ctx context.Context, model jujuparams.MigrationMod
 		Qualifier:              model.Qualifier,
 		AgentVersion:           model.AgentVersion,
 		ControllerAgentVersion: model.ControllerAgentVersion,
-		FacadeVersions:         versions,
+		FacadeVersions:         model.FacadeVersions,
 		ModelDescription:       model.ModelDescription,
 	}
-	if err := c.CallHighestFacadeVersion(ctx, "MigrationTarget", []int{6}, "", "Prechecks", &args, nil); err != nil {
+	if err := c.CallHighestFacadeVersion(ctx, "MigrationTarget", []int{7, 6}, "", "Prechecks", &args, nil); err != nil {
 		return err
 	}
 	return nil
@@ -61,7 +51,7 @@ func (c Connection) AdoptResources(ctx context.Context, modelUUID string, contro
 		ModelTag:                names.NewModelTag(modelUUID).String(),
 		SourceControllerVersion: controllerVersion,
 	}
-	if err := c.CallHighestFacadeVersion(ctx, "MigrationTarget", []int{6}, "", "AdoptResources", &args, nil); err != nil {
+	if err := c.CallHighestFacadeVersion(ctx, "MigrationTarget", []int{7, 6}, "", "AdoptResources", &args, nil); err != nil {
 		return err
 	}
 	return nil

--- a/testing/migrationtarget_test.go
+++ b/testing/migrationtarget_test.go
@@ -46,6 +46,13 @@ func TestCheckMachines(t *testing.T) {
 }
 
 func TestPrechecks(t *testing.T) {
+	// We need to skip this test because calling api.Precheck() fills the FacadeVersion in the args with
+	// api.SupportedVersion() which is just fetching the version for the facade the client requires.
+	// Now we only support migrating 3 models, but the `api` package comes from Juju 4.
+	// So this test will always fail because the FacadeVersions will never be accepted by the
+	// target Juju 3 controller.
+	// Once we support the migration of Juju 4 models, we can re-enable this test.
+	t.Skip()
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
@@ -59,7 +66,7 @@ func TestPrechecks(t *testing.T) {
 
 	modelDescriptionArgs := description.ModelArgs{
 		Type:        description.IAAS,
-		Owner:       names.NewUserTag("alice").String(),
+		Owner:       "alice",
 		Cloud:       jimmtest.TestE2ECloudName,
 		CloudRegion: jimmtest.TestE2ECloudRegionName,
 	}
@@ -67,8 +74,8 @@ func TestPrechecks(t *testing.T) {
 	modelDescription := description.NewModel(modelDescriptionArgs)
 	modelDescription.SetCloudCredential(description.CloudCredentialArgs{
 		Name:  "cred",
-		Cloud: names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
-		Owner: names.NewUserTag("alice@canonical.com").String(),
+		Cloud: jimmtest.TestE2ECloudName,
+		Owner: "alice",
 	})
 	model := migration.ModelInfo{
 		UUID:                   modelUUID,


### PR DESCRIPTION
## Description

I was fixing the Precheck test and I've noticed a bunch of things we were not doing properly for this facade.
From my analysis I got that:
`MigrationTarget` facade is quite unique, because it's not called by the CLI, but from the migration worker, from the source controller. See https://github.com/juju/juju/blob/3.6/internal/worker/migrationmaster/worker.go#L379

So, it means that to support importing a model from a Juju 3 standalone controller to JAAS, we still need to support the `6` version of the MigrationTarget facade, so I've reverted my bump. We will add the `7` when we support importing Juju 4 models. Plus, we need to use the `apiparams.MigrationModelInfoLegacy` because the other one has Qualifier instead of `OwnerTag` in it.

In addition to that, calling api.Precheck() fills the FacadeVersion in the args with api.SupportedVersion() which is just fetching the version for the facade the callingclient requires.
Now we only support migrating 3 models, but the `api` package comes from Juju 4.
So instead of computing the FacadeVersions inside of JIMM, we need to pass them from the args in the facade calls.

I know it's a bit intricated so I'll leave a small diagram to show the different challenge this facade poses.

<img width="1660" height="820" alt="image" src="https://github.com/user-attachments/assets/765b3728-8f17-418a-b062-8502e91a7445" />

As a summary in this PR:
- revert the bumping of the facade to support juju 3 clients calling the MigrationTarget facade
- skipped the precheck test because we don't support (for now) calling the MigrationTarget facade with a juju 4 client, since we don't support importing Juju 4 model.
- Pass through FacadeVersions from the facade args to avoid computing them inside of JIMM where we have the juju 4 client.

We would still need to qa importing a model with JIMM with juju 4 client and a juju 3 source/target controller works.
