### PR TITLE
feat: cascade model access revocation

### DIFF
--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -516,6 +516,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 
 	currentRelation := targetOfgaUser.GetModelAccess(ctx, mt)
 
+	relationToSet := ofganames.NoRelation
 	var relationsToRevoke []openfga.Relation
 	switch targetRelation {
 	case ofganames.ReaderRelation:
@@ -533,7 +534,14 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 		switch currentRelation {
 		case ofganames.NoRelation, ofganames.ReaderRelation:
 			return nil
+		case ofganames.AdministratorRelation:
+			relationToSet = ofganames.ReaderRelation
+			relationsToRevoke = []openfga.Relation{
+				ofganames.WriterRelation,
+				ofganames.AdministratorRelation,
+			}
 		default:
+			relationToSet = ofganames.ReaderRelation
 			relationsToRevoke = []openfga.Relation{
 				ofganames.WriterRelation,
 				ofganames.AdministratorRelation,
@@ -544,9 +552,25 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 		case ofganames.NoRelation, ofganames.ReaderRelation, ofganames.WriterRelation:
 			return nil
 		default:
+			relationToSet = ofganames.WriterRelation
 			relationsToRevoke = []openfga.Relation{
 				ofganames.AdministratorRelation,
 			}
+		}
+	}
+
+	if relationToSet != ofganames.NoRelation {
+		err = targetOfgaUser.SetModelAccess(ctx, mt, relationToSet)
+		if err != nil {
+			zapctx.Error(
+				ctx,
+				"failed to downgrade model access",
+				zaputil.Error(err),
+				zap.String("targetUser", string(ut.Id())),
+				zap.String("model", string(mt.Id())),
+				zap.String("access", string(access)),
+			)
+			return fmt.Errorf("failed to set model access: %w", err)
 		}
 	}
 

--- a/internal/jimm/permissions/access.go
+++ b/internal/jimm/permissions/access.go
@@ -479,8 +479,16 @@ func (j *PermissionManager) GrantModelAccess(ctx context.Context, user *openfga.
 // RevokeModelAccess revokes the given access level on the given model from
 // the given user. If the model is not found then an error with the code
 // CodeNotFound is returned. If the authenticated user does not have admin
-// access to the model, and is not attempting to revoke their own access,
-// then an error with the code CodeUnauthorized is returned.
+// access to the model then an error with the code CodeUnauthorized is
+// returned.
+//
+// This function follows Juju semantics of revocation, that is:
+//  1. Admins can revoke access sequentially of other users, i.e.:
+//     If you remove "admin" from an "admin", they will cascade down to write and not remove their access
+//     entirely.
+//  2. Admins can only revoke their access to writer, at which point they can no longer revoke their access to reader,
+//     and thus cannot fully revoke their access to the model.
+//  3. If an admin is revoking "write" from another "admin", they are downgraded to "reader".
 func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga.User, mt names.ModelTag, ut names.UserTag, access jujuparams.UserAccessPermission) error {
 	targetRelation, err := ToModelRelation(string(access))
 	if err != nil {
@@ -493,13 +501,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 		return errors.Codef(errors.CodeBadRequest, "failed to recognize given access: %q", access)
 	}
 
-	requiredAccess := ofganames.AdministratorRelation
-	if user.Tag() == ut {
-		// If the user is attempting to revoke their own access.
-		requiredAccess = ofganames.ReaderRelation
-	}
-
-	modelAdmin, err := user.HasModelRelation(ctx, mt, requiredAccess)
+	modelAdmin, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
 	if err != nil {
 		return err
 	}
@@ -518,6 +520,7 @@ func (j *PermissionManager) RevokeModelAccess(ctx context.Context, user *openfga
 
 	relationToSet := ofganames.NoRelation
 	var relationsToRevoke []openfga.Relation
+
 	switch targetRelation {
 	case ofganames.ReaderRelation:
 		switch currentRelation {

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -175,10 +175,6 @@ var grantModelAccessTests = []struct {
 		Relation: ofganames.AdministratorRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
 		Relation: ofganames.WriterRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
@@ -193,10 +189,6 @@ var grantModelAccessTests = []struct {
 	expectRelations: []openfga.Tuple{{
 		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
 		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.ReaderRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
@@ -515,6 +507,10 @@ var revokeModelAccessTests = []struct {
 		Relation: ofganames.AdministratorRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
 		Relation: ofganames.ReaderRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
@@ -634,6 +630,10 @@ var revokeModelAccessTests = []struct {
 		Relation: ofganames.AdministratorRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
+		Relation: ofganames.WriterRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
 		Relation: ofganames.WriterRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
@@ -657,6 +657,10 @@ var revokeModelAccessTests = []struct {
 	expectRelations: []openfga.Tuple{{
 		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
 		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
+		Relation: ofganames.ReaderRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
@@ -735,6 +739,10 @@ var revokeModelAccessTests = []struct {
 	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
 		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
+		Relation: ofganames.ReaderRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -175,6 +175,10 @@ var grantModelAccessTests = []struct {
 		Relation: ofganames.AdministratorRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
+		Relation: ofganames.WriterRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
 		Relation: ofganames.WriterRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
@@ -189,6 +193,10 @@ var grantModelAccessTests = []struct {
 	expectRelations: []openfga.Tuple{{
 		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
 		Relation: ofganames.AdministratorRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
+	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
+		Relation: ofganames.ReaderRelation,
 		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
 	}, {
 		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
@@ -708,23 +716,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "charlie@canonical.com",
 	access:         "admin",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Writer revokes 'write' access from themselves",
 	env:            revokeModelAccessTestEnv,
@@ -732,28 +724,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "charlie@canonical.com",
 	access:         "write",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
-	expectRemovedRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Writer revokes 'read' access from themselves",
 	env:            revokeModelAccessTestEnv,
@@ -761,24 +732,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "charlie@canonical.com",
 	access:         "read",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
-	expectRemovedRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Reader revokes 'admin' access from themselves",
 	env:            revokeModelAccessTestEnv,
@@ -786,23 +740,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "daphne@canonical.com",
 	access:         "admin",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Reader revokes 'write' access from themselves",
 	env:            revokeModelAccessTestEnv,
@@ -810,23 +748,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "daphne@canonical.com",
 	access:         "write",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Reader revokes 'read' access from themselves",
 	env:            revokeModelAccessTestEnv,
@@ -834,24 +756,7 @@ var revokeModelAccessTests = []struct {
 	uuid:           "00000002-0000-0000-0000-000000000001",
 	targetUsername: "daphne@canonical.com",
 	access:         "read",
-	expectRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("alice@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("bob@canonical.com")),
-		Relation: ofganames.AdministratorRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}, {
-		Object:   ofganames.ConvertTag(names.NewUserTag("charlie@canonical.com")),
-		Relation: ofganames.WriterRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
-	expectRemovedRelations: []openfga.Tuple{{
-		Object:   ofganames.ConvertTag(names.NewUserTag("daphne@canonical.com")),
-		Relation: ofganames.ReaderRelation,
-		Target:   ofganames.ConvertTag(names.NewModelTag("00000002-0000-0000-0000-000000000001")),
-	}},
+	expectError:    `unauthorized`,
 }, {
 	name:           "Admin revokes 'admin' access from a user who has separate tuples for all accesses (read/write/admin)",
 	env:            revokeModelAccessTestEnv,

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -10,8 +10,11 @@ import (
 	petname "github.com/dustinkirkland/golang-petname"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
+	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/core/crossmodel"
+	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -1479,6 +1482,70 @@ func TestCheckRelationControllerAdministratorFlow(t *testing.T) {
 /*
  None-facade related tests
 */
+
+func TestModifyModelAccessDowngradesUserToNoAccess(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	connBob := s.Open(c, nil, "bob", nil)
+	defer connBob.Close()
+	bobClient := modelmanager.NewClient(connBob)
+
+	connCharlie := s.Open(c, nil, "charlie", nil)
+	defer connCharlie.Close()
+	charlieClient := modelmanager.NewClient(connCharlie)
+
+	modelTag := names.NewModelTag(model.UUID.String)
+
+	err := bobClient.GrantModel("charlie@canonical.com", "admin", model.UUID.String)
+	c.Assert(err, qt.IsNil)
+
+	charlieAccess := func() string {
+		info, err := bobClient.ModelInfo([]names.ModelTag{modelTag})
+		c.Assert(err, qt.IsNil)
+		c.Assert(info, qt.HasLen, 1)
+		c.Assert(info[0].Error, qt.Equals, (*jujuparams.Error)(nil))
+		for _, userInfo := range info[0].Result.Users {
+			if userInfo.UserName == "charlie@canonical.com" {
+				return string(userInfo.Access)
+			}
+		}
+		return ""
+	}
+
+	revoke := func(access jujuparams.UserAccessPermission) {
+		var result jujuparams.ErrorResults
+		err := connBob.APICall("ModelManager", 10, "", "ModifyModelAccess", jujuparams.ModifyModelAccessRequest{
+			Changes: []jujuparams.ModifyModelAccess{{
+				UserTag:  names.NewUserTag("charlie@canonical.com").String(),
+				Action:   jujuparams.RevokeModelAccess,
+				Access:   access,
+				ModelTag: modelTag.String(),
+			}},
+		}, &result)
+		c.Assert(err, qt.IsNil)
+		c.Assert(result.Results, qt.HasLen, 1)
+		c.Assert(result.Results[0].Error, qt.Equals, (*jujuparams.Error)(nil))
+	}
+
+	c.Assert(charlieAccess(), qt.Equals, "admin")
+
+	revoke(jujuparams.ModelAdminAccess)
+	c.Assert(charlieAccess(), qt.Equals, "write")
+
+	revoke(jujuparams.ModelWriteAccess)
+	c.Assert(charlieAccess(), qt.Equals, "read")
+
+	revoke(jujuparams.ModelReadAccess)
+	c.Assert(charlieAccess(), qt.Equals, "")
+
+	charlieInfo, err := charlieClient.ModelInfo([]names.ModelTag{modelTag})
+	c.Assert(err, qt.IsNil)
+	c.Assert(charlieInfo, qt.HasLen, 1)
+	c.Assert(charlieInfo[0].Error, qt.Not(qt.IsNil))
+	c.Assert(charlieInfo[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+}
 
 // createTestControllerEnvironment is a utility function creating the necessary components of adding a:
 //   - user

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -1485,16 +1485,61 @@ func TestCheckRelationControllerAdministratorFlow(t *testing.T) {
 
 func TestModifyModelAccessDowngradesUserToNoAccess(t *testing.T) {
 	c := qt.New(t)
+	revoke, charlieAccess, charlieClient, modelTag := setupModelWithCharlieAsAdmin(c)
+
+	c.Assert(charlieAccess(), qt.Equals, "admin")
+
+	revoke(jujuparams.ModelAdminAccess)
+	c.Assert(charlieAccess(), qt.Equals, "write")
+
+	revoke(jujuparams.ModelWriteAccess)
+	c.Assert(charlieAccess(), qt.Equals, "read")
+
+	revoke(jujuparams.ModelReadAccess)
+	c.Assert(charlieAccess(), qt.Equals, "")
+
+	charlieInfo, err := charlieClient.ModelInfo([]names.ModelTag{modelTag})
+	c.Assert(err, qt.IsNil)
+	c.Assert(charlieInfo, qt.HasLen, 1)
+	c.Assert(charlieInfo[0].Error, qt.Not(qt.IsNil))
+	c.Assert(charlieInfo[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+}
+
+// TestModifyModelAccessRevocationCascadesToReader tests that the "writer" permission is removed from an "admin",
+// then a "reader" is left. This matches Juju behaviour.
+func TestModifyModelAccessRevocationCascadesToReader(t *testing.T) {
+	c := qt.New(t)
+	revoke, charlieAccess, charlieClient, modelTag := setupModelWithCharlieAsAdmin(c)
+
+	c.Assert(charlieAccess(), qt.Equals, "admin")
+
+	revoke(jujuparams.ModelWriteAccess)
+	c.Assert(charlieAccess(), qt.Equals, "read")
+
+	revoke(jujuparams.ModelReadAccess)
+	c.Assert(charlieAccess(), qt.Equals, "")
+
+	charlieInfo, err := charlieClient.ModelInfo([]names.ModelTag{modelTag})
+	c.Assert(err, qt.IsNil)
+	c.Assert(charlieInfo, qt.HasLen, 1)
+	c.Assert(charlieInfo[0].Error, qt.Not(qt.IsNil))
+	c.Assert(charlieInfo[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+}
+
+func setupModelWithCharlieAsAdmin(c *qt.C) (func(jujuparams.UserAccessPermission), func() string, *modelmanager.Client, names.ModelTag) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
 	connBob := s.Open(c, nil, "bob", nil)
-	defer connBob.Close()
 	bobClient := modelmanager.NewClient(connBob)
 
 	connCharlie := s.Open(c, nil, "charlie", nil)
-	defer connCharlie.Close()
 	charlieClient := modelmanager.NewClient(connCharlie)
+
+	c.Cleanup(func() {
+		connBob.Close()
+		connCharlie.Close()
+	})
 
 	modelTag := names.NewModelTag(model.UUID.String)
 
@@ -1529,22 +1574,7 @@ func TestModifyModelAccessDowngradesUserToNoAccess(t *testing.T) {
 		c.Assert(result.Results[0].Error, qt.Equals, (*jujuparams.Error)(nil))
 	}
 
-	c.Assert(charlieAccess(), qt.Equals, "admin")
-
-	revoke(jujuparams.ModelAdminAccess)
-	c.Assert(charlieAccess(), qt.Equals, "write")
-
-	revoke(jujuparams.ModelWriteAccess)
-	c.Assert(charlieAccess(), qt.Equals, "read")
-
-	revoke(jujuparams.ModelReadAccess)
-	c.Assert(charlieAccess(), qt.Equals, "")
-
-	charlieInfo, err := charlieClient.ModelInfo([]names.ModelTag{modelTag})
-	c.Assert(err, qt.IsNil)
-	c.Assert(charlieInfo, qt.HasLen, 1)
-	c.Assert(charlieInfo[0].Error, qt.Not(qt.IsNil))
-	c.Assert(charlieInfo[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+	return revoke, charlieAccess, charlieClient, modelTag
 }
 
 // createTestControllerEnvironment is a utility function creating the necessary components of adding a:

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -457,7 +457,7 @@ func TestGrantAndRevokeModel(t *testing.T) {
 	c.Assert(res[0].Error, qt.ErrorMatches, "unauthorized")
 }
 
-func TestUserRevokeOwnAccess(t *testing.T) {
+func TestUserCannotRevokeOwnAccessWithoutAdmin(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
@@ -480,13 +480,13 @@ func TestUserRevokeOwnAccess(t *testing.T) {
 	c.Assert(res[0].Result.UUID, qt.Equals, model.UUID.String)
 
 	err = client2.RevokeModel("charlie@canonical.com", "read", model.UUID.String)
-	c.Assert(err, qt.Equals, nil)
+	c.Assert(err, qt.ErrorMatches, "unauthorized")
 
 	res, err = client2.ModelInfo([]names.ModelTag{names.NewModelTag(model.UUID.String)})
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(res, qt.HasLen, 1)
-	c.Assert(res[0].Error, qt.Not(qt.IsNil))
-	c.Assert(res[0].Error, qt.ErrorMatches, "unauthorized")
+	c.Assert(res[0].Error, qt.Equals, (*jujuparams.Error)(nil))
+	c.Assert(res[0].Result.UUID, qt.Equals, model.UUID.String)
 }
 
 func TestModifyModelAccessErrors(t *testing.T) {


### PR DESCRIPTION
## Description
Juju cascades model access to 0 on revokes, JIMM was simply removing it.
We now have a default to cascade down to. 

I also added an integration test just to cover a little bit of paranoia, and see it work in tandem with an info call as we return the JIMM permission on our info calls. Happy to remove this test though.

Fixes issue #1978 

I verified this in Juju 3.6 via (stripped the show model output to just users so it is easier to read):
```bash
➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj revoke bob admin yolo
➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj show-model yolo      
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: 1 minute ago
    bob:
      access: write
      last-connection: never connected

➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj revoke bob write yolo
➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj show-model yolo      
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: 1 minute ago
    bob:
      access: read
      last-connection: never connected

➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj revoke bob read  yolo
➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ jj show-model yolo      
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: 1 minute ago

➜  jimm git:(issue-1978/cascade-model-access-revoke) ✗ 
```


## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


