### PR TITLE
ci: miscellanea fixes for e2e tests

### DIFF
--- a/testing/dial_test.go
+++ b/testing/dial_test.go
@@ -104,7 +104,6 @@ func TestDialModelStatusMissingModel(t *testing.T) {
 	_, err = api.ModelStatus(context.Background(), names.NewModelTag(uuid.NewString()))
 	c.Assert(err, qt.Not(qt.IsNil))
 	c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
-	c.Check(err, qt.ErrorMatches, `model .* not found.*`)
 }
 
 // TestConnectStreams tests the ConnectStream and ConnectControllerStream methods

--- a/testing/helpers_test.go
+++ b/testing/helpers_test.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Canonical.
+
+package testing
+
+import (
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/version/v2"
+)
+
+// SkipIfControllerAgentVersionGreaterThan skips the test if the model's
+// controller agent version is greater than the provided version string.
+func SkipIfControllerAgentVersionGreaterThan(c *qt.C, currentVersion string, maxVersion string) {
+	c.Helper()
+	agentVersion := version.MustParse(currentVersion)
+	threshold := version.MustParse(maxVersion)
+	if agentVersion.Compare(threshold) > 0 {
+		c.Skipf("skipping test: controller agent version %s is greater than %s", agentVersion, threshold)
+	}
+}

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -795,7 +795,7 @@ func TestAddExistingCloudToController(t *testing.T) {
 			Name: cloudName,
 			Cloud: jujuapi.CloudToParams(cloud.Cloud{
 				Name:             cloudName,
-				Type:             "MAAS",
+				Type:             "lxd",
 				AuthTypes:        cloud.AuthTypes{cloud.OAuth1AuthType},
 				Endpoint:         "https://0.1.2.3:5678",
 				IdentityEndpoint: "https://0.1.2.3:5679",
@@ -810,7 +810,7 @@ func TestAddExistingCloudToController(t *testing.T) {
 	cloud, err := s.JIMM.JujuManager.GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, qt.IsNil)
 	c.Assert(cloud.Name, qt.DeepEquals, cloudName)
-	c.Assert(cloud.Type, qt.DeepEquals, "MAAS")
+	c.Assert(cloud.Type, qt.DeepEquals, "lxd")
 	// Simulate the cloud being present on the Juju controller but not in JIMM.
 	err = s.JIMM.Database.DeleteCloud(ctx, &cloud)
 	c.Assert(err, qt.IsNil)
@@ -822,7 +822,7 @@ func TestAddExistingCloudToController(t *testing.T) {
 	cloud, err = s.JIMM.JujuManager.GetCloud(context.Background(), user, names.NewCloudTag(cloudName))
 	c.Assert(err, qt.IsNil)
 	c.Assert(cloud.Name, qt.DeepEquals, cloudName)
-	c.Assert(cloud.Type, qt.DeepEquals, "MAAS")
+	c.Assert(cloud.Type, qt.DeepEquals, "lxd")
 
 	req1 := apiparams.RemoveCloudFromControllerRequest{
 		CloudTag:       names.NewCloudTag(cloudName).String(),
@@ -946,6 +946,8 @@ func TestJimmModelMigrationSuperuser(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	model := s.CreateModelForCharlie(c)
+	// Skip for juju 4.0.0 because it doesn't support migration yet.
+	SkipIfControllerAgentVersionGreaterThan(c, model.Controller.AgentVersion, "4.0.0")
 	ctrlName := model.Controller.Name
 
 	conn := s.Open(c, nil, "alice", nil)

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -600,6 +600,7 @@ func TestDumpModelDB(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
+	SkipIfControllerAgentVersionGreaterThan(c, model.Controller.AgentVersion, "4.0.0")
 	conn := s.Open(c, nil, "bob", nil)
 	defer conn.Close()
 


### PR DESCRIPTION
## Description

- TestDialModelStatusMissingModel: the message changed, the code not, so i've just removed the check of the msg
- TestJimmModelMigrationSuperuser with juju 4.0.0 we don't support migration yet
- TestDumpModelDB not implemented in juju 4
- 