### PR TITLE
feat: add support for description v11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,6 +275,7 @@ require (
 require (
 	github.com/google/go-github/v69 v69.2.0
 	github.com/juju/description/v10 v10.0.0
+	github.com/juju/description/v11 v11.0.1
 	github.com/riverqueue/river v0.30.0
 	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.30.0
 	github.com/riverqueue/river/rivertype v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZt
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
 github.com/juju/description/v10 v10.0.0 h1:5BJql9jyiaC3oBjlWuTHYn96mOHiSf08SzykRGYQLHM=
 github.com/juju/description/v10 v10.0.0/go.mod h1:atb839RygQykDwCJxAi2iaEk1fqUdIoptpLWXjjj02A=
+github.com/juju/description/v11 v11.0.1 h1:D9hD4GVoAJcxADoEAy1f2KsJRdTFxdcmAeYxh2jJ3qs=
+github.com/juju/description/v11 v11.0.1/go.mod h1:BFtBIZX120voWjkGO7XmMSqhErTIoDv0rGDje6pEPqI=
 github.com/juju/description/v9 v9.0.0 h1:NgACLkwB5u70ABSTm6TGRe5518ZuSErMmEIxC3WQmeA=
 github.com/juju/description/v9 v9.0.0/go.mod h1:w4GHAaswKodwxc5YMVjR8ZkSwHCjyI3JTtWSbIKHr2s=
 github.com/juju/errors v1.0.0 h1:yiq7kjCLll1BiaRuNY53MGI0+EQ3rF6GB+wvboZDefM=

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -3,12 +3,20 @@
 // Package description provides version-agnostic wrappers around major versions
 // of `github.com/juju/description` which hold Juju model descriptions, to
 // facilitate migrations between different Juju versions.
+// When deserializing, the wrapper will select the appropriate description version
+// based on the target controller version being migrated to. When serializing,
+// the wrapper will use the same description version as was used for deserialization.
+//
+// When updating this package to accomodate a new major version of `github.com/juju/description`,
+// a new wrapper struct should be added that implements the Model interface, and the
+// Deserialize and migrationDescriptionVersion functions should be updated to support the new version.
 package description
 
 import (
 	"fmt"
 
 	descriptionv10 "github.com/juju/description/v10"
+	descriptionv11 "github.com/juju/description/v11"
 	descriptionv9 "github.com/juju/description/v9"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/names/v5"
@@ -17,7 +25,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 )
 
-const latestDescriptionVersion = 10
+const latestDescriptionVersion = 11
 
 // CloudCredentialArgs holds the arguments needed to set a cloud credential.
 type CloudCredentialArgs struct {
@@ -92,6 +100,12 @@ func Deserialize(raw []byte, targetControllerVersion version.Number) (Model, err
 			return nil, fmt.Errorf("failed to deserialize v10 model description: %w", err)
 		}
 		return &migrationDescriptionV10{desc: desc}, nil
+	case 11:
+		desc, err := descriptionv11.Deserialize(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize v11 model description: %w", err)
+		}
+		return &migrationDescriptionV11{desc: desc}, nil
 	default:
 		return nil, errors.New("unsupported description version")
 	}
@@ -107,8 +121,10 @@ func migrationDescriptionVersion(controllerVersion version.Number) (int, error) 
 		return 0, fmt.Errorf("unsupported controller version %s, must be at least 3.6.9", controllerVersion)
 	case v.Compare(version.MustParse("3.6.9")) >= 0 && v.Compare(version.MustParse("3.6.12")) <= 0:
 		return 9, nil
-	case v.Compare(version.MustParse("3.6.13")) == 0:
+	case v.Compare(version.MustParse("3.6.13")) >= 0 && v.Compare(version.MustParse("3.6.22")) <= 0:
 		return 10, nil
+	case v.Compare(version.MustParse("3.6.23")) == 0:
+		return 11, nil
 	default:
 		return latestDescriptionVersion, nil
 	}

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -27,6 +27,11 @@ import (
 
 const latestDescriptionVersion = 11
 
+// latestDescriptionTargetVersion is intentionally higher than any released
+// controller version so migrationDescriptionVersion resolves to the newest
+// supported description wrapper.
+var latestDescriptionTargetVersion = version.MustParse("999.0.0")
+
 // CloudCredentialArgs holds the arguments needed to set a cloud credential.
 type CloudCredentialArgs struct {
 	Owner      names.UserTag
@@ -131,9 +136,9 @@ func migrationDescriptionVersion(controllerVersion version.Number) (int, error) 
 }
 
 // TryDetermineModelUUID attempts to extract the model UUID from the
-// migration description data using the latest known description format.
+// migration description data using the newest supported description wrapper.
 func TryDetermineModelUUID(raw []byte) (string, error) {
-	model, err := descriptionv10.Deserialize(raw)
+	model, err := Deserialize(raw, latestDescriptionTargetVersion)
 	if err != nil {
 		return "", fmt.Errorf("failed to deserialize model description: %w", err)
 	}

--- a/internal/description/description_test.go
+++ b/internal/description/description_test.go
@@ -9,6 +9,7 @@ import (
 	descriptionv10 "github.com/juju/description/v10"
 	descriptionv11 "github.com/juju/description/v11"
 	descriptionv9 "github.com/juju/description/v9"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 )
@@ -196,6 +197,101 @@ func TestDescriptionWrappers(t *testing.T) {
 			c.Check(apps[0].Offers(), qt.HasLen, 1)
 		})
 	}
+}
+
+func TestTryDetermineModelUUID(t *testing.T) {
+	c := qt.New(t)
+	const firstDescriptionVersion = 9
+
+	ownerTag := names.NewUserTag("admin")
+	tests := []struct {
+		name               string
+		descriptionVersion int
+		serialize          func(*qt.C) []byte
+	}{
+		{
+			name:               "v9",
+			descriptionVersion: 9,
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv9.NewModel(descriptionv9.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						config.UUIDKey: "model-uuid",
+					},
+					AgentVersion: "3.6.12",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv9.StatusArgs{Value: "available"})
+				bytes, err := descriptionv9.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+		},
+		{
+			name:               "v10",
+			descriptionVersion: 10,
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv10.NewModel(descriptionv10.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						config.UUIDKey: "model-uuid",
+					},
+					AgentVersion: "3.6.13",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv10.StatusArgs{Value: "available"})
+				bytes, err := descriptionv10.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+		},
+		{
+			name:               "v11",
+			descriptionVersion: 11,
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv11.NewModel(descriptionv11.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						config.UUIDKey: "model-uuid",
+					},
+					AgentVersion: "3.6.23",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv11.StatusArgs{Value: "available"})
+				bytes, err := descriptionv11.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+		},
+	}
+
+	c.Assert(tests, qt.HasLen, latestDescriptionVersion-firstDescriptionVersion+1)
+	for i, tt := range tests {
+		c.Assert(tt.descriptionVersion, qt.Equals, firstDescriptionVersion+i)
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			modelUUID, err := TryDetermineModelUUID(tt.serialize(c))
+			c.Assert(err, qt.IsNil)
+			c.Check(modelUUID, qt.Equals, "model-uuid")
+		})
+	}
+
+	c.Run("missing uuid returns error", func(c *qt.C) {
+		m := descriptionv11.NewModel(descriptionv11.ModelArgs{
+			Owner:        ownerTag,
+			Config:       map[string]any{},
+			AgentVersion: "3.6.23",
+			Type:         "iaas",
+		})
+		m.SetStatus(descriptionv11.StatusArgs{Value: "available"})
+		bytes, err := descriptionv11.Serialize(m)
+		c.Assert(err, qt.IsNil)
+
+		_, err = TryDetermineModelUUID(bytes)
+		c.Assert(err, qt.ErrorMatches, `model config must contain a string value for key "uuid"`)
+	})
 }
 
 func assertWrappedModel(c *qt.C, w Model, ownerTag, userTag names.UserTag, cloudTag names.CloudTag) {

--- a/internal/description/description_test.go
+++ b/internal/description/description_test.go
@@ -7,6 +7,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	descriptionv10 "github.com/juju/description/v10"
+	descriptionv11 "github.com/juju/description/v11"
 	descriptionv9 "github.com/juju/description/v9"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -14,123 +15,216 @@ import (
 
 func TestDescriptionWrappers(t *testing.T) {
 	c := qt.New(t)
+	const firstDescriptionVersion = 9
 
-	// Common data
 	ownerTag := names.NewUserTag("admin")
 	userTag := names.NewUserTag("user1")
 	cloudTag := names.NewCloudTag("aws")
+	updatedOwnerTag := names.NewUserTag("admin-2")
+	updatedCloudTag := names.NewCloudTag("gce")
 
-	// Setup v9 model
-	m9 := descriptionv9.NewModel(descriptionv9.ModelArgs{
-		Owner: ownerTag,
-		Config: map[string]any{
-			"uuid": "model-uuid",
+	tests := []struct {
+		name               string
+		descriptionVersion int
+		controllerVersion  version.Number
+		serialize          func(*qt.C) []byte
+		matchesWrapper     func(Model) bool
+	}{
+		{
+			name:               "v9",
+			descriptionVersion: 9,
+			controllerVersion:  version.MustParse("3.6.12"),
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv9.NewModel(descriptionv9.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						"uuid": "model-uuid",
+					},
+					AgentVersion: "3.6.12",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv9.StatusArgs{Value: "available"})
+				m.AddUser(descriptionv9.UserArgs{Name: userTag, Access: "read"})
+				m.SetCloudCredential(descriptionv9.CloudCredentialArgs{
+					Owner:      ownerTag,
+					Cloud:      cloudTag,
+					Name:       "cred1",
+					AuthType:   "oauth2",
+					Attributes: map[string]string{"a": "b"},
+				})
+				app := m.AddApplication(descriptionv9.ApplicationArgs{Tag: names.NewApplicationTag("app1")})
+				app.SetStatus(descriptionv9.StatusArgs{Value: "active"})
+				app.AddOffer(descriptionv9.ApplicationOfferArgs{
+					OfferName:              "offer1",
+					OfferUUID:              "offer-uuid",
+					ACL:                    map[string]string{"user": "read"},
+					Endpoints:              map[string]string{"relation": "remote"},
+					ApplicationName:        "app1",
+					ApplicationDescription: "desc",
+				})
+				bytes, err := descriptionv9.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+			matchesWrapper: func(m Model) bool {
+				_, ok := m.(*migrationDescriptionV9)
+				return ok
+			},
 		},
-		AgentVersion: "3.6.12",
-		Type:         "iaas",
-	})
-	m9.SetStatus(descriptionv9.StatusArgs{Value: "available"})
-	m9.AddUser(descriptionv9.UserArgs{
-		Name:   userTag,
-		Access: "read",
-	})
-	m9.SetCloudCredential(descriptionv9.CloudCredentialArgs{
-		Owner:      ownerTag,
-		Cloud:      cloudTag,
-		Name:       "cred1",
-		AuthType:   "oauth2",
-		Attributes: map[string]string{"a": "b"},
-	})
-	app9 := m9.AddApplication(descriptionv9.ApplicationArgs{
-		Tag: names.NewApplicationTag("app1"),
-	})
-	app9.SetStatus(descriptionv9.StatusArgs{Value: "active"})
-	app9.AddOffer(descriptionv9.ApplicationOfferArgs{
-		OfferName:              "offer1",
-		OfferUUID:              "offer-uuid",
-		ACL:                    map[string]string{"user": "read"},
-		Endpoints:              map[string]string{"relation": "remote"},
-		ApplicationName:        "app1",
-		ApplicationDescription: "desc",
-	})
-
-	// Serialize v9
-	bytes9, err := descriptionv9.Serialize(m9)
-	c.Assert(err, qt.IsNil)
-
-	// Deserialize using wrapper
-	wrapper9, err := Deserialize(bytes9, version.MustParse("3.6.12"))
-	c.Assert(err, qt.IsNil)
-
-	// Setup v10 model
-	m10 := descriptionv10.NewModel(descriptionv10.ModelArgs{
-		Owner: ownerTag,
-		Config: map[string]any{
-			"uuid": "model-uuid",
+		{
+			name:               "v10",
+			descriptionVersion: 10,
+			controllerVersion:  version.MustParse("3.6.13"),
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv10.NewModel(descriptionv10.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						"uuid": "model-uuid",
+					},
+					AgentVersion: "3.6.13",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv10.StatusArgs{Value: "available"})
+				m.AddUser(descriptionv10.UserArgs{Name: userTag, Access: "read"})
+				m.SetCloudCredential(descriptionv10.CloudCredentialArgs{
+					Owner:      ownerTag,
+					Cloud:      cloudTag,
+					Name:       "cred1",
+					AuthType:   "oauth2",
+					Attributes: map[string]string{"a": "b"},
+				})
+				app := m.AddApplication(descriptionv10.ApplicationArgs{Tag: names.NewApplicationTag("app1")})
+				app.SetStatus(descriptionv10.StatusArgs{Value: "active"})
+				app.AddOffer(descriptionv10.ApplicationOfferArgs{
+					OfferName:              "offer1",
+					OfferUUID:              "offer-uuid",
+					ACL:                    map[string]string{"user": "read"},
+					Endpoints:              map[string]string{"relation": "remote"},
+					ApplicationName:        "app1",
+					ApplicationDescription: "desc",
+				})
+				bytes, err := descriptionv10.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+			matchesWrapper: func(m Model) bool {
+				_, ok := m.(*migrationDescriptionV10)
+				return ok
+			},
 		},
-		AgentVersion: "3.6.13",
-		Type:         "iaas",
-	})
-	m10.SetStatus(descriptionv10.StatusArgs{Value: "available"})
-	m10.AddUser(descriptionv10.UserArgs{
-		Name:   userTag,
-		Access: "read",
-	})
-	m10.SetCloudCredential(descriptionv10.CloudCredentialArgs{
-		Owner:      ownerTag,
-		Cloud:      cloudTag,
-		Name:       "cred1",
-		AuthType:   "oauth2",
-		Attributes: map[string]string{"a": "b"},
-	})
-	app10 := m10.AddApplication(descriptionv10.ApplicationArgs{
-		Tag: names.NewApplicationTag("app1"),
-	})
-	app10.SetStatus(descriptionv10.StatusArgs{Value: "active"})
-	app10.AddOffer(descriptionv10.ApplicationOfferArgs{
-		OfferName:              "offer1",
-		OfferUUID:              "offer-uuid",
-		ACL:                    map[string]string{"user": "read"},
-		Endpoints:              map[string]string{"relation": "remote"},
-		ApplicationName:        "app1",
-		ApplicationDescription: "desc",
-	})
-
-	// Serialize v10
-	bytes10, err := descriptionv10.Serialize(m10)
-	c.Assert(err, qt.IsNil)
-
-	// Deserialize using wrapper
-	wrapper10, err := Deserialize(bytes10, version.MustParse("3.6.13"))
-	c.Assert(err, qt.IsNil)
-
-	// Verify both wrappers return same values
-	wrappers := []Model{wrapper9, wrapper10}
-	for _, w := range wrappers {
-		c.Check(w.Owner(), qt.Equals, ownerTag)
-
-		users := w.Users()
-		c.Assert(users, qt.HasLen, 1)
-		c.Check(users[0].Name(), qt.Equals, userTag)
-		c.Check(users[0].Access(), qt.Equals, "read")
-
-		cred := w.CloudCredential()
-		c.Check(cred.Owner(), qt.Equals, ownerTag.Id())
-		c.Check(cred.Cloud(), qt.Equals, cloudTag.Id())
-		c.Check(cred.Name(), qt.Equals, "cred1")
-		c.Check(cred.AuthType(), qt.Equals, "oauth2")
-		c.Check(cred.Attributes(), qt.DeepEquals, map[string]string{"a": "b"})
-
-		apps := w.Applications()
-		c.Assert(apps, qt.HasLen, 1)
-		c.Check(apps[0].Name(), qt.Equals, "app1")
-
-		offers := apps[0].Offers()
-		c.Assert(offers, qt.HasLen, 1)
-		c.Check(offers[0].OfferName(), qt.Equals, "offer1")
-		c.Check(offers[0].OfferUUID(), qt.Equals, "offer-uuid")
-		c.Check(offers[0].ACL(), qt.DeepEquals, map[string]string{"user": "read"})
+		{
+			name:               "v11",
+			descriptionVersion: 11,
+			controllerVersion:  version.MustParse("3.6.23"),
+			serialize: func(c *qt.C) []byte {
+				m := descriptionv11.NewModel(descriptionv11.ModelArgs{
+					Owner: ownerTag,
+					Config: map[string]any{
+						"uuid": "model-uuid",
+					},
+					AgentVersion: "3.6.23",
+					Type:         "iaas",
+				})
+				m.SetStatus(descriptionv11.StatusArgs{Value: "available"})
+				m.AddUser(descriptionv11.UserArgs{Name: userTag, Access: "read"})
+				m.SetCloudCredential(descriptionv11.CloudCredentialArgs{
+					Owner:      ownerTag,
+					Cloud:      cloudTag,
+					Name:       "cred1",
+					AuthType:   "oauth2",
+					Attributes: map[string]string{"a": "b"},
+				})
+				app := m.AddApplication(descriptionv11.ApplicationArgs{Tag: names.NewApplicationTag("app1")})
+				app.SetStatus(descriptionv11.StatusArgs{Value: "active"})
+				app.AddOffer(descriptionv11.ApplicationOfferArgs{
+					OfferName:              "offer1",
+					OfferUUID:              "offer-uuid",
+					ACL:                    map[string]string{"user": "read"},
+					Endpoints:              map[string]string{"relation": "remote"},
+					ApplicationName:        "app1",
+					ApplicationDescription: "desc",
+				})
+				bytes, err := descriptionv11.Serialize(m)
+				c.Assert(err, qt.IsNil)
+				return bytes
+			},
+			matchesWrapper: func(m Model) bool {
+				_, ok := m.(*migrationDescriptionV11)
+				return ok
+			},
+		},
 	}
+
+	c.Assert(tests, qt.HasLen, latestDescriptionVersion-firstDescriptionVersion+1)
+	for i, tt := range tests {
+		c.Assert(tt.descriptionVersion, qt.Equals, firstDescriptionVersion+i)
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			// Create a wrapper around a specific version of the model description
+			wrapper, err := Deserialize(tt.serialize(c), tt.controllerVersion)
+			c.Assert(err, qt.IsNil)
+			c.Assert(tt.matchesWrapper(wrapper), qt.IsTrue)
+
+			// Check the wrapper's fields match what we expect from the original description
+			assertWrappedModel(c, wrapper, ownerTag, userTag, cloudTag)
+			c.Check(wrapper.Config()["uuid"], qt.Equals, "model-uuid")
+			c.Check(wrapper.CloudRegion(), qt.Equals, "")
+
+			// Update some fields in the wrapper, serialize it, and deserialize it again to check that updates are preserved
+			wrapper.SetOwner(updatedOwnerTag)
+			wrapper.ClearUsers()
+			wrapper.SetCloudCredential(CloudCredentialArgs{
+				Owner:      updatedOwnerTag,
+				Cloud:      updatedCloudTag,
+				Name:       "cred2",
+				AuthType:   "userpass",
+				Attributes: map[string]string{"c": "d"},
+			})
+
+			roundTrip, err := wrapper.Serialize()
+			c.Assert(err, qt.IsNil)
+
+			updatedWrapper, err := Deserialize(roundTrip, tt.controllerVersion)
+			c.Assert(err, qt.IsNil)
+			c.Check(updatedWrapper.Owner(), qt.Equals, updatedOwnerTag)
+			c.Check(updatedWrapper.Users(), qt.HasLen, 0)
+			assertCloudCredential(c, updatedWrapper.CloudCredential(), updatedOwnerTag.Id(), updatedCloudTag.Id(), "cred2", "userpass", map[string]string{"c": "d"})
+			apps := updatedWrapper.Applications()
+			c.Assert(apps, qt.HasLen, 1)
+			c.Check(apps[0].Offers(), qt.HasLen, 1)
+		})
+	}
+}
+
+func assertWrappedModel(c *qt.C, w Model, ownerTag, userTag names.UserTag, cloudTag names.CloudTag) {
+	c.Check(w.Owner(), qt.Equals, ownerTag)
+
+	users := w.Users()
+	c.Assert(users, qt.HasLen, 1)
+	c.Check(users[0].Name(), qt.Equals, userTag)
+	c.Check(users[0].Access(), qt.Equals, "read")
+
+	assertCloudCredential(c, w.CloudCredential(), ownerTag.Id(), cloudTag.Id(), "cred1", "oauth2", map[string]string{"a": "b"})
+
+	apps := w.Applications()
+	c.Assert(apps, qt.HasLen, 1)
+	c.Check(apps[0].Name(), qt.Equals, "app1")
+
+	offers := apps[0].Offers()
+	c.Assert(offers, qt.HasLen, 1)
+	c.Check(offers[0].OfferName(), qt.Equals, "offer1")
+	c.Check(offers[0].OfferUUID(), qt.Equals, "offer-uuid")
+	c.Check(offers[0].ACL(), qt.DeepEquals, map[string]string{"user": "read"})
+}
+
+func assertCloudCredential(c *qt.C, cred CloudCredential, owner, cloud, name, authType string, attributes map[string]string) {
+	c.Check(cred.Owner(), qt.Equals, owner)
+	c.Check(cred.Cloud(), qt.Equals, cloud)
+	c.Check(cred.Name(), qt.Equals, name)
+	c.Check(cred.AuthType(), qt.Equals, authType)
+	c.Check(cred.Attributes(), qt.DeepEquals, attributes)
 }
 
 func TestMigrationDescriptionVersion(t *testing.T) {
@@ -168,17 +262,17 @@ func TestMigrationDescriptionVersion(t *testing.T) {
 			expected: 10,
 		},
 		{
-			name:     "version 3.6.14 returns latest (10)",
+			name:     "version 3.6.14 returns 10",
 			version:  "3.6.14",
-			expected: latestDescriptionVersion,
+			expected: 10,
 		},
 		{
-			name:     "version 3.7.0 returns latest (10)",
+			name:     "version 3.7.0 returns latest (11)",
 			version:  "3.7.0",
 			expected: latestDescriptionVersion,
 		},
 		{
-			name:     "version 4.0.0 returns latest (10)",
+			name:     "version 4.0.0 returns latest (11)",
 			version:  "4.0.0",
 			expected: latestDescriptionVersion,
 		},

--- a/internal/description/v11.go
+++ b/internal/description/v11.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Canonical.
+
+package description
+
+import (
+	descriptionv11 "github.com/juju/description/v11"
+	"github.com/juju/names/v5"
+)
+
+// migrationDescriptionV11 implements the Description interface.
+type migrationDescriptionV11 struct {
+	desc descriptionv11.Model
+}
+
+// Serialize serializes the model description.
+func (md *migrationDescriptionV11) Serialize() ([]byte, error) {
+	return descriptionv11.Serialize(md.desc)
+}
+
+// Owner returns the owner of the model.
+func (md *migrationDescriptionV11) Owner() names.UserTag {
+	return md.desc.Owner()
+}
+
+// SetOwner sets the owner of the model.
+func (md *migrationDescriptionV11) SetOwner(owner names.UserTag) {
+	md.desc.SetOwner(owner)
+}
+
+// Users returns the users with access to the model.
+func (md *migrationDescriptionV11) Users() []User {
+	v10Users := md.desc.Users()
+	users := make([]User, len(v10Users))
+	for i, u := range v10Users {
+		users[i] = u
+	}
+	return users
+}
+
+// ClearUsers removes all users from the model description.
+func (md *migrationDescriptionV11) ClearUsers() {
+	md.desc.SetUsers(nil)
+}
+
+// CloudCredential returns the cloud credential used by the model.
+func (md *migrationDescriptionV11) CloudCredential() CloudCredential {
+	return md.desc.CloudCredential()
+}
+
+// CloudRegion returns the cloud region the model is deployed to.
+func (md *migrationDescriptionV11) CloudRegion() string {
+	return md.desc.CloudRegion()
+}
+
+// SetCloudCredential sets the cloud credential for the model.
+func (md *migrationDescriptionV11) SetCloudCredential(args CloudCredentialArgs) {
+	md.desc.SetCloudCredential(descriptionv11.CloudCredentialArgs{
+		Owner:      args.Owner,
+		Cloud:      args.Cloud,
+		Name:       args.Name,
+		AuthType:   args.AuthType,
+		Attributes: args.Attributes,
+	})
+}
+
+// Config returns the model configuration.
+func (md *migrationDescriptionV11) Config() map[string]any {
+	return md.desc.Config()
+}
+
+// Applications returns the applications in the model.
+func (md *migrationDescriptionV11) Applications() []Application {
+	v11Apps := md.desc.Applications()
+	apps := make([]Application, len(v11Apps))
+	for i, a := range v11Apps {
+		apps[i] = &applicationV11{app: a}
+	}
+	return apps
+}
+
+// applicationV11 wraps an application description.
+type applicationV11 struct {
+	app descriptionv11.Application
+}
+
+// Name returns the application name.
+func (a *applicationV11) Name() string {
+	return a.app.Name()
+}
+
+// Offers returns the application offers.
+func (a *applicationV11) Offers() []ApplicationOffer {
+	v10Offers := a.app.Offers()
+	offers := make([]ApplicationOffer, len(v10Offers))
+	for i, o := range v10Offers {
+		offers[i] = o
+	}
+	return offers
+}

--- a/testing/modelupgrader_test.go
+++ b/testing/modelupgrader_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 
+	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/pkg/api"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 func TestUpgradeModelDryRun(t *testing.T) {
@@ -33,33 +36,49 @@ func TestUpgradeModel(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	// Create a reference model to discover the controller's current agent version.
-	refModel := s.CreateModelForBob(c)
-	ctrlVersion := version.MustParse(refModel.Controller.AgentVersion)
-	if ctrlVersion.Patch == 0 {
-		c.Skip("controller patch version is 0, cannot create a model at a lower patch version")
-	}
-	lowerVersion := version.Number{
-		Major: ctrlVersion.Major,
-		Minor: ctrlVersion.Minor,
-		Patch: ctrlVersion.Patch - 1,
+	ctrlName, _ := s.GetOneControllerConfig(c)
+	controller := dbmodel.Controller{Name: ctrlName}
+	err := s.JIMM.Database.GetController(c.Context(), &controller)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controller.AgentVersion, qt.Not(qt.Equals), "")
+
+	ctrlVersion := version.MustParse(controller.AgentVersion)
+	var lowerVersion version.Number
+	switch ctrlVersion.Major {
+	case 3:
+		lowerVersion = version.Number{
+			Major: 3,
+			Minor: 6,
+			Patch: 20,
+		}
+	case 4:
+		lowerVersion = version.Number{
+			Major: 4,
+			Minor: 0,
+			Patch: 6,
+		}
+	default:
+		c.Fatalf("unexpected controller major version %d", ctrlVersion.Major)
 	}
 
 	conn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
+	jimmClient := api.NewClient(conn)
 
 	// Create a model pinned to a lower agent version so there is something to upgrade.
-	var mi jujuparams.ModelInfo
-	err := conn.APICall("ModelManager", 10, "", "CreateModel", jujuparams.ModelCreateArgs{
-		Name:               petname.Generate(2, "-"),
-		OwnerTag:           names.NewUserTag("bob@canonical.com").String(),
-		CloudTag:           names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
-		CloudRegion:        jimmtest.TestE2ECloudRegionName,
-		CloudCredentialTag: "cloudcred-" + jimmtest.TestE2ECloudName + "_bob@canonical.com_cred",
-		Config: map[string]any{
-			"agent-version": lowerVersion.String(),
+	mi, err := jimmClient.AddModelToController(&apiparams.AddModelToControllerRequest{
+		ModelCreateArgs: jujuparams.ModelCreateArgs{
+			Name:               petname.Generate(2, "-"),
+			OwnerTag:           names.NewUserTag("bob@canonical.com").String(),
+			CloudTag:           names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+			CloudRegion:        jimmtest.TestE2ECloudRegionName,
+			CloudCredentialTag: "cloudcred-" + jimmtest.TestE2ECloudName + "_bob@canonical.com_cred",
+			Config: map[string]any{
+				"agent-version": lowerVersion.String(),
+			},
 		},
-	}, &mi)
+		ControllerName: controller.Name,
+	})
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(mi.UUID))


### PR DESCRIPTION
## Description
This PR adds support in JIMM for description v11, introduced in Juju 3.6.23. Without this change our integration test that imports a model from a standalone Juju controller into JIMM fails.

I've updated the main test to make it easier to add a test case for a new version as the current test was hard-coding test logic for v9 and v10.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests