### PR TITLE
feat: allow multiple model-uuids for the upgrade-to facade

### DIFF
--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -88,10 +88,9 @@ func (c *upgradeToCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer client.Close()
 
-	modelTag := names.NewModelTag(c.modelUUID)
 	resp, err := client.UpgradeTo(&apiparams.UpgradeToRequest{
 		TargetControllerName: c.controllerName,
-		ModelTag:             modelTag.String(),
+		ModelUUIDs:           []string{c.modelUUID},
 	})
 	if err != nil {
 		return err

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -25,7 +25,7 @@ func TestUpgradeTo(t *testing.T) {
 	}
 
 	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Results: []apiparams.UpgradeToResult{{Success: true}},
+		Results: []apiparams.UpgradeToResult{{}},
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 
@@ -37,7 +37,9 @@ func TestUpgradeTo(t *testing.T) {
 	ctx := newTestContext(c)
 	err := upgradeToCmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Matches, "results:\n- success: true\n")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Matches, `results:
+- \{\}
+`)
 }
 
 func TestUpgradeToWithFailureResponse(t *testing.T) {
@@ -124,7 +126,7 @@ func TestUpgradeToWithPositionalArgs(t *testing.T) {
 	}
 
 	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Results: []apiparams.UpgradeToResult{{Success: true}},
+		Results: []apiparams.UpgradeToResult{{}},
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 

--- a/cmd/jaas/cmd/upgradeto_test.go
+++ b/cmd/jaas/cmd/upgradeto_test.go
@@ -17,17 +17,15 @@ func TestUpgradeTo(t *testing.T) {
 	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
-	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetController := "test-controller"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
 		TargetControllerName: testTargetController,
-		ModelTag:             testModelTag,
+		ModelUUIDs:           []string{testModelUUID},
 	}
 
 	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Success: true,
-		JobID:   12345,
+		Results: []apiparams.UpgradeToResult{{Success: true}},
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 
@@ -39,7 +37,7 @@ func TestUpgradeTo(t *testing.T) {
 	ctx := newTestContext(c)
 	err := upgradeToCmd.Run(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Matches, "success: true\njob-id: 12345\n")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Matches, "results:\n- success: true\n")
 }
 
 func TestUpgradeToWithFailureResponse(t *testing.T) {
@@ -47,13 +45,12 @@ func TestUpgradeToWithFailureResponse(t *testing.T) {
 	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
-	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetController := "test-controller"
 	testErrorMessage := "upgrade failed: controller not ready"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
 		TargetControllerName: testTargetController,
-		ModelTag:             testModelTag,
+		ModelUUIDs:           []string{testModelUUID},
 	}
 
 	// Now the error is returned directly by UpgradeTo instead of embedded in the response.
@@ -74,12 +71,11 @@ func TestUpgradeToWithError(t *testing.T) {
 	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
-	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetController := "test-controller"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
 		TargetControllerName: testTargetController,
-		ModelTag:             testModelTag,
+		ModelUUIDs:           []string{testModelUUID},
 	}
 	errorToReturn := errors.New("failed to initiate upgrade")
 	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{}, errorToReturn)
@@ -120,16 +116,15 @@ func TestUpgradeToWithPositionalArgs(t *testing.T) {
 	s := setupCmdMocks(c)
 
 	testModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
-	testModelTag := "model-93608db4-f1cb-4da5-9926-8233981aef0a"
 	testTargetController := "test-controller"
 
 	upgradeToParams := &apiparams.UpgradeToRequest{
 		TargetControllerName: testTargetController,
-		ModelTag:             testModelTag,
+		ModelUUIDs:           []string{testModelUUID},
 	}
 
 	s.client.EXPECT().UpgradeTo(upgradeToParams).Return(apiparams.UpgradeToResponse{
-		Success: true,
+		Results: []apiparams.UpgradeToResult{{Success: true}},
 	}, nil)
 	s.client.EXPECT().Close().Return(nil)
 

--- a/internal/jimm/upgrade/mocks/enqueuer.go
+++ b/internal/jimm/upgrade/mocks/enqueuer.go
@@ -43,18 +43,18 @@ func (m *MockUpgradeEnqueuer) EXPECT() *MockUpgradeEnqueuerMockRecorder {
 }
 
 // EnqueueUpgradeTo mocks base method.
-func (m *MockUpgradeEnqueuer) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
+func (m *MockUpgradeEnqueuer) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs, metadata rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueUpgradeTo", ctx, args)
+	ret := m.ctrl.Call(m, "EnqueueUpgradeTo", ctx, args, metadata)
 	ret0, _ := ret[0].(*rivertype.JobInsertResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnqueueUpgradeTo indicates an expected call of EnqueueUpgradeTo.
-func (mr *MockUpgradeEnqueuerMockRecorder) EnqueueUpgradeTo(ctx, args any) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (mr *MockUpgradeEnqueuerMockRecorder) EnqueueUpgradeTo(ctx, args, metadata any) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueUpgradeTo", reflect.TypeOf((*MockUpgradeEnqueuer)(nil).EnqueueUpgradeTo), ctx, args)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueUpgradeTo", reflect.TypeOf((*MockUpgradeEnqueuer)(nil).EnqueueUpgradeTo), ctx, args, metadata)
 	return &MockUpgradeEnqueuerEnqueueUpgradeToCall{Call: call}
 }
 
