### PR TITLE
fix: switch to external admin user

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -464,10 +464,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 		Expiry: jwtExpiry,
 	})
 
-	dialer := &jujuclient.Dialer{
-		ControllerCredentialsStore: credentialStore,
-		JWTService:                 jwtService,
-	}
+	dialer := jujuclient.NewDialer(credentialStore, jwtService, controllerUUID)
 
 	deps := &ServiceDependencies{
 		ControllerUUID:                controllerUUID,

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -36,10 +36,6 @@ import (
 	jimmversion "github.com/canonical/jimm/v3/version"
 )
 
-const (
-	adminUser = "admin"
-)
-
 // A ControllerCredentialsStore is a store for controller credentials.
 type ControllerCredentialsStore interface {
 	// GetControllerCredentials retrieves the credentials for the given controller from a vault
@@ -52,8 +48,20 @@ type ControllerCredentialsStore interface {
 type Dialer struct {
 	ControllerCredentialsStore ControllerCredentialsStore
 	JWTService                 *jimmjwx.JWTService
+	AdminUsername              string
 }
 
+// NewDialer creates a new Dialer from dependencies.
+func NewDialer(store ControllerCredentialsStore, jwtService *jimmjwx.JWTService, controllerUUID string) *Dialer {
+	return &Dialer{
+		ControllerCredentialsStore: store,
+		JWTService:                 jwtService,
+		// The admin username is a Juju external user, just like the JIMM users.
+		AdminUsername: fmt.Sprintf("jaas-%s@external", controllerUUID),
+	}
+}
+
+// createLoginRequest creates a jujuparams.LoginRequest for the given controller, model and user.
 func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*jujuparams.LoginRequest, error) {
 	// Always request superuser permissions, even when representing a non-admin user
 	// This is only safe because we have already checked the user's openfga permissions in a layer above.
@@ -95,7 +103,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	client := rpc.NewClient(conn)
 
 	if user == nil {
-		user = &openfga.User{Identity: &dbmodel.Identity{Name: adminUser}}
+		user = &openfga.User{Identity: &dbmodel.Identity{Name: d.AdminUsername}}
 	}
 
 	var loginRequest *jujuparams.LoginRequest

--- a/internal/jujuclient/modelmanager.go
+++ b/internal/jujuclient/modelmanager.go
@@ -100,7 +100,7 @@ func (c Connection) ModelInfo(ctx context.Context, model names.ModelTag) (ModelI
 // ModelManager facade.
 func (c Connection) GrantJIMMModelAdmin(ctx context.Context, tag names.ModelTag) error {
 	access := string(jujuparams.ModelAdminAccess)
-	return modelmanager.NewClient(&c).GrantModel(adminUser, access, tag.Id())
+	return modelmanager.NewClient(&c).GrantModel(c.dialer.AdminUsername, access, tag.Id())
 }
 
 // DumpModel dumps debugging details for the given model. If the simplied

--- a/internal/testutils/jimmtest/setup_jimm.go
+++ b/internal/testutils/jimmtest/setup_jimm.go
@@ -105,10 +105,7 @@ func SetupJimmEnv(c *qt.C, opts ...SetupOption) JIMMEnv {
 		Expiry: jwtExpiry,
 	})
 
-	dialer := &jujuclient.Dialer{
-		ControllerCredentialsStore: credentialStore,
-		JWTService:                 jwtService,
-	}
+	dialer := jujuclient.NewDialer(credentialStore, jwtService, ControllerUUID)
 
 	deps := &jimmsvc.ServiceDependencies{
 		ControllerUUID:                params.ControllerUUID,

--- a/testing/dial_test.go
+++ b/testing/dial_test.go
@@ -64,7 +64,8 @@ func TestDialWithJWT(t *testing.T) {
 	}
 
 	dialer := &jujuclient.Dialer{
-		JWTService: s.JIMM.JWTService,
+		JWTService:    s.JIMM.JWTService,
+		AdminUsername: "jaas-test@external",
 	}
 
 	// Check dial is OK


### PR DESCRIPTION
## Description
Change the user set as subject in the JWT when dialling to a Juju controller as self/admin.

Previously it was `admin`, now it is `jaas-<jimm-controller-uuid>@external`.

This ensures always we always dial as a Juju external user when using a JWT.

Improved version of https://github.com/canonical/jimm/pull/1945

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
