### PR TITLE
refactor: switch from bare usernames to `@canonical.com` ones

### DIFF
--- a/cmd/jimmsrv/service/service_test.go
+++ b/cmd/jimmsrv/service/service_test.go
@@ -125,7 +125,7 @@ func TestAuthenticator(t *testing.T) {
 	}
 
 	conn, err := api.Open(&info, api.DialOpts{
-		LoginProvider:      jimmtest.NewUserSessionLogin(c, "alice"),
+		LoginProvider:      jimmtest.NewUserSessionLogin(c, "alice@canonical.com"),
 		InsecureSkipVerify: true,
 	})
 	c.Assert(err, qt.IsNil)
@@ -140,7 +140,7 @@ func TestAuthenticator(t *testing.T) {
 	c.Check(conn.ControllerAccess(), qt.Equals, "")
 
 	conn, err = api.Open(&info, api.DialOpts{
-		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob"),
+		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob@canonical.com"),
 		InsecureSkipVerify: true,
 	})
 	c.Assert(err, qt.IsNil)
@@ -191,7 +191,7 @@ func TestVault(t *testing.T) {
 	}
 
 	conn, err := api.Open(&info, api.DialOpts{
-		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob"),
+		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob@canonical.com"),
 		InsecureSkipVerify: true,
 	})
 	c.Assert(err, qt.IsNil)
@@ -265,7 +265,7 @@ func TestOpenFGA(t *testing.T) {
 	}
 
 	conn, err := api.Open(&info, api.DialOpts{
-		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob"),
+		LoginProvider:      jimmtest.NewUserSessionLogin(c, "bob@canonical.com"),
 		InsecureSkipVerify: true,
 	})
 	c.Assert(err, qt.IsNil)

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -178,9 +178,9 @@ func (m *mockOAuthAuthenticator) VerifyClientCredentials(ctx context.Context, cl
 // newSessionToken returns a serialised JWT that can be used in tests.
 // Tests using a mock authenticator can provide an empty signatureSecret
 // while integration tests must provide the same secret used when verifying JWTs.
-func newSessionToken(c SimpleTester, email string, signatureSecret string) string {
+func newSessionToken(c SimpleTester, username string, signatureSecret string) string {
 	token, err := jwt.NewBuilder().
-		Subject(email).
+		Subject(username).
 		Expiration(time.Now().Add(1 * time.Hour)).
 		Build()
 	if err != nil {

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -179,8 +178,7 @@ func (m *mockOAuthAuthenticator) VerifyClientCredentials(ctx context.Context, cl
 // newSessionToken returns a serialised JWT that can be used in tests.
 // Tests using a mock authenticator can provide an empty signatureSecret
 // while integration tests must provide the same secret used when verifying JWTs.
-func newSessionToken(c SimpleTester, username string, signatureSecret string) string {
-	email := ConvertUsernameToEmail(username)
+func newSessionToken(c SimpleTester, email string, signatureSecret string) string {
 	token, err := jwt.NewBuilder().
 		Subject(email).
 		Expiration(time.Now().Add(1 * time.Hour)).
@@ -206,14 +204,6 @@ func newSessionToken(c SimpleTester, username string, signatureSecret string) st
 func NewUserSessionLogin(c SimpleTester, username string) api.LoginProvider {
 	b64Token := newSessionToken(c, username, JWTTestSecret)
 	return api.NewSessionTokenLoginProvider(b64Token, nil, nil)
-}
-
-// ConvertUsernameToEmail appends an "@canonical.com" domain to a string if it doesn't already contain a domain.
-func ConvertUsernameToEmail(username string) string {
-	if !strings.Contains(username, "@") {
-		return username + "@canonical.com"
-	}
-	return username
 }
 
 func SetupTestDashboardCallbackHandler(browserURL string, db *db.Database, sessionStore sessions.Store) (*httptest.Server, error) {

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -201,7 +201,11 @@ func newSessionToken(c SimpleTester, username string, signatureSecret string) st
 // NewUserSessionLogin returns a login provider than be used with Juju Dial Opts
 // to define how login will take place. In this case we login using a session token
 // that the JIMM server should verify with the same test secret.
+// The username must be a fully qualified external user (e.g. "alice@canonical.com").
 func NewUserSessionLogin(c SimpleTester, username string) api.LoginProvider {
+	if _, err := mail.ParseAddress(username); err != nil {
+		c.Fatalf("invalid username %q: must contain @", username)
+	}
 	b64Token := newSessionToken(c, username, JWTTestSecret)
 	return api.NewSessionTokenLoginProvider(b64Token, nil, nil)
 }

--- a/internal/testutils/jimmtest/auth.go
+++ b/internal/testutils/jimmtest/auth.go
@@ -201,11 +201,7 @@ func newSessionToken(c SimpleTester, username string, signatureSecret string) st
 // NewUserSessionLogin returns a login provider than be used with Juju Dial Opts
 // to define how login will take place. In this case we login using a session token
 // that the JIMM server should verify with the same test secret.
-// The username must be a fully qualified external user (e.g. "alice@canonical.com").
 func NewUserSessionLogin(c SimpleTester, username string) api.LoginProvider {
-	if _, err := mail.ParseAddress(username); err != nil {
-		c.Fatalf("invalid username %q: must contain @", username)
-	}
 	b64Token := newSessionToken(c, username, JWTTestSecret)
 	return api.NewSessionTokenLoginProvider(b64Token, nil, nil)
 }

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -31,7 +31,7 @@ import (
 func TestAddGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -46,7 +46,7 @@ func TestAddGroup(t *testing.T) {
 func TestGetGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -72,7 +72,7 @@ func TestGetGroup(t *testing.T) {
 func TestRemoveGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -177,7 +177,7 @@ func TestRemoveGroupRemovesTuples(t *testing.T) {
 func TestRenameGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -201,7 +201,7 @@ func TestRenameGroup(t *testing.T) {
 func TestListGroups(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1025,7 +1025,7 @@ func TestListRelationshipTuplesWithMissingGroups(t *testing.T) {
 func TestCheckRelationAsNonAdmin(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -1530,10 +1530,10 @@ func setupModelWithCharlieAsAdmin(c *qt.C) (func(jujuparams.UserAccessPermission
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	connBob := s.Open(c, nil, "bob", nil)
+	connBob := s.Open(c, nil, "bob@canonical.com", nil)
 	bobClient := modelmanager.NewClient(connBob)
 
-	connCharlie := s.Open(c, nil, "charlie", nil)
+	connCharlie := s.Open(c, nil, "charlie@canonical.com", nil)
 	charlieClient := modelmanager.NewClient(connCharlie)
 
 	c.Cleanup(func() {
@@ -1680,7 +1680,7 @@ func createTestControllerEnvironment(c *qt.C, s jimmtest.JimmWithControllers) (
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(offer.UUID), qt.Equals, 36)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	client := api.NewClient(conn)
 
 	return *u, group, controller, model, offer, cloud, cred, client, func() {

--- a/testing/admin_test.go
+++ b/testing/admin_test.go
@@ -38,7 +38,7 @@ func TestLoginToController(t *testing.T) {
 
 	conn := s.Open(c, &api.Info{
 		SkipLogin: true,
-	}, "test", nil)
+	}, "test@canonical.com", nil)
 	defer conn.Close()
 	err := conn.Login(nil, "", "", nil)
 	c.Assert(err, qt.ErrorMatches, `JIMM does not support login from old clients \(not supported\)`)
@@ -163,7 +163,7 @@ func TestDeviceLogin(t *testing.T) {
 
 	conn := s.Open(c, &api.Info{
 		SkipLogin: true,
-	}, "test", nil)
+	}, "test@canonical.com", nil)
 	defer conn.Close()
 
 	err := s.JIMM.Database.Migrate(context.Background())
@@ -307,7 +307,7 @@ func TestLoginWithClientCredentials(t *testing.T) {
 
 	conn := s.Open(c, &api.Info{
 		SkipLogin: true,
-	}, "test", nil)
+	}, "test@canonical.com", nil)
 	defer conn.Close()
 
 	const (

--- a/testing/apiproxy_test.go
+++ b/testing/apiproxy_test.go
@@ -29,7 +29,7 @@ func TestConnectToModel(t *testing.T) {
 	conn := s.Open(c, &api.Info{
 		ModelTag:  model.ResourceTag(),
 		SkipLogin: true,
-	}, "test", nil)
+	}, "test@canonical.com", nil)
 	defer conn.Close()
 	var resp map[string]any
 	err := conn.APICall("Admin", 3, "", "TestMethod", nil, &resp)
@@ -54,7 +54,7 @@ func TestSessionTokenLoginProvider(t *testing.T) {
 	conn, err := s.OpenCustomLoginProvider(c, &api.Info{
 		ModelTag:  model.ResourceTag(),
 		SkipLogin: false,
-	}, "alice", api.NewSessionTokenLoginProvider("", &output, func(s string) {}))
+	}, "alice@canonical.com", api.NewSessionTokenLoginProvider("", &output, func(s string) {}))
 	c.Assert(err, qt.IsNil)
 	defer conn.Close()
 	c.Check(err, qt.Equals, nil)
@@ -144,7 +144,7 @@ func TestProxyModelStatusWithoutPermission(t *testing.T) {
 	conn, err := s.OpenCustomLoginProvider(c, &api.Info{
 		ModelTag:  model.ResourceTag(),
 		SkipLogin: false,
-	}, "foo", api.NewSessionTokenLoginProvider("", &output, func(s string) {}))
+	}, "foo@canonical.com", api.NewSessionTokenLoginProvider("", &output, func(s string) {}))
 	c.Check(err, qt.ErrorMatches, "permission denied .*")
 	if conn != nil {
 		defer conn.Close()

--- a/testing/applicationoffers_test.go
+++ b/testing/applicationoffers_test.go
@@ -396,7 +396,7 @@ func TestModifyOfferAccess(t *testing.T) {
 	testUserAccess = testUser.GetApplicationOfferAccess(ctx, offer.ResourceTag())
 	c.Assert(testUserAccess, qt.Equals, ofganames.NoRelation)
 
-	conn3 := s.Open(c, nil, "user3", nil)
+	conn3 := s.Open(c, nil, "user3@canonical.com", nil)
 	defer conn3.Close()
 	client3 := applicationoffers.NewClient(conn3)
 

--- a/testing/caasmodelmanager_test.go
+++ b/testing/caasmodelmanager_test.go
@@ -57,7 +57,7 @@ func SetupCaasModelTest(c *qt.C) caasModelManagerDeps {
 func TestCreateModelKubernetes(t *testing.T) {
 	c := qt.New(t)
 	s := SetupCaasModelTest(c)
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelmanager.NewClient(conn)
@@ -78,7 +78,7 @@ func TestCreateModelKubernetes(t *testing.T) {
 func TestListCAASModelSummaries(t *testing.T) {
 	c := qt.New(t)
 	s := SetupCaasModelTest(c)
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelmanager.NewClient(conn)
@@ -152,7 +152,7 @@ func TestListCAASModels(t *testing.T) {
 	s := SetupCaasModelTest(c)
 	model := s.CreateModelForBob(c)
 	model3 := s.CreateModelForCharlieWithBobReadAccess(c)
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelmanager.NewClient(conn)

--- a/testing/cloud_test.go
+++ b/testing/cloud_test.go
@@ -41,7 +41,7 @@ func TestCloudCall(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	info, err := client.Cloud(names.NewCloudTag(jimmtest.TestE2ECloudName))
@@ -59,7 +59,7 @@ func TestClouds(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := cloudapi.NewClient(conn)
@@ -80,7 +80,7 @@ func TestUserCredentials(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	creds, err := client.UserCredentials(names.NewUserTag("bob@canonical.com"), names.NewCloudTag(jimmtest.TestE2ECloudName))
@@ -114,7 +114,7 @@ func TestUserCredentialsErrors(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	req := jujuparams.UserClouds{
 		UserClouds: []jujuparams.UserCloud{{
@@ -133,7 +133,7 @@ func TestUpdateCloudCredentials(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	credentialTag := names.NewCloudCredentialTag(fmt.Sprintf(jimmtest.TestE2ECloudName + "/test@canonical.com/cred3"))
@@ -162,7 +162,7 @@ func TestUpdateCloudCredentialsErrors(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	req := jujuparams.TaggedCredentials{
 		Credentials: []jujuparams.TaggedCredential{{
@@ -204,7 +204,7 @@ func TestUpdateCloudCredentialsForce(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 
@@ -356,7 +356,7 @@ func TestCredential(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	cred1Name := petname.Generate(2, "-")
 	cred1Tag := names.NewCloudCredentialTag(jimmtest.TestE2ECloudName + "/test@canonical.com/" + cred1Name)
@@ -422,7 +422,7 @@ func TestRevokeCredential(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	credName := petname.Generate(2, "-")
@@ -468,7 +468,7 @@ func TestAddCloud(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "test", cloud.Cloud{
+	addCloud(c, s, "test@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -478,7 +478,7 @@ func TestAddCloud(t *testing.T) {
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false, true)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	clouds, err := client.Clouds()
@@ -501,7 +501,7 @@ func TestRevokeCredentialsCheckModels(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	s.AddAdminUser(c, "test@canonical.com")
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	credentialName := petname.Generate(2, "-")
@@ -583,7 +583,7 @@ func TestAddCloudError(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	cloudName := petname.Generate(2, "-")
@@ -602,7 +602,7 @@ func TestAddCloudNoHostCloudRegion(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	cloudName := petname.Generate(2, "-")
@@ -621,7 +621,7 @@ func TestAddCloudBadName(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	err := client.AddCloud(cloud.Cloud{
@@ -639,7 +639,7 @@ func TestAddCredential(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	credentialTag := names.NewCloudCredentialTag(jimmtest.TestE2ECloudName + "/test@canonical.com/cred3")
@@ -763,7 +763,7 @@ func TestCredentialContentsWithEmptyAttributes(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	credentialName := petname.Generate(2, "-")
@@ -795,7 +795,7 @@ func TestRemoveCloud(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "test", cloud.Cloud{
+	addCloud(c, s, "test@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -805,7 +805,7 @@ func TestRemoveCloud(t *testing.T) {
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false, false)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	clouds, err := client.Clouds()
@@ -833,7 +833,7 @@ func TestRemoveCloudNotFound(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 
@@ -847,7 +847,7 @@ func TestModifyCloudAccess(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "test", cloud.Cloud{
+	addCloud(c, s, "test@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -857,7 +857,7 @@ func TestModifyCloudAccess(t *testing.T) {
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false, true)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	clouds, err := client.Clouds()
@@ -866,7 +866,7 @@ func TestModifyCloudAccess(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 
 	// Check that bob@canonical.com does not yet have access
-	conn2 := s.Open(c, nil, "bob", nil)
+	conn2 := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn2.Close()
 	client2 := cloudapi.NewClient(conn2)
 	clouds, err = client2.Clouds()
@@ -895,7 +895,7 @@ func TestModifyCloudAccessUnauthorized(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "test", cloud.Cloud{
+	addCloud(c, s, "test@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -905,7 +905,7 @@ func TestModifyCloudAccessUnauthorized(t *testing.T) {
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false, true)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	clouds, err := client.Clouds()
@@ -914,7 +914,7 @@ func TestModifyCloudAccessUnauthorized(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 
 	// Try granting cloud access as an unauthorized user.
-	conn2 := s.Open(c, nil, "charlie", nil)
+	conn2 := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn2.Close()
 	client2 := cloudapi.NewClient(conn2)
 	err = client2.GrantCloud("charlie@canonical.com", "add-model", "test-cloud")
@@ -925,7 +925,7 @@ func TestUpdateCloud(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := cloudapi.NewClient(conn)
 	err := client.UpdateCloud(cloud.Cloud{
@@ -944,7 +944,7 @@ func TestCloudInfo(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "alice", cloud.Cloud{
+	addCloud(c, s, "alice@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -954,7 +954,7 @@ func TestCloudInfo(t *testing.T) {
 		HostCloudRegion:  jimmtest.TestE2ECloudName + "/" + jimmtest.TestE2ECloudRegionName,
 	}, false, true)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	args := jujuparams.Entities{
@@ -1009,7 +1009,7 @@ func TestListCloudInfo(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	cloudName := petname.Generate(2, "-")
-	addCloud(c, s, "alice", cloud.Cloud{
+	addCloud(c, s, "alice@canonical.com", cloud.Cloud{
 		Name:             cloudName,
 		Type:             "kubernetes",
 		AuthTypes:        cloud.AuthTypes{cloud.CertificateAuthType},
@@ -1038,7 +1038,7 @@ func TestListCloudInfo(t *testing.T) {
 		All:     false,
 	}
 	var result jujuparams.ListCloudInfoResults
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	err = conn.APICall("Cloud", 7, "", "ListCloudInfo", args, &result)
 	c.Assert(err, qt.Equals, nil)
@@ -1075,7 +1075,7 @@ func TestListCloudInfo(t *testing.T) {
 			}},
 	})
 
-	conn = s.Open(c, nil, "bob", nil)
+	conn = s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	args = jujuparams.ListCloudsRequest{

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -25,7 +25,7 @@ func TestControllerConfigSetNotSupported(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	client := controllerapi.NewClient(conn)
 	err := client.ConfigSet(nil)
@@ -36,7 +36,7 @@ func TestMongoVersion(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := controllerapi.NewClient(conn)
 	_, err := client.MongoVersion()
@@ -50,7 +50,7 @@ func TestAllModels(t *testing.T) {
 	model := s.CreateModelForBob(c)
 	model3 := s.CreateModelForCharlieWithBobReadAccess(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := controllerapi.NewClient(conn)
 
@@ -106,7 +106,7 @@ func TestModelStatus(t *testing.T) {
 		c.Check(status[0].Error, qt.ErrorMatches, "unauthorized")
 	}
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	doTest(controllerapi.NewClient(conn))
 	doTest(modelmanager.NewClient(conn))
@@ -116,7 +116,7 @@ func TestIdentityProviderURL(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	var result jujuparams.StringResult
@@ -129,7 +129,7 @@ func TestControllerVersion(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 
 	var result jujuparams.ControllerVersionResults
@@ -143,7 +143,7 @@ func TestControllerAccess(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := controllerapi.NewClient(conn)
@@ -155,7 +155,7 @@ func TestControllerAccess(t *testing.T) {
 	c.Assert(err, qt.Equals, nil)
 	c.Check(string(access), qt.Equals, "login")
 
-	conn = s.Open(c, nil, "bob", nil)
+	conn = s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client = controllerapi.NewClient(conn)
@@ -171,7 +171,7 @@ func TestControllerConfig(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := controllerapi.NewClient(conn)
@@ -225,7 +225,7 @@ func TestWatchModelSummaries(t *testing.T) {
 		return expectedModels[i].UUID < expectedModels[j].UUID
 	})
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	var watcherID jujuparams.SummaryWatcherID
@@ -284,7 +284,7 @@ func TestWatchAllModelSummaries(t *testing.T) {
 		return expectedModels[i].UUID < expectedModels[j].UUID
 	})
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	var watcherID jujuparams.SummaryWatcherID

--- a/testing/controllerprofile_test.go
+++ b/testing/controllerprofile_test.go
@@ -54,7 +54,7 @@ func TestControllerProfileCRUD(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -96,7 +96,7 @@ func TestControllerProfileValidation(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -145,7 +145,7 @@ func TestControllerProfileListFiltering(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -177,7 +177,7 @@ func TestControllerProfileUnauthorized(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	adminConn := s.Open(c, nil, "alice", nil)
+	adminConn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer adminConn.Close()
 	adminClient := api.NewClient(adminConn)
 
@@ -185,7 +185,7 @@ func TestControllerProfileUnauthorized(t *testing.T) {
 	_, err := adminClient.SaveControllerProfile(&req)
 	c.Assert(err, qt.IsNil)
 
-	conn := s.Open(c, nil, "not-authorized-user", nil)
+	conn := s.Open(c, nil, "not-authorized-user@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 

--- a/testing/controllerroot_test.go
+++ b/testing/controllerroot_test.go
@@ -22,7 +22,7 @@ func TestServerVersion(t *testing.T) {
 	err := s.JIMM.Database.UpdateController(c.Context(), &model.Controller)
 	c.Assert(err, qt.Equals, nil)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 
 	v, ok := conn.ServerVersion()
@@ -38,7 +38,7 @@ func TestUnimplementedMethodFails(t *testing.T) {
 	conn := s.Open(c, &api.Info{
 		ModelTag:  model.ResourceTag(),
 		SkipLogin: true,
-	}, "test", nil)
+	}, "test@canonical.com", nil)
 	defer conn.Close()
 	var resp jujuparams.RedirectInfoResult
 	err := conn.APICall("Admin", 3, "", "Logout", nil, &resp)
@@ -49,7 +49,7 @@ func TestUnimplementedRootFails(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "test", nil)
+	conn := s.Open(c, nil, "test@canonical.com", nil)
 	defer conn.Close()
 	var resp jujuparams.RedirectInfoResult
 	err := conn.APICall("NoSuch", 1, "", "Method", nil, &resp)

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -35,7 +35,7 @@ func TestListControllersAdmin(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -163,7 +163,7 @@ func TestModelGet(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelconfig.NewClient(conn)
@@ -182,7 +182,7 @@ func TestListControllersUnauthorized(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "abrandnewuserwithnopermissions", nil)
+	conn := s.Open(c, nil, "abrandnewuserwithnopermissions@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -195,7 +195,7 @@ func TestAddControllerPublicAddressWithoutPort(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -238,7 +238,7 @@ func TestAddController(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	_, conf := s.GetOneControllerConfig(c)
@@ -279,7 +279,7 @@ func TestAddController(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `cannot add a controller with name "jimm" \(bad request\)`)
 	c.Assert(jujuparams.IsBadRequest(err), qt.Equals, true)
 
-	conn = s.Open(c, nil, "bob", nil)
+	conn = s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client = api.NewClient(conn)
 	acr.Name = "controller-2"
@@ -292,7 +292,7 @@ func TestRemoveAndAddController(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -322,7 +322,7 @@ func TestAddControllerCustomTLSHostname(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -362,7 +362,7 @@ func TestRemoveController(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -385,7 +385,7 @@ func TestRemoveController(t *testing.T) {
 	c.Check(jujuparams.ErrCode(err), qt.Equals, apiparams.CodeStillAlive)
 	s.DestroyModelAndDeleteFromDatabase(c, model.ResourceTag())
 
-	conn2 := s.Open(c, nil, "bob", nil)
+	conn2 := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn2.Close()
 	client2 := api.NewClient(conn2)
 
@@ -418,7 +418,7 @@ func TestSetControllerDeprecated(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -468,7 +468,7 @@ func TestSetControllerDeprecated(t *testing.T) {
 	c.Check(err, qt.ErrorMatches, `controller not found \(not found\)`)
 	c.Check(jujuparams.IsCodeNotFound(err), qt.Equals, true)
 
-	conn = s.Open(c, nil, "bob", nil)
+	conn = s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client = api.NewClient(conn)
 	_, err = client.SetControllerDeprecated(&apiparams.SetControllerDeprecatedRequest{
@@ -484,7 +484,7 @@ func TestAuditLog(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -497,7 +497,7 @@ func TestAuditLog(t *testing.T) {
 	err = mmclient.DestroyModel(model.ResourceTag(), nil, nil, nil, &zeroDuration)
 	c.Assert(err, qt.Equals, nil)
 
-	conn2 := s.Open(c, nil, "alice", nil)
+	conn2 := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn2.Close()
 	client2 := api.NewClient(conn2)
 
@@ -571,7 +571,7 @@ func TestAuditLog(t *testing.T) {
 	c.Assert(err, qt.Equals, nil)
 
 	// now bob can access audit events as well
-	conn3 := s.Open(c, nil, "bob", nil)
+	conn3 := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn3.Close()
 	client3 := api.NewClient(conn3)
 
@@ -585,7 +585,7 @@ func TestAuditLogFilterByMethod(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	evs, err := client.FindAuditEvents(&apiparams.FindAuditEventsRequest{Method: "Deploy"})
@@ -647,7 +647,7 @@ func TestUpdateMigratedModel(t *testing.T) {
 	model2 := s.CreateModelForCharlie(c)
 
 	// Open the API connection as user "bob".
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	req := apiparams.UpdateMigratedModelRequest{
@@ -658,7 +658,7 @@ func TestUpdateMigratedModel(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `unauthorized \(unauthorized access\)`)
 
 	// Open the API connection as user "alice".
-	conn = s.Open(c, nil, "alice", nil)
+	conn = s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	req = apiparams.UpdateMigratedModelRequest{
@@ -682,7 +682,7 @@ func TestImportModel(t *testing.T) {
 	model2 := s.CreateModelForCharlie(c)
 
 	// Open the API connection as user "bob".
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	controllerName := model2.Controller.Name
 
@@ -700,7 +700,7 @@ func TestImportModel(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `unauthorized \(unauthorized access\)`)
 
 	// Open the API connection as user "alice".
-	conn = s.Open(c, nil, "alice", nil)
+	conn = s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	err = conn.APICall("JIMM", 4, "", "ImportModel", &req, nil)
@@ -893,7 +893,7 @@ func TestCrossModelQuery(t *testing.T) {
 	model2 := s.CreateModelForCharlie(c)
 	model3 := s.CreateModelForCharlie(c)
 
-	conn := s.Open(c, nil, "charlie", nil)
+	conn := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -949,7 +949,7 @@ func TestJimmModelMigrationSuperuser(t *testing.T) {
 	model := s.CreateModelForCharlie(c)
 	ctrlName := model.Controller.Name
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 
@@ -998,7 +998,7 @@ func TestVersion(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	versionInfo, err := client.Version()
@@ -1011,7 +1011,7 @@ func TestPrepareModelMigration(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 	_, conf := s.GetOneControllerConfig(c)
@@ -1054,7 +1054,7 @@ func TestListMigrationTargets(t *testing.T) {
 		})
 	}
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1073,7 +1073,7 @@ func TestUpgradeTo_Unauthorized(t *testing.T) {
 	model := s.CreateModelForBob(c)
 	model2 := s.CreateModelForCharlie(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1092,7 +1092,7 @@ func TestUpgradeTo_InvalidModelTag(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1110,7 +1110,7 @@ func TestUpgradeTo_InvalidController(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model2 := s.CreateModelForCharlie(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1126,7 +1126,7 @@ func TestCreateModelOnTargetController(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	// Generate unique model names for each test
@@ -1183,7 +1183,7 @@ func TestModelControllerInfo(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1238,7 +1238,7 @@ func TestPurgeLogs(t *testing.T) {
 	tomorrow := relativeNow.AddDate(0, 0, 1)
 
 	// alice is superuser
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1255,7 +1255,7 @@ func TestPurgeLogs_NotAdmin(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	// bob is not a superuser
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -1269,7 +1269,7 @@ func TestJobInfo(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)

--- a/testing/migrationtarget_test.go
+++ b/testing/migrationtarget_test.go
@@ -22,7 +22,7 @@ func TestAbort(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	modelUUID := "00000001-0000-0000-0000-000000000001"
@@ -35,7 +35,7 @@ func TestCheckMachines(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	modelUUID := "00000001-0000-0000-0000-000000000001"
@@ -48,7 +48,7 @@ func TestPrechecks(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	cct := names.NewCloudCredentialTag(jimmtest.TestE2ECloudName + "/alice@canonical.com/cred")
@@ -102,7 +102,7 @@ func TestCACert(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := migrationtarget.NewClient(conn)
@@ -115,7 +115,7 @@ func TestAdoptResources(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	modelUUID := "00000001-0000-0000-0000-000000000001"
@@ -128,7 +128,7 @@ func TestActivate(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	modelUUID := "00000001-0000-0000-0000-000000000001"
@@ -147,7 +147,7 @@ func TestLatestLogTime(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := migrationtarget.NewClient(conn)
@@ -159,7 +159,7 @@ func TestImport(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := migrationtarget.NewClient(conn)

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -31,7 +31,7 @@ func TestListModelSummaries(t *testing.T) {
 	model := s.CreateModelForBob(c)
 	model3 := s.CreateModelForCharlieWithBobReadAccess(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelmanager.NewClient(conn)
@@ -106,12 +106,12 @@ func TestListModelSummariesWithoutControllerUUIDMasking(t *testing.T) {
 
 	s.CreateModelForBob(c)
 
-	conn1 := s.Open(c, nil, "bob", nil)
+	conn1 := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn1.Close()
 	err := conn1.APICall("JIMM", 4, "", "DisableControllerUUIDMasking", nil, nil)
 	c.Assert(err, qt.ErrorMatches, `unauthorized \(unauthorized access\)`)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	err = conn.APICall("JIMM", 4, "", "DisableControllerUUIDMasking", nil, nil)
@@ -169,7 +169,7 @@ func TestModelInfo(t *testing.T) {
 	model2 := s.CreateModelForCharlie(c)
 	model3 := s.CreateModelForCharlieWithBobReadAccess(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 	models, err := client.ModelInfo([]names.ModelTag{
@@ -243,7 +243,7 @@ func TestModelInfoDisableControllerUUIDMasking(t *testing.T) {
 	)
 	c.Assert(err, qt.Equals, nil)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	// Disable controller UUID masking
@@ -267,7 +267,7 @@ func TestCreateModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	// Generate unique model names for each test
@@ -401,7 +401,7 @@ func TestCreateDuplicateModelsFails(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelName := petname.Generate(2, "-")
@@ -425,11 +425,11 @@ func TestGrantAndRevokeModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 
-	conn2 := s.Open(c, nil, "charlie", nil)
+	conn2 := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn2.Close()
 	client2 := modelmanager.NewClient(conn2)
 
@@ -462,11 +462,11 @@ func TestUserCannotRevokeOwnAccessWithoutAdmin(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 
-	conn2 := s.Open(c, nil, "charlie", nil)
+	conn2 := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn2.Close()
 	client2 := modelmanager.NewClient(conn2)
 
@@ -495,7 +495,7 @@ func TestModifyModelAccessErrors(t *testing.T) {
 	model := s.CreateModelForBob(c)
 	model2 := s.CreateModelForCharlie(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modifyModelAccessErrorTests := []struct {
@@ -589,7 +589,7 @@ func TestDestroyModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	// Create a new model to destroy so we don't affect other tests
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelName := petname.Generate(2, "-")
@@ -624,7 +624,7 @@ func TestDumpModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	tag := model.ResourceTag()
@@ -639,7 +639,7 @@ func TestDumpModelUnauthorized(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "charlie", nil)
+	conn := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn.Close()
 
 	tag := model.ResourceTag()
@@ -654,7 +654,7 @@ func TestDumpModelDB(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	tag := model.ResourceTag()
@@ -669,7 +669,7 @@ func TestDumpModelDBUnauthorized(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "charlie", nil)
+	conn := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn.Close()
 
 	tag := model.ResourceTag()
@@ -684,7 +684,7 @@ func TestChangeModelCredential(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := model.ResourceTag()
@@ -706,7 +706,7 @@ func TestChangeModelCredentialUnauthorizedModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "charlie", nil)
+	conn := s.Open(c, nil, "charlie@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := model.ResourceTag()
@@ -721,7 +721,7 @@ func TestChangeModelCredentialUnauthorizedCredential(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := model.ResourceTag()
@@ -736,7 +736,7 @@ func TestChangeModelCredentialNotFoundModel(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := names.NewModelTag("00000000-0000-0000-0000-000000000000")
@@ -751,7 +751,7 @@ func TestChangeModelCredentialNotFoundCredential(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := model.ResourceTag()
@@ -766,7 +766,7 @@ func TestChangeModelCredentialLocalUserCredential(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	modelTag := model.ResourceTag()
@@ -791,7 +791,7 @@ func TestModelDefaults(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 	client := modelmanager.NewClient(conn)
 
@@ -855,7 +855,7 @@ func TestModelDefaults(t *testing.T) {
 		},
 	})
 
-	conn1 := s.Open(c, nil, "bob", nil)
+	conn1 := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn1.Close()
 	client1 := modelmanager.NewClient(conn1)
 

--- a/testing/role_test.go
+++ b/testing/role_test.go
@@ -24,7 +24,7 @@ func TestAddRole(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -40,7 +40,7 @@ func TestGetRole(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -73,7 +73,7 @@ func TestRemoveRole(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -162,7 +162,7 @@ func TestRenameRole(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -187,7 +187,7 @@ func TestListRoles(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
@@ -220,7 +220,7 @@ func TestUnauthorizedUserForRoleManagerment(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "not-authorized-user", nil)
+	conn := s.Open(c, nil, "not-authorized-user@canonical.com", nil)
 	defer conn.Close()
 	client := api.NewClient(conn)
 

--- a/testing/streammodelproxy_test.go
+++ b/testing/streammodelproxy_test.go
@@ -22,7 +22,7 @@ func TestDebugLogs(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "bob", nil)
+	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "bob@canonical.com", nil)
 	defer conn.Close()
 	logs, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{})
 	c.Assert(err, qt.IsNil)
@@ -40,7 +40,7 @@ func TestDebugLogsWithParams(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "bob", nil)
+	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	logChan, err := common.StreamDebugLog(context.TODO(), conn, common.DebugLogParams{
@@ -89,7 +89,7 @@ func TestDebugLogsError(t *testing.T) {
 	}
 	err = s.JIMM.OpenFGAClient.AddRelation(ctx, tuple)
 	c.Assert(err, qt.IsNil)
-	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "foo", nil)
+	conn := s.Open(c, &api.Info{ModelTag: model.ResourceTag()}, "foo@canonical.com", nil)
 	defer conn.Close()
 	err = s.JIMM.OpenFGAClient.RemoveRelation(ctx, tuple)
 	c.Assert(err, qt.IsNil)

--- a/testing/usermanager_test.go
+++ b/testing/usermanager_test.go
@@ -17,7 +17,7 @@ func TestAddUser(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -29,7 +29,7 @@ func TestRemoveUser(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -41,7 +41,7 @@ func TestEnableUser(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -53,7 +53,7 @@ func TestDisableUser(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -65,7 +65,7 @@ func TestUserInfoAllUsers(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -78,7 +78,7 @@ func TestUserInfoSpecifiedUser(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -99,7 +99,7 @@ func TestUserInfoSpecifiedUsers(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -133,7 +133,7 @@ func TestUserInfoInvalidUsername(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -146,7 +146,7 @@ func TestUserInfoLocalUsername(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)
@@ -159,7 +159,7 @@ func TestSetPassword(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice", nil)
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := usermanager.NewClient(conn)


### PR DESCRIPTION
## Description
Refactor tests to pass in full `@canonical.com` usernames. This makes it clearer what is being tested.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
