### PR TITLE
fix(vault-dockerfile): fix vault image

### DIFF
--- a/local/vault/Dockerfile
+++ b/local/vault/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/vault:latest
+FROM hashicorp/vault:1.21
 
 # Add our policy and entrypoint
 COPY policy.hcl                   /vault/policy.hcl

--- a/local/vault/Dockerfile
+++ b/local/vault/Dockerfile
@@ -1,9 +1,5 @@
 FROM hashicorp/vault:latest
 
-# Add jq to make scripting the calls a bit easier
-# ref: https://stedolan.github.io/jq/
-RUN apk add --no-cache bash jq
-
 # Add our policy and entrypoint
 COPY policy.hcl                   /vault/policy.hcl
 COPY entrypoint.sh                /vault/entrypoint.sh
@@ -17,4 +13,4 @@ HEALTHCHECK \
     --interval=1s \
     --timeout=1s \
     --retries=30 \
-        CMD [ "/bin/sh", "-c", "[ -f /tmp/healthy ]" ]
+    CMD [ "/bin/sh", "-c", "[ -f /tmp/healthy ]" ]


### PR DESCRIPTION
# Description

Remove installation of bash/jq.

I think it was a left-over to do some initialization, but it's not used anymore and it was returning the error for the v2 image.
```
[2/4] RUN apk add --no-cache bash jq:
0.471 ERROR: Unable to open log: Permission denied
```
Plus, pin vault to `1.21` for the time being.

# QA
If the tests pass it should be ok.

