### PR TITLE
fix: fix cache key in github workflow

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -18,12 +18,12 @@ jobs:
         id: docker-cache
         uses: actions/cache@v5
         with:
-          path: /tmp/docker-images.tar
-          key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
+          path: docker-images.tar
+          key: docker-v2-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
 
       - name: Load Docker images from cache
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/docker-images.tar
+        run: docker load -i docker-images.tar
 
       - name: Pull all Docker Compose images
         run: docker compose --profile dev pull --ignore-buildable
@@ -33,7 +33,7 @@ jobs:
 
       - name: Save Docker images for cache
         if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>') -o /tmp/docker-images.tar
+        run: docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>') -o docker-images.tar
 
   go_cache:
     name: Cache Go Dependencies and Build/Lint Artifacts

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -22,12 +22,12 @@ jobs:
         id: docker-cache
         uses: actions/cache/restore@v5
         with:
-          path: /tmp/docker-images.tar
-          key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
+          path: docker-images.tar
+          key: docker-v2-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
 
       - name: Load Docker images from cache
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/docker-images.tar
+        run: docker load -i docker-images.tar
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -21,12 +21,12 @@ jobs:
         id: docker-cache
         uses: actions/cache/restore@v5
         with:
-          path: /tmp/docker-images.tar
-          key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
+          path: docker-images.tar
+          key: docker-v2-${{ runner.os }}-${{ hashFiles('docker-compose.yaml', 'docker-compose.common.yaml', 'local/*/Dockerfile') }}
 
       - name: Load Docker images from cache
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/docker-images.tar
+        run: docker load -i docker-images.tar
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1


### PR DESCRIPTION
# Description

Apparently we can't unpack to /tmp but we need to use github workflow home. 

The reason why just changing the `key` is not enough to fix the cache is:

----------

Cache version is a way to stamp a cache with metadata of the path and the compression tool used while creating the cache. This ensures that the consuming workflow run uniquely matches a cache it can actually decompress and use. For more information, see [Cache Version](https://github.com/actions/cache#cache-version) in the Actions Cache documentation.

-------------

What we were seeing together in call is consistent with this because if you change the path it produces a new "version" of the cache, and it's why i could fetch the key when the path was "/tmp" and not "workspace".

Hopefully this should fix the caching

> i've added the v2, so i can check the caching is actually working properly without worry about the previous ghost versions