### PR TITLE
Add errorlint to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - errorlint
     - nilerr
     - promlinter
     - reassign

--- a/cmd/jaas/cmd/addmodel.go
+++ b/cmd/jaas/cmd/addmodel.go
@@ -586,10 +586,10 @@ func (c *addModelCommand) findLocalCredential(ctx *cmd.Context, p *findCredentia
 	if err == nil {
 		return credential, credentialName, cloudRegion, nil
 	}
-	switch errors.Cause(err) {
-	case modelcmd.ErrMultipleCredentials:
+	switch {
+	case errors.Is(errors.Cause(err), modelcmd.ErrMultipleCredentials):
 		return fail(errAmbiguousCredential)
-	case common.ErrMultipleDetectedCredentials:
+	case errors.Is(errors.Cause(err), common.ErrMultipleDetectedCredentials):
 		return fail(errAmbiguousDetectedCredential)
 	}
 	return fail(err)
@@ -609,7 +609,7 @@ func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]any, err
 		return nil, fmt.Errorf("params must contain a YAML map with string keys")
 	}
 	if err := common.FinalizeAuthorizedKeys(ctx, attrs); err != nil {
-		if errors.Cause(err) != common.ErrNoAuthorizedKeys {
+		if !errors.Is(errors.Cause(err), common.ErrNoAuthorizedKeys) {
 			return nil, err
 		}
 	}

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -239,7 +239,7 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 
 	client, err := c.getJIMMAPI()
 	if err != nil {
-		return fmt.Errorf("could not create JIMM client: %v", err)
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 

--- a/cmd/jaas/cmd/bootstrapstatus.go
+++ b/cmd/jaas/cmd/bootstrapstatus.go
@@ -83,7 +83,7 @@ func (c *bootstrapStatusCommand) Init(args []string) error {
 func (c *bootstrapStatusCommand) Run(ctxt *cmd.Context) error {
 	client, err := c.getJIMMAPI()
 	if err != nil {
-		return fmt.Errorf("failed to create JIMM client: %v", err)
+		return fmt.Errorf("failed to create JIMM client: %w", err)
 	}
 	defer client.Close()
 

--- a/cmd/jaas/cmd/bootstrapstop.go
+++ b/cmd/jaas/cmd/bootstrapstop.go
@@ -65,18 +65,18 @@ func (c *bootstrapStopCommand) Init(args []string) error {
 func (c *bootstrapStopCommand) Run(ctxt *cmd.Context) error {
 	client, err := c.getJIMMAPI()
 	if err != nil {
-		return fmt.Errorf("failed to create JIMM client: %v", err)
+		return fmt.Errorf("failed to create JIMM client: %w", err)
 	}
 
 	err = client.StopBootstrap(&params.StopBootstrapRequest{
 		JobID: c.jobId,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to stop bootstrap: %v", err)
+		return fmt.Errorf("failed to stop bootstrap: %w", err)
 	}
 	_, err = fmt.Fprintf(ctxt.Stdout, "Bootstrap job with ID %q has been stopped.\n", c.jobId)
 	if err != nil {
-		return fmt.Errorf("failed to write output: %v", err)
+		return fmt.Errorf("failed to write output: %w", err)
 	}
 	return nil
 }

--- a/cmd/jaas/cmd/destroycontroller.go
+++ b/cmd/jaas/cmd/destroycontroller.go
@@ -114,7 +114,7 @@ func (c *destroyControllerCommand) Run(ctxt *cmd.Context) error {
 
 	client, err := c.getJIMMAPI()
 	if err != nil {
-		return fmt.Errorf("could not create JIMM client: %v", err)
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 

--- a/cmd/jaas/cmd/listmigrationtargets.go
+++ b/cmd/jaas/cmd/listmigrationtargets.go
@@ -89,7 +89,7 @@ func (c *listMigrationTargetsCommand) Run(ctxt *cmd.Context) error {
 
 	client, err := c.getJIMMAPI()
 	if err != nil {
-		return fmt.Errorf("could not create JIMM client: %v", err)
+		return fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer client.Close()
 

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -162,7 +162,7 @@ func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
 	// Get the model info from the current controller.
 	modelInfo, err := c.ClientStore().ModelByName(currentController, c.modelName)
 	if err != nil {
-		return fmt.Errorf("could not find model %q on controller %q: %v", c.modelName, currentController, err)
+		return fmt.Errorf("could not find model %q on controller %q: %w", c.modelName, currentController, err)
 	}
 
 	userMapping, err := c.parseUserMappingFile()
@@ -172,7 +172,7 @@ func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
 
 	jujuAPI, err := c.jujuApiFunc()
 	if err != nil {
-		return fmt.Errorf("could not create Juju API client: %v", err)
+		return fmt.Errorf("could not create Juju API client: %w", err)
 	}
 	defer jujuAPI.Close()
 
@@ -184,22 +184,22 @@ func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
 
 	token, err := c.prepareMigration(userMapping, modelInfo.ModelUUID)
 	if err != nil {
-		return fmt.Errorf("failure preparing migration: %v", err)
+		return fmt.Errorf("failure preparing migration: %w", err)
 	}
 
 	spec, err := c.getMigrationSpec(token, modelInfo.ModelUUID)
 	if err != nil {
-		return fmt.Errorf("could not get migration spec: %v", err)
+		return fmt.Errorf("could not get migration spec: %w", err)
 	}
 
 	events, err := jujuAPI.InitiateMigration(spec)
 	if err != nil {
-		return fmt.Errorf("could not initiate migration from controller %q: %v", currentController, err)
+		return fmt.Errorf("could not initiate migration from controller %q: %w", currentController, err)
 	}
 
 	err = c.out.Write(ctxt, events)
 	if err != nil {
-		return fmt.Errorf("could not write migration events: %v", err)
+		return fmt.Errorf("could not write migration events: %w", err)
 	}
 	return nil
 }
@@ -209,7 +209,7 @@ func (c *migrateModelCommand) Run(ctxt *cmd.Context) error {
 func (c *migrateModelCommand) prepareMigration(userMapping map[string]string, modelUUID string) (string, error) {
 	jimmClient, err := c.jimmAPIFunc()
 	if err != nil {
-		return "", fmt.Errorf("could not create JIMM client: %v", err)
+		return "", fmt.Errorf("could not create JIMM client: %w", err)
 	}
 	defer jimmClient.Close()
 	response, err := jimmClient.PrepareModelMigration(&apiparams.PrepareModelMigrationRequest{
@@ -226,12 +226,12 @@ func (c *migrateModelCommand) prepareMigration(userMapping map[string]string, mo
 func (c *migrateModelCommand) parseUserMappingFile() (map[string]string, error) {
 	content, err := os.ReadFile(c.userMappingFile)
 	if err != nil {
-		return nil, fmt.Errorf("could not read user mapping file: %v", err)
+		return nil, fmt.Errorf("could not read user mapping file: %w", err)
 	}
 	userMapping := make(map[string]string)
 	err = yaml.Unmarshal(content, &userMapping)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse user mapping file: %v", err)
+		return nil, fmt.Errorf("could not parse user mapping file: %w", err)
 	}
 	if len(userMapping) < 1 {
 		return nil, fmt.Errorf("user mapping file is empty or not properly formatted")
@@ -272,7 +272,7 @@ func (c *migrateModelCommand) getMigrationSpec(token string, modelUUID string) (
 func (c *migrateModelCommand) validateUserMapping(userMapping map[string]string, modelUUID, modelName string, jujuAPI MigrateAPI) error {
 	modelInfo, err := jujuAPI.ModelInfo([]names.ModelTag{names.NewModelTag(modelUUID)})
 	if err != nil {
-		return fmt.Errorf("could not get model info: %v", err)
+		return fmt.Errorf("could not get model info: %w", err)
 	}
 	if len(modelInfo) == 0 {
 		return fmt.Errorf("model %q not found", modelName)
@@ -304,7 +304,7 @@ func (c *migrateModelCommand) validateUserMapping(userMapping map[string]string,
 	}
 	offers, err := jujuAPI.ListOffers(filter)
 	if err != nil {
-		return fmt.Errorf("could not list application offers: %v", err)
+		return fmt.Errorf("could not list application offers: %w", err)
 	}
 	for _, offer := range offers {
 		for _, user := range offer.Users {
@@ -326,7 +326,7 @@ func (c *migrateModelCommand) validateUserMapping(userMapping map[string]string,
 func (c *migrateModelCommand) newJujuClient() (MigrateAPI, error) {
 	currentController, err := c.ClientStore().CurrentController()
 	if err != nil {
-		return nil, fmt.Errorf("could not determine controller: %v", err)
+		return nil, fmt.Errorf("could not determine controller: %w", err)
 	}
 
 	apiCaller, err := c.NewAPIRootWithDialOpts(c.ClientStore(), currentController, "", nil)

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,7 +35,8 @@ func main() {
 	err := s.Wait()
 
 	zapctx.Error(context.Background(), "jimm shutdown complete", zap.Error(err))
-	if _, ok := err.(*service.SignalError); !ok {
+	signalError := &service.SignalError{}
+	if !stderrors.As(err, &signalError) {
 		os.Exit(1)
 	}
 }
@@ -122,7 +124,7 @@ func start(ctx context.Context, s *service.Service) error {
 	if key, ok := os.LookupEnv("INSECURE_SECRET_STORAGE"); ok && key != "" {
 		insecureSecretStorage, err = strconv.ParseBool(key)
 		if err != nil {
-			return fmt.Errorf("failed to parse INSECURE_SECRET_STORAGE env var: %v", err)
+			return fmt.Errorf("failed to parse INSECURE_SECRET_STORAGE env var: %w", err)
 		}
 	}
 	if insecureSecretStorage {

--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -421,7 +421,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 
 	publicDNS, err := parseURLWithOptionalScheme(p.PublicDNSName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse public DNS name: %v", err)
+		return nil, fmt.Errorf("failed to parse public DNS name: %w", err)
 	}
 
 	if p.DSN == "" {
@@ -619,7 +619,7 @@ func NewServiceFromDependencies(ctx context.Context, deps *ServiceDependencies) 
 		ControllerUUID:         deps.ControllerUUID,
 	}, deps.Database, s.jimm.OfferAuthorizer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set up discharger: %v", err)
+		return nil, fmt.Errorf("failed to set up discharger: %w", err)
 	}
 	s.mux.Handle(localDischargePath+"/*", discharger.GetDischargerMux(macaroonDischarger, localDischargePath))
 
@@ -800,7 +800,7 @@ func setupCredentialStore(ctx context.Context, p Params, db *db.Database) (jimmc
 
 	vs, err := newVaultStore(ctx, p)
 	if err != nil {
-		return nil, fmt.Errorf("vault store error: %v", err)
+		return nil, fmt.Errorf("vault store error: %w", err)
 	}
 	if vs != nil {
 		return vs, nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -223,7 +223,7 @@ func (as *AuthenticationService) AuthCodeURL() (string, string, error) {
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate state secret: %s", err.Error())
+		return "", "", fmt.Errorf("failed to generate state secret: %w", err)
 	}
 	state := base64.RawURLEncoding.EncodeToString(b)
 	return as.oauthConfig.AuthCodeURL(state), state, nil
@@ -243,7 +243,7 @@ func (as *AuthenticationService) Exchange(ctx context.Context, code string) (*oa
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("authorisation code exchange failed: %v", err)
+		return nil, fmt.Errorf("authorisation code exchange failed: %w", err)
 	}
 
 	return t, nil
@@ -270,7 +270,7 @@ func (as *AuthenticationService) Device(ctx context.Context) (*oauth2.DeviceAuth
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("device auth call failed: %v", err)
+		return nil, fmt.Errorf("device auth call failed: %w", err)
 	}
 
 	return resp, nil
@@ -288,7 +288,7 @@ func (as *AuthenticationService) DeviceAccessToken(ctx context.Context, res *oau
 		oauth2.SetAuthURLParam("client_secret", as.oauthConfig.ClientSecret),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("device access token call failed: %v", err)
+		return nil, fmt.Errorf("device access token call failed: %w", err)
 	}
 
 	return t, nil
@@ -310,7 +310,7 @@ func (as *AuthenticationService) ExtractAndVerifyIDToken(ctx context.Context, oa
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify id token: %v", err)
+		return nil, fmt.Errorf("failed to verify id token: %w", err)
 	}
 
 	return token, nil
@@ -328,7 +328,7 @@ func (as *AuthenticationService) Email(idToken *oidc.IDToken) (string, error) {
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
-		return "", fmt.Errorf("failed to extract claims: %v", err)
+		return "", fmt.Errorf("failed to extract claims: %w", err)
 	}
 
 	return claims.Email, nil
@@ -343,12 +343,12 @@ func (as *AuthenticationService) MintSessionToken(email string) (string, error) 
 		Expiration(time.Now().Add(as.sessionTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", fmt.Errorf("failed to build access token: %v", err)
+		return "", fmt.Errorf("failed to build access token: %w", err)
 	}
 
 	freshToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", fmt.Errorf("failed to sign access token: %v", err)
+		return "", fmt.Errorf("failed to sign access token: %w", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(freshToken), nil
@@ -368,12 +368,12 @@ func (as *AuthenticationService) NewMigrationToken(ctx context.Context, username
 		Expiration(time.Now().Add(migrationTokenExpiry)).
 		Build()
 	if err != nil {
-		return "", fmt.Errorf("failed to mint migration token: %v", err)
+		return "", fmt.Errorf("failed to mint migration token: %w", err)
 	}
 
 	migrationToken, err := jwt.Sign(token, jwt.WithKey(as.signingAlg, []byte(as.jwtSessionKey)))
 	if err != nil {
-		return "", fmt.Errorf("failed to sign migration token: %v", err)
+		return "", fmt.Errorf("failed to sign migration token: %w", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(migrationToken), nil
@@ -528,7 +528,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to retrieve session: %v", err)
+		return ctx, fmt.Errorf("failed to retrieve session: %w", err)
 	}
 	session = sessionCrossOriginSafe(session, as.secureCookies)
 
@@ -541,7 +541,7 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	if err != nil {
 		// If the user's access token AND refresh token have expired
 		// then we will fail authentication here.
-		return ctx, fmt.Errorf("failed to validate and update status token: %v", err)
+		return ctx, fmt.Errorf("failed to validate and update status token: %w", err)
 	}
 
 	ctx = ContextWithSessionIdentity(ctx, identityId)
@@ -562,7 +562,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 
 	session, err := as.sessionStore.Get(req, SessionName)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve session: %v", err)
+		return fmt.Errorf("failed to retrieve session: %w", err)
 	}
 
 	identityId, ok := session.Values[SessionIdentityKey]
@@ -576,7 +576,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 	}
 
 	if err := as.deleteSession(session, w, req); err != nil {
-		return fmt.Errorf("failed to delete session: %v", err)
+		return fmt.Errorf("failed to delete session: %w", err)
 	}
 
 	if err := as.UpdateIdentity(ctx, identityIdStr, &oauth2.Token{
@@ -585,7 +585,7 @@ func (as *AuthenticationService) Logout(ctx context.Context, w http.ResponseWrit
 		Expiry:       time.Now(),
 		TokenType:    "",
 	}); err != nil {
-		return fmt.Errorf("failed to update identity: %v", err)
+		return fmt.Errorf("failed to update identity: %w", err)
 	}
 
 	return nil

--- a/internal/db/controller_test.go
+++ b/internal/db/controller_test.go
@@ -4,6 +4,7 @@ package db_test
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -51,7 +52,8 @@ func (s *dbSuite) TestAddController(c *qt.C) {
 
 	err = s.Database.AddController(context.Background(), &c1)
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
+	eError := &errors.Error{}
+	ok := stderrors.As(err, &eError)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(eError.Code, qt.Equals, errors.CodeAlreadyExists)
 }
@@ -225,7 +227,8 @@ func (s *dbSuite) TestUpdateController(c *qt.C) {
 
 	err = s.Database.UpdateController(context.Background(), &dbmodel.Controller{})
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
+	eError := &errors.Error{}
+	ok := stderrors.As(err, &eError)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(eError.Code, qt.Equals, errors.CodeNotFound)
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -3,6 +3,8 @@
 package db
 
 import (
+	stderrors "errors"
+
 	"gorm.io/gorm"
 
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -21,7 +23,7 @@ type pgError interface {
 func dbError(err error) error {
 	code := errors.Code(errors.ErrorCode(err))
 
-	if err == gorm.ErrRecordNotFound {
+	if stderrors.Is(err, gorm.ErrRecordNotFound) {
 		code = errors.CodeNotFound
 	}
 

--- a/internal/db/job_logs.go
+++ b/internal/db/job_logs.go
@@ -48,7 +48,7 @@ func (d *Database) AddJobLog(ctx context.Context, jobId int64, logLine string) (
 
 		log, err := dbmodel.NewJobLog(jobId, nextLineNumber, logLine)
 		if err != nil {
-			return fmt.Errorf("failed to construct job log: %v", err)
+			return fmt.Errorf("failed to construct job log: %w", err)
 		}
 
 		if err := d.DB.WithContext(ctx).Create(log).Error; err != nil {

--- a/internal/db/model_test.go
+++ b/internal/db/model_test.go
@@ -5,6 +5,7 @@ package db_test
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"sort"
 	"testing"
 	"time"
@@ -86,7 +87,8 @@ func (s *dbSuite) TestAddModel(c *qt.C) {
 
 	err = s.Database.AddModel(context.Background(), &m1)
 	c.Assert(err, qt.Not(qt.IsNil))
-	eError, ok := err.(*errors.Error)
+	eError := &errors.Error{}
+	ok := stderrors.As(err, &eError)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(eError.Code, qt.Equals, errors.CodeAlreadyExists)
 }

--- a/internal/db/rootkeys.go
+++ b/internal/db/rootkeys.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"errors"
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -29,7 +30,7 @@ func (d *Database) GetKey(id []byte) (_ dbrootkeystore.RootKey, err error) {
 		ID: id,
 	}
 	if err := d.DB.First(&rk).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return dbrootkeystore.RootKey{}, bakery.ErrNotFound
 		}
 		return dbrootkeystore.RootKey{}, err
@@ -59,7 +60,7 @@ func (d *Database) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.
 	db = db.Order("created_at DESC")
 	var rk dbmodel.RootKey
 	if err := db.First(&rk).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return dbrootkeystore.RootKey{}, nil
 		}
 		return dbrootkeystore.RootKey{}, dbError(err)

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -22,7 +22,8 @@ func TestCodefWrapsError(t *testing.T) {
 	c.Check(err, qt.ErrorMatches, `an error happened`)
 	c.Check(errors.ErrorCode(err), qt.Equals, code)
 
-	errValue, ok := err.(*errors.Error)
+	errValue := &errors.Error{}
+	ok := stderr.As(err, &errValue)
 	c.Assert(ok, qt.IsTrue)
 	c.Check(errValue.Code, qt.Equals, code)
 	c.Assert(errValue.Err, qt.IsNotNil)

--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -246,7 +246,7 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 	}
 
 	if err := params.validate(); err != nil {
-		return 0, fmt.Errorf("invalid bootstrap parameters: %v", err)
+		return 0, fmt.Errorf("invalid bootstrap parameters: %w", err)
 	}
 
 	bootstrapArgs := rivertypes.BootstrapArgs{

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -294,7 +295,7 @@ func (j *JujuManager) ForEachUserCloudCredential(ctx context.Context, u *dbmodel
 		}
 		return nil
 	})
-	if err == errStop {
+	if stderrors.Is(err, errStop) {
 		err = iterErr
 	}
 	return err

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -206,13 +206,13 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 
 	api, err := j.dialController(ctx, ctl, user)
 	if err != nil {
-		return fmt.Errorf("failed to dial the controller: %v", err)
+		return fmt.Errorf("failed to dial the controller: %w", err)
 	}
 	defer api.Close()
 
 	cloudSpec, err := api.CloudSpec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get model summary: %v", err)
+		return fmt.Errorf("failed to get model summary: %w", err)
 	}
 
 	ctl.CloudName = cloudSpec.Name
@@ -687,7 +687,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		return tx.UpdateModel(ctx, &model)
 	})
 	if err != nil {
-		return result, fmt.Errorf("failed to update the model's migration mode: %v", err)
+		return result, fmt.Errorf("failed to update the model's migration mode: %w", err)
 	}
 
 	// Until we have better handling for partial failures we try to revert

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -5,6 +5,7 @@ package juju
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"math/rand/v2"
 	"sort"
@@ -510,10 +511,10 @@ func (j *JujuManager) ForEachUserModel(ctx context.Context, user *openfga.User, 
 		}
 		return nil
 	})
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return nil
-	case errStop:
+	case stderrors.Is(err, errStop):
 		return iterErr
 	default:
 		return err
@@ -541,10 +542,10 @@ func (j *JujuManager) ForEachModel(ctx context.Context, user *openfga.User, f fu
 		}
 		return nil
 	})
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return nil
-	case errStop:
+	case stderrors.Is(err, errStop):
 		return iterErr
 	default:
 		return err
@@ -730,13 +731,13 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 	// Get uuids of models the user has access to
 	uuids, err := user.ListModels(ctx, ofganames.ReaderRelation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list user models: %v", err)
+		return nil, fmt.Errorf("failed to list user models: %w", err)
 	}
 
 	// Get the models from the database
 	models, err := j.Database.GetModelsByUUID(ctx, uuids)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get models by uuid: %v", err)
+		return nil, fmt.Errorf("failed to get models by uuid: %w", err)
 	}
 
 	// Create map for lookup later
@@ -785,7 +786,7 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list models: %v", err)
+		return nil, fmt.Errorf("failed to list models: %w", err)
 	}
 
 	return userModels, nil

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -197,7 +197,7 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 		}
 		ok, err := b.ofgaUser.IsAllowedAddModelToController(b.ctx, c.ResourceTag())
 		if err != nil {
-			return fmt.Errorf("failed to verify permissions for adding model to controller: %v", err)
+			return fmt.Errorf("failed to verify permissions for adding model to controller: %w", err)
 		}
 		if ok {
 			candidateControllers = append(candidateControllers, candidateController{

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -121,12 +121,12 @@ type SSHManager struct {
 func (s *SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key []byte) (*openfga.User, error) {
 	zapctx.Info(ctx, "PublicKeyHandler")
 	if ok, err := s.sshKeyManager.VerifyPublicKey(ctx, claimUser, key); !ok || err != nil {
-		return nil, fmt.Errorf("cannot verify key for user %s: %v", claimUser, err)
+		return nil, fmt.Errorf("cannot verify key for user %s: %w", claimUser, err)
 	}
 	user, err := s.identityManager.FetchIdentity(ctx, claimUser)
 	if err != nil {
 		zapctx.Info(ctx, fmt.Sprintf("cannot find user %s", claimUser))
-		return nil, fmt.Errorf("cannot find user %s: %v", claimUser, err)
+		return nil, fmt.Errorf("cannot find user %s: %w", claimUser, err)
 	}
 	return user, nil
 }
@@ -139,7 +139,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 	zapctx.Info(ctx, "SSHDialInfo")
 	model, err := s.jujuManager.GetModel(ctx, modelUUID)
 	if err != nil {
-		return DialInfo{}, fmt.Errorf("cannot find model: %v", err)
+		return DialInfo{}, fmt.Errorf("cannot find model: %w", err)
 	}
 
 	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, user, model.Controller.Name)
@@ -149,7 +149,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 
 	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return DialInfo{}, fmt.Errorf("cannot find addresses for model's controller: %v", err)
+		return DialInfo{}, errors.New("cannot find addresses for model's controller")
 	}
 
 	addrsNoPort := make([]string, len(addrs))
@@ -178,7 +178,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 	jwtGenerator := s.jwtFactory.NewSSHGenerator()
 	token, err := jwtGenerator.NewSSHToken(ctx, tokenArgs)
 	if err != nil {
-		return DialInfo{}, fmt.Errorf("cannot generate jwt: %v", err)
+		return DialInfo{}, fmt.Errorf("cannot generate jwt: %w", err)
 	}
 
 	return DialInfo{
@@ -216,7 +216,7 @@ func (s *SSHManager) DialController(ctx context.Context, dialInfo DialInfo, user
 	}
 
 	if client == nil {
-		return nil, fmt.Errorf("failed to dial controller: %v", goerr.Join(errs...))
+		return nil, fmt.Errorf("failed to dial controller: %w", goerr.Join(errs...))
 	}
 	return client, nil
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -650,7 +650,7 @@ func (r *controllerRoot) StopBootstrap(ctx context.Context, req apiparams.StopBo
 
 	err = r.jimm.BootstrapManager().StopJob(ctx, r.user, jobID)
 	if err != nil {
-		return fmt.Errorf("failed to stop job: %v", err)
+		return fmt.Errorf("failed to stop job: %w", err)
 	}
 	return nil
 }
@@ -706,7 +706,7 @@ func (r *controllerRoot) StartBootstrap(ctx context.Context, req apiparams.Boots
 
 	jobID, err := r.jimm.BootstrapManager().StartBootstrapJob(ctx, r.user, params)
 	if err != nil {
-		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start bootstrap job: %v", err)
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start bootstrap job: %w", err)
 	}
 	return apiparams.StartBootstrapResponse{
 		JobID: strconv.FormatInt(jobID, 10),
@@ -751,7 +751,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 		CACertificate:  ctrl.CACertificate,
 	})
 	if err != nil {
-		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start destroy-controller job: %v", err)
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to start destroy-controller job: %w", err)
 	}
 
 	return apiparams.StartBootstrapResponse{
@@ -855,7 +855,7 @@ func (r *controllerRoot) JobInfo(ctx context.Context, req apiparams.JobInfoReque
 
 	jobInfo, err := r.jimm.JobManager().GetJobInfo(ctx, jobID)
 	if err != nil {
-		return apiparams.JobInfoResponse{}, fmt.Errorf("failed to get job info: %v", err)
+		return apiparams.JobInfoResponse{}, fmt.Errorf("failed to get job info: %w", err)
 	}
 
 	return toJobInfoParams(jobInfo), nil

--- a/internal/jujuclistore/store.go
+++ b/internal/jujuclistore/store.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -282,7 +283,7 @@ func (p *jujuCLIStore) downloadFile(ctx context.Context, downloadUrl string, log
 	var binaryFile *os.File
 	for {
 		hdr, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	stderrors "errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -143,7 +144,8 @@ func TestCallErrorResponse(t *testing.T) {
 	var res string
 	err = conn.Call(context.Background(), "test", 0, "1234", "Test", "SUCCESS", &res)
 	c.Check(err, qt.ErrorMatches, `test error \(test error code\)`)
-	e, ok := err.(*rpc.Error)
+	e := &rpc.Error{}
+	ok := stderrors.As(err, &e)
 	c.Logf("expected %T, received %T", e, err)
 	c.Assert(ok, qt.IsTrue)
 
@@ -187,7 +189,11 @@ func TestClientReceiveRequest(t *testing.T) {
 	var res string
 	err = conn.Call(context.Background(), "test", 1, "", "Test", "SUCCESS", &res)
 	c.Check(err, qt.ErrorMatches, `test\(1\).Test not implemented \(not implemented\)`)
-	e := err.(*rpc.Error)
+	e := func() *rpc.Error {
+		target := &rpc.Error{}
+		_ = stderrors.As(err, &target)
+		return target
+	}()
 	c.Check(e.ErrorCode(), qt.Equals, "not implemented")
 	c.Check(res, qt.Equals, "")
 

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"sync"
 	"time"
@@ -192,7 +193,7 @@ func (c *writeLockConn) sendMessage(responseObject any, request *message) {
 			if err := c.writeJson(errorMsg); err != nil {
 				zapctx.Error(context.Background(), "failed to send error message in proxy", zap.Error(err))
 			}
-
+			return
 		}
 		msg.Response = responseData
 	}
@@ -355,7 +356,8 @@ func unexpectedReadError(err error) bool {
 		websocket.CloseAbnormalClosure) {
 		return true
 	}
-	_, unmarshalError := err.(*json.InvalidUnmarshalError)
+	invalidUnmarshalError := &json.InvalidUnmarshalError{}
+	unmarshalError := stderrors.As(err, &invalidUnmarshalError)
 	return unmarshalError
 }
 
@@ -800,7 +802,7 @@ func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*mes
 	}
 	tag, err := names.ParseTag(request.AuthTag)
 	if err != nil {
-		return nil, fmt.Errorf("invalid user tag: %v", err)
+		return nil, fmt.Errorf("invalid user tag: %w", err)
 	}
 	switch tag := tag.(type) {
 	case names.UserTag:

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -209,7 +209,7 @@ func fetchAndAuthorizeUser(ctx ssh.Context, modelTag names.ModelTag) (*openfga.U
 	}
 	ok, err := user.IsModelAdmin(ctx, modelTag)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for model access: %v", err)
+		return nil, fmt.Errorf("failed to check for model access: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("user doesn't have permission")

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -5,6 +5,7 @@ package streamproxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/gorilla/websocket"
 	"github.com/juju/juju/api/base"
@@ -56,6 +57,7 @@ func unexpectedReadError(err error) bool {
 		websocket.CloseAbnormalClosure) {
 		return true
 	}
-	_, unmarshalError := err.(*json.InvalidUnmarshalError)
+	invalidUnmarshalError := &json.InvalidUnmarshalError{}
+	unmarshalError := errors.As(err, &invalidUnmarshalError)
 	return unmarshalError
 }

--- a/internal/testutils/rpctest/server.go
+++ b/internal/testutils/rpctest/server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -65,7 +66,8 @@ func HandleWS(f func(*websocket.Conn) error) http.Handler {
 		defer c.Close()
 		err = f(c)
 		var cm []byte
-		closeError, isCloseError := err.(*websocket.CloseError)
+		closeError := &websocket.CloseError{}
+		isCloseError := stderrors.As(err, &closeError)
 		switch {
 		case err == nil:
 			cm = websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")

--- a/internal/testutils/testdb/gorm.go
+++ b/internal/testutils/testdb/gorm.go
@@ -171,7 +171,7 @@ func createDatabaseFromTemplate(suggestedName string, templateName string) (stri
 
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing DSN as a URI: %s", err)
+		return "", "", fmt.Errorf("error parsing DSN as a URI: %w", err)
 	}
 
 	createDatabaseMutex.Lock()
@@ -215,17 +215,17 @@ func DeleteDatabase(databaseName string) (err error) {
 
 	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
-		return fmt.Errorf("error opening database: %s", err)
+		return fmt.Errorf("error opening database: %w", err)
 	}
 	db, err := gdb.DB()
 	if err != nil {
-		return fmt.Errorf("error getting db: %s", err)
+		return fmt.Errorf("error getting db: %w", err)
 	}
 	defer func() { err = db.Close() }()
 
 	dropDatabaseCommand := fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, databaseName)
 	if err := gdb.Exec(dropDatabaseCommand).Error; err != nil {
-		return fmt.Errorf("failed to delete database (%s): %s", databaseName, err)
+		return fmt.Errorf("failed to delete database (%s): %w", databaseName, err)
 	}
 	return nil
 }
@@ -244,7 +244,7 @@ func createEmptyDatabase(suggestedName string) (string, string, error) {
 
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing DSN as a URI: %s", err)
+		return "", "", fmt.Errorf("error parsing DSN as a URI: %w", err)
 	}
 
 	createDatabaseMutex.Lock()

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -73,7 +73,7 @@ func (s *VaultStore) Get(ctx context.Context, tag names.CloudCredentialTag) (_ m
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.path(tag))
-	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+	if err != nil && !goerr.Is(goerr.Unwrap(err), api.ErrSecretNotFound) {
 		return nil, err
 	}
 	if secret == nil || secret.Data == nil {
@@ -133,7 +133,8 @@ func (s *VaultStore) delete(ctx context.Context, tag names.CloudCredentialTag) (
 		return err
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.path(tag))
-	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
+	rerr := &api.ResponseError{}
+	if goerr.As(err, &rerr) && rerr.StatusCode == http.StatusNotFound {
 		// Ignore the error if attempting to delete something that isn't there.
 		err = nil
 	}
@@ -158,7 +159,7 @@ func (s *VaultStore) GetControllerCredentials(ctx context.Context, controllerNam
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.controllerCredentialsPath(controllerName))
-	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+	if err != nil && !goerr.Is(goerr.Unwrap(err), api.ErrSecretNotFound) {
 		return "", "", err
 	}
 	if secret == nil || secret.Data == nil {
@@ -245,7 +246,7 @@ func (s *VaultStore) GetJWKS(ctx context.Context) (_ jwk.Set, err error) {
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPath())
-	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+	if err != nil && !goerr.Is(goerr.Unwrap(err), api.ErrSecretNotFound) {
 		return nil, err
 	}
 
@@ -285,7 +286,7 @@ func (s *VaultStore) GetJWKSPrivateKey(ctx context.Context) (_ []byte, err error
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSPrivateKeyPath())
-	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+	if err != nil && !goerr.Is(goerr.Unwrap(err), api.ErrSecretNotFound) {
 		return nil, err
 	}
 
@@ -320,7 +321,7 @@ func (s *VaultStore) GetJWKSExpiry(ctx context.Context) (_ time.Time, err error)
 	}
 
 	secret, err := client.KVv2(s.KVPath).Get(ctx, s.getJWKSExpiryPath())
-	if err != nil && goerr.Unwrap(err) != api.ErrSecretNotFound {
+	if err != nil && !goerr.Is(goerr.Unwrap(err), api.ErrSecretNotFound) {
 		return now, err
 	}
 
@@ -447,7 +448,8 @@ func (s *VaultStore) deleteControllerCredentials(ctx context.Context, controller
 		return err
 	}
 	err = client.KVv2(s.KVPath).Delete(ctx, s.controllerCredentialsPath(controllerName))
-	if rerr, ok := err.(*api.ResponseError); ok && rerr.StatusCode == http.StatusNotFound {
+	rerr := &api.ResponseError{}
+	if goerr.As(err, &rerr) && rerr.StatusCode == http.StatusNotFound {
 		// Ignore the error if attempting to delete something that isn't there.
 		err = nil
 	}

--- a/testing/admin_test.go
+++ b/testing/admin_test.go
@@ -363,7 +363,7 @@ func getDialWebsocketWithCustomCookieJar(jar *cookiejar.Jar) func(ctx context.Co
 
 		c, resp, err := dialer.Dial(urlStr, nil)
 		if err != nil {
-			if err == websocket.ErrBadHandshake {
+			if errors.Is(err, websocket.ErrBadHandshake) {
 				defer resp.Body.Close()
 				body, readErr := io.ReadAll(resp.Body)
 				if readErr == nil {

--- a/testing/apiproxy_test.go
+++ b/testing/apiproxy_test.go
@@ -83,7 +83,8 @@ func TestAgentLoginReturnsRedirect(t *testing.T) {
 	}
 	_, err = api.Open(&info, dialOpts)
 	c.Assert(err, qt.Not(qt.IsNil))
-	redirectErr, ok := errors.Cause(err).(*api.RedirectError)
+	redirectErr := &api.RedirectError{}
+	ok := errors.As(errors.Cause(err), &redirectErr)
 	c.Check(ok, qt.Equals, true)
 	c.Assert(redirectErr.Servers, qt.HasLen, 1)
 	servers := redirectErr.Servers[0].HostPorts().Strings()


### PR DESCRIPTION
## Description
Add errorlint to golangci-lint config

  Adds the errorlint linter, which flags fmt.Errorf calls that use %v or %s to format an error as these produce opaque strings and break errors.Is/errors.As for callers.

  Also fixes a bunch of missing imports that surfaced once typecheck could actually see the errors.As/errors.Is calls from the previous fixes, plus two actual bugs uncovered in the
  process:

   - vault.go: status code check was dropped when converting a type assertion to errors.As, meaning all Vault response errors during delete were silently swallowed instead of just
  404s
   - main.go: logic was inverted when converting err.(*service.SignalError) — the server was exiting on signal shutdown and staying up on real errors
## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
