### PR TITLE
chore: ran go fix ./...

### DIFF
--- a/cmd/jaas/cmd/addmodel.go
+++ b/cmd/jaas/cmd/addmodel.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -253,7 +254,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	}
 
 	messageFormat := "Added '%s' model"
-	messageArgs := []interface{}{c.Name}
+	messageArgs := []any{c.Name}
 
 	details := jujuclient.ModelDetails{
 		ModelUUID: model.UUID,
@@ -471,10 +472,8 @@ func (c *addModelCommand) findUnspecifiedCredential(ctx *cmd.Context, p *findCre
 	}
 	// If the user has not specified a credential, and the cloud advertises
 	// itself as supporting the "empty" auth-type, then return immediately.
-	for _, authType := range p.cloud.AuthTypes {
-		if authType == jujucloud.EmptyAuthType {
-			return nil, names.CloudCredentialTag{}, p.cloudRegion, nil
-		}
+	if slices.Contains(p.cloud.AuthTypes, jujucloud.EmptyAuthType) {
+		return nil, names.CloudCredentialTag{}, p.cloudRegion, nil
 	}
 
 	if p.cloudTag.Id() == "" {
@@ -596,7 +595,7 @@ func (c *addModelCommand) findLocalCredential(ctx *cmd.Context, p *findCredentia
 	return fail(err)
 }
 
-func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interface{}, error) {
+func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]any, error) {
 	configValues, err := c.Config.ReadAttrs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse config: %w", err)
@@ -605,7 +604,7 @@ func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interfac
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse config: %w", err)
 	}
-	attrs, ok := coercedValues.(map[string]interface{})
+	attrs, ok := coercedValues.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("params must contain a YAML map with string keys")
 	}

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -392,7 +392,7 @@ func readStringMapFlag(ctxt *cmd.Context, flag *common.ConfigFlag, flagName stri
 	return stringifyMapValues(attrs, flagName)
 }
 
