### PR TITLE
feat: rename admin user used when dialling as self

### DIFF
--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	adminUser = "admin"
+	adminUser = "jaas@external"
 )
 
 // A ControllerCredentialsStore is a store for controller credentials.


### PR DESCRIPTION
## Description
This ensures JIMM always dials Juju controllers as a Juju external user, whether dialling on behalf of a user that in turn dialled JIMM or not.

