### PR TITLE
feat: allow use of controller profiles during bootstrap

### DIFF
--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -373,6 +373,7 @@ func mergeBootstrapCloud(profile, explicit apiparams.BootstrapCloud) apiparams.B
 	return merged
 }
 
+// mergeBootstrapCloudRegion merges parameters from a profile with those explicitly provided for the cloud region.
 func mergeBootstrapCloudRegion(profile, explicit apiparams.BootstrapCloudRegion) apiparams.BootstrapCloudRegion {
 	merged := profile
 	if explicit.Name != "" {
@@ -425,6 +426,7 @@ func (c *bootstrapCommand) bootstrapOptions(ctxt *cmd.Context) (apiparams.Bootst
 	}, nil
 }
 
+// mergeBootstrapOptions merges parameters from a profile with those explicitly provided for the bootstrap options.
 func mergeBootstrapOptions(profile, explicit apiparams.BootstrapOptions) apiparams.BootstrapOptions {
 	merged := apiparams.BootstrapOptions{
 		BootstrapBase:         profile.BootstrapBase,
@@ -451,8 +453,7 @@ func mergeMaps[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](base M1, override 
 	if len(base) == 0 && len(override) == 0 {
 		return nil
 	}
-	merged := make(map[K]V, len(base)+len(override))
-	maps.Copy(merged, base)
+	merged := maps.Clone(base)
 	maps.Copy(merged, override)
 	return merged
 }

--- a/cmd/jaas/cmd/bootstrap.go
+++ b/cmd/jaas/cmd/bootstrap.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -26,6 +27,10 @@ const (
 Requests the JIMM server to bootstrap a Juju controller.
 The controller will be created asychronously on the specificed
 cloud and region.
+
+Saved controller profiles can be applied with --profile. The profile's saved
+cloud definition and bootstrap options are used as defaults, and any explicit
+command line arguments or flags override those saved values.
 
 By default the command will wait for the bootstrap job to complete
 while printing the job logs. Note that the logs will not follow the
@@ -75,6 +80,7 @@ Note that JIMM will internally do the following:
 	bootstrapExamples = `
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --profile production-aws
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --config controller-service-type=loadbalancer
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --bootstrap-base ubuntu@24.04 --bootstrap-constraints mem=8G --constraints arch=amd64
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --storage-pool name=controller-pool --storage-pool type=ebs --config audit-log-enabled=true
@@ -95,6 +101,7 @@ type bootstrapCommand struct {
 
 	credentialName string
 	detach         bool
+	profileName    string
 	bootstrapBase  string
 	constraints    common.ConstraintsFlag
 	bootstrapCons  common.BootstrapConstraintsFlag
@@ -143,6 +150,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 		"json": cmd.FormatJson,
 	})
 	f.StringVar(&c.credentialName, "credential", "", "The name of the cloud credential to use for bootstrapping. Only required if more than one credential is available for the cloud.")
+	f.StringVar(&c.profileName, "profile", "", "Apply a saved controller profile before processing explicit bootstrap flags. Explicit command line values override the profile.")
 	f.StringVar(&c.bootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine.")
 	f.Var(&c.bootstrapCons, "bootstrap-constraints", "Specify bootstrap machine constraints.")
 	f.Var(&c.constraints, "constraints", "Set model constraints")
@@ -226,22 +234,32 @@ func (c *bootstrapCommand) Run(ctxt *cmd.Context) error {
 		return err
 	}
 
+	client, err := c.getJIMMAPI()
+	if err != nil {
+		return fmt.Errorf("could not create JIMM client: %v", err)
+	}
+	defer client.Close()
+
+	bootstrapCloudParams := cloudToParams(c.cloud, c.region, bootstrapCloud)
+	if c.profileName != "" {
+		resp, err := client.GetControllerProfile(&apiparams.GetControllerProfileRequest{Name: c.profileName})
+		if err != nil {
+			return fmt.Errorf("failed to get controller profile %q: %w", c.profileName, err)
+		}
+		bootstrapCloudParams = mergeBootstrapCloud(resp.Cloud, bootstrapCloudParams)
+		bootstrapOptions = mergeBootstrapOptions(resp.BootstrapOptions, bootstrapOptions)
+	}
+
 	req := apiparams.BootstrapParams{
 		ControllerName:    c.controllerName,
 		ControllerVersion: c.controllerVersion,
-		Cloud:             cloudToParams(c.cloud, c.region, bootstrapCloud),
+		Cloud:             bootstrapCloudParams,
 		Credential: jujuparams.CloudCredential{
 			Attributes: bootstrapCred.Attributes(),
 			AuthType:   string(bootstrapCred.AuthType()),
 		},
 		BootstrapOptions: bootstrapOptions,
 	}
-
-	client, err := c.getJIMMAPI()
-	if err != nil {
-		return fmt.Errorf("could not create JIMM client: %v", err)
-	}
-	defer client.Close()
 
 	resp, err := client.StartBootstrap(&req)
 	if err != nil {
@@ -322,6 +340,56 @@ func cloudToParams(cloudName, regionName string, cloud *jujucloud.Cloud) apipara
 	return paramsCloud
 }
 
+// mergeBootstrapCloud merges parameters from a profile with those explicitly provided.
+// All fields are copied to avoid re-using the underlying data structures from the profile.
+func mergeBootstrapCloud(profile, explicit apiparams.BootstrapCloud) apiparams.BootstrapCloud {
+	merged := profile
+	if explicit.Name != "" {
+		merged.Name = explicit.Name
+	}
+	if explicit.Type != "" {
+		merged.Type = explicit.Type
+	}
+	if len(explicit.AuthTypes) > 0 {
+		merged.AuthTypes = append([]string(nil), explicit.AuthTypes...)
+	} else if len(merged.AuthTypes) > 0 {
+		// Create a new slice to avoid sharing the underlying array with the profile.
+		merged.AuthTypes = append([]string(nil), merged.AuthTypes...)
+	}
+	if len(explicit.CACertificates) > 0 {
+		merged.CACertificates = append([]string(nil), explicit.CACertificates...)
+	} else if len(merged.CACertificates) > 0 {
+		// Create a new slice to avoid sharing the underlying array with the profile.
+		merged.CACertificates = append([]string(nil), merged.CACertificates...)
+	}
+	merged.Config = mergeMaps(profile.Config, explicit.Config)
+	if explicit.Endpoint != "" {
+		merged.Endpoint = explicit.Endpoint
+	}
+	if explicit.HostCloudRegion != "" {
+		merged.HostCloudRegion = explicit.HostCloudRegion
+	}
+	merged.Region = mergeBootstrapCloudRegion(profile.Region, explicit.Region)
+	return merged
+}
+
+func mergeBootstrapCloudRegion(profile, explicit apiparams.BootstrapCloudRegion) apiparams.BootstrapCloudRegion {
+	merged := profile
+	if explicit.Name != "" {
+		merged.Name = explicit.Name
+	}
+	if explicit.Endpoint != "" {
+		merged.Endpoint = explicit.Endpoint
+	}
+	if explicit.IdentityEndpoint != "" {
+		merged.IdentityEndpoint = explicit.IdentityEndpoint
+	}
+	if explicit.StorageEndpoint != "" {
+		merged.StorageEndpoint = explicit.StorageEndpoint
+	}
+	return merged
+}
+
 func (c *bootstrapCommand) bootstrapOptions(ctxt *cmd.Context) (apiparams.BootstrapOptions, error) {
 	bootstrapConfig, err := readStringMapFlag(ctxt, &c.config, "config")
 	if err != nil {
@@ -355,6 +423,49 @@ func (c *bootstrapCommand) bootstrapOptions(ctxt *cmd.Context) (apiparams.Bootst
 		// but JIMM merges those maps again when it shells out to juju bootstrap.
 		BootstrapConfig: bootstrapConfig,
 	}, nil
+}
+
+func mergeBootstrapOptions(profile, explicit apiparams.BootstrapOptions) apiparams.BootstrapOptions {
+	merged := apiparams.BootstrapOptions{
+		BootstrapBase:         profile.BootstrapBase,
+		BootstrapConstraints:  mergeMaps(profile.BootstrapConstraints, explicit.BootstrapConstraints),
+		ModelConstraints:      mergeMaps(profile.ModelConstraints, explicit.ModelConstraints),
+		ModelDefault:          mergeMaps(profile.ModelDefault, explicit.ModelDefault),
+		StoragePool:           cloneStoragePool(profile.StoragePool),
+		BootstrapConfig:       mergeMaps(profile.BootstrapConfig, explicit.BootstrapConfig),
+		ControllerConfig:      mergeMaps(profile.ControllerConfig, explicit.ControllerConfig),
+		ControllerModelConfig: mergeMaps(profile.ControllerModelConfig, explicit.ControllerModelConfig),
+	}
+	if explicit.BootstrapBase != "" {
+		merged.BootstrapBase = explicit.BootstrapBase
+	}
+	if explicit.StoragePool != nil {
+		merged.StoragePool = cloneStoragePool(explicit.StoragePool)
+	}
+	return merged
+}
+
+// mergeMaps merges two maps of the same type.
+// See maps.Copy where the generic type signatures were lifted from.
+func mergeMaps[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](base M1, override M2) map[K]V {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[K]V, len(base)+len(override))
+	maps.Copy(merged, base)
+	maps.Copy(merged, override)
+	return merged
+}
+
+func cloneStoragePool(pool *apiparams.BootstrapStoragePool) *apiparams.BootstrapStoragePool {
+	if pool == nil {
+		return nil
+	}
+	return &apiparams.BootstrapStoragePool{
+		Name:       pool.Name,
+		Type:       pool.Type,
+		Attributes: maps.Clone(pool.Attributes),
+	}
 }
 
 func readStoragePoolFlag(ctxt *cmd.Context, flag *common.ConfigFlag) (*apiparams.BootstrapStoragePool, error) {

--- a/cmd/jaas/cmd/bootstrap_test.go
+++ b/cmd/jaas/cmd/bootstrap_test.go
@@ -62,6 +62,7 @@ func TestBootstrapArgParsing(t *testing.T) {
 				"test-cloud/region",
 				"controller-name",
 				"controller-version",
+				"--profile", "aws-prod",
 				"--bootstrap-base", "ubuntu@24.04",
 				"--bootstrap-constraints", "mem=8G",
 				"--constraints", "arch=amd64",
@@ -74,6 +75,7 @@ func TestBootstrapArgParsing(t *testing.T) {
 			checkFlags: func(c *qt.C, command *bootstrapCommand) {
 				c.Check(command.cloud, qt.Equals, "test-cloud")
 				c.Check(command.region, qt.Equals, "region")
+				c.Check(command.profileName, qt.Equals, "aws-prod")
 				c.Check(command.bootstrapBase, qt.Equals, "ubuntu@24.04")
 				c.Check([]string(command.bootstrapCons), qt.DeepEquals, []string{"mem=8G"})
 				c.Check([]string(command.constraints), qt.DeepEquals, []string{"arch=amd64"})
@@ -258,6 +260,101 @@ func TestBootstrapApiParams(t *testing.T) {
 	ctx := newTestContext(c)
 	mcmd := modelcmd.WrapBase(command)
 	err = mcmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestBootstrapProfileMergesWithExplicitFlags(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	cloudName := "aws"
+
+	s.store.EXPECT().CredentialForCloud(cloudName).Return(&jujucloud.CloudCredential{
+		AuthCredentials: map[string]jujucloud.Credential{
+			"cred-1": jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{}),
+		},
+	}, nil)
+	s.client.EXPECT().GetControllerProfile(&params.GetControllerProfileRequest{Name: "aws-prod"}).Return(
+		params.GetControllerProfileResponse{ControllerProfile: params.ControllerProfile{
+			Name:        "aws-prod",
+			JujuVersion: "3.6",
+			Cloud: params.BootstrapCloud{
+				Name:      cloudName,
+				Type:      "ec2",
+				AuthTypes: []string{string(jujucloud.UserPassAuthType)},
+				Region: params.BootstrapCloudRegion{
+					Name: "eu-west-1",
+				},
+			},
+			BootstrapOptions: params.BootstrapOptions{
+				BootstrapBase: "ubuntu@22.04",
+				BootstrapConstraints: map[string]string{
+					"mem": "4G",
+				},
+				ModelDefault: map[string]string{
+					"logging-config": "<root>=WARNING",
+				},
+				BootstrapConfig: map[string]string{
+					"bootstrap-timeout":       "30",
+					"controller-service-type": "loadbalancer",
+				},
+				ControllerConfig: map[string]string{
+					"audit-log-enabled": "true",
+				},
+			},
+		}},
+		nil,
+	)
+	s.client.EXPECT().StartBootstrap(gomock.Any()).DoAndReturn(func(bsp *params.BootstrapParams) (*params.StartBootstrapResponse, error) {
+		c.Check(bsp.Cloud, qt.DeepEquals, params.BootstrapCloud{
+			Name:      cloudName,
+			Type:      "ec2",
+			AuthTypes: []string{string(jujucloud.UserPassAuthType)},
+			Region: params.BootstrapCloudRegion{
+				Name: "region",
+			},
+		})
+		c.Check(bsp.BootstrapOptions, qt.DeepEquals, params.BootstrapOptions{
+			BootstrapBase: "ubuntu@24.04",
+			BootstrapConstraints: map[string]string{
+				"mem":   "4G",
+				"cores": "2",
+			},
+			ModelDefault: map[string]string{
+				"logging-config": "<root>=INFO",
+			},
+			BootstrapConfig: map[string]string{
+				"bootstrap-timeout":       "30",
+				"controller-service-type": "loadbalancer",
+				"image-stream":            "released",
+			},
+			ControllerConfig: map[string]string{
+				"audit-log-enabled": "true",
+			},
+		})
+		return &params.StartBootstrapResponse{JobID: "test-job-id"}, nil
+	})
+	s.client.EXPECT().Close().Return(nil)
+
+	command := &bootstrapCommand{}
+	command.setJIMMAPI(s.client)
+	command.SetClientStore(s.store)
+
+	initCommand(c, command,
+		fmt.Sprintf("%s/region", cloudName),
+		"controller-name",
+		"controller-version",
+		"--detach",
+		"--profile", "aws-prod",
+		"--bootstrap-base", "ubuntu@24.04",
+		"--bootstrap-constraints", "cores=2",
+		"--model-default", "logging-config=<root>=INFO",
+		"--config", "image-stream=released",
+	)
+
+	ctx := newTestContext(c)
+	mcmd := modelcmd.WrapBase(command)
+	err := mcmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
 }
 

--- a/cmd/jaas/cmd/controllerprofile.go
+++ b/cmd/jaas/cmd/controllerprofile.go
@@ -25,6 +25,35 @@ const (
 Adds a controller profile.
 
 The controller profile definition is read from a YAML file or from stdin.
+The command argument sets the saved profile name.
+
+The YAML schema mirrors the saved controller profile payload:
+
+description: Production AWS bootstrap defaults
+juju-version: 3.6
+cloud:
+	name: aws
+	region:
+		name: eu-west-1
+bootstrap-options:
+	bootstrap-base: ubuntu@24.04
+	bootstrap-constraints:
+		mem: 8G
+	model-constraints:
+		arch: amd64
+	model-default:
+		logging-config: <root>=INFO
+	storage-pool:
+		name: controller-pool
+		type: ebs
+		attributes:
+			volume-type: gp3
+	bootstrap-config:
+		controller-service-type: loadbalancer
+	controller-config:
+		audit-log-enabled: "true"
+	controller-model-config:
+		automatically-retry-hooks: "false"
 `
 	addControllerProfileExample = `
     juju jaas add-controller-profile my-profile --file ./profile.yaml
@@ -35,8 +64,9 @@ The controller profile definition is read from a YAML file or from stdin.
 Updates a saved controller profile.
 
 The controller profile definition is read from a YAML file or from stdin.
-If the provided profile does not specify a version, the current version is
-retrieved before saving.
+The same YAML schema accepted by add-controller-profile is used here.
+
+The command argument sets the profile name.
 `
 	updateControllerProfileExample = `
     juju jaas update-controller-profile my-profile --file ./profile.yaml
@@ -67,6 +97,16 @@ Removes a saved controller profile.
     juju jaas remove-controller-profile my-profile --force
 `
 )
+
+// controllerProfileFileInput is the accepted payload shape for --file input.
+// Metadata fields (name/version/timestamps) are intentionally omitted because
+// those are managed by the command argument and server state.
+type controllerProfileFileInput struct {
+	Description      string                     `json:"description" yaml:"description"`
+	JujuVersion      string                     `json:"juju-version" yaml:"juju-version"`
+	Cloud            apiparams.BootstrapCloud   `json:"cloud" yaml:"cloud"`
+	BootstrapOptions apiparams.BootstrapOptions `json:"bootstrap-options" yaml:"bootstrap-options"`
+}
 
 // NewAddControllerProfileCommand returns a command to add a controller profile.
 func NewAddControllerProfileCommand() cmd.Command {
@@ -147,21 +187,22 @@ func (c *addControllerProfileCommand) readSaveRequest(ctxt *cmd.Context) (apipar
 	if err != nil {
 		return apiparams.SaveControllerProfileRequest{}, err
 	}
-	var req apiparams.SaveControllerProfileRequest
-	if err := yaml.Unmarshal(data, &req); err != nil {
+	var in controllerProfileFileInput
+	if err := yaml.Unmarshal(data, &in); err != nil {
 		return apiparams.SaveControllerProfileRequest{}, err
 	}
-	if req.Name != "" && req.Name != c.name {
-		return apiparams.SaveControllerProfileRequest{}, fmt.Errorf("provided controller profile name doesn't match, %s != %s", c.name, req.Name)
-	}
-	req.Name = c.name
-	req.CreatedAt = ""
-	req.UpdatedAt = ""
-	// This may look odd, but if a user accidentally puts a version here,
-	// the server will reject it with a profile does not exist error which
-	// would be confusing to users.
-	req.Version = 0
-	return req, nil
+	// Ignore metadata fields from file input so name/version are controlled by
+	// command arguments and update flow can fetch the latest server version.
+	return apiparams.SaveControllerProfileRequest{
+		ControllerProfile: apiparams.ControllerProfile{
+			Name:             c.name,
+			Description:      in.Description,
+			JujuVersion:      in.JujuVersion,
+			Cloud:            in.Cloud,
+			BootstrapOptions: in.BootstrapOptions,
+			Version:          0,
+		},
+	}, nil
 }
 
 // NewUpdateControllerProfileCommand returns a command to update a controller profile.

--- a/docs/howto/manage-juju-controllers.md
+++ b/docs/howto/manage-juju-controllers.md
@@ -147,6 +147,69 @@ use the command in your desired use-case.
 
 ````
 
+
+## Controller profiles
+
+Controller profiles let JIMM administrators store reusable, non-secret bootstrap defaults on the server and apply them later with `juju jaas bootstrap --profile ...`.
+
+A profile can capture:
+
+- The cloud metadata and bootstrap region the profile was created for.
+- The Juju version the profile is intended to be used with.
+- Bootstrap settings such as bootstrap-base, constraints, model defaults, storage pool configuration, and bootstrap/controller/controller-model config maps.
+
+Controller profiles can be created, viewed, updated, listed, and removed with the `juju jaas` {doc}`commands <../reference/list-of-jaas-plugin-commands/index.md>` including `add-controller-profile`, `show-controller-profile`, `update-controller-profile`, `list-controller-profiles`, and `remove-controller-profile`.
+
+A typical profile looks like this:
+
+```yaml
+description: Production AWS bootstrap defaults
+juju-version: 3.6
+cloud:
+  name: aws
+  region:
+    name: eu-west-1
+bootstrap-options:
+  bootstrap-base: ubuntu@24.04
+  bootstrap-constraints:
+    mem: 8G
+  model-constraints:
+    arch: amd64
+  model-default:
+    logging-config: <root>=INFO
+  storage-pool:
+    name: controller-pool
+    type: ebs
+    attributes:
+      volume-type: gp3
+  bootstrap-config:
+    controller-service-type: loadbalancer
+  controller-config:
+    audit-log-enabled: "true"
+```
+
+Create the profile by passing the profile name on the command line and the YAML definition via `--file`:
+
+```text
+juju switch jimm
+juju jaas add-controller-profile aws-production --file ./aws-production.yaml
+```
+
+Later, apply the saved profile during bootstrap:
+
+```text
+juju switch jimm
+juju jaas bootstrap aws/eu-west-1 mycontroller 3.6.8 --profile aws-production
+```
+
+Any bootstrap flags you pass alongside `--profile` are merged with and override the saved defaults. For example, you can keep a common profile but override a single setting for a controller:
+
+```text
+juju jaas bootstrap aws/eu-west-1 mycontroller 3.6.8 --profile aws-production --config controller-service-type=loadbalancer
+```
+
+Use `juju jaas list-controller-profiles --juju-version 3.6.8` to discover profiles intended for the Juju version you plan to bootstrap.
+
 (control-user-access-to-a-juju-controller)=
 ## Control user access to a Juju controller
 

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -59,6 +59,35 @@ Add a controller profile.
 Adds a controller profile.
 
 The controller profile definition is read from a YAML file or from stdin.
+The command argument sets the saved profile name.
+
+The YAML schema mirrors the saved controller profile payload:
+
+description: Production AWS bootstrap defaults
+juju-version: 3.6
+cloud:
+	name: aws
+	region:
+		name: eu-west-1
+bootstrap-options:
+	bootstrap-base: ubuntu@24.04
+	bootstrap-constraints:
+		mem: 8G
+	model-constraints:
+		arch: amd64
+	model-default:
+		logging-config: &lt;root&gt;=INFO
+	storage-pool:
+		name: controller-pool
+		type: ebs
+		attributes:
+			volume-type: gp3
+	bootstrap-config:
+		controller-service-type: loadbalancer
+	controller-config:
+		audit-log-enabled: "true"
+	controller-model-config:
+		automatically-retry-hooks: "false"
 
 
 (command-jaas-add-group)=
@@ -275,12 +304,14 @@ Bootstrap a Juju controller via JIMM
 | `--format` | json | Specify output format (json&#x7c;yaml) |
 | `--model-default` |  | Specify a configuration file, or one or more configuration options to be set for all models, unless otherwise specified.     (`--model-default config.yaml [--model-default key=value ...])` |
 | `-o`, `--output` |  | Specify an output file |
+| `--profile` |  | Apply a saved controller profile before processing explicit bootstrap flags. Explicit command line values override the profile. |
 | `--storage-pool` |  | Specify options for an initial storage pool. 'name' and 'type' are required, plus any additional attributes.     (`--storage-pool pool-config.yaml [--storage-pool key=value ...])` |
 
 ## Examples
 
 	juju [jaas] bootstrap <cloud[/region]> <controller name> <controller version>
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8
+	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --profile production-aws
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --config controller-service-type=loadbalancer
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --bootstrap-base ubuntu@24.04 --bootstrap-constraints mem=8G --constraints arch=amd64
 	juju [jaas] bootstrap mycloud/region mycontroller 3.6.8 --storage-pool name=controller-pool --storage-pool type=ebs --config audit-log-enabled=true
@@ -291,6 +322,10 @@ Bootstrap a Juju controller via JIMM
 Requests the JIMM server to bootstrap a Juju controller.
 The controller will be created asychronously on the specificed
 cloud and region.
+
+Saved controller profiles can be applied with --profile. The profile's saved
+cloud definition and bootstrap options are used as defaults, and any explicit
+command line arguments or flags override those saved values.
 
 By default the command will wait for the bootstrap job to complete
 while printing the job logs. Note that the logs will not follow the
@@ -1537,8 +1572,9 @@ Update a saved controller profile.
 Updates a saved controller profile.
 
 The controller profile definition is read from a YAML file or from stdin.
-If the provided profile does not specify a version, the current version is
-retrieved before saving.
+The same YAML schema accepted by add-controller-profile is used here.
+
+The command argument sets the profile name.
 
 
 (command-jaas-update-migrated-model)=


### PR DESCRIPTION
## Description
This PR does a few things to close out the work on controller profiles.
1. It adds a flag `--profile` to `juju jaas bootstrap` allowing you to specify a profile, this sets the default values for bootstrap. These defaults can be modified by supplying additional flags to `juju jaas bootstrap` and additional config options are merged with those from the profile. The merging logic is a bit of ugly/tedious code, but it seems necessary if we want to allow this capability.
2. It updates the help text for the `juju jaas add-controller-profile` command to describe the schema for a controller profile. Currently there is no way to discern, besides reading the code, the supported fields for creating a controller profile.
3. It updates the format ingested by the `juju jaas add-controller-profile` command so that we don't read fields that are set by the server / command args. E.g. the command is `juju jaas add-controller-profile my-profile --file ./profile.yaml` where the name `my-profile` is a required argument but _could_ also be specified in `profile.yaml` and the code would error if they didn't match. Now the file format ingested is only the relevant fields.
4. It updates our how-to manage controllers doc to add a section on the controller profile feature.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
