### PR TITLE
chore: update to Go 1.26

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -28,5 +28,5 @@ jobs:
       - name: Run Golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.8.0
+          version: v2.11.4
           args: --timeout 30m --verbose

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Run Golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.8.0
+          version: v2.11.4
           args: --timeout 30m --verbose
 

--- a/cmd/jaas/cmd/registercontroller.go
+++ b/cmd/jaas/cmd/registercontroller.go
@@ -180,6 +180,7 @@ func (c *registerControllerCommand) getControllerDetails(ctxt *cmd.Context) ([]b
 		info.PublicAddress = c.publicAddress
 	}
 
+	// #nosec G117 - intended marshalling of password over the wire
 	data, err := yaml.Marshal(info)
 	if err != nil {
 		return nil, errors.Mask(err)

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -43,6 +43,7 @@ func TestMain(m *testing.M) {
 // for tests. A test can override any parameter that it needs.
 // Note that newTestServiceParameters will create an empty test database.
 func newTestServiceParameters(c *qt.C) jimmsvc.Params {
+	// #nosec G101 Fixed test keys
 	return jimmsvc.Params{
 		DSN:            testdb.CreateEmptyDatabase(c),
 		ControllerUUID: "6acf4fd8-32d6-49ea-b4eb-dcb9d1590c11",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/jimm/v3
 
-go 1.25.8
+go 1.26
 
 // Juju based dependencies
 require (

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -40,6 +40,7 @@ func setupTestAuthSvc(ctx context.Context, c *qt.C, expiry time.Duration) (*auth
 	sessionStore, err := pgstore.NewPGStoreFromPool(sqldb, []byte("secretsecretdigletts"))
 	c.Assert(err, qt.IsNil)
 
+	// #nosec G101 Fake test credentials and keys.
 	authSvc, err := auth.NewAuthenticationService(ctx, auth.AuthenticationServiceParams{
 		IssuerURL:           "http://localhost:8082/realms/jimm",
 		ClientID:            "jimm-device",

--- a/internal/common/pagination/entitlement_test.go
+++ b/internal/common/pagination/entitlement_test.go
@@ -14,6 +14,7 @@ import (
 func TestMarshalEntitlementToken(t *testing.T) {
 	c := qt.New(t)
 
+	// #nosec G101 token value is not secret
 	tests := []struct {
 		desc          string
 		token         pagination.ComboToken
@@ -140,6 +141,7 @@ func TestDecodeEntitlementFilter(t *testing.T) {
 
 func TestNextEntitlementToken(t *testing.T) {
 	c := qt.New(t)
+	//nolint:gosec // Test fixtures intentionally include token-shaped values.
 	testCases := []struct {
 		desc          string
 		openFGAToken  string

--- a/internal/common/pagination/pagination_test.go
+++ b/internal/common/pagination/pagination_test.go
@@ -8,7 +8,6 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/common/utils"
 )
 
 func TestOffsetFilter(t *testing.T) {
@@ -76,34 +75,34 @@ func TestCreatePagination(t *testing.T) {
 			size:         nil,
 			page:         nil,
 			wantPage:     0,
-			wantNextPage: utils.IntToPointer(1),
+			wantNextPage: new(1),
 			wantOffset:   0,
 			wantLimit:    pagination.DefaultPageSize,
 		},
 		{
 			desc:         "test with set page size",
-			size:         utils.IntToPointer(100),
-			page:         utils.IntToPointer(1),
+			size:         new(100),
+			page:         new(1),
 			total:        1000,
 			wantPage:     1,
-			wantNextPage: utils.IntToPointer(2),
+			wantNextPage: new(2),
 			wantOffset:   100,
 			wantLimit:    100,
 		},
 		{
 			desc:         "test with set page size number 2",
-			size:         utils.IntToPointer(100),
-			page:         utils.IntToPointer(5),
+			size:         new(100),
+			page:         new(5),
 			total:        1000,
 			wantPage:     5,
-			wantNextPage: utils.IntToPointer(6),
+			wantNextPage: new(6),
 			wantOffset:   500,
 			wantLimit:    100,
 		},
 		{
 			desc:         "test with last current page and nextPage not present",
-			size:         utils.IntToPointer(10),
-			page:         utils.IntToPointer(0),
+			size:         new(10),
+			page:         new(0),
 			total:        10,
 			wantPage:     0,
 			wantNextPage: nil,
@@ -112,8 +111,8 @@ func TestCreatePagination(t *testing.T) {
 		},
 		{
 			desc:         "test with current page over the total",
-			size:         utils.IntToPointer(10),
-			page:         utils.IntToPointer(2),
+			size:         new(10),
+			page:         new(2),
 			total:        10,
 			wantPage:     2,
 			wantNextPage: nil,
@@ -140,8 +139,8 @@ func TestCreatePagination(t *testing.T) {
 // test the requested size is 1 more than then page size.
 func TestCreatePaginationWithoutTotal(t *testing.T) {
 	c := qt.New(t)
-	pPage := utils.IntToPointer(0)
-	pSize := utils.IntToPointer(10)
+	pPage := new(0)
+	pSize := new(10)
 	page, size, pag := pagination.CreatePaginationWithoutTotal(pSize, pPage)
 	c.Assert(page, qt.Equals, 0)
 	c.Assert(pag.Limit(), qt.Equals, 11)

--- a/internal/common/utils/test_utils.go
+++ b/internal/common/utils/test_utils.go
@@ -1,10 +1,12 @@
 // Copyright 2024 Canonical.
 package utils
 
+//go:fix inline
 func IntToPointer(i int) *int {
-	return &i
+	return new(i)
 }
 
+//go:fix inline
 func StringToPointer(s string) *string {
-	return &s
+	return new(s)
 }

--- a/internal/db/pgx_test.go
+++ b/internal/db/pgx_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	// #nosec G101 Test DSN for the local development Postgres instance.
 	defaultDSN = "postgresql://jimm:jimm@127.0.0.1:5432/jimm"
 )
 

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -463,6 +463,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob(c *qt.C) {
 		nil,
 	)
 	mocks.clientStore.EXPECT().AccountDetails(p.ControllerName).Return(
+		// #nosec G101 Fake test controller credentials.
 		&jujuclient.AccountDetails{
 			User:     "diglett",
 			Password: "diglett's password",
@@ -987,6 +988,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_JujuManagerFailsToAddController
 		nil,
 	)
 	mocks.clientStore.EXPECT().AccountDetails(p.ControllerName).Return(
+		// #nosec G101 Fake test controller credentials.
 		&jujuclient.AccountDetails{
 			User:     "diglett",
 			Password: "diglett's password",
@@ -1113,6 +1115,7 @@ func (s *bootstrapManagerSuite) TestBootstrapJob_CleanupControllerFailure(c *qt.
 		nil,
 	)
 	mocks.clientStore.EXPECT().AccountDetails(p.ControllerName).Return(
+		// #nosec G101 Fake test controller credentials.
 		&jujuclient.AccountDetails{
 			User:     "diglett",
 			Password: "diglett's password",

--- a/internal/jimm/juju/migrationtarget_test.go
+++ b/internal/jimm/juju/migrationtarget_test.go
@@ -543,6 +543,7 @@ func TestPrechecks_MissingCloudCredential(t *testing.T) {
 	dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
 	user := openfga.NewUser(&dbUser, nil)
 
+	// #nosec G101 No fields are secret
 	model, desc := newMigrationInfo(modelDescriptionArgs{
 		Owner:               "bob",
 		ModelName:           "test-model-2",
@@ -1213,6 +1214,7 @@ func TestImport_UserNotFoundInUserMapping(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*not found.*")
 }
 
+//nolint:gosec // Test fixtures intentionally include cloud credential names.
 func TestImport_MissingCloudCredentialFromJIMMState(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -2684,8 +2684,8 @@ var destroyModelTests = []struct {
 	},
 	username:       "alice@canonical.com",
 	uuid:           "00000002-0000-0000-0000-000000000001",
-	destroyStorage: newBool(true),
-	force:          newBool(false),
+	destroyStorage: new(true),
+	force:          new(false),
 	maxWait:        newDuration(time.Second),
 	timeout:        newDuration(time.Second),
 	expectedLife:   "dying",
@@ -3628,12 +3628,14 @@ func TestListModels(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func newBool(b bool) *bool {
-	return &b
+	return new(b)
 }
 
+//go:fix inline
 func newDuration(d time.Duration) *time.Duration {
-	return &d
+	return new(d)
 }
 
 // newDate wraps time.Date to return a *time.Time.

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -2686,8 +2686,8 @@ var destroyModelTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	destroyStorage: new(true),
 	force:          new(false),
-	maxWait:        newDuration(time.Second),
-	timeout:        newDuration(time.Second),
+	maxWait:        new(time.Second),
+	timeout:        new(time.Second),
 	expectedLife:   "dying",
 }, {
 	name: "SuperuserSuccess",
@@ -3626,16 +3626,6 @@ func TestListModels(t *testing.T) {
 			},
 		)
 	}
-}
-
-//go:fix inline
-func newBool(b bool) *bool {
-	return new(b)
-}
-
-//go:fix inline
-func newDuration(d time.Duration) *time.Duration {
-	return new(d)
 }
 
 // newDate wraps time.Date to return a *time.Time.

--- a/internal/jimm/juju/supportedversions_test.go
+++ b/internal/jimm/juju/supportedversions_test.go
@@ -22,11 +22,11 @@ import (
 // makeRelease builds a RepositoryRelease pointer suitable for use in tests.
 func makeRelease(tag string, draft, prerelease bool, publishedAt time.Time, htmlURL string) *github.RepositoryRelease {
 	return &github.RepositoryRelease{
-		TagName:     github.Ptr(tag),
-		Draft:       github.Ptr(draft),
-		Prerelease:  github.Ptr(prerelease),
+		TagName:     new(tag),
+		Draft:       new(draft),
+		Prerelease:  new(prerelease),
 		PublishedAt: &github.Timestamp{Time: publishedAt},
-		HTMLURL:     github.Ptr(htmlURL),
+		HTMLURL:     new(htmlURL),
 	}
 }
 

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -140,7 +140,7 @@ func TestCallbackFailsNoState(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - no state cookie present")
+	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - no state cookie present\n")
 }
 
 func TestCallbackFailsStateNoMatch(t *testing.T) {
@@ -159,7 +159,7 @@ func TestCallbackFailsStateNoMatch(t *testing.T) {
 	defer res.Body.Close()
 	b, err := io.ReadAll(res.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - state does not match")
+	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - state does not match\n")
 }
 
 func TestCallbackFailsNoCodePresent(t *testing.T) {
@@ -180,7 +180,7 @@ func TestCallbackFailsNoCodePresent(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - missing auth code")
+	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+" - missing auth code\n")
 }
 
 func TestCallbackFailsExchange(t *testing.T) {
@@ -201,5 +201,5 @@ func TestCallbackFailsExchange(t *testing.T) {
 
 	b, err := io.ReadAll(res.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+` - authorisation code exchange failed: oauth2: "invalid_grant" "Code not valid"`)
+	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+` - authorisation code exchange failed: oauth2: "invalid_grant" "Code not valid"`+"\n")
 }

--- a/internal/jimmhttp/httpproxy_handler_test.go
+++ b/internal/jimmhttp/httpproxy_handler_test.go
@@ -111,14 +111,14 @@ func TestHTTPProxyHandler(t *testing.T) {
 			url:            fmt.Sprintf("/model/%s/charms", "fake-uuid"),
 			modelUUID:      "fake-uuid",
 			statusExpected: http.StatusBadRequest,
-			bodyExpected:   "Bad Request - invalid model UUID format",
+			bodyExpected:   "Bad Request - invalid model UUID format\n",
 		},
 		{
 			description:    "model not existing",
 			url:            fmt.Sprintf("/model/%s/charms", "54d9f921-c45a-4825-8253-74e7edc28066"),
 			modelUUID:      "54d9f921-c45a-4825-8253-74e7edc28066",
 			statusExpected: http.StatusNotFound,
-			bodyExpected:   "Not Found - model not found",
+			bodyExpected:   "Not Found - model not found\n",
 		},
 	}
 

--- a/internal/jimmhttp/migrationproxy_handler_test.go
+++ b/internal/jimmhttp/migrationproxy_handler_test.go
@@ -103,14 +103,14 @@ func TestMigrationHTTPProxyHandler(t *testing.T) {
 			url:            "/foo",
 			headers:        http.Header{"X-Juju-Migration-Model-UUID": []string{"non-existent-model-uuid"}},
 			statusExpected: http.StatusNotFound,
-			bodyExpected:   `Not Found - model not found`,
+			bodyExpected:   `Not Found - model not found\n`,
 		},
 		{
 			description:    "missing model header",
 			url:            "/foo",
 			headers:        http.Header{"X-Juju-Migration-Model-UUID": []string{""}},
 			statusExpected: http.StatusBadRequest,
-			bodyExpected:   "Bad Request - missing X-Juju-Migration-Model-UUID header value",
+			bodyExpected:   "Bad Request - missing X-Juju-Migration-Model-UUID header value\n",
 		},
 	}
 

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/common/utils"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
@@ -98,28 +97,28 @@ func TestListIdentities(t *testing.T) {
 	}{
 		{
 			desc:         "test with first page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(0),
+			size:         new(2),
+			page:         new(0),
 			wantPage:     0,
 			wantSize:     2,
-			wantNextpage: utils.IntToPointer(1),
+			wantNextpage: new(1),
 			wantTotal:    len(testUsers),
 			emails:       []string{testUsers[0].Name, testUsers[1].Name},
 		},
 		{
 			desc:         "test with second page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(1),
+			size:         new(2),
+			page:         new(1),
 			wantPage:     1,
 			wantSize:     2,
-			wantNextpage: utils.IntToPointer(2),
+			wantNextpage: new(2),
 			wantTotal:    len(testUsers),
 			emails:       []string{testUsers[2].Name, testUsers[3].Name},
 		},
 		{
 			desc:         "test with last page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(2),
+			size:         new(2),
+			page:         new(2),
 			wantPage:     2,
 			wantSize:     1,
 			wantNextpage: nil,

--- a/internal/jimmhttp/rebac_admin/resources_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/resources_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 	qt "github.com/frankban/quicktest"
 
-	"github.com/canonical/jimm/v3/internal/common/utils"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
@@ -117,33 +116,33 @@ func TestListResourcesIntegration(t *testing.T) {
 		},
 		{
 			desc:     "test default sizes",
-			page:     utils.IntToPointer(0),
+			page:     new(0),
 			wantPage: 0,
 			wantSize: 5,
 			ids:      ids,
 		},
 		{
 			desc:         "test with first page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(0),
+			size:         new(2),
+			page:         new(0),
 			wantPage:     0,
 			wantSize:     2,
-			wantNextpage: utils.IntToPointer(1),
+			wantNextpage: new(1),
 			ids:          []testEntity{ids[0], ids[1]},
 		},
 		{
 			desc:         "test with second page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(1),
+			size:         new(2),
+			page:         new(1),
 			wantPage:     1,
 			wantSize:     2,
-			wantNextpage: utils.IntToPointer(2),
+			wantNextpage: new(2),
 			ids:          []testEntity{ids[2], ids[3]},
 		},
 		{
 			desc:         "test with last page",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(2),
+			size:         new(2),
+			page:         new(2),
 			wantPage:     2,
 			wantSize:     1,
 			wantNextpage: nil,
@@ -151,12 +150,12 @@ func TestListResourcesIntegration(t *testing.T) {
 		},
 		{
 			desc:         "test first page with model name filter",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(0),
+			size:         new(2),
+			page:         new(0),
 			nameFilter:   "model",
 			wantPage:     0,
 			wantSize:     2,
-			wantNextpage: utils.IntToPointer(1),
+			wantNextpage: new(1),
 			ids: func() []testEntity {
 				filteredIds := make([]testEntity, 0)
 				for _, id := range ids {
@@ -169,8 +168,8 @@ func TestListResourcesIntegration(t *testing.T) {
 		},
 		{
 			desc:         "test first page with model name filter",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(1),
+			size:         new(2),
+			page:         new(1),
 			nameFilter:   "model",
 			wantPage:     1,
 			wantSize:     1,
@@ -187,8 +186,8 @@ func TestListResourcesIntegration(t *testing.T) {
 		},
 		{
 			desc:         "test first page with controller entity type",
-			size:         utils.IntToPointer(2),
-			page:         utils.IntToPointer(0),
+			size:         new(2),
+			page:         new(0),
 			typeFilter:   rebac_admin.Controller,
 			wantPage:     0,
 			wantSize:     1,
@@ -205,8 +204,8 @@ func TestListResourcesIntegration(t *testing.T) {
 		},
 		{
 			desc:         "test big page with model entity type",
-			size:         utils.IntToPointer(10),
-			page:         utils.IntToPointer(0),
+			size:         new(10),
+			page:         new(0),
 			typeFilter:   rebac_admin.Model,
 			wantPage:     0,
 			wantSize:     3,

--- a/internal/jimmhttp/rebac_admin/resources_test.go
+++ b/internal/jimmhttp/rebac_admin/resources_test.go
@@ -11,7 +11,6 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/canonical/jimm/v3/internal/common/pagination"
-	"github.com/canonical/jimm/v3/internal/common/utils"
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
@@ -48,10 +47,10 @@ func TestListResources(t *testing.T) {
 	}{
 		{
 			desc:       "test good",
-			size:       utils.IntToPointer(2),
-			page:       utils.IntToPointer(0),
-			nameFilter: utils.StringToPointer(""),
-			typeFilter: utils.StringToPointer(""),
+			size:       new(2),
+			page:       new(0),
+			nameFilter: new(""),
+			typeFilter: new(""),
 		},
 		{
 			desc:       "test good with all params set to nil",
@@ -65,7 +64,7 @@ func TestListResources(t *testing.T) {
 			size:             nil,
 			page:             nil,
 			nameFilter:       nil,
-			typeFilter:       utils.StringToPointer("type-not-found"),
+			typeFilter:       new("type-not-found"),
 			expectErrorMatch: ".*this resource type is not supported.*",
 		},
 	}

--- a/internal/jimmhttp/utils.go
+++ b/internal/jimmhttp/utils.go
@@ -85,13 +85,9 @@ func splitPath(s string) (elem, remain string) {
 // is an erroneous status code.
 func writeError(ctx context.Context, w http.ResponseWriter, status int, err error, logMessage string) {
 	zapctx.Error(ctx, logMessage, zap.Error(err))
-	w.WriteHeader(status)
 	errMsg := ""
 	if err != nil {
 		errMsg = " - " + err.Error()
 	}
-	_, err = w.Write([]byte(http.StatusText(status) + errMsg))
-	if err != nil {
-		zapctx.Error(ctx, "failed to write status text error", zap.Error(err))
-	}
+	http.Error(w, http.StatusText(status)+errMsg, status)
 }

--- a/internal/jimmhttp/websocket.go
+++ b/internal/jimmhttp/websocket.go
@@ -42,11 +42,7 @@ func (h *WSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx, authErr := h.Server.Authenticate(ctx, w, req)
 	if authErr != nil {
 		zapctx.Error(ctx, "authentication error", zap.Error(authErr))
-		w.WriteHeader(http.StatusUnauthorized)
-		_, err := w.Write([]byte(authErr.Error()))
-		if err != nil {
-			zapctx.Error(ctx, "failed to write authentication error", zap.Error(err))
-		}
+		http.Error(w, "authentication failed", http.StatusUnauthorized)
 		return
 	}
 

--- a/internal/jimmhttp/websocket_test.go
+++ b/internal/jimmhttp/websocket_test.go
@@ -137,5 +137,5 @@ func TestWSHandlerAuthFailsServer(t *testing.T) {
 	c.Assert(httpResp.StatusCode, qt.Equals, http.StatusUnauthorized)
 	bodyBytes, err := io.ReadAll(httpResp.Body)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(bodyBytes), qt.Equals, "authentication failed")
+	c.Assert(string(bodyBytes), qt.Equals, "authentication failed\n")
 }

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -551,6 +551,7 @@ func TestAddModelToController(t *testing.T) {
 	}
 
 	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+	// #nosec G101 No secrets in ModelCreateArgs.
 	req := apiparams.AddModelToControllerRequest{
 		ModelCreateArgs: jujuparams.ModelCreateArgs{
 			Name:               "mymodel",

--- a/internal/jujuapi/rpc/root.go
+++ b/internal/jujuapi/rpc/root.go
@@ -73,6 +73,7 @@ func (r *Root) Kill() {
 }
 
 func (r *Root) start(ctx context.Context) (context.Context, uint64) {
+	// #nosec G118 Cancel func is called when end is called
 	ctx, cancel := context.WithCancel(ctx)
 	r.inflightMu.Lock()
 	defer r.inflightMu.Unlock()

--- a/internal/jujuapi/types_test.go
+++ b/internal/jujuapi/types_test.go
@@ -25,6 +25,7 @@ func TestModelCreateArgs(t *testing.T) {
 
 	authenticatedUser := names.NewUserTag("vorbis@canonical.com")
 
+	// #nosec G101 No secret fields
 	tests := []struct {
 		about         string
 		args          jujuparams.ModelCreateArgs

--- a/internal/jujucommands/bootstrap_test.go
+++ b/internal/jujucommands/bootstrap_test.go
@@ -41,6 +41,7 @@ func (s *jujucommandsSuite) TestBootstrapCmdParams_Validate(c *qt.C) {
 }
 
 func (s *jujucommandsSuite) TestBootstrapCmdParams_LoginTokenRefreshURLOverrideFromBootstrapConfig(c *qt.C) {
+	// #nosec G101 No hardcoded credentials
 	p := jujucommands.BootstrapCmdParams{
 		CloudNameAndRegion:   "testregion/testcloud",
 		ControllerName:       "my-controller",

--- a/internal/river/bootstrap_test.go
+++ b/internal/river/bootstrap_test.go
@@ -75,6 +75,7 @@ func TestBootstrapWorker(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer func() { _ = tx.Rollback() }()
 
+	// #nosec G101 No harcoded credentials
 	result, err := testWorker.Work(c.Context(), c.TB, tx, rivertypes.BootstrapArgs{
 		Username: u.Name,
 		CloudCred: cloud.NewCredential(cloud.AccessKeyAuthType, map[string]string{

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -730,6 +730,7 @@ func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clie
 		if err != nil {
 			return errorFnc(err)
 		}
+		// #nosec G117 session token is sensitive but the data object is not logged.
 		data, err := json.Marshal(apiparams.GetDeviceSessionTokenResponse{
 			SessionToken: sessionToken,
 		})

--- a/internal/rpcproxy/rpcproxylogin_test.go
+++ b/internal/rpcproxy/rpcproxylogin_test.go
@@ -34,18 +34,21 @@ func TestProxySocketsAdminFacade(t *testing.T) {
 		clientSecret = "test-client-secret"
 	)
 
+	// #nosec G101
 	loginData, err := json.Marshal(params.LoginRequest{
 		AuthTag: names.NewUserTag("alice@wonderland.io").String(),
 		Token:   "dGVzdCB0b2tlbg==",
 	})
 	c.Assert(err, qt.IsNil)
 
+	// #nosec G101
 	serviceAccountLoginData, err := json.Marshal(params.LoginRequest{
 		AuthTag: names.NewUserTag("test-client-id@serviceaccount").String(),
 		Token:   "dGVzdCB0b2tlbg==",
 	})
 	c.Assert(err, qt.IsNil)
 
+	// #nosec G117
 	ccData, err := json.Marshal(apiparams.LoginWithClientCredentialsRequest{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -230,6 +230,7 @@ func SetupTestDashboardCallbackHandler(browserURL string, db *db.Database, sessi
 
 	// Remember redirect url to check it matches after test server starts
 	redirectURL := "http://127.0.0.1:" + port + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint
+	// #nosec G101 Test credentials
 	authSvc, err := auth.NewAuthenticationService(context.Background(), auth.AuthenticationServiceParams{
 		IssuerURL:          "http://localhost:8082/realms/jimm",
 		ClientID:           "jimm-device",

--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -67,6 +67,7 @@ func (s *JimmWithControllers) GetControllersConfig(c *qt.C) *ControllersConfig {
 			"Set it to the path of your controllers.yaml file or configure it in VS Code settings.",
 		ControllersConfigEnvVar))
 
+	// #nosec G703 Test-only config path is explicitly provided by the environment.
 	data, err := os.ReadFile(configPath)
 	c.Assert(err, qt.IsNil, qt.Commentf(
 		"failed to read controller config file: %s. "+

--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -31,7 +31,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
-	"github.com/canonical/jimm/v3/internal/utils"
 )
 
 const (
@@ -279,7 +278,7 @@ func (s *JimmWithControllers) DeployApplication(c *qt.C, user *openfga.User, mod
 	defer conn.Close()
 
 	client := application.NewClient(conn)
-	channel := utils.Ptr("latest/stable")
+	channel := new("latest/stable")
 	if params.Channel != "" {
 		channel = &params.Channel
 	}
@@ -288,8 +287,8 @@ func (s *JimmWithControllers) DeployApplication(c *qt.C, user *openfga.User, mod
 		CharmName:       params.Charm,
 		ApplicationName: params.App,
 		Channel:         channel,
-		NumUnits:        utils.Ptr(1),
-		Cons:            constraints.Value{Arch: utils.Ptr(runtime.GOARCH)},
+		NumUnits:        new(1),
+		Cons:            constraints.Value{Arch: new(runtime.GOARCH)},
 	})
 	for _, err := range errs {
 		c.Assert(err, qt.Equals, nil)

--- a/internal/testutils/jimmtest/setup_jimm.go
+++ b/internal/testutils/jimmtest/setup_jimm.go
@@ -76,6 +76,7 @@ func SetupJimmEnv(c *qt.C, opts ...SetupOption) JIMMEnv {
 		database.Close()
 	})
 
+	// #nosec G101 fixed test signing keys
 	params := jimmsvc.Params{
 		ControllerUUID:                ControllerUUID,
 		PrivateKey:                    "ly/dzsI9Nt/4JxUILQeAX79qZ4mygDiuYGqc2ZEiDEc=",
@@ -235,6 +236,7 @@ func (s *JIMMEnv) realAuthenticationService(c *qt.C, db *db.Database) *auth.Auth
 		sessionStore.Close()
 	})
 
+	// #nosec G101 fixed test secret
 	authSvc, err := auth.NewAuthenticationService(context.Background(), auth.AuthenticationServiceParams{
 		IssuerURL:           "http://localhost:8082/realms/jimm",
 		ClientID:            "jimm-device",

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -105,6 +105,8 @@ func dbCleanup(t Tester, gdb *gorm.DB, databaseName string) {
 }
 
 const unsafeCharsPattern = "[ .:;`'\"|<>~/\\?!@#$%^&*()[\\]{}=+-]"
+
+// #nosec G101 Test DSN for the local development Postgres instance.
 const defaultDSN = "postgresql://jimm:jimm@127.0.0.1:5432/jimm"
 
 // maxDatabaseNameLength Postgres's limit on database name length.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -22,7 +22,3 @@ func NewConversationID() string {
 	}
 	return hex.EncodeToString(buf)
 }
-
-func Ptr[T any](v T) *T {
-	return &v
-}

--- a/local/jimm/Dockerfile
+++ b/local/jimm/Dockerfile
@@ -2,8 +2,8 @@
 # Installing air to avoid breakages when we update our Go version before a new air image is available.
 FROM golang:1.25 AS dev
 
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.25.2
-RUN go install github.com/air-verse/air@v1.63.1
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.1
+RUN go install github.com/air-verse/air@v1.65.1
 
 ENTRYPOINT [ "air" ]
 


### PR DESCRIPTION
## Description
Update to Go 1.26 and ran `go fix ./...` which replaced usages of our value->ptr function with Go 1.26 `new()` that returns a pointer for a value type.

Also updated golangci-lint to support Go 1.26 and addressed many security warnings:
- G101 harcoded credentials: All ignored as these were pretty much just tests.
- G117 marshalling struct with sensitive content: The linter [is targetted](https://github.com/securego/gosec/issues/1416) at avoiding leaking serialised secret data in logs. We need to serialise the data to send it over the wire and we don't log it, ignored these.
- G118 missing use of context cancel function: Incorrect, ignored.
- G703 path traversal via taint analysis: untrusted input performing file reads, ignored as this was just in tests.
- G705 XSS via taint analysis: Resolved by using http.Error.