### PR TITLE
test(e2e): fix apiproxy tests by making the match on the regex looser

### DIFF
--- a/testing/apiproxy_test.go
+++ b/testing/apiproxy_test.go
@@ -34,7 +34,7 @@ func TestConnectToModel(t *testing.T) {
 	defer conn.Close()
 	var resp map[string]interface{}
 	err := conn.APICall(t.Context(), "Admin", 3, "", "TestMethod", nil, &resp)
-	c.Assert(err, qt.ErrorMatches, `(?s).*no such request - method Admin.TestMethod is not implemented \(not implemented\).*`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*\(not implemented\).*`)
 }
 
 // TestSessionTokenLoginProvider verifies that the session token login provider works as expected.


### PR DESCRIPTION
## Description
Simple e2e fix, just made the regex a little more looser to accomodate 4.0 and 3.

# QA

apiproxy_test.go shouldn't have any failure in both 3 and 4 workflows