-func stringifyMapValues(attrs map[string]interface{}, flagName string) (map[string]string, error) {
+func stringifyMapValues(attrs map[string]any, flagName string) (map[string]string, error) {
 	if len(attrs) == 0 {
 		return nil, nil
 	}
@@ -407,7 +407,7 @@ func stringifyMapValues(attrs map[string]interface{}, flagName string) (map[stri
 	return values, nil
 }
 
-func stringifyScalar(value interface{}) (string, error) {
+func stringifyScalar(value any) (string, error) {
 	if value == nil {
 		return "", fmt.Errorf("nil value")
 	}

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -89,7 +89,6 @@ func TestBootstrapArgParsing(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		test := test
 		t.Run(fmt.Sprintf("%02d-%s", i, test.name), func(t *testing.T) {
 			c := qt.New(t)
 			command := &bootstrapCommand{}

--- a/cmd/jaas/cmd/listauditevents.go
+++ b/cmd/jaas/cmd/listauditevents.go
@@ -104,7 +104,7 @@ func (c *listAuditEventsCommand) Run(ctxt *cmd.Context) error {
 	return nil
 }
 
-func formatTabular(writer io.Writer, value interface{}) error {
+func formatTabular(writer io.Writer, value any) error {
 	e, ok := value.(apiparams.AuditEvents)
 	if !ok {
 		return fmt.Errorf("expected value of type %T, got %T", e, value)

--- a/cmd/jaas/cmd/listcontrollers_test.go
+++ b/cmd/jaas/cmd/listcontrollers_test.go
@@ -30,7 +30,7 @@ func TestListControllersSuperuser(t *testing.T) {
 			Status: jujuparams.EntityStatus{
 				Status: "available",
 				Info:   "",
-				Data:   map[string]interface{}{},
+				Data:   map[string]any{},
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestListControllersSuperuser(t *testing.T) {
 			Status: jujuparams.EntityStatus{
 				Status: "available",
 				Info:   "",
-				Data:   map[string]interface{}{},
+				Data:   map[string]any{},
 			},
 		},
 	}

--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -392,7 +392,7 @@ func (c *checkPermissionCommand) Init(args []string) error {
 	return nil
 }
 
-func formatCheckRelationString(writer io.Writer, value interface{}) error {
+func formatCheckRelationString(writer io.Writer, value any) error {
 	accessResult, ok := value.(accessResult)
 	if !ok {
 		return fmt.Errorf("failed to parse access result")
@@ -554,7 +554,7 @@ func fetchRelations(client JIMMAPI, params apiparams.ListRelationshipTuplesReque
 	}
 }
 
-func formatRelationsTabular(writer io.Writer, value interface{}) error {
+func formatRelationsTabular(writer io.Writer, value any) error {
 	resp, ok := value.(*apiparams.ListRelationshipTuplesResponse)
 	if !ok {
 		return fmt.Errorf("expected value of type %T, got %T", resp, value)

--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -138,7 +138,7 @@ func (c *registerControllerCommand) Run(ctxt *cmd.Context) error {
 	return c.out.Write(ctxt, info)
 }
 
-func unmarshalControllerDetails(v interface{}, data []byte) error {
+func unmarshalControllerDetails(v any, data []byte) error {
 	err := yaml.Unmarshal(data, &v)
 	if err != nil {
 		return err

--- a/cmd/jaas/cmd/showmodel.go
+++ b/cmd/jaas/cmd/showmodel.go
@@ -104,7 +104,7 @@ func (c *showModelCommand) Run(ctxt *cmd.Context) error {
 }
 
 // formatTabular formats the model controller info in a tabular format.
-func (c *showModelCommand) formatTabular(writer io.Writer, value interface{}) error {
+func (c *showModelCommand) formatTabular(writer io.Writer, value any) error {
 	info, ok := value.(*apiparams.ModelControllerInfo)
 	if !ok {
 		return fmt.Errorf("expected *apiparams.ModelControllerInfo, got %T", value)

--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -115,7 +115,6 @@ func (d *Database) FindApplicationOffersByModel(ctx context.Context, modelName, 
 	}
 
 	for i, offer := range offers {
-		offer := offer
 		err := d.GetApplicationOffer(ctx, &offer)
 		if err != nil {
 			return nil, dbError(err)

--- a/internal/db/clouddefaults.go
+++ b/internal/db/clouddefaults.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"maps"
 
 	"github.com/juju/names/v5"
 	"gorm.io/gorm/clause"
@@ -50,9 +51,7 @@ func (d *Database) SetCloudDefaults(ctx context.Context, defaults *dbmodel.Cloud
 		}
 
 		// update defaults
-		for k, v := range defaults.Defaults {
-			dbDefaults.Defaults[k] = v
-		}
+		maps.Copy(dbDefaults.Defaults, defaults.Defaults)
 		if err := db.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
 				{Name: "identity_name"},

--- a/internal/db/clouddefaults_test.go
+++ b/internal/db/clouddefaults_test.go
@@ -52,7 +52,7 @@ func (s *dbSuite) TestModelDefaults(c *qt.C) {
 		CloudID:      cloud.ID,
 		Cloud:        cloud,
 		Region:       cloud1.Regions[0].Name,
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key1": float64(17),
 			"key2": "some other data",
 		},
@@ -110,7 +110,7 @@ func (s *dbSuite) TestModelDefaults(c *qt.C) {
 		CloudID:      cloud1.ID,
 		Cloud:        cloud1,
 		Region:       cloud1.Regions[0].Name,
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key3": "more data",
 		},
 	})

--- a/internal/db/group_test.go
+++ b/internal/db/group_test.go
@@ -194,12 +194,12 @@ func (s *dbSuite) TestListGroups(c *qt.C) {
 	ctx := context.Background()
 	firstGroups, err := s.Database.ListGroups(ctx, 5, 0, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(firstGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i))
 	}
 	secondGroups, err := s.Database.ListGroups(ctx, 5, 5, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(secondGroups[i].Name, qt.Equals, fmt.Sprintf("test-group-%d", i+5))
 	}
 

--- a/internal/db/identity_test.go
+++ b/internal/db/identity_test.go
@@ -78,7 +78,7 @@ func (s *dbSuite) TestGetIdentityConcurrent(c *qt.C) {
 
 	N := 50
 	errorChannel := make(chan error, N)
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			u, err := dbmodel.NewIdentity("bob@canonical.com")
 			c.Check(err, qt.IsNil)
@@ -87,7 +87,7 @@ func (s *dbSuite) TestGetIdentityConcurrent(c *qt.C) {
 		}()
 	}
 
-	for i := 0; i < N; i++ {
+	for range N {
 		err = <-errorChannel
 		c.Assert(err, qt.IsNil)
 	}
@@ -251,12 +251,12 @@ func (s *dbSuite) TestListIdentities(c *qt.C) {
 	ctx := context.Background()
 	firstIdentities, err := s.Database.ListIdentities(ctx, 5, 0, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(firstIdentities[i].Name, qt.Equals, fmt.Sprintf("bob%d@canonical.com", i))
 	}
 	secondIdentities, err := s.Database.ListIdentities(ctx, 5, 5, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(secondIdentities[i].Name, qt.Equals, fmt.Sprintf("bob%d@canonical.com", i+5))
 	}
 

--- a/internal/db/role_test.go
+++ b/internal/db/role_test.go
@@ -156,12 +156,12 @@ func (s *dbSuite) TestListRole(c *qt.C) {
 	ctx := context.Background()
 	firstRoles, err := s.Database.ListRoles(ctx, 5, 0, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(firstRoles[i].Name, qt.Equals, fmt.Sprintf("test-role-%d", i))
 	}
 	secondRoles, err := s.Database.ListRoles(ctx, 5, 5, "")
 	c.Assert(err, qt.IsNil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Assert(secondRoles[i].Name, qt.Equals, fmt.Sprintf("test-role-%d", i+5))
 	}
 

--- a/internal/db/rootkeys_test.go
+++ b/internal/db/rootkeys_test.go
@@ -86,7 +86,7 @@ func (s *dbSuite) TestFindLatestKey(c *qt.C) {
 
 	// Add some keys
 	rks := make([]dbrootkeystore.RootKey, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		var name, key bytes.Buffer
 		fmt.Fprintf(&name, "test-%d", i)
 		fmt.Fprintf(&key, "secret %d", i)

--- a/internal/dbmodel/cloud.go
+++ b/internal/dbmodel/cloud.go
@@ -92,15 +92,15 @@ func (c Cloud) ToJujuCloud() jujuparams.Cloud {
 	cl.IdentityEndpoint = c.IdentityEndpoint
 	cl.StorageEndpoint = c.StorageEndpoint
 	cl.Regions = make([]jujuparams.CloudRegion, len(c.Regions))
-	cl.RegionConfig = make(map[string]map[string]interface{}, len(c.Regions))
+	cl.RegionConfig = make(map[string]map[string]any, len(c.Regions))
 	for i, r := range c.Regions {
 		cl.Regions[i] = r.ToJujuCloudRegion()
 		if r.Config != nil {
-			cl.RegionConfig[r.Name] = map[string]interface{}(r.Config)
+			cl.RegionConfig[r.Name] = map[string]any(r.Config)
 		}
 	}
 	cl.CACertificates = []string(c.CACertificates)
-	cl.Config = map[string]interface{}(c.Config)
+	cl.Config = map[string]any(c.Config)
 	return cl
 }
 

--- a/internal/dbmodel/cloud_test.go
+++ b/internal/dbmodel/cloud_test.go
@@ -48,7 +48,7 @@ func TestCloud(t *testing.T) {
 		Config: dbmodel.Map{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{"v"}},
+			"k3": map[string]any{"k": []any{"v"}},
 		},
 	}
 	result = db.Create(&cl1)
@@ -96,13 +96,13 @@ func TestToJujuCloud(t *testing.T) {
 			Config: dbmodel.Map{
 				"k1": float64(2),
 				"k2": "B",
-				"k3": map[string]interface{}{"k": []interface{}{"V"}},
+				"k3": map[string]any{"k": []any{"V"}},
 			},
 		}},
 		Config: dbmodel.Map{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{"v"}},
+			"k3": map[string]any{"k": []any{"v"}},
 		},
 	}
 	pc := cl.ToJujuCloud()
@@ -119,16 +119,16 @@ func TestToJujuCloud(t *testing.T) {
 			StorageEndpoint:  "https://storage.region.example.com",
 		}},
 		CACertificates: []string{"cert1", "cert2"},
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{string("v")}},
+			"k3": map[string]any{"k": []any{string("v")}},
 		},
-		RegionConfig: map[string]map[string]interface{}{
+		RegionConfig: map[string]map[string]any{
 			"test-region": {
 				"k1": float64(2),
 				"k2": "B",
-				"k3": map[string]interface{}{"k": []interface{}{string("V")}},
+				"k3": map[string]any{"k": []any{string("V")}},
 			},
 		},
 	})
@@ -151,16 +151,16 @@ func TestFromJujuCloud(t *testing.T) {
 			StorageEndpoint:  "https://storage.region.example.com",
 		}},
 		CACertificates: []string{"cert1", "cert2"},
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{string("v")}},
+			"k3": map[string]any{"k": []any{string("v")}},
 		},
 		RegionConfig: jujucloud.RegionConfig{
 			"test-region": {
 				"k1": float64(2),
 				"k2": "B",
-				"k3": map[string]interface{}{"k": []interface{}{string("V")}},
+				"k3": map[string]any{"k": []any{string("V")}},
 			},
 		},
 	}
@@ -186,14 +186,14 @@ func TestFromJujuCloud(t *testing.T) {
 			Config: dbmodel.Map{
 				"k1": float64(2),
 				"k2": "B",
-				"k3": map[string]interface{}{"k": []interface{}{string("V")}},
+				"k3": map[string]any{"k": []any{string("V")}},
 			},
 		}},
 		CACertificates: dbmodel.Strings{"cert1", "cert2"},
 		Config: dbmodel.Map{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{string("v")}},
+			"k3": map[string]any{"k": []any{string("v")}},
 		},
 	})
 }
@@ -217,13 +217,13 @@ func TestToJujuCloudInfo(t *testing.T) {
 			Config: dbmodel.Map{
 				"k1": float64(2),
 				"k2": "B",
-				"k3": map[string]interface{}{"k": []interface{}{"V"}},
+				"k3": map[string]any{"k": []any{"V"}},
 			},
 		}},
 		Config: dbmodel.Map{
 			"k1": float64(1),
 			"k2": "A",
-			"k3": map[string]interface{}{"k": []interface{}{"v"}},
+			"k3": map[string]any{"k": []any{"v"}},
 		},
 	}
 	pci := cl.ToJujuCloudInfo()

--- a/internal/dbmodel/types.go
+++ b/internal/dbmodel/types.go
@@ -26,7 +26,7 @@ func (j JSON) Value() (driver.Value, error) {
 }
 
 // Scan scan value into Jsonb, implements sql.Scanner interface
-func (j *JSON) Scan(value interface{}) error {
+func (j *JSON) Scan(value any) error {
 	if value == nil {
 		*j = JSON("null")
 		return nil
@@ -83,7 +83,7 @@ func (s *Strings) FromPointer(sp *[]string) {
 }
 
 // Scan implements sql.Scanner.
-func (s *Strings) Scan(src interface{}) error {
+func (s *Strings) Scan(src any) error {
 	if src == nil {
 		*s = nil
 		return nil
@@ -119,7 +119,7 @@ func (m StringMap) Value() (driver.Value, error) {
 }
 
 // Scan implements sql.Scanner.
-func (m *StringMap) Scan(src interface{}) error {
+func (m *StringMap) Scan(src any) error {
 	if src == nil {
 		*m = nil
 		return nil
@@ -138,7 +138,7 @@ func (m *StringMap) Scan(src interface{}) error {
 
 // A Map stores a generic map in a database column. The map is encoded as
 // JSON and stored in a BLOB element.
-type Map map[string]interface{}
+type Map map[string]any
 
 // GormDataType implements schema.GormDataTypeInterface.
 func (m Map) GormDataType() string {
@@ -154,7 +154,7 @@ func (m Map) Value() (driver.Value, error) {
 }
 
 // Scan implements sql.Scanner.
-func (m *Map) Scan(src interface{}) error {
+func (m *Map) Scan(src any) error {
 	if src == nil {
 		*m = nil
 		return nil
@@ -194,7 +194,7 @@ func (hp HostPorts) Value() (driver.Value, error) {
 }
 
 // Scan implements sql.Scanner.
-func (hp *HostPorts) Scan(src interface{}) error {
+func (hp *HostPorts) Scan(src any) error {
 	if src == nil {
 		*hp = nil
 		return nil

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -39,7 +39,7 @@ type Model interface {
 	ClearUsers()
 	CloudCredential() CloudCredential
 	SetCloudCredential(args CloudCredentialArgs)
-	Config() map[string]interface{}
+	Config() map[string]any
 	Serialize() ([]byte, error)
 }
 

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -192,7 +192,7 @@ func TestListJobs_ErrorState(t *testing.T) {
 	jobManager, client := setupJobsIntegrationTest(c)
 
 	// Insert jobs that will fail
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := client.Insert(ctx, failureJobArgs{
 			Name: "test-fail",
 		}, nil)

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	jujucloud "github.com/juju/juju/cloud"
@@ -255,10 +256,8 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 	if len(reservedNames) == 0 {
 		reservedNames = DefaultReservedCloudNames
 	}
-	for _, n := range reservedNames {
-		if tag.Id() == n {
-			return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
-		}
+	if slices.Contains(reservedNames, tag.Id()) {
+		return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
 	}
 
 	// Validate that the requested cloud is valid.
@@ -580,7 +579,6 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 	// from cloud regions
 	for _, cr := range cloud.Regions {
 		for _, crp := range cr.Controllers {
-			crp := crp
 			if err := j.Database.DeleteCloudRegionControllerPriority(ctx, &crp); err != nil {
 				return fmt.Errorf("cannot update database after updating controller: %w", err)
 			}
@@ -660,10 +658,8 @@ func checkReservedCloudNames(tag names.CloudTag, reservedCloudNames []string) er
 	if len(reservedNames) == 0 {
 		reservedNames = DefaultReservedCloudNames
 	}
-	for _, n := range reservedNames {
-		if tag.Id() == n {
-			return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
-		}
+	if slices.Contains(reservedNames, tag.Id()) {
+		return errors.Codef(errors.CodeAlreadyExists, "cloud %q already exists", tag.Id())
 	}
 	return nil
 }

--- a/internal/jimm/juju/cloud_test.go
+++ b/internal/jimm/juju/cloud_test.go
@@ -416,7 +416,7 @@ var addHostedCloudTests = []struct {
 			Name: "default",
 		}}
 		cld.CACertificates = []string{"CACERT"}
-		cld.Config = map[string]interface{}{"A": "a"}
+		cld.Config = map[string]any{"A": "a"}
 		cld.RegionConfig = jujucloud.RegionConfig{
 			"default": {"B": 2},
 		}
@@ -473,7 +473,7 @@ var addHostedCloudTests = []struct {
 			Name: "default",
 		}}
 		cld.CACertificates = []string{"CACERT"}
-		cld.Config = map[string]interface{}{"A": "a"}
+		cld.Config = map[string]any{"A": "a"}
 		cld.RegionConfig = jujucloud.RegionConfig{
 			"default": {"B": 2},
 		}
@@ -530,7 +530,7 @@ var addHostedCloudTests = []struct {
 			Name: "default",
 		}}
 		cld.CACertificates = []string{"CACERT"}
-		cld.Config = map[string]interface{}{"A": "a"}
+		cld.Config = map[string]any{"A": "a"}
 		cld.RegionConfig = jujucloud.RegionConfig{
 			"default": {"B": 2},
 		}
@@ -764,7 +764,7 @@ var addHostedCloudToControllerTests = []struct {
 			Name: "default",
 		}}
 		cld.CACertificates = []string{"CACERT"}
-		cld.Config = map[string]interface{}{"A": "a"}
+		cld.Config = map[string]any{"A": "a"}
 		cld.RegionConfig = jujucloud.RegionConfig{
 			"default": {"B": 2},
 		}
@@ -821,7 +821,7 @@ var addHostedCloudToControllerTests = []struct {
 			Name: "default",
 		}}
 		cld.CACertificates = []string{"CACERT"}
-		cld.Config = map[string]interface{}{"A": "a"}
+		cld.Config = map[string]any{"A": "a"}
 		cld.RegionConfig = jujucloud.RegionConfig{
 			"default": {"B": 2},
 		}

--- a/internal/jimm/juju/clouddefaults.go
+++ b/internal/jimm/juju/clouddefaults.go
@@ -18,7 +18,7 @@ const (
 )
 
 // SetModelDefaults writes new default model setting values for the specified cloud/region.
-func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error {
+func (j *JujuManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error {
 
 	var keys strings.Builder
 	var needComma bool

--- a/internal/jimm/juju/clouddefaults_test.go
+++ b/internal/jimm/juju/clouddefaults_test.go
@@ -26,7 +26,7 @@ func TestSetCloudDefaults(t *testing.T) {
 		user             *dbmodel.Identity
 		cloud            names.CloudTag
 		region           string
-		defaults         map[string]interface{}
+		defaults         map[string]any
 		expectedError    string
 		expectedDefaults *dbmodel.CloudDefaults
 	}
@@ -51,7 +51,7 @@ func TestSetCloudDefaults(t *testing.T) {
 			}
 			c.Assert(j.Database.DB.Create(&cloud).Error, qt.IsNil)
 
-			defaults := map[string]interface{}{
+			defaults := map[string]any{
 				"key1": float64(42),
 				"key2": "a test string",
 			}
@@ -91,7 +91,7 @@ func TestSetCloudDefaults(t *testing.T) {
 			}
 			c.Assert(j.Database.DB.Create(&cloud).Error, qt.IsNil)
 
-			defaults := map[string]interface{}{
+			defaults := map[string]any{
 				"key1": float64(42),
 				"key2": "a test string",
 			}
@@ -136,14 +136,14 @@ func TestSetCloudDefaults(t *testing.T) {
 				CloudID:      cloud.ID,
 				Cloud:        cloud,
 				Region:       cloud.Regions[0].Name,
-				Defaults: map[string]interface{}{
+				Defaults: map[string]any{
 					"key1": float64(17),
 					"key2": "a test string",
 				},
 			})
 			c.Assert(err, qt.IsNil)
 
-			defaults := map[string]interface{}{
+			defaults := map[string]any{
 				"key1": float64(42),
 				"key2": "a changed string",
 				"key3": "a new value",
@@ -182,7 +182,7 @@ func TestSetCloudDefaults(t *testing.T) {
 				}},
 			}
 
-			defaults := map[string]interface{}{
+			defaults := map[string]any{
 				"key1": float64(42),
 				"key2": "a changed string",
 				"key3": "a new value",
@@ -211,7 +211,7 @@ func TestSetCloudDefaults(t *testing.T) {
 				}},
 			}
 
-			defaults := map[string]interface{}{
+			defaults := map[string]any{
 				"agent-version": "2.0",
 				"key2":          "a changed string",
 				"key3":          "a new value",
@@ -292,7 +292,7 @@ func TestUnsetCloudDefaults(t *testing.T) {
 				IdentityName: user.Name,
 				CloudID:      cloud.ID,
 				Region:       cloud.Regions[0].Name,
-				Defaults: map[string]interface{}{
+				Defaults: map[string]any{
 					"key1": float64(17),
 					"key2": "a test string",
 					"key3": "some value",
@@ -313,7 +313,7 @@ func TestUnsetCloudDefaults(t *testing.T) {
 				CloudID:      cloud.ID,
 				Cloud:        cloud,
 				Region:       "test-region",
-				Defaults: map[string]interface{}{
+				Defaults: map[string]any{
 					"key2": "a test string",
 				},
 			}
@@ -346,7 +346,7 @@ func TestUnsetCloudDefaults(t *testing.T) {
 			err = j.Database.SetCloudDefaults(ctx, &dbmodel.CloudDefaults{
 				IdentityName: user.Name,
 				CloudID:      cloud.ID,
-				Defaults: map[string]interface{}{
+				Defaults: map[string]any{
 					"key1": float64(17),
 					"key2": "a test string",
 					"key3": "some value",
@@ -367,7 +367,7 @@ func TestUnsetCloudDefaults(t *testing.T) {
 				CloudID:      cloud.ID,
 				Cloud:        cloud,
 				Region:       "",
-				Defaults: map[string]interface{}{
+				Defaults: map[string]any{
 					"key2": "a test string",
 				},
 			}
@@ -478,7 +478,7 @@ func TestModelDefaultsForCloud(t *testing.T) {
 		IdentityName: user.Name,
 		CloudID:      cloud1.ID,
 		Region:       cloud1.Regions[0].Name,
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key1": float64(17),
 			"key2": "a test string",
 			"key3": "some value",
@@ -490,7 +490,7 @@ func TestModelDefaultsForCloud(t *testing.T) {
 		IdentityName: user.Name,
 		CloudID:      cloud1.ID,
 		Region:       cloud1.Regions[1].Name,
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key2": "a different string",
 			"key4": float64(42),
 		},
@@ -501,7 +501,7 @@ func TestModelDefaultsForCloud(t *testing.T) {
 		IdentityName: user.Name,
 		CloudID:      cloud2.ID,
 		Region:       cloud2.Regions[0].Name,
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key2": "a different string",
 			"key4": float64(42),
 			"key5": "test",
@@ -513,7 +513,7 @@ func TestModelDefaultsForCloud(t *testing.T) {
 		IdentityName: user.Name,
 		CloudID:      cloud2.ID,
 		Region:       "",
-		Defaults: map[string]interface{}{
+		Defaults: map[string]any{
 			"key1": "value",
 			"key4": float64(37),
 		},

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -61,7 +61,7 @@ func TestAddController(t *testing.T) {
 						StorageEndpoint:  "https://eu-west-2.storage.example.com",
 					}},
 					CACertificates: []string{"CA CERT 1", "CA CERT 2"},
-					Config: map[string]interface{}{
+					Config: map[string]any{
 						"A": "a",
 						"B": 0xb,
 					},
@@ -247,7 +247,7 @@ func TestAddControllerWithVault(t *testing.T) {
 						StorageEndpoint:  "https://eu-west-2.storage.example.com",
 					}},
 					CACertificates: []string{"CA CERT 1", "CA CERT 2"},
-					Config: map[string]interface{}{
+					Config: map[string]any{
 						"A": "a",
 						"B": 0xb,
 					},
@@ -411,7 +411,7 @@ func TestControllerConfig(t *testing.T) {
 
 	api := &jimmtest.API{
 		ControllerConfig_: func(_ context.Context) (jujucontroller.Config, error) {
-			return jujucontroller.Config(map[string]interface{}{
+			return jujucontroller.Config(map[string]any{
 				"controller-uuid": "00000001-0000-0000-0000-000000000001",
 			},
 			), nil

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -96,10 +96,10 @@ type API interface {
 	ConnectStream(string, url.Values) (base.Stream, error)
 
 	// DumpModel collects a database-agnostic dump of a model.
-	DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error)
+	DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error)
 
 	// DumpModelDB collects a database dump of a model.
-	DumpModelDB(context.Context, names.ModelTag) (map[string]interface{}, error)
+	DumpModelDB(context.Context, names.ModelTag) (map[string]any, error)
 
 	// FindApplicationOffers finds application offers that match the filter.
 	FindApplicationOffers(context.Context, []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error)

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -42,7 +42,6 @@ var (
 func (j *JujuManager) forEachController(ctx context.Context, controllers []dbmodel.Controller, f func(*dbmodel.Controller, API) error) error {
 	eg := new(errgroup.Group)
 	for i := range controllers {
-		i := i
 		eg.Go(func() error {
 			api, err := j.dial(ctx, &controllers[i], names.ModelTag{}, nil)
 			if err != nil {

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -459,7 +459,7 @@ func TestFullModelStatus(t *testing.T) {
 			ModelStatus: jujuparams.DetailedStatus{
 				Status: "available",
 				Info:   "",
-				Data:   map[string]interface{}{},
+				Data:   map[string]any{},
 			},
 			SLA: "unsupported",
 		},

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -903,7 +903,7 @@ func newModelDescription(args modelDescriptionArgs) descriptionv9.Model {
 		Owner:        names.NewUserTag(args.Owner),
 		Type:         descriptionv9.IAAS,
 		Cloud:        args.CloudName,
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"uuid": migratingModelUUID,
 			"name": args.ModelName,
 		},

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -45,7 +45,7 @@ func shuffleRegionControllers(controllers []dbmodel.CloudRegionControllerPriorit
 type ModelCreateArgs struct {
 	Name            string
 	Owner           names.UserTag
-	Config          map[string]interface{}
+	Config          map[string]any
 	Cloud           names.CloudTag
 	CloudRegion     string
 	CloudCredential names.CloudCredentialTag
@@ -590,8 +590,8 @@ func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt n
 // juju controller. If simplified is true a simpllified dump is requested.
 // If the given user is not a controller superuser or a model admin an
 // error with the code CodeUnauthorized is returned.
-func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt names.ModelTag, simplified bool) (map[string]interface{}, error) {
-	var dump map[string]interface{}
+func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt names.ModelTag, simplified bool) (map[string]any, error) {
+	var dump map[string]any
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		var err error
 		dump, err = api.DumpModel(ctx, mt, simplified)
@@ -606,8 +606,8 @@ func (j *JujuManager) DumpModel(ctx context.Context, user *openfga.User, mt name
 // DumpModelDB retrieves a database dump of the given model from its juju
 // controller. If the given user is not a controller superuser or a model
 // admin an error with the code CodeUnauthorized is returned.
-func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt names.ModelTag) (map[string]interface{}, error) {
-	var dump map[string]interface{}
+func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt names.ModelTag) (map[string]any, error) {
+	var dump map[string]any
 	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
 		var err error
 		dump, err = api.DumpModelDB(ctx, mt)

--- a/internal/jimm/juju/model_status_parser_test.go
+++ b/internal/jimm/juju/model_status_parser_test.go
@@ -130,7 +130,7 @@ func getFullStatus(
 				Status: "available",
 				Info:   "",
 				Since:  &now,
-				Data:   map[string]interface{}{},
+				Data:   map[string]any{},
 			},
 			SLA: "unsupported",
 		},

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"sort"
 	"testing"
 	"time"
@@ -102,7 +103,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -212,7 +213,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -323,7 +324,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -883,7 +884,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -999,7 +1000,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key4": "value4",
 	}, createModel(`
 uuid: 00000001-0000-0000-0000-0000-000000000001
@@ -1174,7 +1175,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -1349,7 +1350,7 @@ controllers:
 	grantJIMMModelAdmin: func(_ context.Context, _ names.ModelTag) error {
 		return nil
 	},
-	createModel: assertConfig(map[string]interface{}{
+	createModel: assertConfig(map[string]any{
 		"key1": "value1",
 		"key2": "value2",
 		"key3": "value3",
@@ -1523,12 +1524,10 @@ func convertParamsModelInfo(modelInfo jujuparams.ModelInfo) (base.ModelInfo, err
 	result.Status = base.Status{
 		Status: modelInfo.Status.Status,
 		Info:   modelInfo.Status.Info,
-		Data:   make(map[string]interface{}),
+		Data:   make(map[string]any),
 		Since:  modelInfo.Status.Since,
 	}
-	for k, v := range modelInfo.Status.Data {
-		result.Status.Data[k] = v
-	}
+	maps.Copy(result.Status.Data, modelInfo.Status.Data)
 	result.Users = make([]base.UserInfo, len(modelInfo.Users))
 	for i, u := range modelInfo.Users {
 		result.Users[i] = base.UserInfo{
@@ -1589,7 +1588,7 @@ func createModel(template string) func(context.Context, *jujuclient.CreateModelA
 	}
 }
 
-func assertConfig(config map[string]interface{}, fnc func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error)) func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
+func assertConfig(config map[string]any, fnc func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error)) func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 	return func(ctx context.Context, args *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 		if args.Cloud == "" {
 			return base.ModelInfo{}, errors.New("cloud not specified")
@@ -2771,7 +2770,7 @@ func TestDestroyModel(t *testing.T) {
 var dumpModelTests = []struct {
 	name            string
 	env             string
-	dumpModel       func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error)
+	dumpModel       func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error)
 	dialError       error
 	username        string
 	uuid            string
@@ -2796,14 +2795,14 @@ var dumpModelTests = []struct {
 }, {
 	name: "Success",
 	env:  destroyModelTestEnv,
-	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
+	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error) {
 		if tag.Id() != "00000002-0000-0000-0000-000000000001" {
 			return nil, errors.New("incorrect model uuid")
 		}
 		if simplified != true {
 			return nil, errors.New("invalid simplified")
 		}
-		return map[string]interface{}{}, nil
+		return map[string]any{}, nil
 	},
 	username:   "alice@canonical.com",
 	uuid:       "00000002-0000-0000-0000-000000000001",
@@ -2811,8 +2810,8 @@ var dumpModelTests = []struct {
 }, {
 	name: "SuperuserSuccess",
 	env:  destroyModelTestEnv,
-	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
-		return map[string]interface{}{}, nil
+	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error) {
+		return map[string]any{}, nil
 	},
 	username: "charlie@canonical.com",
 	uuid:     "00000002-0000-0000-0000-000000000001",
@@ -2826,8 +2825,8 @@ var dumpModelTests = []struct {
 }, {
 	name: "APIError",
 	env:  destroyModelTestEnv,
-	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
-		return map[string]interface{}{}, errors.New("api error")
+	dumpModel: func(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error) {
+		return map[string]any{}, errors.New("api error")
 	},
 	username:    "charlie@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
@@ -2874,11 +2873,11 @@ func TestDumpModel(t *testing.T) {
 var dumpModelDBTests = []struct {
 	name            string
 	env             string
-	dumpModelDB     func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error)
+	dumpModelDB     func(ctx context.Context, tag names.ModelTag) (map[string]any, error)
 	dialError       error
 	username        string
 	uuid            string
-	expectDump      map[string]interface{}
+	expectDump      map[string]any
 	expectError     string
 	expectErrorCode errors.Code
 }{{
@@ -2899,24 +2898,24 @@ var dumpModelDBTests = []struct {
 }, {
 	name: "Success",
 	env:  destroyModelTestEnv,
-	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]any, error) {
 		if tag.Id() != "00000002-0000-0000-0000-000000000001" {
 			return nil, errors.New("incorrect model uuid")
 		}
-		return map[string]interface{}{"model": "dump"}, nil
+		return map[string]any{"model": "dump"}, nil
 	},
 	username:   "alice@canonical.com",
 	uuid:       "00000002-0000-0000-0000-000000000001",
-	expectDump: map[string]interface{}{"model": "dump"},
+	expectDump: map[string]any{"model": "dump"},
 }, {
 	name: "SuperuserSuccess",
 	env:  destroyModelTestEnv,
-	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
-		return map[string]interface{}{"model": "dump 2"}, nil
+	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]any, error) {
+		return map[string]any{"model": "dump 2"}, nil
 	},
 	username:   "charlie@canonical.com",
 	uuid:       "00000002-0000-0000-0000-000000000001",
-	expectDump: map[string]interface{}{"model": "dump 2"},
+	expectDump: map[string]any{"model": "dump 2"},
 }, {
 	name:        "DialError",
 	env:         destroyModelTestEnv,
@@ -2927,7 +2926,7 @@ var dumpModelDBTests = []struct {
 }, {
 	name: "APIError",
 	env:  destroyModelTestEnv,
-	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+	dumpModelDB: func(ctx context.Context, tag names.ModelTag) (map[string]any, error) {
 		return nil, errors.New("api error")
 	},
 	username:    "charlie@canonical.com",

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 
@@ -56,7 +57,7 @@ type modelBuilder struct {
 
 	name               string
 	candidates         []candidateController
-	config             map[string]interface{}
+	config             map[string]any
 	owner              *dbmodel.Identity
 	credential         *dbmodel.CloudCredential
 	controller         *dbmodel.Controller
@@ -137,13 +138,11 @@ func (b *modelBuilder) WithName(name string) *modelBuilder {
 }
 
 // WithConfig returns a builder with the specified model config.
-func (b *modelBuilder) WithConfig(cfg map[string]interface{}) *modelBuilder {
+func (b *modelBuilder) WithConfig(cfg map[string]any) *modelBuilder {
 	if b.config == nil {
-		b.config = make(map[string]interface{})
+		b.config = make(map[string]any)
 	}
-	for key, value := range cfg {
-		b.config[key] = value
-	}
+	maps.Copy(b.config, cfg)
 	return b
 }
 

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -20,7 +20,7 @@ import (
 // Publisher defines the interface used by the Watcher
 // to publish model summaries.
 type Publisher interface {
-	Publish(model string, content interface{}) <-chan struct{}
+	Publish(model string, content any) <-chan struct{}
 }
 
 // A Watcher watches juju controllers for changes to all models.

--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -112,7 +112,7 @@ var modelSummaryWatcherTests = []struct {
 		nil,
 	},
 	checkPublisher: func(c *qt.C, publisher *testPublisher) {
-		c.Assert(publisher.messages, qt.DeepEquals, []interface{}{
+		c.Assert(publisher.messages, qt.DeepEquals, []any{
 			jujuparams.ModelAbstract{
 				UUID:   "00000002-0000-0000-0000-000000000001",
 				Status: "test status",
@@ -192,12 +192,10 @@ func TestModelSummaryWatcher(t *testing.T) {
 			env.PopulateDB(c, w.Database)
 
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				err := w.WatchAllModelSummaries(ctx, time.Millisecond)
 				checkIfContextCanceled(c, ctx, err)
-			}()
+			})
 
 			for _, summary := range test.summaries {
 				select {
@@ -238,12 +236,10 @@ func TestWatcherSetsControllerUnavailable(t *testing.T) {
 	env.PopulateDB(c, w.Database)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := w.WatchAllModelSummaries(ctx, time.Millisecond)
 		checkIfContextCanceled(c, ctx, err)
-	}()
+	})
 
 	// it appears that the jimm code does not treat failing to
 	// set a controller as unavailable as an error - so
@@ -323,12 +319,10 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 
 	// start the watcher
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := w.WatchAllModelSummaries(ctx, time.Millisecond)
 		checkIfContextCanceled(c, ctx, err)
-	}()
+	})
 	wg.Wait()
 
 	// check that the unavailable since time has been cleared
@@ -407,10 +401,10 @@ func checkIfContextCanceled(c *qt.C, ctx context.Context, err error) {
 
 type testPublisher struct {
 	mu       sync.Mutex
-	messages []interface{}
+	messages []any
 }
 
-func (p *testPublisher) Publish(model string, content interface{}) <-chan struct{} {
+func (p *testPublisher) Publish(model string, content any) <-chan struct{} {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.messages = append(p.messages, content)

--- a/internal/jimm/jujuauth/logintokens.go
+++ b/internal/jimm/jujuauth/logintokens.go
@@ -35,7 +35,7 @@ type GeneratorAccessChecker interface {
 	GetUserModelAccess(context.Context, *openfga.User, names.ModelTag) (string, error)
 	GetUserControllerAccess(context.Context, *openfga.User, names.ControllerTag) (string, error)
 	GetUserCloudAccess(context.Context, *openfga.User, names.CloudTag) (string, error)
-	CheckPermission(context.Context, *openfga.User, map[string]string, map[string]interface{}) (map[string]string, error)
+	CheckPermission(context.Context, *openfga.User, map[string]string, map[string]any) (map[string]string, error)
 }
 
 // JWTService specifies the service JWT generator uses to generate JWTs.
@@ -150,7 +150,7 @@ func (auth *LoginTokenGenerator) MakeLoginToken(ctx context.Context, user *openf
 // MakeToken assumes MakeLoginToken has already been called and checks the permissions
 // specified in the permissionMap. If the logged in user has all those permissions
 // a JWT will be returned with assertions confirming all those permissions.
-func (auth *LoginTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
+func (auth *LoginTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]any) ([]byte, error) {
 
 	auth.mu.Lock()
 	defer auth.mu.Unlock()

--- a/internal/jimm/jujuauth/logintokens_test.go
+++ b/internal/jimm/jujuauth/logintokens_test.go
@@ -4,6 +4,7 @@ package jujuauth_test
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -70,17 +71,13 @@ func (tac *testAccessChecker) GetUserCloudAccess(ctx context.Context, user *open
 }
 
 // CheckPermission implements the CheckPermission methods of the JWTGeneratorAccessChecker interface.
-func (tac *testAccessChecker) CheckPermission(ctx context.Context, user *openfga.User, accessMap map[string]string, permissions map[string]interface{}) (map[string]string, error) {
+func (tac *testAccessChecker) CheckPermission(ctx context.Context, user *openfga.User, accessMap map[string]string, permissions map[string]any) (map[string]string, error) {
 	if tac.permissionCheckErr != nil {
 		return nil, tac.permissionCheckErr
 	}
 	access := make(map[string]string)
-	for k, v := range accessMap {
-		access[k] = v
-	}
-	for k, v := range tac.permissions {
-		access[k] = v
-	}
+	maps.Copy(access, accessMap)
+	maps.Copy(access, tac.permissions)
 	return access, nil
 }
 
@@ -268,7 +265,7 @@ func TestJWTGeneratorMakeToken(t *testing.T) {
 		checkPermissionsError error
 		jwtService            *testJWTService
 		expectedError         string
-		permissions           map[string]interface{}
+		permissions           map[string]any
 		expectedJWTParams     jimmjwx.JWTParams
 	}{{
 		about:      "all is well",
@@ -285,7 +282,7 @@ func TestJWTGeneratorMakeToken(t *testing.T) {
 	}, {
 		about:      "check permission fails",
 		jwtService: &testJWTService{},
-		permissions: map[string]interface{}{
+		permissions: map[string]any{
 			"entity1": "access_level1",
 		},
 		checkPermissionsError: errors.New("a test error"),
@@ -293,7 +290,7 @@ func TestJWTGeneratorMakeToken(t *testing.T) {
 	}, {
 		about:      "additional permissions need checking",
 		jwtService: &testJWTService{},
-		permissions: map[string]interface{}{
+		permissions: map[string]any{
 			"entity1": "access_level1",
 		},
 		checkPermissions: map[string]string{

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -191,7 +191,7 @@ func (j *PermissionManager) RevokeAuditLogAccess(ctx context.Context, user *open
 // to cachedPerms if they exist. If the user does not have any of the desired permissions then an
 // error is returned.
 // Note that cachedPerms map is modified and returned.
-func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.User, cachedPerms map[string]string, desiredPerms map[string]interface{}) (map[string]string, error) {
+func (j *PermissionManager) CheckPermission(ctx context.Context, user *openfga.User, cachedPerms map[string]string, desiredPerms map[string]any) (map[string]string, error) {
 
 	for key, val := range desiredPerms {
 		if _, ok := cachedPerms[key]; !ok {

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -2274,7 +2274,7 @@ func (s *permissionManagerSuite) TestOpenFGACleanup(c *qt.C) {
 	}}
 
 	orphanedTuples := []ofga.Tuple{}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		for _, test := range tagTests {
 			objectTag := test.createObjectTag(i)
 			targetTag := test.createTargetTag(i)

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -37,10 +37,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 		return err
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
-		end := i + BATCH_SIZE_OPENFGA
-		if end > len(parsedTuples) {
-			end = len(parsedTuples)
-		}
+		end := min(i+BATCH_SIZE_OPENFGA, len(parsedTuples))
 		batch := parsedTuples[i:end]
 
 		err = j.authSvc.AddRelation(ctx, batch...)
@@ -64,10 +61,7 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 		return err
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
-		end := i + BATCH_SIZE_OPENFGA
-		if end > len(parsedTuples) {
-			end = len(parsedTuples)
-		}
+		end := min(i+BATCH_SIZE_OPENFGA, len(parsedTuples))
 		batch := parsedTuples[i:end]
 
 		err = j.authSvc.RemoveRelation(ctx, batch...)

--- a/internal/jimm/role/role_test.go
+++ b/internal/jimm/role/role_test.go
@@ -193,7 +193,7 @@ func (s *roleManagerSuite) TestListRoles(c *qt.C) {
 	// Check happypath
 	s.user.JimmAdmin = true
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err = s.db.AddRole(ctx, "r"+strconv.Itoa(i))
 		c.Assert(err, qt.IsNil)
 	}
@@ -224,7 +224,7 @@ func (s *roleManagerSuite) TestCountRoles(c *qt.C) {
 	// Check happypath
 	s.user.JimmAdmin = true
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err = s.db.AddRole(ctx, "r"+strconv.Itoa(i))
 		c.Assert(err, qt.IsNil)
 	}

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -111,7 +111,7 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 			return m, err
 		},
 	}
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"ssh-server-port": "17023",
 	}
 	cfg, err := jujucontroller.NewConfig(uuid, jujutesting.CACert, attrs)

--- a/internal/jimmhttp/debug_handler.go
+++ b/internal/jimmhttp/debug_handler.go
@@ -56,7 +56,6 @@ func (dh *DebugHandler) Status(w http.ResponseWriter, r *http.Request) {
 	var wg sync.WaitGroup
 	wg.Add(len(checks))
 	for k, check := range checks {
-		k, check := k, check
 		go func() {
 			defer wg.Done()
 			result := statusResult{
@@ -84,7 +83,7 @@ func (dh *DebugHandler) Status(w http.ResponseWriter, r *http.Request) {
 // in the /debug/status response body.
 type statusResult struct {
 	Name     string
-	Value    interface{}
+	Value    any
 	Passed   bool
 	Duration time.Duration
 }
@@ -95,12 +94,12 @@ type StatusCheck interface {
 	Name() string
 
 	// Check runs the actual check.
-	Check(ctx context.Context) (interface{}, error)
+	Check(ctx context.Context) (any, error)
 }
 
 // MakeStatusCheck creates a status check with the given human readable
 // name which runs the given function.
-func MakeStatusCheck(name string, f func(context.Context) (interface{}, error)) StatusCheck {
+func MakeStatusCheck(name string, f func(context.Context) (any, error)) StatusCheck {
 	return statusCheck{
 		name: name,
 		f:    f,
@@ -111,7 +110,7 @@ func MakeStatusCheck(name string, f func(context.Context) (interface{}, error)) 
 // MakeStatusCheck.
 type statusCheck struct {
 	name string
-	f    func(context.Context) (interface{}, error)
+	f    func(context.Context) (any, error)
 }
 
 // Name implements StatusCheck.Name.
@@ -120,13 +119,13 @@ func (c statusCheck) Name() string {
 }
 
 // Check implements StatusCheck.Check.
-func (c statusCheck) Check(ctx context.Context) (interface{}, error) {
+func (c statusCheck) Check(ctx context.Context) (any, error) {
 	return c.f(ctx)
 }
 
 var startTime = time.Now().UTC()
 
 // ServerStartTime is a StatusCheck that returns the server start time.
-var ServerStartTime = MakeStatusCheck("server start time", func(_ context.Context) (interface{}, error) {
+var ServerStartTime = MakeStatusCheck("server start time", func(_ context.Context) (any, error) {
 	return startTime, nil
 })

--- a/internal/jimmhttp/debug_handler_test.go
+++ b/internal/jimmhttp/debug_handler_test.go
@@ -62,7 +62,7 @@ func TestDebugStatus(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	fmt.Println(string(buf))
-	var v map[string]map[string]interface{}
+	var v map[string]map[string]any
 	err = json.Unmarshal(buf, &v)
 	c.Assert(err, qt.IsNil)
 
@@ -74,7 +74,7 @@ func TestDebugStatus(t *testing.T) {
 func TestDebugStatusStatusError(t *testing.T) {
 	c := qt.New(t)
 
-	rr := setupDebugHandlerAndRecorder(c, jimmhttp.MakeStatusCheck("Test", func(context.Context) (interface{}, error) {
+	rr := setupDebugHandlerAndRecorder(c, jimmhttp.MakeStatusCheck("Test", func(context.Context) (any, error) {
 		return nil, errors.New("test error")
 	}), "/status")
 
@@ -84,7 +84,7 @@ func TestDebugStatusStatusError(t *testing.T) {
 	buf, err := io.ReadAll(resp.Body)
 	c.Assert(err, qt.IsNil)
 
-	var v map[string]map[string]interface{}
+	var v map[string]map[string]any
 	err = json.Unmarshal(buf, &v)
 	c.Assert(err, qt.IsNil)
 	c.Check(v["start_time"]["Name"], qt.Equals, "Test")

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -68,10 +68,7 @@ func TestListIdentities(t *testing.T) {
 	identityManager := mocks.IdentityManager{
 		ListIdentities_: func(ctx context.Context, user *openfga.User, pagination pagination.LimitOffsetPagination, match string) ([]openfga.User, error) {
 			start := pagination.Offset()
-			end := start + pagination.Limit()
-			if end > len(testUsers) {
-				end = len(testUsers)
-			}
+			end := min(start+pagination.Limit(), len(testUsers))
 			return testUsers[start:end], nil
 		},
 		CountIdentities_: func(ctx context.Context, user *openfga.User) (int, error) {

--- a/internal/jimmjwx/jwks_test.go
+++ b/internal/jimmjwx/jwks_test.go
@@ -47,8 +47,7 @@ func TestGenerateJWKS(t *testing.T) {
 // As such, it will retry 60 times on a 500ms basis.
 func TestStartJWKSRotatorWithNoJWKSInTheStore(t *testing.T) {
 	c := qt.New(t)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 
 	store := newStore(c)
 	err := store.CleanupJWKS(ctx)
@@ -63,8 +62,7 @@ func TestStartJWKSRotatorWithNoJWKSInTheStore(t *testing.T) {
 // So I suppose this test is "best effort", but will only ever pass if the code is truly OK.
 func TestStartJWKSRotatorRotatesAJWKS(t *testing.T) {
 	c := qt.New(t)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	defer cancelCtx()
+	ctx := t.Context()
 	store := newStore(c)
 	err := store.CleanupJWKS(ctx)
 	c.Assert(err, qt.IsNil)
@@ -85,7 +83,7 @@ func TestStartJWKSRotatorRotatesAJWKS(t *testing.T) {
 	err = svc.StartJWKSRotator(ctx, time.NewTicker(time.Second).C, time.Now())
 	c.Assert(err, qt.IsNil)
 	// We retry 500ms * 60 (30s) to test the diff
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(500 * time.Millisecond)
 		ks2, err := store.GetJWKS(ctx)
 		c.Assert(err, qt.IsNil)

--- a/internal/jimmjwx/jwt.go
+++ b/internal/jimmjwx/jwt.go
@@ -85,7 +85,7 @@ type JWTParams struct {
 	Access map[string]string
 	// ExtraClaims contain any extra claims that should be added to the JWT.
 	// "access" is a reserved claim and will cause an error if used.
-	ExtraClaims map[string]interface{}
+	ExtraClaims map[string]any
 	// Expiry is the duration after which the JWT will expire.
 	// If not set, it will default to the configured default expiry.
 	// If set, it will override the JWTServiceParams.Expiry.

--- a/internal/jimmjwx/utils_test.go
+++ b/internal/jimmjwx/utils_test.go
@@ -62,7 +62,7 @@ func startAndTestRotator(c *qt.C, ctx context.Context, store credentials.Credent
 
 	var ks jwk.Set
 	// We retry 500ms * 60 (30s)
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		if ks == nil {
 			ks, err = store.GetJWKS(ctx)
 			if err != nil {

--- a/internal/jujuapi/cloud.go
+++ b/internal/jujuapi/cloud.go
@@ -524,10 +524,10 @@ func CloudToParams(cloud cloud.Cloud) jujuparams.Cloud {
 			StorageEndpoint:  region.StorageEndpoint,
 		}
 	}
-	var regionConfig map[string]map[string]interface{}
+	var regionConfig map[string]map[string]any
 	for r, attr := range cloud.RegionConfig {
 		if regionConfig == nil {
-			regionConfig = make(map[string]map[string]interface{})
+			regionConfig = make(map[string]map[string]any)
 		}
 		regionConfig[r] = attr
 	}

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -233,7 +233,7 @@ func (r *controllerRoot) ControllerConfig(ctx context.Context) (jujuparams.Contr
 	if err != nil {
 		return jujuparams.ControllerConfigResult{}, err
 	}
-	cfg := make(map[string]interface{})
+	cfg := make(map[string]any)
 	cfg[jujucontroller.ControllerUUIDKey] = config.ControllerUUID
 	cfg[jujucontroller.SSHServerPort] = config.SSHPort
 	// TODO: update this to use the key coming from juju when we update the juju dependency.

--- a/internal/jujuapi/controller_test.go
+++ b/internal/jujuapi/controller_test.go
@@ -69,7 +69,6 @@ func TestInitiateMigration(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		test := test
 		c.Run(test.about, func(c *qt.C) {
 			jujuManager := mocks.JujuManager{
 				InitiateMigration_: test.initiateMigration,

--- a/internal/jujuapi/controllerprofile.go
+++ b/internal/jujuapi/controllerprofile.go
@@ -172,7 +172,7 @@ func controllerProfileToParams(profile dbmodel.ControllerProfile) apiparams.Cont
 			Type:            profile.Cloud.Type,
 			AuthTypes:       []string(profile.Cloud.AuthTypes),
 			CACertificates:  []string(profile.Cloud.CACertificates),
-			Config:          map[string]interface{}(profile.Cloud.Config),
+			Config:          map[string]any(profile.Cloud.Config),
 			Endpoint:        profile.Cloud.Endpoint,
 			HostCloudRegion: profile.Cloud.HostCloudRegion,
 			Region: apiparams.BootstrapCloudRegion{

--- a/internal/jujuapi/export_test.go
+++ b/internal/jujuapi/export_test.go
@@ -24,7 +24,7 @@ func NewModelSummaryWatcher() *modelSummaryWatcher {
 	}
 }
 
-func PublishToWatcher(w *modelSummaryWatcher, model string, data interface{}) {
+func PublishToWatcher(w *modelSummaryWatcher, model string, data any) {
 	w.pubsubHandler(model, data)
 }
 
@@ -33,11 +33,9 @@ func ModelAccessWatcherMatch(w *modelAccessWatcher, model string) bool {
 }
 
 func RunModelAccessWatcher(w *modelAccessWatcher, wg *sync.WaitGroup) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		w.loop()
-	}()
+	})
 }
 
 type ControllerRoot = controllerRoot

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -237,8 +237,8 @@ type JujuManager interface {
 	AddModel(ctx context.Context, u *openfga.User, args *juju.ModelCreateArgs) (_ base.ModelInfo, err error)
 	ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error
 	DestroyModel(ctx context.Context, u *openfga.User, mt names.ModelTag, destroyStorage *bool, force *bool, maxWait *time.Duration, timeout *time.Duration) error
-	DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]interface{}, error)
-	DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]interface{}, error)
+	DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]any, error)
+	DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]any, error)
 	ForEachModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	ForEachUserModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, string) error) error
 	FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
@@ -250,7 +250,7 @@ type JujuManager interface {
 	ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) ([]base.UserModelSummary, error)
 	ModelStatus(ctx context.Context, u *openfga.User, mt names.ModelTag) (base.ModelStatus, error)
 	QueryModelsJq(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)
-	SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error
+	SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error
 	UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -365,10 +365,7 @@ func auditParamsToFilter(req apiparams.FindAuditEventsRequest) (db.AuditLogFilte
 		limit = maxLimit
 	}
 	filter.Limit = limit
-	offset := req.Offset
-	if offset < 0 {
-		offset = 0
-	}
+	offset := max(req.Offset, 0)
 	filter.Offset = offset
 	return filter, nil
 }

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -78,7 +78,7 @@ type ModelManager interface {
 	ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error
 	DestroyModel(ctx context.Context, u *openfga.User, mt names.ModelTag, destroyStorage *bool, force *bool, maxWait *time.Duration, timeout *time.Duration) error
 	DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (string, error)
-	DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]interface{}, error)
+	DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]any, error)
 	ForEachModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	ForEachUserModel(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	FullModelStatus(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
@@ -88,7 +88,7 @@ type ModelManager interface {
 	ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) (jujuparams.ModelSummaryResults, error)
 	ModelStatus(ctx context.Context, u *openfga.User, mt names.ModelTag) (*jujuparams.ModelStatus, error)
 	QueryModelsJq(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)
-	SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error
+	SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error
 	UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error

--- a/internal/jujuapi/modelsummarywatcher.go
+++ b/internal/jujuapi/modelsummarywatcher.go
@@ -141,7 +141,7 @@ type modelSummaryWatcher struct {
 	summaries map[string]jujuparams.ModelAbstract
 }
 
-func (w *modelSummaryWatcher) pubsubHandler(model string, summaryI interface{}) {
+func (w *modelSummaryWatcher) pubsubHandler(model string, summaryI any) {
 	summary, ok := summaryI.(jujuparams.ModelAbstract)
 	if !ok {
 		zapctx.Error(

--- a/internal/jujuapi/recorder.go
+++ b/internal/jujuapi/recorder.go
@@ -53,7 +53,7 @@ func (r auditLogger) newEntry(header *rpc.Header) dbmodel.AuditLogEntry {
 }
 
 // LogRequest creates an audit log entry from a client request.
-func (r auditLogger) LogRequest(header *rpc.Header, body interface{}) error {
+func (r auditLogger) LogRequest(header *rpc.Header, body any) error {
 	ale := r.newEntry(header)
 	ale.ObjectId = header.Request.Id
 	ale.FacadeName = header.Request.Type
@@ -72,7 +72,7 @@ func (r auditLogger) LogRequest(header *rpc.Header, body interface{}) error {
 }
 
 // LogResponse creates an audit log entry from a controller response.
-func (o auditLogger) LogResponse(r rpc.Request, header *rpc.Header, body interface{}) error {
+func (o auditLogger) LogResponse(r rpc.Request, header *rpc.Header, body any) error {
 	var allErrors params.ErrorResults
 	bulkError, ok := body.(params.ErrorResults)
 	if ok {
@@ -116,12 +116,12 @@ func NewRecorder(logger auditLogger) recorder {
 }
 
 // HandleRequest implements rpc.Recorder.
-func (r recorder) HandleRequest(header *rpc.Header, body interface{}) error {
+func (r recorder) HandleRequest(header *rpc.Header, body any) error {
 	return r.logger.LogRequest(header, body)
 }
 
 // HandleReply implements rpc.Recorder.
-func (o recorder) HandleReply(r rpc.Request, header *rpc.Header, body interface{}) error {
+func (o recorder) HandleReply(r rpc.Request, header *rpc.Header, body any) error {
 	d := time.Since(o.start)
 	servermon.WebsocketRequestDuration.WithLabelValues(r.Type, r.Action).Observe(float64(d) / float64(time.Second))
 	return o.logger.LogResponse(r, header, body)

--- a/internal/jujuapi/rpc/method.go
+++ b/internal/jujuapi/rpc/method.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
-	errorType   = reflect.TypeOf((*error)(nil)).Elem()
-	stringType  = reflect.TypeOf("")
+	contextType = reflect.TypeFor[context.Context]()
+	errorType   = reflect.TypeFor[error]()
+	stringType  = reflect.TypeFor[string]()
 )
 
 // Method converts the given function to an RPC method that can be used
@@ -24,7 +24,7 @@ var (
 //
 // Note that all parameters and return values are optional. Method will
 // panic if the given value is not a function of the correct type.
-func Method(f interface{}) rpcreflect.MethodCaller {
+func Method(f any) rpcreflect.MethodCaller {
 	v := reflect.ValueOf(f)
 	if k := v.Kind(); k != reflect.Func {
 		panic(fmt.Sprintf("method must be a func not %s", k))

--- a/internal/jujuapi/rpc/method_test.go
+++ b/internal/jujuapi/rpc/method_test.go
@@ -17,40 +17,40 @@ type S2 struct{}
 
 var procTests = []struct {
 	name             string
-	f                interface{}
+	f                any
 	expectPanic      string
 	expectParamsType reflect.Type
 	expectResultType reflect.Type
 }{{
 	name:             "full",
 	f:                func(ctx context.Context, objID string, params S1) (resutlt S2, err error) { return },
-	expectParamsType: reflect.TypeOf(S1{}),
-	expectResultType: reflect.TypeOf(S2{}),
+	expectParamsType: reflect.TypeFor[S1](),
+	expectResultType: reflect.TypeFor[S2](),
 }, {
 	name:             "no context",
 	f:                func(objID string, params S1) (resutlt S2, err error) { return },
-	expectParamsType: reflect.TypeOf(S1{}),
-	expectResultType: reflect.TypeOf(S2{}),
+	expectParamsType: reflect.TypeFor[S1](),
+	expectResultType: reflect.TypeFor[S2](),
 }, {
 	name:             "no object ID",
 	f:                func(ctx context.Context, params S1) (resutlt S2, err error) { return },
-	expectParamsType: reflect.TypeOf(S1{}),
-	expectResultType: reflect.TypeOf(S2{}),
+	expectParamsType: reflect.TypeFor[S1](),
+	expectResultType: reflect.TypeFor[S2](),
 }, {
 	name:             "no params",
 	f:                func(ctx context.Context, objId string) (resutlt S2, err error) { return },
 	expectParamsType: nil,
-	expectResultType: reflect.TypeOf(S2{}),
+	expectResultType: reflect.TypeFor[S2](),
 }, {
 	name:             "no result",
 	f:                func(ctx context.Context, objId string, params S1) (err error) { return },
-	expectParamsType: reflect.TypeOf(S1{}),
+	expectParamsType: reflect.TypeFor[S1](),
 	expectResultType: nil,
 }, {
 	name:             "no error",
 	f:                func(ctx context.Context, objId string, params S1) (result S2) { return },
-	expectParamsType: reflect.TypeOf(S1{}),
-	expectResultType: reflect.TypeOf(S2{}),
+	expectParamsType: reflect.TypeFor[S1](),
+	expectResultType: reflect.TypeFor[S2](),
 }, {
 	name:             "empty function",
 	f:                func() {},

--- a/internal/jujuapi/rpc/root_test.go
+++ b/internal/jujuapi/rpc/root_test.go
@@ -84,7 +84,7 @@ func TestKill(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			err := cl.Call(t.Context(), req, nil, nil)

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -317,7 +317,7 @@ func TestToFullModelInfo(t *testing.T) {
 				Name:                "vault",
 				BackendType:         "vault",
 				TokenRotateInterval: &rotateInterval,
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"endpoint": "https://vault.example.com",
 				},
 			},
@@ -348,7 +348,7 @@ func TestToFullModelInfo(t *testing.T) {
 			Name:                "vault",
 			BackendType:         "vault",
 			TokenRotateInterval: &rotateInterval,
-			Config: map[string]interface{}{
+			Config: map[string]any{
 				"endpoint": "https://vault.example.com",
 			},
 		},

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -228,7 +228,7 @@ func (c *Connection) hasFacadeVersion(facade string, version int) bool {
 // Call makes an RPC call to the server. Call sends the request message to
 // the server and waits for the response to be returned or the context to
 // be canceled.
-func (c *Connection) Call(ctx context.Context, facade string, version int, id, method string, args, resp interface{}) (err error) {
+func (c *Connection) Call(ctx context.Context, facade string, version int, id, method string, args, resp any) (err error) {
 	labels := []string{facade, method, ""}
 	if c.ctl != nil {
 		labels = []string{facade, method, c.ctl.UUID}
@@ -246,7 +246,7 @@ func (c *Connection) Call(ctx context.Context, facade string, version int, id, m
 
 // CallHighestFacadeVersion calls the specified method on the highest supported version of
 // the facade.
-func (c *Connection) CallHighestFacadeVersion(ctx context.Context, facade string, versions []int, id, method string, args, resp interface{}) error {
+func (c *Connection) CallHighestFacadeVersion(ctx context.Context, facade string, versions []int, id, method string, args, resp any) error {
 	sort.Sort(sort.Reverse(sort.IntSlice(versions)))
 
 	for _, version := range versions {
@@ -295,7 +295,7 @@ func (c *Connection) BakeryClient() base.MacaroonDischarger {
 // APICall makes a call to the API server with the given object type,
 // id, request and parameters. The response is filled in with the
 // call's result if the call is successful.
-func (c *Connection) APICall(objType string, version int, id, request string, params, response interface{}) error {
+func (c *Connection) APICall(objType string, version int, id, request string, params, response any) error {
 	return c.Call(c.ctx, objType, version, id, request, params, response)
 }
 

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -21,7 +21,7 @@ type CreateModelArgs struct {
 	Cloud              string
 	CloudRegion        string
 	CloudCredentialTag names.CloudCredentialTag
-	Config             map[string]interface{}
+	Config             map[string]any
 }
 
 // CreateModel creates a new model as specified by the given model
@@ -56,7 +56,7 @@ type SecretBackend struct {
 	Name                string
 	BackendType         string
 	TokenRotateInterval *time.Duration
-	Config              map[string]interface{}
+	Config              map[string]any
 }
 
 // SecretBackendResult represents jujuparams.SecretBackendResult.
@@ -106,13 +106,13 @@ func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag)
 // DumpModel dumps debugging details for the given model. If the simplied
 // dump is requested then a simplified dump is returned. DumpModel uses the
 // DumpModels method on the ModelManager facade.
-func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
+func (c Connection) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error) {
 	return modelmanager.NewClient(&c).DumpModel(tag, simplified)
 }
 
 // DumpModelDB dumps the controller database entry given model.
 // DumpModelDB uses the DumpModelsDB method on the ModelManager facade..
-func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+func (c Connection) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]any, error) {
 	return modelmanager.NewClient(&c).DumpModelDB(tag)
 }
 

--- a/internal/jujuclient/types.go
+++ b/internal/jujuclient/types.go
@@ -3,6 +3,8 @@
 package jujuclient
 
 import (
+	"maps"
+
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -62,12 +64,10 @@ func convertParamsModelInfo(modelInfo params.ModelInfo) (ModelInfo, error) {
 	result.Status = base.Status{
 		Status: modelInfo.Status.Status,
 		Info:   modelInfo.Status.Info,
-		Data:   make(map[string]interface{}),
+		Data:   make(map[string]any),
 		Since:  modelInfo.Status.Since,
 	}
-	for k, v := range modelInfo.Status.Data {
-		result.Status.Data[k] = v
-	}
+	maps.Copy(result.Status.Data, modelInfo.Status.Data)
 	result.Users = make([]base.UserInfo, len(modelInfo.Users))
 	for i, u := range modelInfo.Users {
 		result.Users[i] = base.UserInfo{

--- a/internal/jujucommands/bootstrap.go
+++ b/internal/jujucommands/bootstrap.go
@@ -136,9 +136,7 @@ func withBootstrapArch(constraints map[string]string) map[string]string {
 func mergedBootstrapConfig(defaultLoginTokenURL string, options BootstrapOptions) map[string]string {
 	merged := make(map[string]string)
 	for _, configMap := range []map[string]string{options.ControllerConfig, options.ControllerModelConfig, options.BootstrapConfig} {
-		for key, value := range configMap {
-			merged[key] = value
-		}
+		maps.Copy(merged, configMap)
 	}
 	if _, ok := merged[loginTokenRefreshURLKey]; !ok {
 		merged[loginTokenRefreshURLKey] = defaultLoginTokenURL

--- a/internal/logger/gorm_logger.go
+++ b/internal/logger/gorm_logger.go
@@ -32,17 +32,17 @@ func (gl *GormLogger) LogMode(level logger.LogLevel) logger.Interface {
 }
 
 // Error implements logger.Interface, it logs at ERROR level.
-func (GormLogger) Error(ctx context.Context, f string, args ...interface{}) {
+func (GormLogger) Error(ctx context.Context, f string, args ...any) {
 	zapctx.Error(ctx, fmt.Sprintf(f, args...))
 }
 
 // Warn implements logger.Interface, it logs at WARN level.
-func (GormLogger) Warn(ctx context.Context, f string, args ...interface{}) {
+func (GormLogger) Warn(ctx context.Context, f string, args ...any) {
 	zapctx.Warn(ctx, fmt.Sprintf(f, args...))
 }
 
 // Info implements logger.Interface, it logs at INFO level.
-func (GormLogger) Info(ctx context.Context, f string, args ...interface{}) {
+func (GormLogger) Info(ctx context.Context, f string, args ...any) {
 	zapctx.Info(ctx, fmt.Sprintf(f, args...))
 }
 

--- a/internal/logger/gormtest_logger.go
+++ b/internal/logger/gormtest_logger.go
@@ -13,8 +13,8 @@ import (
 
 // A Tester is the test interface required by gorm for the logger.
 type Tester interface {
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
 	Name() string
 	Cleanup(f func())
 }

--- a/internal/logger/http_logger.go
+++ b/internal/logger/http_logger.go
@@ -21,7 +21,7 @@ type httpLogEntry struct {
 }
 
 // Write is called when the request handler has finished.
-func (l *httpLogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
+func (l *httpLogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra any) {
 	fields := make([]zap.Field, 0)
 
 	if status != 0 {
@@ -42,7 +42,7 @@ func (l *httpLogEntry) Write(status, bytes int, header http.Header, elapsed time
 }
 
 // Panic is called when the request handler panicked.
-func (l *httpLogEntry) Panic(v interface{}, stack []byte) {
+func (l *httpLogEntry) Panic(v any, stack []byte) {
 	middleware.PrintPrettyStack(v)
 }
 

--- a/internal/logger/migration_logger.go
+++ b/internal/logger/migration_logger.go
@@ -15,7 +15,7 @@ type MigrationLogger struct {
 }
 
 // Printf implements the Printf function of the migrate.Logger interface.
-func (l MigrationLogger) Printf(format string, v ...interface{}) {
+func (l MigrationLogger) Printf(format string, v ...any) {
 	line := fmt.Sprintf(format, v...)
 	// Remove unneeded new lines since the zap logger adds them.
 	if line[len(line)-1] == '\n' {

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -156,7 +156,7 @@ func TestRemoveTuplesSucceeds(t *testing.T) {
 	// limits.
 
 	// Test a large number of tuples
-	for i := 0; i < 150; i++ {
+	for i := range 150 {
 		tuple := openfga.Tuple{
 			Object:   ofganames.ConvertTag(names.NewUserTag("test" + strconv.Itoa(i))),
 			Relation: "member",

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -418,7 +418,7 @@ func unsetMultipleResourceAccesses[T ofganames.ResourceTagger](ctx context.Conte
 	tupleTarget := ofganames.ConvertTag(resource)
 
 	lastContinuationToken := ""
-	existingRelations := map[Relation]interface{}{}
+	existingRelations := map[Relation]any{}
 	for {
 		timestampedTuples, continuationToken, err := user.client.cofgaClient.FindMatchingTuples(ctx, Tuple{
 			Object: tupleObject,

--- a/internal/pubsub/hub.go
+++ b/internal/pubsub/hub.go
@@ -14,7 +14,7 @@ import (
 )
 
 // HandlerFunc takes two arguments - a model ID and the message about this model.
-type HandlerFunc func(string, interface{})
+type HandlerFunc func(string, any)
 
 type subscriber struct {
 	matcher func(string) bool
@@ -33,7 +33,7 @@ type Hub struct {
 	parallel    *parallel.Run
 	idx         int
 	subscribers map[int]subscriber
-	messages    map[string]interface{}
+	messages    map[string]any
 }
 
 func (h *Hub) setupParallel() {
@@ -48,7 +48,7 @@ func (h *Hub) setupParallel() {
 
 // Publish notifies all subscribers by calling their notify
 // function.
-func (h *Hub) Publish(model string, content interface{}) <-chan struct{} {
+func (h *Hub) Publish(model string, content any) <-chan struct{} {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -58,7 +58,7 @@ func (h *Hub) Publish(model string, content interface{}) <-chan struct{} {
 	h.setupParallel()
 
 	if h.messages == nil {
-		h.messages = make(map[string]interface{})
+		h.messages = make(map[string]any)
 	}
 	h.messages[model] = content
 	for _, s := range h.subscribers {

--- a/internal/pubsub/hub_test.go
+++ b/internal/pubsub/hub_test.go
@@ -15,8 +15,8 @@ func TestSubscribeToModelMessages(t *testing.T) {
 	c := qt.New(t)
 	hub := &pubsub.Hub{}
 
-	messages := make(chan interface{}, 10)
-	handlerFunc := func(model string, content interface{}) {
+	messages := make(chan any, 10)
+	handlerFunc := func(model string, content any) {
 		select {
 		case messages <- content:
 		default:
@@ -44,8 +44,8 @@ func TestSubscribeToModelMessagesAfterMessagesHaveBeenSent(t *testing.T) {
 	c := qt.New(t)
 	hub := &pubsub.Hub{}
 
-	messages := make(chan interface{}, 10)
-	handlerFunc := func(model string, content interface{}) {
+	messages := make(chan any, 10)
+	handlerFunc := func(model string, content any) {
 		select {
 		case messages <- content:
 		default:
@@ -68,8 +68,8 @@ func TestSubscribeMatcher(t *testing.T) {
 	c := qt.New(t)
 	hub := &pubsub.Hub{}
 
-	messages := make(chan interface{}, 10)
-	handlerFunc := func(model string, content interface{}) {
+	messages := make(chan any, 10)
+	handlerFunc := func(model string, content any) {
 		select {
 		case messages <- content:
 		default:
@@ -115,10 +115,10 @@ func TestSubscribeMatcher(t *testing.T) {
 }
 
 type messageHub interface {
-	Publish(string, interface{}) <-chan struct{}
+	Publish(string, any) <-chan struct{}
 }
 
-func assertPublish(c *qt.C, hub messageHub, model string, message interface{}) {
+func assertPublish(c *qt.C, hub messageHub, model string, message any) {
 	done := hub.Publish(model, message)
 	select {
 	case <-done:
@@ -127,8 +127,8 @@ func assertPublish(c *qt.C, hub messageHub, model string, message interface{}) {
 	}
 }
 
-func assertMessage(c *qt.C, messages chan interface{}, expectedMessage string) {
-	var message interface{}
+func assertMessage(c *qt.C, messages chan any, expectedMessage string) {
+	var message any
 	select {
 	case message = <-messages:
 		if expectedMessage != "" {

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -26,7 +26,7 @@ const (
 type Error struct {
 	Message string
 	Code    string
-	Info    map[string]interface{}
+	Info    map[string]any
 }
 
 // Error implements the error interface.
@@ -152,7 +152,7 @@ func (c *Client) handleResponse(msg *message) {
 // Call makes an RPC call to the server. Call sends the request message to
 // the server and waits for the response to be returned or the context to
 // be canceled.
-func (c *Client) Call(ctx context.Context, facade string, version int, id, method string, args, resp interface{}) error {
+func (c *Client) Call(ctx context.Context, facade string, version int, id, method string, args, resp any) error {
 
 	var argsb []byte
 	if args != nil {

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -93,7 +93,7 @@ func TestCallClosedWithoutResponse(t *testing.T) {
 	c := qt.New(t)
 
 	srv := newServer(func(conn *websocket.Conn) error {
-		var req map[string]interface{}
+		var req map[string]any
 		if err := conn.ReadJSON(&req); err != nil {
 			return err
 		}
@@ -117,15 +117,15 @@ func TestCallErrorResponse(t *testing.T) {
 	c := qt.New(t)
 
 	srv := newServer(func(conn *websocket.Conn) error {
-		var req map[string]interface{}
+		var req map[string]any
 		if err := conn.ReadJSON(&req); err != nil {
 			return err
 		}
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"request-id": req["request-id"],
 			"error":      "test error",
 			"error-code": "test error code",
-			"error-info": map[string]interface{}{
+			"error-info": map[string]any{
 				"k1": "v1",
 				"k2": 2,
 			},
@@ -148,7 +148,7 @@ func TestCallErrorResponse(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 
 	c.Check(e.ErrorCode(), qt.Equals, "test error code")
-	c.Check(e.Info, qt.DeepEquals, map[string]interface{}{
+	c.Check(e.Info, qt.DeepEquals, map[string]any{
 		"k1": "v1",
 		"k2": float64(2),
 	})
@@ -163,14 +163,14 @@ func TestClientReceiveRequest(t *testing.T) {
 	c := qt.New(t)
 
 	srv := newServer(func(conn *websocket.Conn) error {
-		var req map[string]interface{}
+		var req map[string]any
 		if err := conn.ReadJSON(&req); err != nil {
 			return err
 		}
 		if err := conn.WriteJSON(req); err != nil {
 			return err
 		}
-		var req2 map[string]interface{}
+		var req2 map[string]any
 		if err := conn.ReadJSON(&req2); err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func TestClientReceiveInvalidMessage(t *testing.T) {
 	c := qt.New(t)
 
 	srv := newServer(func(conn *websocket.Conn) error {
-		var req map[string]interface{}
+		var req map[string]any
 		if err := conn.ReadJSON(&req); err != nil {
 			return err
 		}

--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -164,9 +164,7 @@ func dialAllHelper(ctx context.Context, dialer *Dialer, urls []string, headers h
 	for _, url := range urls {
 		zapctx.Info(ctx, "dialing", zap.String("url", url))
 		url := url
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			conn, dErr := dialer.DialWebsocket(ctx, url, headers)
 			if dErr != nil {
 				errOnce.Do(func() {
@@ -183,7 +181,7 @@ func dialAllHelper(ctx context.Context, dialer *Dialer, urls []string, headers h
 			if !keep {
 				conn.Close()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	if res != nil {

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -15,16 +15,16 @@ import (
 // connection. It contains the union of fields in a request or response
 // message.
 type message struct {
-	RequestID uint64                 `json:"request-id,omitempty"`
-	Type      string                 `json:"type,omitempty"`
-	Version   int                    `json:"version,omitempty"`
-	ID        string                 `json:"id,omitempty"`
-	Request   string                 `json:"request,omitempty"`
-	Params    json.RawMessage        `json:"params,omitempty"`
-	Error     string                 `json:"error,omitempty"`
-	ErrorCode string                 `json:"error-code,omitempty"`
-	ErrorInfo map[string]interface{} `json:"error-info,omitempty"`
-	Response  json.RawMessage        `json:"response,omitempty"`
+	RequestID uint64          `json:"request-id,omitempty"`
+	Type      string          `json:"type,omitempty"`
+	Version   int             `json:"version,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Request   string          `json:"request,omitempty"`
+	Params    json.RawMessage `json:"params,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	ErrorCode string          `json:"error-code,omitempty"`
+	ErrorInfo map[string]any  `json:"error-info,omitempty"`
+	Response  json.RawMessage `json:"response,omitempty"`
 }
 
 // isRequest returns whether the message is a request

--- a/internal/rpcproxy/message.go
+++ b/internal/rpcproxy/message.go
@@ -12,14 +12,14 @@ import (
 // message.
 type message struct {
 	start     time.Time
-	RequestID uint64                 `json:"request-id,omitempty"`
-	Type      string                 `json:"type,omitempty"`
-	Version   int                    `json:"version,omitempty"`
-	ID        string                 `json:"id,omitempty"`
-	Request   string                 `json:"request,omitempty"`
-	Params    json.RawMessage        `json:"params,omitempty"`
-	Error     string                 `json:"error,omitempty"`
-	ErrorCode string                 `json:"error-code,omitempty"`
-	ErrorInfo map[string]interface{} `json:"error-info,omitempty"`
-	Response  json.RawMessage        `json:"response,omitempty"`
+	RequestID uint64          `json:"request-id,omitempty"`
+	Type      string          `json:"type,omitempty"`
+	Version   int             `json:"version,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Request   string          `json:"request,omitempty"`
+	Params    json.RawMessage `json:"params,omitempty"`
+	Error     string          `json:"error,omitempty"`
+	ErrorCode string          `json:"error-code,omitempty"`
+	ErrorInfo map[string]any  `json:"error-info,omitempty"`
+	Response  json.RawMessage `json:"response,omitempty"`
 }

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -60,7 +60,7 @@ type TokenGenerator interface {
 	// MakeToken assumes MakeLoginToken has already been called and checks the permissions
 	// specified in the permissionMap. If the logged in user has all those permissions
 	// a JWT will be returned with assertions confirming all those permissions.
-	MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error)
+	MakeToken(ctx context.Context, permissionMap map[string]any) ([]byte, error)
 	// SetTags sets the desired model and controller tags that this TokenGenerator is valid for.
 	SetTags(mt names.ModelTag, ct names.ControllerTag)
 	// GetUser returns the authenticated user.
@@ -69,8 +69,8 @@ type TokenGenerator interface {
 
 // WebsocketConnection represents the websocket connection interface used by the proxy.
 type WebsocketConnection interface {
-	ReadJSON(v interface{}) error
-	WriteJSON(v interface{}) error
+	ReadJSON(v any) error
+	WriteJSON(v any) error
 	Close() error
 }
 
@@ -142,11 +142,9 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 		errChan:              errChan,
 		createControllerConn: helpers.ConnectController,
 	}
-	clProxy.wg.Add(1)
-	go func() {
-		defer clProxy.wg.Done()
+	clProxy.wg.Go(func() {
 		errChan <- clProxy.start(ctx)
-	}()
+	})
 	var err error
 	select {
 	case err = <-errChan:
@@ -172,12 +170,12 @@ type writeLockConn struct {
 }
 
 // readJson allows for non-concurrent reads on the websocket.
-func (c *writeLockConn) readJson(v interface{}) error {
+func (c *writeLockConn) readJson(v any) error {
 	return c.conn.ReadJSON(v)
 }
 
 // writeJson allows for concurrent writes on the websocket.
-func (c *writeLockConn) writeJson(v interface{}) error {
+func (c *writeLockConn) writeJson(v any) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.conn.WriteJSON(v)
@@ -460,11 +458,9 @@ func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
 				modelMigrationMode: p.modelMigrationMode,
 			},
 		}
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
+		p.wg.Go(func() {
 			p.errChan <- controllerToClient.start(ctx)
-		}()
+		})
 	})
 	return createConnErr
 }
@@ -631,7 +627,7 @@ func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]
 }
 
 // addJWT adds a JWT token to the the provided message.
-func addJWT(ctx context.Context, msg *message, permissions map[string]interface{}, tokenGen TokenGenerator) error {
+func addJWT(ctx context.Context, msg *message, permissions map[string]any, tokenGen TokenGenerator) error {
 
 	// First we unmarshal the existing LoginRequest.
 	if msg == nil {
@@ -670,7 +666,7 @@ func createErrResponse(err error, req *message) *message {
 }
 
 func modifyControllerResponse(msg *message) error {
-	var response map[string]interface{}
+	var response map[string]any
 	err := json.Unmarshal(msg.Response, &response)
 	if err != nil {
 		return err

--- a/internal/rpcproxy/rpcproxy_test.go
+++ b/internal/rpcproxy/rpcproxy_test.go
@@ -25,7 +25,7 @@ func (p *testTokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.U
 	return nil, nil
 }
 
-func (p *testTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
+func (p *testTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]any) ([]byte, error) {
 	return nil, nil
 }
 

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -356,16 +356,14 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 				RedirectInfo:            &mockRedirectInfo{},
 			}
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				err = rpcproxy.ProxySockets(ctx, helpers)
 				if proxyError {
 					c.Assert(err, qt.ErrorMatches, test.expectedProxyError)
 				} else {
 					c.Assert(err, qt.ErrorMatches, "Context cancelled")
 				}
-			}()
+			})
 			data, err := json.Marshal(test.messageToSend)
 			c.Assert(err, qt.IsNil)
 			clientWebsocket.read <- data
@@ -471,13 +469,13 @@ type mockWebsocketConnection struct {
 	once  sync.Once
 }
 
-func (w *mockWebsocketConnection) ReadJSON(v interface{}) error {
+func (w *mockWebsocketConnection) ReadJSON(v any) error {
 	data := <-w.read
 
 	return json.Unmarshal(data, v)
 }
 
-func (w *mockWebsocketConnection) WriteJSON(v interface{}) error {
+func (w *mockWebsocketConnection) WriteJSON(v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -508,7 +506,7 @@ func (m *mockTokenGenerator) MakeLoginToken(ctx context.Context, user *openfga.U
 	return []byte("test token"), nil
 }
 
-func (m *mockTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]interface{}) ([]byte, error) {
+func (m *mockTokenGenerator) MakeToken(ctx context.Context, permissionMap map[string]any) ([]byte, error) {
 	return []byte("test token"), nil
 }
 
@@ -542,8 +540,8 @@ func (m *mockRedirectInfo) GetRedirectInfo(_ context.Context) (rpcproxy.Controll
 	}, nil
 }
 
-func expectedRedirectInfo() map[string]interface{} {
-	return map[string]interface{}{
+func expectedRedirectInfo() map[string]any {
+	return map[string]any{
 		"servers": []any{
 			[]any{
 				map[string]any{

--- a/internal/streamproxy/streamproxy_test.go
+++ b/internal/streamproxy/streamproxy_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func echoSingleMessage(c *websocket.Conn) error {
-	msg := make(map[string]interface{})
+	msg := make(map[string]any)
 	if err := c.ReadJSON(&msg); err != nil {
 		return err
 	}

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -142,8 +142,8 @@ type API struct {
 	CreateModel_                       func(context.Context, *jujuclient.CreateModelArgs) (base.ModelInfo, error)
 	DestroyApplicationOffer_           func(context.Context, string, bool) error
 	DestroyModel_                      func(context.Context, names.ModelTag, *bool, *bool, *time.Duration, *time.Duration) error
-	DumpModel_                         func(context.Context, names.ModelTag, bool) (map[string]interface{}, error)
-	DumpModelDB_                       func(context.Context, names.ModelTag) (map[string]interface{}, error)
+	DumpModel_                         func(context.Context, names.ModelTag, bool) (map[string]any, error)
+	DumpModelDB_                       func(context.Context, names.ModelTag) (map[string]any, error)
 	FindApplicationOffers_             func(context.Context, []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error)
 	GetApplicationOffer_               func(context.Context, string) (*crossmodel.ApplicationOfferDetails, error)
 	GetApplicationOfferConsumeDetails_ func(context.Context, string) (jujuparams.ConsumeOfferDetails, error)
@@ -273,14 +273,14 @@ func (a *API) DestroyModel(ctx context.Context, tag names.ModelTag, destroyStora
 	return a.DestroyModel_(ctx, tag, destroyStorage, force, maxWait, timeout)
 }
 
-func (a *API) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]interface{}, error) {
+func (a *API) DumpModel(ctx context.Context, tag names.ModelTag, simplified bool) (map[string]any, error) {
 	if a.DumpModel_ == nil {
 		return nil, errors.New("not implemented")
 	}
 	return a.DumpModel_(ctx, tag, simplified)
 }
 
-func (a *API) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]interface{}, error) {
+func (a *API) DumpModelDB(ctx context.Context, tag names.ModelTag) (map[string]any, error) {
 	if a.DumpModelDB_ == nil {
 		return nil, errors.New("not implemented")
 	}

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -51,8 +51,8 @@ const (
 // that both the GoChecker and QuickTest checker satisfy.
 // Useful for enabling test setup functions to fail without a panic.
 type SimpleTester interface {
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
 }
 
 // An Authenticator is an implementation of jimm.Authenticator that returns

--- a/internal/testutils/jimmtest/env.go
+++ b/internal/testutils/jimmtest/env.go
@@ -324,10 +324,10 @@ func (cd *ApplicationOffer) DBObject(c *qt.C, db *db.Database) dbmodel.Applicati
 
 // CloudDefaults represents default cloud/region configuration for a new model.
 type CloudDefaults struct {
-	User     string                 `json:"user"`
-	Cloud    string                 `json:"cloud"`
-	Region   string                 `json:"region"`
-	Defaults map[string]interface{} `json:"defaults"`
+	User     string         `json:"user"`
+	Cloud    string         `json:"cloud"`
+	Region   string         `json:"region"`
+	Defaults map[string]any `json:"defaults"`
 
 	env *Environment
 	dbo dbmodel.CloudDefaults
@@ -639,7 +639,7 @@ func ParseMachineHardware(s string) *instance.HardwareCharacteristics {
 		return nil
 	}
 	var hw instance.HardwareCharacteristics
-	for _, f := range strings.Fields(s) {
+	for f := range strings.FieldsSeq(s) {
 		var err error
 
 		parts := strings.SplitN(f, "=", 2)

--- a/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
@@ -23,20 +23,20 @@ type ModelManager struct {
 	AddModel_               func(ctx context.Context, u *openfga.User, args *juju.ModelCreateArgs) (base.ModelInfo, error)
 	ChangeModelCredential_  func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error
 	DestroyModel_           func(ctx context.Context, u *openfga.User, mt names.ModelTag, destroyStorage *bool, force *bool, maxWait *time.Duration, timeout *time.Duration) error
-	DumpModel_              func(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]interface{}, error)
-	DumpModelDB_            func(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]interface{}, error)
+	DumpModel_              func(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]any, error)
+	DumpModelDB_            func(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]any, error)
 	ForEachModel_           func(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, jujuparams.UserAccessPermission) error) error
 	ForEachUserModel_       func(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, string) error) error
 	FullModelStatus_        func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, patterns []string) (*jujuparams.FullStatus, error)
 	ListModelSummaries_     func(ctx context.Context, user *openfga.User, maskingControllerUUID string) ([]base.UserModelSummary, error)
 	GetModel_               func(ctx context.Context, uuid string) (dbmodel.Model, error)
 	ImportModel_            func(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error
-	IdentityModelDefaults_  func(ctx context.Context, user *dbmodel.Identity) (map[string]interface{}, error)
+	IdentityModelDefaults_  func(ctx context.Context, user *dbmodel.Identity) (map[string]any, error)
 	ModelDefaultsForCloud_  func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo_              func(ctx context.Context, u *openfga.User, mt names.ModelTag) (jujuclient.ModelInfo, error)
 	ModelStatus_            func(ctx context.Context, u *openfga.User, mt names.ModelTag) (base.ModelStatus, error)
 	QueryModelsJq_          func(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)
-	SetModelDefaults_       func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error
+	SetModelDefaults_       func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error
 	UnsetModelDefaults_     func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	UpdateMigratedModel_    func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
 	ValidateModelUpgrade_   func(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
@@ -64,13 +64,13 @@ func (j *ModelManager) DestroyModel(ctx context.Context, u *openfga.User, mt nam
 	return j.DestroyModel_(ctx, u, mt, destroyStorage, force, maxWait, timeout)
 }
 
-func (j *ModelManager) DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]interface{}, error) {
+func (j *ModelManager) DumpModel(ctx context.Context, u *openfga.User, mt names.ModelTag, simplified bool) (map[string]any, error) {
 	if j.DumpModel_ == nil {
 		return nil, errors.New("not implemented")
 	}
 	return j.DumpModel_(ctx, u, mt, simplified)
 }
-func (j *ModelManager) DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]interface{}, error) {
+func (j *ModelManager) DumpModelDB(ctx context.Context, u *openfga.User, mt names.ModelTag) (map[string]any, error) {
 	if j.DumpModelDB_ == nil {
 		return nil, errors.New("not implemented")
 	}
@@ -146,7 +146,7 @@ func (j *ModelManager) QueryModelsJq(ctx context.Context, models []string, jqQue
 	return j.QueryModelsJq_(ctx, models, jqQuery)
 }
 
-func (j *ModelManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]interface{}) error {
+func (j *ModelManager) SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error {
 	if j.SetModelDefaults_ == nil {
 		return errors.New("not implemented")
 	}
@@ -166,7 +166,7 @@ func (j *ModelManager) UpdateMigratedModel(ctx context.Context, user *openfga.Us
 	}
 	return j.UpdateMigratedModel_(ctx, user, modelTag, targetControllerName)
 }
-func (j *ModelManager) IdentityModelDefaults(ctx context.Context, user *dbmodel.Identity) (map[string]interface{}, error) {
+func (j *ModelManager) IdentityModelDefaults(ctx context.Context, user *dbmodel.Identity) (map[string]any, error) {
 	if j.IdentityModelDefaults_ == nil {
 		return nil, errors.New("not implemented")
 	}

--- a/internal/testutils/jimmtest/store.go
+++ b/internal/testutils/jimmtest/store.go
@@ -4,6 +4,7 @@ package jimmtest
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -51,9 +52,7 @@ func (s *InMemoryCredentialStore) Get(ctx context.Context, credTag names.CloudCr
 		return nil, errors.Codef(errors.CodeNotFound, "not found")
 	}
 	attrsCopy := make(map[string]string, len(attrs))
-	for k, v := range attrs {
-		attrsCopy[k] = v
-	}
+	maps.Copy(attrsCopy, attrs)
 	return attrsCopy, nil
 }
 
@@ -67,9 +66,7 @@ func (s *InMemoryCredentialStore) Put(ctx context.Context, credTag names.CloudCr
 	}
 
 	attrsCopy := make(map[string]string, len(attrs))
-	for k, v := range attrs {
-		attrsCopy[k] = v
-	}
+	maps.Copy(attrsCopy, attrs)
 	s.cloudCredentialAttributes[credTag.String()] = attrsCopy
 	return nil
 }

--- a/internal/testutils/jimmtest/vault.go
+++ b/internal/testutils/jimmtest/vault.go
@@ -13,7 +13,7 @@ const (
 
 type fatalF interface {
 	Name() string
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 }
 
 // VaultClient returns a new vault client for use in a test.

--- a/internal/testutils/rpctest/server.go
+++ b/internal/testutils/rpctest/server.go
@@ -81,7 +81,7 @@ func HandleWS(f func(*websocket.Conn) error) http.Handler {
 
 func Echo(c *websocket.Conn) error {
 	for {
-		msg := make(map[string]interface{})
+		msg := make(map[string]any)
 		if err := c.ReadJSON(&msg); err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func Echo(c *websocket.Conn) error {
 
 func Unauthorized(c *websocket.Conn) error {
 	for {
-		msg := make(map[string]interface{})
+		msg := make(map[string]any)
 		if err := c.ReadJSON(&msg); err != nil {
 			return err
 		}

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -27,8 +27,8 @@ import (
 
 // A Tester is the test interface required by this package.
 type Tester interface {
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
 	Name() string
 	Cleanup(f func())
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -109,7 +109,7 @@ func (s *VaultStore) Put(ctx context.Context, tag names.CloudCredentialTag, attr
 		return err
 	}
 
-	data := make(map[string]interface{}, len(attr))
+	data := make(map[string]any, len(attr))
 	for k, v := range attr {
 		data[k] = v
 	}
@@ -193,7 +193,7 @@ func (s *VaultStore) PutControllerCredentials(ctx context.Context, controllerNam
 		return err
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		usernameKey: username,
 		passwordKey: password,
 	}
@@ -385,7 +385,7 @@ func (s *VaultStore) PutJWKSPrivateKey(ctx context.Context, pem []byte) (err err
 		return err
 	}
 
-	privateKeyData := map[string]interface{}{jwksPrivateKey: pem}
+	privateKeyData := map[string]any{jwksPrivateKey: pem}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSPrivateKeyPath(), privateKeyData); err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func (s *VaultStore) PutJWKSExpiry(ctx context.Context, expiry time.Time) (err e
 	if err != nil {
 		return err
 	}
-	expiryData := map[string]interface{}{jwksExpiryKey: expiry}
+	expiryData := map[string]any{jwksExpiryKey: expiry}
 	if _, err := client.KVv2(s.KVPath).Put(ctx, s.getJWKSExpiryPath(), expiryData); err != nil {
 		return err
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -16,7 +16,7 @@ type APICallCloser interface {
 	// APICall makes a call to the API server with the given object type,
 	// id, request and parameters. The response is filled in with the
 	// call's result if the call is successful.
-	APICall(objType string, version int, id, request string, params, response interface{}) error
+	APICall(objType string, version int, id, request string, params, response any) error
 	Close() error
 }
 

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -535,7 +535,7 @@ type CheckRelationsResponse struct {
 
 // ListRelationshipTuplesRequests holds the request information to list tuples.
 type ListRelationshipTuplesRequest struct {
-	Tuple             RelationshipTuple `json:"tuple,omitempty"`
+	Tuple             RelationshipTuple `json:"tuple"`
 	PageSize          int32             `json:"page_size,omitempty"`
 	ContinuationToken string            `json:"continuation_token,omitempty"`
 	ResolveUUIDs      bool              `json:"resolve_uuids,omitempty"`

--- a/pkg/names/group_test.go
+++ b/pkg/names/group_test.go
@@ -36,7 +36,6 @@ func TestParseGroupTag(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		test := test
 		c.Run(fmt.Sprintf("test case %d", i), func(c *qt.C) {
 			gt, err := names.ParseGroupTag(test.tag)
 			if test.expectedError == "" {

--- a/pkg/names/role_test.go
+++ b/pkg/names/role_test.go
@@ -36,7 +36,6 @@ func TestParseRoleTag(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		test := test
 		c.Run(fmt.Sprintf("test case %d", i), func(c *qt.C) {
 			gt, err := names.ParseRoleTag(test.tag)
 			if test.expectedError == "" {

--- a/pkg/names/service_account_test.go
+++ b/pkg/names/service_account_test.go
@@ -57,7 +57,6 @@ func TestIsValidServiceAccountId(t *testing.T) {
 		expectedValid: false,
 	}}
 	for i, test := range tests {
-		test := test
 		c.Run(fmt.Sprintf("test case %d", i), func(c *qt.C) {
 			c.Assert(names.IsValidServiceAccountId(test.id), qt.Equals, test.expectedValid)
 		})
@@ -101,7 +100,6 @@ func TestEnsureValidClientIdWithDomain(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		c.Run(test.name, func(c *qt.C) {
 			result, err := names.EnsureValidServiceAccountId(test.id)
 			if test.expectedError {

--- a/testing/apiproxy_test.go
+++ b/testing/apiproxy_test.go
@@ -31,7 +31,7 @@ func TestConnectToModel(t *testing.T) {
 		SkipLogin: true,
 	}, "test", nil)
 	defer conn.Close()
-	var resp map[string]interface{}
+	var resp map[string]any
 	err := conn.APICall("Admin", 3, "", "TestMethod", nil, &resp)
 	c.Assert(err, qt.ErrorMatches, `(?s).*no such request - method Admin.TestMethod is not implemented \(not implemented\).*`)
 }
@@ -114,7 +114,7 @@ func TestAgentLoginModelDoesNotExist(t *testing.T) {
 
 type logger struct{}
 
-func (l logger) Errorf(string, ...interface{}) {}
+func (l logger) Errorf(string, ...any) {}
 
 func TestProxyModelStatus(t *testing.T) {
 	c := qt.New(t)

--- a/testing/caasmodelmanager_test.go
+++ b/testing/caasmodelmanager_test.go
@@ -117,7 +117,7 @@ func TestListCAASModelSummaries(t *testing.T) {
 		Status: base.Status{
 			Status: "available",
 			Info:   "",
-			Data:   map[string]interface{}{},
+			Data:   map[string]any{},
 			Since:  nil,
 		},
 		ModelUserAccess:    "admin",

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -23,7 +23,7 @@ func testControllerProfileRequest(name string) apiparams.SaveControllerProfileRe
 				Type:           "ec2",
 				AuthTypes:      []string{"access-key"},
 				CACertificates: []string{"ca-cert"},
-				Config:         map[string]interface{}{"default-base": "ubuntu@24.04"},
+				Config:         map[string]any{"default-base": "ubuntu@24.04"},
 				Endpoint:       "https://aws.example.com",
 				Region: apiparams.BootstrapCloudRegion{
 					Name:             "eu-west-1",

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -66,7 +66,7 @@ func TestListModelSummaries(t *testing.T) {
 		Life:            life.Value(state.Alive.String()),
 		Status: base.Status{
 			Status: status.Available,
-			Data:   map[string]interface{}{},
+			Data:   map[string]any{},
 		},
 		ModelUserAccess: "admin",
 		Counts:          []base.EntityCount{{Entity: "units", Count: 1}},
@@ -88,7 +88,7 @@ func TestListModelSummaries(t *testing.T) {
 		Life:            life.Value(state.Alive.String()),
 		Status: base.Status{
 			Status: status.Available,
-			Data:   map[string]interface{}{},
+			Data:   map[string]any{},
 		},
 		ModelUserAccess: "read",
 		Counts:          []base.EntityCount{},
@@ -282,7 +282,7 @@ func TestCreateModel(t *testing.T) {
 		region        string
 		cloudTag      string
 		credentialTag string
-		config        map[string]interface{}
+		config        map[string]any
 		expectError   string
 	}{{
 		about:         "success",
@@ -795,12 +795,12 @@ func TestModelDefaults(t *testing.T) {
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 
-	err = client.SetModelDefaults("aws", "eu-central-1", map[string]interface{}{
+	err = client.SetModelDefaults("aws", "eu-central-1", map[string]any{
 		"a": 1,
 		"b": "value1",
 	})
 	c.Assert(err, qt.IsNil)
-	err = client.SetModelDefaults("aws", "eu-central-2", map[string]interface{}{
+	err = client.SetModelDefaults("aws", "eu-central-2", map[string]any{
 		"b": "value2",
 		"c": 17,
 	})


### PR DESCRIPTION
## Description
Ran `go fix ./...`, see https://go.dev/blog/gofix on how the new functionality in Go 1.26 works, c/p from there,
> Go fix uses a suite of algorithms to identify opportunities to improve your code, often by taking advantage of more modern features of the language and library.

Most of the changes simply change `interface{}` -> `any`, but others are more elaborate and cool to see.

It's also worth noting this related blog post https://go.dev/blog/inliner on the use of `//go:fix inline` which we can use to deprecate a function in favor of another and use `go fix` to make the change, preserving behavior due to re-ordered arguments and other subtle behaviors.  