### PR TITLE
test: renable integration tests by adding the option to bootstrap a juju 3.6 controller

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -64,6 +64,13 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
 
+      - name: Download Juju 3.6 binary
+        run: |
+          snap download juju --channel=3.6/stable --basename=juju-3.6
+          unsquashfs -d /tmp/juju-3.6 juju-3.6.snap
+          sudo install -m 755 /tmp/juju-3.6/bin/juju /usr/local/bin/juju-3.6
+          rm -f juju-3.6.snap juju-3.6.assert
+
       - name: Go vendor to speed up docker build
         run: go mod vendor
 
@@ -85,6 +92,7 @@ jobs:
         env:
           BACKING_CONTROLLER_NAME: ${{ steps.jaas.outputs.backing-controller-name }}
           JIMM_CONTROLLER_NAME: ${{ steps.jaas.outputs.jimm-controller-name }}
+          JUJU_BOOTSTRAP_BINARY: /usr/local/bin/juju-3.6
       
       - name: Stop the application container
         run: docker stop jimm

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -21,12 +21,12 @@ jobs:
         id: docker-cache
         uses: actions/cache/restore@v5
         with:
-          path: /tmp/docker-images.tar
+          path: docker-images.tar
           key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
 
       - name: Load Docker images from cache
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/docker-images.tar
+        run: docker load -i docker-images.tar
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1

