### PR TITLE
internal/db: close sql.Conn after migration

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -102,6 +102,7 @@ func (d *Database) migrateFromSource(ctx context.Context, fs embed.FS, sqlPath s
 	if err != nil {
 		return fmt.Errorf("failed to obtain DB conn: %w", err)
 	}
+	defer conn.Close()
 
 	driver, err := postgres.WithConnection(ctx, conn, &postgres.Config{MigrationsTable: migrationTableName})
 	if err != nil {


### PR DESCRIPTION

## Description
migrateFromSource acquired a dedicated *sql.Conn via sqlDB.Conn() but never closed it.

Add defer conn.Close() immediately after the connection is acquired.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