@@ -70,13 +70,13 @@ func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Return(arg0 *rivertype.JobInse
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Do(f func(context.Context, rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) Do(f func(context.Context, rivertypes.UpgradeToArgs, rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) DoAndReturn(f func(context.Context, rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
+func (c *MockUpgradeEnqueuerEnqueueUpgradeToCall) DoAndReturn(f func(context.Context, rivertypes.UpgradeToArgs, rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error)) *MockUpgradeEnqueuerEnqueueUpgradeToCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -48,7 +48,7 @@ type Store interface {
 
 // UpgradeEnqueuer defines the method to enqueue an upgrade job.
 type UpgradeEnqueuer interface {
-	EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error)
+	EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs, metadata rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error)
 }
 
 // UpgradeManager provides a means to manage controller upgrades within JIMM.
@@ -189,7 +189,7 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 		TargetVersion:        targetVersion,
 		Username:             user.Name,
 		TargetControllerName: targetControllerName,
-	})
+	}, rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
 	if err != nil {
 		return 0, fmt.Errorf("failed to enqueue model migration and upgrade job: %w", err)
 	}

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -95,11 +95,12 @@ func TestUpgradeTo_Success(t *testing.T) {
 		}, nil)
 
 	// Migration expectations.
-	s.enqueuer.EXPECT().EnqueueUpgradeTo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, uta rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
+	s.enqueuer.EXPECT().EnqueueUpgradeTo(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, uta rivertypes.UpgradeToArgs, metadata rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error) {
 		c.Check(uta.ModelUUID, qt.Equals, modelUUID)
 		c.Check(uta.TargetVersion, qt.Equals, version.Number{Major: 4, Minor: 1, Patch: 0})
 		c.Check(uta.TargetControllerName, qt.Equals, targetController)
 		c.Check(uta.Username, qt.Equals, user.Name)
+		c.Check(metadata, qt.DeepEquals, rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
 		// Don't check target controller name since that is currently generated based on the current time.
 		return &rivertype.JobInsertResult{
 			Job: &rivertype.JobRow{ID: 1},

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -778,19 +778,28 @@ func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToR
 		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	mt, err := names.ParseModelTag(req.ModelTag)
-	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeBadRequest, "invalid model tag %q: %w", req.ModelTag, err)
+	if len(req.ModelUUIDs) == 0 {
+		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeBadRequest, "at least one model UUID must be provided")
 	}
 
-	jobID, err := r.jimm.UpgradeManager().UpgradeTo(ctx, r.user, mt.Id(), req.TargetControllerName)
-	if err != nil {
-		return apiparams.UpgradeToResponse{}, errors.Codef(errors.CodeBadRequest, "failed to run upgrade to: %w", err)
+	results := make([]apiparams.UpgradeToResult, len(req.ModelUUIDs))
+	for i, modelUUID := range req.ModelUUIDs {
+		if !names.IsValidModel(modelUUID) {
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "invalid model UUID %q", modelUUID))
+			continue
+		}
+
+		_, err := r.jimm.UpgradeManager().UpgradeTo(ctx, r.user, modelUUID, req.TargetControllerName)
+		if err != nil {
+			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "failed to run upgrade to for model %q: %w", modelUUID, err))
+			continue
+		}
+
+		results[i].Success = true
 	}
 
 	return apiparams.UpgradeToResponse{
-		Success: true,
-		JobID:   jobID,
+		Results: results,
 	}, nil
 }
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -794,8 +794,6 @@ func (r *controllerRoot) UpgradeTo(ctx context.Context, req apiparams.UpgradeToR
 			results[i].Error = r.mapError(ctx, errors.Codef(errors.CodeBadRequest, "failed to run upgrade to for model %q: %w", modelUUID, err))
 			continue
 		}