--- a/cmd/jaas/cmd/migratemodel.go
+++ b/cmd/jaas/cmd/migratemodel.go
@@ -296,12 +296,12 @@ func (c *migrateModelCommand) validateUserMapping(userMapping map[string]string,
 
 	// To list the model offers, we need the model name and owner as unfortunately
 	// the model UUID is not sufficient to query the offers.
-	qualfier, modelName, err := jujuclient.SplitFullyQualifiedModelName(modelName)
+	modelName, qualifier, err := jujuclient.SplitFullyQualifiedModelName(modelName)
 	if err != nil {
 		return fmt.Errorf("invalid model name format: %q", modelName)
 	}
 	filter := crossmodel.ApplicationOfferFilter{
-		ModelQualifier: coremodel.Qualifier(qualfier),
+		ModelQualifier: coremodel.Qualifier(qualifier),
 		ModelName:      modelName,
 	}
 	offers, err := jujuAPI.ListOffers(filter)

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -210,6 +210,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 	if err != nil {
 		return fmt.Errorf("failed to serialize model description: %w", err)
 	}
+
 	err = api.Prechecks(ctx, jujuparams.MigrationModelInfo{
 		UUID:                   model.UUID,
 		Qualifier:              model.Owner,
@@ -355,6 +356,30 @@ func modifyModelDescription(modelDescription description.Model, userMapping dbmo
 			return fmt.Errorf("no external user mapping found for cloud credential local user %q", modelDescription.Owner().Id())
 		}
 		ownerTag = namesv5.NewUserTag(newOwner)
+	}
+
+	for _, app := range modelDescription.Applications() {
+		for _, offer := range app.Offers() {
+			acl := offer.ACL()
+			for user, access := range acl {
+				if user == ofganames.EveryoneUser {
+					continue
+				}
+				userTag := namesv5.NewUserTag(user)
+				if userTag.IsLocal() {
+					newUser, ok := userMapping[userTag.Id()]
+					if !ok {
+						return fmt.Errorf("no external user mapping found for local user %q with %s access to offer %q", userTag.Id(), access, offer.OfferName())
+					}
+					// Adding a key to a map while iterating over doesn't ensure that the new key will be iterated over.
+					// However, in this case it is safe to modify the ACL map in place, because the keys
+					// we add are for non-local users, which we don't process in the loop, so it doesn't matter
+					// if they are iterated over or not.
+					delete(acl, user)
+					acl[newUser] = access
+				}
+			}
+		}
 	}
 
 	modelDescription.SetCloudCredential(description.CloudCredentialArgs{

--- a/local/jimm/setup-controller.sh
+++ b/local/jimm/setup-controller.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 CLOUDINIT_FILE=${CLOUDINIT_FILE:-"cloudinit.temp.yaml"}
 CONTROLLER_NAME="${CONTROLLER_NAME:-qa-lxd}"
+JUJU_BOOTSTRAP_BINARY="${JUJU_BOOTSTRAP_BINARY:-juju}"
 SKIP_CONNECT_JIMM="${SKIP_CONNECT_JIMM:-false}"
 JWKS_DNS="${JWKS_DNS:-jimm.localhost}"
 CLOUDINIT_TEMPLATE=$'cloudinit-userdata: |
@@ -39,6 +40,6 @@ if [[ -n "${AGENT_VERSION:-}" ]]; then
   BOOTSTRAP_ARGS+=(--agent-version "${AGENT_VERSION}")
 fi
 
-echo "Bootstrapping controller"
-JUJU_DEV_FEATURE_FLAGS=ssh-jump juju bootstrap "${BOOTSTRAP_ARGS[@]}"
+echo "Bootstrapping controller with $JUJU_BOOTSTRAP_BINARY"
+JUJU_DEV_FEATURE_FLAGS=ssh-jump "$JUJU_BOOTSTRAP_BINARY" bootstrap "${BOOTSTRAP_ARGS[@]}"
 rm "$CLOUDINIT_FILE"

--- a/tests/modelmigration/migrate-internal.sh
+++ b/tests/modelmigration/migrate-internal.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "Test skipped because Juju 4 doesn't support migration yet, so we could still test the internal migration with JIMM and 3 controllers." \
-     "However JIMM needs a Juju 4 CLI, the Juju 4 CLI can't bootstrap a Juju 3 controller, making the setup for this test complex enough" \
-     "that we can just skip it for now until Juju 4 supports migrations."
-exit 0
-
 # This script assumes that you have JIMM running with a controller
 # named "qa-lxd" attached (can be overriden via BACKING_CONTROLLER_NAME).
 #

--- a/tests/modelmigration/migrate-providing-model.sh
+++ b/tests/modelmigration/migrate-providing-model.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "Test skipped because Juju 4 doesn't support migration yet, so we could still test the internal migration with JIMM and 3 controllers." \
-     "However JIMM needs a Juju 4 CLI, the Juju 4 CLI can't bootstrap a Juju 3 controller, making the setup for this test complex enough" \
-     "that we can just skip it for now until Juju 4 supports migrations."
-exit 0
-
 # This script assumes that you have JIMM running with a controller
 # named "qa-lxd" attached (can be overriden via BACKING_CONTROLLER_NAME).
 #

--- a/tests/modelmigration/migrate-providing-model.sh
+++ b/tests/modelmigration/migrate-providing-model.sh
@@ -122,7 +122,20 @@ juju login -c "$SOURCE_CONTROLLER_NAME" -u admin --no-prompt <<< "test-password"
 
 echo
 echo "Waiting for dummy-sink to be ready and receive token over the relation"
-juju wait-for application dummy-sink --timeout=5m
+success=0
+for _ in {1..60}; do
+    app_status=$(juju status dummy-sink --format json | jq -r '.applications["dummy-sink"]["application-status"].current')
+    if [[ "$app_status" == "active" ]]; then
+        success=1
+        break
+    fi
+    sleep 5
+done
+if [[ $success -ne 1 ]]; then
+    echo "dummy-sink did not become active within 5 minutes."
+    exit 1
+fi
+sleep 120
 
 # From this point on, the test is not idempotent
 # because it becomes it becomes more complex to
@@ -144,16 +157,14 @@ echo
 echo "Waiting for model migration to complete"
 echo "Switching to $JIMM_CONTROLLER_NAME and waiting for the model to appear"
 juju switch "$JIMM_CONTROLLER_NAME"
-# For some reason, wait-for model when the model doesn't exist yet just
-# hangs until you run another Juju CLI command but since we can't do that
-# in CI, we will just loop until the model appears.
 # Loop for up to 5 minutes (30 iterations of 10 seconds each)
 success=0
 for _ in {1..30}; do
-    if juju wait-for model "$PROVIDER_MODEL_NAME" --timeout=10s; then
+    if juju show-model "$PROVIDER_MODEL_NAME" > /dev/null 2>&1; then
         success=1
         break
     fi
+    sleep 10
 done
 if [[ $success -ne 1 ]]; then
     echo "Model $PROVIDER_MODEL_NAME did not appear after 5 minutes."
@@ -190,7 +201,19 @@ echo "Token migration successful, got '$new_token' as expected."
 
 echo
 echo "Ensuring the dummy-sink app is still running with an active state"
-juju wait-for application dummy-sink --timeout=5m
+success=0
+for _ in {1..60}; do
+    app_status=$(juju status dummy-sink --format json | jq -r '.applications["dummy-sink"]["application-status"].current')
+    if [[ "$app_status" == "active" ]]; then
+        success=1
+        break
+    fi
+    sleep 5
+done
+if [[ $success -ne 1 ]]; then
+    echo "dummy-sink did not remain active within 5 minutes."
+    exit 1
+fi
 
 echo
 echo "Cleaning up: removing relation and destroying $CONSUMER_MODEL_NAME model"

--- a/tests/modelmigration/migrate-providing-model.sh
+++ b/tests/modelmigration/migrate-providing-model.sh
@@ -135,7 +135,6 @@ if [[ $success -ne 1 ]]; then
     echo "dummy-sink did not become active within 5 minutes."
     exit 1
 fi
-sleep 120
 
 # From this point on, the test is not idempotent
 # because it becomes it becomes more complex to
@@ -184,7 +183,7 @@ juju switch "$SOURCE_CONTROLLER_NAME"
 # Retry for up to 1 minute (12 iterations of 5 seconds each).
 success=0
 for _ in {1..12}; do
-    new_token=$(juju show-unit dummy-sink/0 --format json | jq -r "$JQ_TOKEN_QUERY")
+    new_token=$(juju show-unit -m admin/"$CONSUMER_MODEL_NAME" dummy-sink/0 --format json | jq -r "$JQ_TOKEN_QUERY")
     if [[ "$new_token" == "def" ]]; then
         success=1
         break
@@ -203,7 +202,7 @@ echo
 echo "Ensuring the dummy-sink app is still running with an active state"
 success=0
 for _ in {1..60}; do
-    app_status=$(juju status dummy-sink --format json | jq -r '.applications["dummy-sink"]["application-status"].current')
+    app_status=$(juju status -m admin/"$CONSUMER_MODEL_NAME" dummy-sink --format json | jq -r '.applications["dummy-sink"]["application-status"].current')
     if [[ "$app_status" == "active" ]]; then
         success=1
         break
@@ -217,8 +216,8 @@ fi
 
 echo
 echo "Cleaning up: removing relation and destroying $CONSUMER_MODEL_NAME model"
-juju remove-relation dummy-sink dummy-source
-juju remove-saas dummy-source
+juju remove-relation -m admin/"$CONSUMER_MODEL_NAME" dummy-sink dummy-source
+juju remove-saas -m admin/"$CONSUMER_MODEL_NAME" dummy-source
 juju destroy-model "$CONSUMER_MODEL_NAME" --no-prompt
 
 echo

--- a/tests/upgrades/upgrade.sh
+++ b/tests/upgrades/upgrade.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "Test skipped because Juju 4 doesn't support migration yet, so we could still test the internal migration with JIMM and 3 controllers." \
-     "However JIMM needs a Juju 4 CLI, the Juju 4 CLI can't bootstrap a Juju 3 controller, making the setup for this test complex enough" \
-     "that we can just skip it for now until Juju 4 supports migrations."
-exit 0
-
 # This test upgrades a single model from one version to another
 # utilising JAAS' upgrade-to command.
 
@@ -18,7 +13,6 @@ source "local/jimm/detect-jaas.sh"
 # See: https://warthogs.atlassian.net/browse/JUJU-8938
 JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
 UPGRADE_CONTROLLER="upgrade-source-controller"
-SOURCE_CONTROLLER_VERSION="4.0.8.1"
 # Generate a random 4-character suffix for the model name.
 RAND_SUFFIX=$(tr -dc 'a-z0-9' </dev/urandom | head -c 4 || true)
 UPGRADING_MODEL_NAME="upgrading-model-$RAND_SUFFIX"
@@ -30,7 +24,7 @@ if [[ "$controller_exists" -gt 0 ]]; then
     echo "Controller $UPGRADE_CONTROLLER already exists, skipping setup."
 else
     echo "Setting up $UPGRADE_CONTROLLER"
-    AGENT_VERSION="$SOURCE_CONTROLLER_VERSION" CONTROLLER_NAME="$UPGRADE_CONTROLLER" local/jimm/setup-controller.sh
+    CONTROLLER_NAME="$UPGRADE_CONTROLLER" local/jimm/setup-controller.sh
     CONTROLLER_NAME="$UPGRADE_CONTROLLER" local/jimm/add-controller.sh
 fi
 
@@ -48,11 +42,6 @@ model_info="$(juju show-model "$UPGRADING_MODEL_NAME" --format json)"
 model_uuid="$(echo "$model_info" | jq -r ".[\"$UPGRADING_MODEL_NAME\"].\"model-uuid\"")"
 current_model_version="$(echo "$model_info" | jq -r ".[\"$UPGRADING_MODEL_NAME\"].\"agent-version\"")"
 echo "Current model version is $current_model_version"
-
-if [ "$current_model_version" != "$SOURCE_CONTROLLER_VERSION" ]; then
-    echo "Model should be at version $SOURCE_CONTROLLER_VERSION to perform upgrade test, but is at $current_model_version"
-    exit 1
-fi
 
 echo
 echo "Listing migration targets for $UPGRADING_MODEL_NAME"


### PR DESCRIPTION
## Description

I've originally disabled this test because it was required to bootstrap a juju 3 controller to perform the upgrade, or migration. And our `setup-controller.sh` script wasn't ready for it.
Now i've made the necessary changes to enable these tests.