### PR TITLE
fix: ipv6 parsing for vault and publicdns

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -688,21 +689,23 @@ func NewService(ctx context.Context, p Params) (*Service, error) {
 	return NewServiceFromDependencies(ctx, deps)
 }
 
-// parseURLWithOptionalScheme parses an input string
-// that may exclude a scheme, i.e. missing "http://".
-// If no scheme is provided, "https" will be used.
+// parseURLWithOptionalScheme parses an input string that may exclude a scheme,
+// i.e. missing "http://". If no scheme is provided, "https" will be used.
+// Bare IPv6 addresses (e.g. "::1") are bracketed before parsing because
+// url.Parse rejects unbracketed IPv6 literals.
 func parseURLWithOptionalScheme(addr string) (*url.URL, error) {
-	uriScheme := "https"
-	// Add the schema if parsing fails or the host is empty.
-	// This avoids parsing ambiguity in url.Parse.
-	url, err := url.Parse(addr)
-	if err != nil || url.Host == "" {
-		url, err = url.Parse(uriScheme + "://" + addr)
+	u, err := url.Parse(addr)
+	if err != nil || u.Host == "" {
+		// If the ip is a valid Ipv6 address, it needs to be bracketed to be parsed correctly.
+		if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
+			addr = "[" + addr + "]"
+		}
+		u, err = url.Parse("https://" + addr)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return url, nil
+	return u, nil
 }
 
 func (s *Service) StartServices(ctx context.Context, svc *service.Service) {
@@ -818,7 +821,11 @@ func newVaultStore(ctx context.Context, p Params) (jimmcreds.CredentialStore, er
 
 	cfg := vaultapi.DefaultConfig()
 	if p.VaultAddress != "" {
-		cfg.Address = p.VaultAddress
+		vaultURL, err := parseURLWithOptionalScheme(p.VaultAddress)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vault address %q: %w", p.VaultAddress, err)
+		}
+		cfg.Address = vaultURL.String()
 	}
 
 	client, err := vaultapi.NewClient(cfg)

--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -637,6 +637,46 @@ func TestParseURLWithOptionalSchem(t *testing.T) {
 			url:         "foo\bar",
 			expectError: `parse "https://foo\\bar": net/url: invalid control character in URL`,
 		},
+		{
+			about:    "bare IPv4 address",
+			url:      "127.0.0.1",
+			expected: "https://127.0.0.1",
+		},
+		{
+			about:    "IPv4 address with port, no scheme",
+			url:      "127.0.0.1:8200",
+			expected: "https://127.0.0.1:8200",
+		},
+		{
+			about:    "IPv4 address with scheme",
+			url:      "http://127.0.0.1:8200",
+			expected: "http://127.0.0.1:8200",
+		},
+		{
+			about:    "IPv4 address with path, no scheme",
+			url:      "127.0.0.1/my-vault",
+			expected: "https://127.0.0.1/my-vault",
+		},
+		{
+			about:    "bare IPv6 address",
+			url:      "::1",
+			expected: "https://[::1]",
+		},
+		{
+			about:    "bracketed IPv6 address with port, no scheme",
+			url:      "[::1]:8200",
+			expected: "https://[::1]:8200",
+		},
+		{
+			about:    "IPv6 address with scheme and brackets",
+			url:      "http://[::1]:8200",
+			expected: "http://[::1]:8200",
+		},
+		{
+			about:    "full IPv6 address without brackets, no scheme",
+			url:      "2001:db8::1",
+			expected: "https://[2001:db8::1]",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

`url.Parse` doesn't support parsing addr without bracketed ipv6. This is a fix for the issue reported.
Added a few test for ipv4 as well.

Fix #1972
