### PR TITLE
ci(e2e): skip tests relying on validating cloud creds before updates

### DIFF
--- a/testing/cloud_test.go
+++ b/testing/cloud_test.go
@@ -201,6 +201,11 @@ func TestUpdateCloudCredentialsErrors(t *testing.T) {
 }
 
 func TestUpdateCloudCredentialsForce(t *testing.T) {
+	t.Skip(`
+See https://github.com/juju/juju/issues/22273. Juju 4 doesn't validate the cloud credential.
+So the force argument is basically always set to true.
+Since we can't target a specific backing controller we need to skip the test for now.
+`)
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
@@ -297,6 +302,10 @@ func TestCheckCredentialsModels(t *testing.T) {
 }
 
 func TestCheckCredentialsModelsInvalidCreds(t *testing.T) {
+	t.Skip(`
+See https://github.com/juju/juju/issues/22273. Juju 4 doesn't validate the cloud credential.
+Since we can't target a specific backing controller we need to skip the test for now.
+`)
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
@@ -563,7 +572,7 @@ func TestAddCloudError(t *testing.T) {
 		StorageEndpoint:  "https://0.1.2.3:5680",
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false)
-	c.Assert(err, qt.ErrorMatches, `invalid cloud: empty auth-types not valid.*`)
+	c.Assert(err, qt.ErrorMatches, `.*empty auth-types not valid.*`)
 }
 
 func TestAddCloudNoHostCloudRegion(t *testing.T) {


### PR DESCRIPTION
## Description

Skip the tests relying on cloud credentials validation in Juju 4.
In Juju 4 this is not implemented: see https://github.com/juju/juju/issues/22273 and for the time being we can just skip this.

We can't skip it conditionally on the backing controller version because in a scenario with mixed deployment juju 4 and juju 3, we don't know during the test which controller jimm will try to add the controller to.