-
-		results[i].Success = true
 	}
 
 	return apiparams.UpgradeToResponse{

--- a/internal/river/client.go
+++ b/internal/river/client.go
@@ -5,6 +5,8 @@ package river
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -40,8 +42,14 @@ func NewRiverClient(db *db.Database) (*Client, error) {
 
 // EnqueueUpgradeTo inserts a River job to upgrade a model to the specified version
 // by migrating and upgrading it.
-func (c *Client) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs) (*rivertype.JobInsertResult, error) {
-	job, err := c.client.Insert(ctx, args, nil)
+
+func (c *Client) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeToArgs, metadata rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error) {
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal job metadata: %w", err)
+	}
+
+	job, err := c.client.Insert(ctx, args, &river.InsertOpts{Metadata: metadataBytes})
 	return job, err
 }
 

--- a/internal/rivertypes/types.go
+++ b/internal/rivertypes/types.go
@@ -17,6 +17,11 @@ type UpgradeToArgs struct {
 	TargetControllerName string         `json:"target_controller_name"`
 }
 
+// JobModelUUIDMetadata contains model UUID metadata attached to supervisor jobs.
+type JobModelUUIDMetadata struct {
+	ModelUUID string `json:"model-uuid"`
+}
+
 const UpgradeToJobKind = "upgrade-to"
 
 // Kind implements the [river.JobArgs] interface.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -385,16 +385,21 @@ type RemoveControllerProfileRequest struct {
 
 // UpgradeToRequest holds the parameters for phase 1 for automated upgrades.
 type UpgradeToRequest struct {
-	// ModelTag is the tag of the model to upgrade.
-	ModelTag string `json:"model-tag"`
+	// ModelUUIDs are the UUIDs of the models to upgrade.
+	ModelUUIDs []string `json:"model-uuids" yaml:"model-uuids"`
 	// TargetControllerName is the target controller's name to upgrade to.
 	TargetControllerName string `json:"target-controller-name"`
 }
 
 // UpgradeToResponse holds the response for phase 1 of an automated upgrade.
 type UpgradeToResponse struct {
-	Success bool  `json:"success" yaml:"success"`
-	JobID   int64 `json:"job-id" yaml:"job-id"`
+	Results []UpgradeToResult `json:"results" yaml:"results"`
+}
+
+// UpgradeToResult holds the result for a single model in an UpgradeTo request.
+type UpgradeToResult struct {
+	Success bool              `json:"success" yaml:"success"`
+	Error   *jujuparams.Error `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 // FullModelStatusRequest is the request that is sent in a FullModelStatus method.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -402,8 +402,7 @@ type UpgradeToResponse struct {
 
 // UpgradeToResult holds the result for a single model in an UpgradeTo request.
 type UpgradeToResult struct {
-	Success bool              `json:"success" yaml:"success"`
-	Error   *jujuparams.Error `json:"error,omitempty" yaml:"error,omitempty"`
+	Error *jujuparams.Error `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 // FullModelStatusRequest is the request that is sent in a FullModelStatus method.

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"regexp"
 	"slices"
 	"testing"
 	"time"
@@ -1078,7 +1077,7 @@ func TestUpgradeTo_Unauthorized(t *testing.T) {
 
 	client := api.NewClient(conn)
 	req := apiparams.UpgradeToRequest{
-		ModelTag:             names.NewModelTag(model2.UUID.String).String(),
+		ModelUUIDs:           []string{model2.UUID.String},
 		TargetControllerName: model.Controller.Name,
 	}
 	_, err := client.UpgradeTo(&req)
@@ -1086,8 +1085,8 @@ func TestUpgradeTo_Unauthorized(t *testing.T) {
 	c.Assert(jujuparams.IsCodeUnauthorized(err), qt.Equals, true)
 }
 
-// TestUpgradeTo_InvalidModelTag verifies invalid model tags are rejected.
-func TestUpgradeTo_InvalidModelTag(t *testing.T) {
+// TestUpgradeTo_InvalidModelUUID verifies invalid model UUIDs are rejected.
+func TestUpgradeTo_InvalidModelUUID(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
@@ -1097,11 +1096,15 @@ func TestUpgradeTo_InvalidModelTag(t *testing.T) {
 
 	client := api.NewClient(conn)
 	req := apiparams.UpgradeToRequest{
-		ModelTag:             "invalid-model-tag",
+		ModelUUIDs:           []string{"invalid-model-uuid"},
 		TargetControllerName: model.Controller.Name,
 	}
-	_, err := client.UpgradeTo(&req)
-	c.Assert(err, qt.ErrorMatches, `(invalid model tag "invalid-model-tag": )?"invalid-model-tag" is not a valid tag \(bad request\)`)
+	resp, err := client.UpgradeTo(&req)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp.Results, qt.HasLen, 1)
+	c.Assert(resp.Results[0].Success, qt.IsFalse)
+	c.Assert(resp.Results[0].Error, qt.IsNotNil)
+	c.Assert(resp.Results[0].Error.Message, qt.Equals, `invalid model UUID "invalid-model-uuid"`)
 }
 
 // TestUpgradeTo_InvalidController verifies invalid controllers are rejected.
@@ -1115,11 +1118,15 @@ func TestUpgradeTo_InvalidController(t *testing.T) {
 
 	client := api.NewClient(conn)
 	req := apiparams.UpgradeToRequest{
-		ModelTag:             names.NewModelTag(model2.UUID.String).String(),
+		ModelUUIDs:           []string{model2.UUID.String},
 		TargetControllerName: "does-not-exist",
 	}
-	_, err := client.UpgradeTo(&req)
-	c.Assert(err, qt.ErrorMatches, regexp.QuoteMeta(`failed to run upgrade to: target controller does-not-exist is not a valid migration target for this model (bad request)`))
+	resp, err := client.UpgradeTo(&req)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp.Results, qt.HasLen, 1)
+	c.Assert(resp.Results[0].Success, qt.IsFalse)
+	c.Assert(resp.Results[0].Error, qt.IsNotNil)
+	c.Assert(resp.Results[0].Error.Message, qt.Equals, `failed to run upgrade to for model "`+model2.UUID.String+`": target controller does-not-exist is not a valid migration target for this model`)
 }
 
 func TestCreateModelOnTargetController(t *testing.T) {

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -1102,9 +1102,8 @@ func TestUpgradeTo_InvalidModelUUID(t *testing.T) {
 	resp, err := client.UpgradeTo(&req)
 	c.Assert(err, qt.IsNil)
 	c.Assert(resp.Results, qt.HasLen, 1)
-	c.Assert(resp.Results[0].Success, qt.IsFalse)
 	c.Assert(resp.Results[0].Error, qt.IsNotNil)
-	c.Assert(resp.Results[0].Error.Message, qt.Equals, `invalid model UUID "invalid-model-uuid"`)
+	c.Assert(resp.Results[0].Error.Code, qt.Equals, string(errors.CodeBadRequest))
 }
 
 // TestUpgradeTo_InvalidController verifies invalid controllers are rejected.
@@ -1124,9 +1123,8 @@ func TestUpgradeTo_InvalidController(t *testing.T) {
 	resp, err := client.UpgradeTo(&req)
 	c.Assert(err, qt.IsNil)
 	c.Assert(resp.Results, qt.HasLen, 1)
-	c.Assert(resp.Results[0].Success, qt.IsFalse)
 	c.Assert(resp.Results[0].Error, qt.IsNotNil)
-	c.Assert(resp.Results[0].Error.Message, qt.Equals, `failed to run upgrade to for model "`+model2.UUID.String+`": target controller does-not-exist is not a valid migration target for this model`)
+	c.Assert(resp.Results[0].Error.Code, qt.Equals, string(errors.CodeBadRequest))
 }
 
 func TestCreateModelOnTargetController(t *testing.T) {


### PR DESCRIPTION
## Description

UpgradeTo facede accepts multiple model-uuids. It returns a slice of `Results` to be closer to Juju's way of handling batches