### PR TITLE
test: fix localcharm_tests

### DIFF
--- a/testing/localcharm_test.go
+++ b/testing/localcharm_test.go
@@ -31,14 +31,31 @@ func TestLocalCharmDeploy(t *testing.T) {
 
 	client, err := charms.NewLocalCharmClient(conn)
 	c.Assert(err, qt.IsNil)
+
 	charmArchive := testcharms.Repo.CharmArchive(c.TempDir(), "dummy")
+
 	curl := charm.MustParseURL(
+		// Revision only need be sent for pre-4.0.
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
+
 	vers := semversion.MustParse("2.6.6")
+
 	url, err := client.AddLocalCharm(curl, charmArchive, false, vers)
 	c.Assert(err, qt.IsNil)
-	c.Assert(url.String(), qt.Equals, curl.String())
+
+	ctrlVers, _ := conn.ServerVersion()
+
+	if ctrlVers.Compare(semversion.MustParse("4.0.0")) == -1 {
+		c.Assert(url.String(), qt.Equals, curl.String())
+	} else {
+		// In 4.0, it is auto-incremented for us from 0.
+		c.Assert(url.String(), qt.Equals, "local:dummy-0")
+		// As such, we'll upload it twice and verify it is incremented accordingly.
+		url, err := client.AddLocalCharm(curl, charmArchive, false, vers)
+		c.Assert(err, qt.IsNil)
+		c.Assert(url.String(), qt.Equals, "local:dummy-1")
+	}
 }
 
 func TestResourceEndpoint(t *testing.T) {
@@ -55,10 +72,11 @@ func TestResourceEndpoint(t *testing.T) {
 	charmClient, err := charms.NewLocalCharmClient(conn)
 	c.Assert(err, qt.IsNil)
 
-	charmArchive := testcharms.Repo.CharmArchive(c.TempDir(), "dummy")
+	charmArchive := testcharms.Repo.CharmArchive(c.TempDir(), "starsay")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
 	)
+
 	url, err := charmClient.AddLocalCharm(curl, charmArchive, false, semversion.MustParse("2.6.6"))
 	c.Assert(err, qt.IsNil)
 
@@ -72,7 +90,7 @@ func TestResourceEndpoint(t *testing.T) {
 		CharmID:       resources.CharmID{URL: url.String()},
 		Resources: []resource.Resource{
 			{
-				Meta:   resource.Meta{Name: "test", Type: 1, Path: "file"},
+				Meta:   resource.Meta{Name: "store-resource", Type: 1, Path: "filename.tgz"},
 				Origin: resource.OriginStore,
 			},
 		},
@@ -82,6 +100,6 @@ func TestResourceEndpoint(t *testing.T) {
 	pendingId := pendingIDs[0]
 
 	// act
-	err = uploadClient.Upload(t.Context(), appName, "test", "file", pendingId, strings.NewReader("<data>"))
+	err = uploadClient.Upload(t.Context(), appName, "store-resource", "filename.tgz", pendingId, strings.NewReader("<data>"))
 	c.Assert(err, qt.IsNil)
 }


### PR DESCRIPTION
## Description
Two integration tests in localcharm_test were added to cover the local charm upload and resource upload paths through JIMM proxying to a real Juju controller.

### TestLocalCharmDeploy
TestLocalCharmDeploy (which probably needs renaming, as it isn't deploying the charm) checks that uploading a local charm via AddLocalCharm gives back the right URL. Juju 4.0 changed this: it now ignores the caller's revision, sequences from zero on the server side, and drops the series from the returned URL. The test now branches off based on the controller version - pre-4.0 expects the URL to match what was sent, post-4.0 expects local:dummy-0 on first upload and local:dummy-1 on second. I did this after getting @alesstimec opinion on this, and he agreed that instead of reverting Juju 4 to match 3's behaviour, this change is actually a welcome change and makes sense in Juju. From an API call standpoint, it doesn't change anything for us and it is merely just test logic. In the 4.0 branch, I did just add an extra upload so we can see the sequencing for future readers. 

### TestResourceEndpoint
TestResourceEndpoint covers the resource upload flow: 
1. upload a charm
2. reserve a pending resource with AddPendingResources
3.  stream the bytes with Upload(...) taking the pending resource id. 

Previously,  we were using the `dummy` test charm and it actually has no resources, or no manifest.yaml (to declare it has resources) and ships a stub zip that isn't a real archive, which caused the failure.

It now uses the `starsay` fixture (had to scour around all of the fixture resources for this, and found this one, which appears to be for this usecase) because it's the only one in our pinned Juju module that has all three things needed: 
1. a manifest.yaml (required to build the archive) 
2. a metadata with resources declared (required by the FK constraint backing AddPendingResources). 

Fortunately, the kind of data you push up with the resource doesn't matter, so pushing `<data>` suffices 😄.

This fixes all tests in this file.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests


