### PR TITLE
docs: add sphinx-llm extension for AI-friendly documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,6 +252,7 @@ extensions = [
     "sphinx_config_options",
     "sphinx_contributor_listing",
     "sphinx_filtered_toctree",
+    "sphinx_llm.txt",
     "sphinx_related_links",
     "sphinx_roles",
     "sphinx_terminal",
@@ -269,6 +270,17 @@ extensions = [
 ]
 
 new_tab_link_show_external_link_icon = True
+
+######################
+# sphinx-llm options #
+######################
+
+llms_txt_description = (
+    "JAAS is an enterprise layer on top of Juju that provides centralized controller management, "
+    "OIDC authentication, and ReBAC authorization."
+)
+llms_txt_suffix_mode = "url-suffix"
+markdown_http_base = "https://documentation.ubuntu.com/jaas/latest"
 
 # Excludes files or directories from processing
 

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -9,15 +9,6 @@ myst:
 
 These how-to guides cover key operations and processes in JAAS.
 
-<!--
-```{toctree}
-:titlesonly:
-:glob:
-
-*
-```
--->
-
 ## Your JAAS deployment, the bird's eye
 
 ```{toctree}

--- a/docs/howto/manage-juju-controllers.md
+++ b/docs/howto/manage-juju-controllers.md
@@ -10,16 +10,6 @@ myst:
 >
 > See also: {ref}`controller`
 
-<!--
-ADD:
-juju register-controller
-juju controllers --managed
-add-cloud-to-controller
-juju remove-cloud --target-controller
-juju remove-controller
-juju set-controller-deprecated
--->
-
 (add-a-juju-controller)=
 ## Add a Juju controller
 
@@ -40,7 +30,6 @@ For this how-to you will need the following:
 
 - Basic knowledge of Juju
 - A JIMM controller deployed in MicroK8s, see {doc}`the tutorial <../tutorial/index>`.
-<!--- Administrator permission on the JIMM controller, see {ref}`add-a-juju-controller`.-->
 
 
 ### Prelude

--- a/docs/howto/manage-your-jaas-deployment.md
+++ b/docs/howto/manage-your-jaas-deployment.md
@@ -182,7 +182,7 @@ This document shows how to integrate the different components of JAAS with the
 The Canonical Observability Stack is a Juju bundle that includes a series of
 open source observability applications and related automation.
 For the complete list of components in COS, read the
-[Stack variants](https://documentation.ubuntu.com/observability/latest/explanation/stack-variants/).
+[Stack variants](https://documentation.ubuntu.com/observability/latest/explanation/architecture/stack-variants/).
 
 ### Prerequisites
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ sphinxext-opengraph
 sphinx-config-options>=0.1.0
 sphinx-contributor-listing>=0.1.0
 sphinx-filtered-toctree>=0.1.0
+sphinx-llm
 sphinx-related-links>=0.1.1
 sphinx-roles>=0.1.0
 sphinx-terminal>=1.0.2


### PR DESCRIPTION
## Description

We'r trying to make our docs more AI friendly. To that end this PR sets up the `sphinx-llm` extension and cleans up clutter (stub contributing doc, some HTML).

<details>
Adds llms.txt generation to improve AI agent accessibility:

`llms.txt` setup:

- Add `sphinx-llm` to [requirements.txt](vscode-file://vscode-app/snap/code/233/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Add `sphinx_llm.txt` extension to `conf.py`.
- Configure with project description and `markdown_http_base = "https://documentation.ubuntu.com/jaas/latest"`.
- Set `llms_txt_suffix_mode = "url-suffix"` for cleaner markdown URLs.


Cleanup:

- Remove stub contributing.md file
- Remove HTML comments from howto/manage-applications.md, index.md, and tutorial.md
- Generates llms.txt (17KB) and llms-full.txt (237KB) providing AI agents with structured access to Terraform Provider for Juju documentation.

</details>

## Engineering checklist

Documentation tooling.

## Test instructions

RTD preview: Try https://canonical-ubuntu-documentation-library--1952.com.readthedocs.build/jaas/1952/llms.txt

local:

In `docs` run `make clean && make run`. Open the browser preview and append `llms.txt`, `llms-full.txt`, or click on some page and delete the trailing / and add `.md`. Essentially, inspect the following:

http://127.0.0.1:8000/llms.txt
http://127.0.0.1:8000/llms-full.txt
http://127.0.0.1:8000/howto.md