### PR TITLE
feat(modelupgrader): add ModelUpgrader facade to support model upgrade

### DIFF
--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -182,6 +182,9 @@ type API interface {
 	// cloud and credential name. Secrets will be included if requested.
 	CredentialContents(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
 
+	// AbortModelUpgrade aborts and archives any in-progress model upgrade.
+	AbortModelUpgrade(modelUUID string) error
+
 	// UpgradeModel upgrades the model to the provided agent version.
 	// The provided target version could be version.Zero, in which case the
 	// best version is selected by the controller and returned as ChosenVersion

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -16,6 +16,7 @@ import (
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -617,6 +618,30 @@ func (j *JujuManager) DumpModelDB(ctx context.Context, user *openfga.User, mt na
 		return nil, err
 	}
 	return dump, nil
+}
+
+// AbortModelUpgrade aborts and archives any in-progress upgrade synchronisation
+// record on the controller for the given model. The user must have writer access
+// to the model (equivalent to Juju's WriteAccess permission).
+func (j *JujuManager) AbortModelUpgrade(ctx context.Context, user *openfga.User, mt names.ModelTag) error {
+	return j.doModel(ctx, user, mt, ofganames.WriterRelation, func(_ *dbmodel.Model, api API) error {
+		return api.AbortModelUpgrade(mt.Id())
+	})
+}
+
+// UpgradeModel upgrades the model with the given model tag to the provided agent
+// version. If the given user does not have writer access to the model then an
+// error with the code CodeUnauthorized is returned. The targetVersion can be
+// version.Zero, in which case the best version is selected by the controller.
+// Writer access is equivalent to Juju's WriteAccess permission.
+func (j *JujuManager) UpgradeModel(ctx context.Context, user *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+	var chosenVersion version.Number
+	err := j.doModel(ctx, user, mt, ofganames.WriterRelation, func(_ *dbmodel.Model, api API) error {
+		var err error
+		chosenVersion, err = api.UpgradeModel(mt.Id(), targetVersion, stream, ignoreAgentVersions, dryRun)
+		return err
+	})
+	return chosenVersion, err
 }
 
 // ValidateModelUpgrade validates that a model is in a state that can be

--- a/internal/jimm/upgrade/mocks/api.go
+++ b/internal/jimm/upgrade/mocks/api.go
@@ -130,6 +130,44 @@ func (c *MockAPIAbortCall) DoAndReturn(f func(string) error) *MockAPIAbortCall {
 	return c
 }
 
+// AbortModelUpgrade mocks base method.
+func (m *MockAPI) AbortModelUpgrade(modelUUID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AbortModelUpgrade", modelUUID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AbortModelUpgrade indicates an expected call of AbortModelUpgrade.
+func (mr *MockAPIMockRecorder) AbortModelUpgrade(modelUUID any) *MockAPIAbortModelUpgradeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortModelUpgrade", reflect.TypeOf((*MockAPI)(nil).AbortModelUpgrade), modelUUID)
+	return &MockAPIAbortModelUpgradeCall{Call: call}
+}
+
+// MockAPIAbortModelUpgradeCall wrap *gomock.Call
+type MockAPIAbortModelUpgradeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAPIAbortModelUpgradeCall) Return(arg0 error) *MockAPIAbortModelUpgradeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAPIAbortModelUpgradeCall) Do(f func(string) error) *MockAPIAbortModelUpgradeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAPIAbortModelUpgradeCall) DoAndReturn(f func(string) error) *MockAPIAbortModelUpgradeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Activate mocks base method.
 func (m *MockAPI) Activate(modelUUID string, sourceInfo migration.SourceControllerInfo, relatedModels []string) error {
 	m.ctrl.T.Helper()

--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -16,6 +16,7 @@ var SupportedFacadeVersions = map[string][]int{
 	"ModelConfig":         []int{3},
 	"ModelManager":        []int{9, 10},
 	"ModelSummaryWatcher": []int{1},
+	"ModelUpgrader":       []int{1},
 	"Pinger":              []int{1},
 	"UserManager":         []int{3},
 }

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -253,6 +253,8 @@ type JujuManager interface {
 	SetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error
 	UnsetModelDefaults(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
+	AbortModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag) error
+	UpgradeModel(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 	SupportedVersions(ctx context.Context, contextualVersion *string) (params.SupportedJujuVersionsResponse, error)
 	// Migration related methods

--- a/internal/jujuapi/modelupgrader.go
+++ b/internal/jujuapi/modelupgrader.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Canonical.
+
+package jujuapi
+
+import (
+	"context"
+
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
+)
+
+func init() {
+	facadeInit["ModelUpgrader"] = func(r *controllerRoot) []int {
+		abortModelUpgradeMethod := rpc.Method(r.AbortModelUpgrade)
+		upgradeModelMethod := rpc.Method(r.UpgradeModel)
+		r.AddMethod("ModelUpgrader", 1, "AbortModelUpgrade", abortModelUpgradeMethod)
+		r.AddMethod("ModelUpgrader", 1, "UpgradeModel", upgradeModelMethod)
+		return []int{1}
+	}
+}
+
+// AbortModelUpgrade aborts and archives any in-progress upgrade for the given model.
+// Aborting a model upgrade is idempotent, so if there is no in-progress upgrade, this method will still succeed.
+func (r *controllerRoot) AbortModelUpgrade(ctx context.Context, args jujuparams.ModelParam) error {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	mt, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.Codef(errors.CodeBadRequest, "%w", err)
+	}
+	return r.jimm.JujuManager().AbortModelUpgrade(ctx, r.user, mt)
+}
+
+// UpgradeModel upgrades the given model's agent to the specified version.
+// If no target version is given (version.Zero), the controller selects the best version.
+// If the target version is greater than the controller's agent version, the upgrade will fail.
+func (r *controllerRoot) UpgradeModel(ctx context.Context, args jujuparams.UpgradeModelParams) (jujuparams.UpgradeModelResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	mt, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return jujuparams.UpgradeModelResult{}, errors.Codef(errors.CodeBadRequest, "%w", err)
+	}
+
+	chosenVersion, err := r.jimm.JujuManager().UpgradeModel(ctx, r.user, mt, args.TargetVersion, args.AgentStream, args.IgnoreAgentVersions, args.DryRun)
+	if err != nil {
+		return jujuparams.UpgradeModelResult{}, err
+	}
+	return jujuparams.UpgradeModelResult{ChosenVersion: chosenVersion}, nil
+}

--- a/internal/jujuapi/modelupgrader_test.go
+++ b/internal/jujuapi/modelupgrader_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+func TestUpgradeModel_BadModelTag(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	result, err := root.UpgradeModel(ctx, jujuparams.UpgradeModelParams{
+		ModelTag: "not-a-valid-tag",
+	})
+	c.Assert(err, qt.ErrorMatches, `.*not-a-valid-tag.*`)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeBadRequest)
+	c.Assert(result, qt.DeepEquals, jujuparams.UpgradeModelResult{})
+}
+
+func TestUpgradeModel_Unauthorized(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	modelUUID := "00000000-0000-0000-0000-000000000001"
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeModel_: func(_ context.Context, _ *openfga.User, _ names.ModelTag, _ version.Number, _ string, _ bool, _ bool) (version.Number, error) {
+						return version.Zero, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	result, err := root.UpgradeModel(ctx, jujuparams.UpgradeModelParams{
+		ModelTag: names.NewModelTag(modelUUID).String(),
+	})
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeUnauthorized)
+	c.Assert(result, qt.DeepEquals, jujuparams.UpgradeModelResult{})
+}
+
+func TestUpgradeModel_Success(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	modelUUID := "00000000-0000-0000-0000-000000000001"
+	targetVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+	chosenVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	called := false
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeModel_: func(_ context.Context, _ *openfga.User, mt names.ModelTag, tv version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+						called = true
+						c.Assert(mt.Id(), qt.Equals, modelUUID)
+						c.Assert(tv, qt.DeepEquals, targetVersion)
+						c.Assert(stream, qt.Equals, "")
+						c.Assert(ignoreAgentVersions, qt.IsFalse)
+						c.Assert(dryRun, qt.IsFalse)
+						return chosenVersion, nil
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	result, err := root.UpgradeModel(ctx, jujuparams.UpgradeModelParams{
+		ModelTag:      names.NewModelTag(modelUUID).String(),
+		TargetVersion: targetVersion,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(called, qt.IsTrue)
+	c.Assert(result.ChosenVersion, qt.DeepEquals, chosenVersion)
+}
+
+func TestUpgradeModel_DryRun(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	modelUUID := "00000000-0000-0000-0000-000000000001"
+	targetVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeModel_: func(_ context.Context, _ *openfga.User, _ names.ModelTag, _ version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+						c.Assert(stream, qt.Equals, "proposed")
+						c.Assert(ignoreAgentVersions, qt.IsTrue)
+						c.Assert(dryRun, qt.IsTrue)
+						return targetVersion, nil
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	result, err := root.UpgradeModel(ctx, jujuparams.UpgradeModelParams{
+		ModelTag:            names.NewModelTag(modelUUID).String(),
+		TargetVersion:       targetVersion,
+		AgentStream:         "proposed",
+		IgnoreAgentVersions: true,
+		DryRun:              true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.ChosenVersion, qt.DeepEquals, targetVersion)
+}

--- a/internal/jujuclient/modelupgrader.go
+++ b/internal/jujuclient/modelupgrader.go
@@ -7,6 +7,11 @@ import (
 	"github.com/juju/version/v2"
 )
 
+// AbortModelUpgrade aborts and archives any in-progress upgrade on the given model.
+func (c Connection) AbortModelUpgrade(modelUUID string) error {
+	return modelupgrader.NewClient(&c).AbortModelUpgrade(modelUUID)
+}
+
 // UpgradeModel upgrades the model to the provided agent version.
 // The provided target version could be version.Zero, in which case the
 // best version is selected by the controller and returned as ChosenVersion

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -172,6 +172,7 @@ type API struct {
 	ListModels_                        func(context.Context) ([]base.UserModel, error)
 	CredentialContents_                func(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
 	UpgradeModel_                      func(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
+	AbortModelUpgrade_                 func(modelUUID string) error
 }
 
 func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
@@ -482,6 +483,13 @@ func (a *API) UpgradeModel(modelUUID string, targetVersion version.Number, strea
 		return version.Number{}, errors.New("not implemented")
 	}
 	return a.UpgradeModel_(modelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
+}
+
+func (a *API) AbortModelUpgrade(modelUUID string) error {
+	if a.AbortModelUpgrade_ == nil {
+		return errors.New("not implemented")
+	}
+	return a.AbortModelUpgrade_(modelUUID)
 }
 
 var _ juju.API = &API{}

--- a/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/api/base"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -38,7 +39,9 @@ type ModelManager struct {
 	QueryModelsJq_          func(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)
 	SetModelDefaults_       func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, configs map[string]any) error
 	UnsetModelDefaults_     func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
+	AbortModelUpgrade_      func(ctx context.Context, u *openfga.User, mt names.ModelTag) error
 	UpdateMigratedModel_    func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
+	UpgradeModel_           func(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	ValidateModelUpgrade_   func(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 	WatchAllModelSummaries_ func(ctx context.Context, controller *dbmodel.Controller) (_ func() error, err error)
 }
@@ -48,6 +51,13 @@ func (j *ModelManager) AddModel(ctx context.Context, u *openfga.User, args *juju
 		return base.ModelInfo{}, errors.New("not implemented")
 	}
 	return j.AddModel_(ctx, u, args)
+}
+
+func (j *ModelManager) AbortModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag) error {
+	if j.AbortModelUpgrade_ == nil {
+		return errors.New("not implemented")
+	}
+	return j.AbortModelUpgrade_(ctx, u, mt)
 }
 
 func (j *ModelManager) ChangeModelCredential(ctx context.Context, user *openfga.User, modelTag names.ModelTag, cloudCredentialTag names.CloudCredentialTag) error {
@@ -165,6 +175,12 @@ func (j *ModelManager) UpdateMigratedModel(ctx context.Context, user *openfga.Us
 		return errors.New("not implemented")
 	}
 	return j.UpdateMigratedModel_(ctx, user, modelTag, targetControllerName)
+}
+func (j *ModelManager) UpgradeModel(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+	if j.UpgradeModel_ == nil {
+		return version.Zero, errors.New("not implemented")
+	}
+	return j.UpgradeModel_(ctx, u, mt, targetVersion, stream, ignoreAgentVersions, dryRun)
 }
 func (j *ModelManager) IdentityModelDefaults(ctx context.Context, user *dbmodel.Identity) (map[string]any, error) {
 	if j.IdentityModelDefaults_ == nil {

--- a/testing/modelupgrader_test.go
+++ b/testing/modelupgrader_test.go
@@ -20,7 +20,7 @@ func TestUpgradeModelDryRun(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelupgrader.NewClient(conn)
@@ -45,7 +45,7 @@ func TestUpgradeModel(t *testing.T) {
 		Patch: ctrlVersion.Patch - 1,
 	}
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	// Create a model pinned to a lower agent version so there is something to upgrade.
@@ -82,7 +82,7 @@ func TestUpgradeModelCrossMajor(t *testing.T) {
 		Major: ctrlVersion.Major + 1,
 	}
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelupgrader.NewClient(conn)
@@ -98,7 +98,7 @@ func TestUpgradeModelUnauthorized(t *testing.T) {
 	// Charlie owns the model; bob only has read access.
 	model := s.CreateModelForCharlieWithBobReadAccess(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelupgrader.NewClient(conn)
@@ -111,7 +111,7 @@ func TestAbortModelUpgrade(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelupgrader.NewClient(conn)
@@ -125,7 +125,7 @@ func TestAbortModelUpgradeUnauthorized(t *testing.T) {
 	// Charlie owns the model; bob only has read access.
 	model := s.CreateModelForCharlieWithBobReadAccess(c)
 
-	conn := s.Open(c, nil, "bob", nil)
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := modelupgrader.NewClient(conn)

--- a/testing/modelupgrader_test.go
+++ b/testing/modelupgrader_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api/client/modelupgrader"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+func TestUpgradeModelDryRun(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	client := modelupgrader.NewClient(conn)
+	chosenVersion, err := client.UpgradeModel(model.UUID.String, version.Zero, "", false, true)
+	c.Assert(err, qt.IsNil)
+	c.Assert(chosenVersion, qt.Not(qt.Equals), version.Zero)
+}
+
+func TestUpgradeModel(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	// Create a reference model to discover the controller's current agent version.
+	refModel := s.CreateModelForBob(c)
+	ctrlVersion := version.MustParse(refModel.Controller.AgentVersion)
+	if ctrlVersion.Patch == 0 {
+		c.Skip("controller patch version is 0, cannot create a model at a lower patch version")
+	}
+	lowerVersion := version.Number{
+		Major: ctrlVersion.Major,
+		Minor: ctrlVersion.Minor,
+		Patch: ctrlVersion.Patch - 1,
+	}
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	// Create a model pinned to a lower agent version so there is something to upgrade.
+	var mi jujuparams.ModelInfo
+	err := conn.APICall("ModelManager", 10, "", "CreateModel", jujuparams.ModelCreateArgs{
+		Name:               petname.Generate(2, "-"),
+		OwnerTag:           names.NewUserTag("bob@canonical.com").String(),
+		CloudTag:           names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:        jimmtest.TestE2ECloudRegionName,
+		CloudCredentialTag: "cloudcred-" + jimmtest.TestE2ECloudName + "_bob@canonical.com_cred",
+		Config: map[string]any{
+			"agent-version": lowerVersion.String(),
+		},
+	}, &mi)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(mi.UUID))
+	})
+
+	// Upgrade the model to the current controller version.
+	upgradeClient := modelupgrader.NewClient(conn)
+	result, err := upgradeClient.UpgradeModel(mi.UUID, ctrlVersion, "", false, false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Equals, ctrlVersion)
+}
+
+func TestUpgradeModelCrossMajor(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+	ctrlVersion := version.MustParse(model.Controller.AgentVersion)
+
+	nextMajorVersion := version.Number{
+		Major: ctrlVersion.Major + 1,
+	}
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	client := modelupgrader.NewClient(conn)
+	// Attempting to upgrade to a version beyond the controller's version is rejected
+	// by the backing controller with the message below.
+	_, err := client.UpgradeModel(model.UUID.String, nextMajorVersion, "", false, false)
+	c.Assert(err, qt.ErrorMatches, `.*cannot upgrade to a version .* greater than that of the controller .*`)
+}
+
+func TestUpgradeModelUnauthorized(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	// Charlie owns the model; bob only has read access.
+	model := s.CreateModelForCharlieWithBobReadAccess(c)
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	client := modelupgrader.NewClient(conn)
+	_, err := client.UpgradeModel(model.UUID.String, version.Zero, "", false, true)
+	c.Assert(err, qt.ErrorMatches, `.*unauthorized.*`)
+}
+
+func TestAbortModelUpgrade(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	client := modelupgrader.NewClient(conn)
+	err := client.AbortModelUpgrade(model.UUID.String)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestAbortModelUpgradeUnauthorized(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	// Charlie owns the model; bob only has read access.
+	model := s.CreateModelForCharlieWithBobReadAccess(c)
+
+	conn := s.Open(c, nil, "bob", nil)
+	defer conn.Close()
+
+	client := modelupgrader.NewClient(conn)
+	err := client.AbortModelUpgrade(model.UUID.String)
+	c.Assert(err, qt.ErrorMatches, `.*unauthorized.*`)
+}


### PR DESCRIPTION
## Description
Add ModelUpgrader.

It's quite simple:
- it calls the juju api client method
- the permission is following juju's https://github.com/juju/juju/blob/3.6/apiserver/facades/client/modelupgrader/upgrader.go#L86-L99, so model writer or controller superuser. 

## QA

e2e testing