### PR TITLE
feat: store child jobs on supervisor job output

### DIFF
--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -5,7 +5,9 @@ package river
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -56,6 +58,10 @@ func (w *upgradeToWorker) Timeout(*river.Job[rivertypes.UpgradeToArgs]) time.Dur
 // of the migration job and the insertion of the upgrade job).
 func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.UpgradeToArgs]) error {
 	client := river.ClientFromContext[*sql.Tx](ctx)
+	supervisorOutput, err := loadUpgradeToSupervisorOutput(job)
+	if err != nil {
+		return err
+	}
 
 	eventCh, cancel := client.Subscribe(
 		river.EventKindJobCompleted,
@@ -79,6 +85,11 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.Up
 		return err
 	}
 
+	supervisorOutput = withMigrationJobID(supervisorOutput, migrateInsertResponse.Job.ID)
+	if err := persistUpgradeToSupervisorOutput(ctx, client, job.ID, supervisorOutput); err != nil {
+		return err
+	}
+
 	if err := w.awaitCompletion(ctx, migrateInsertResponse, eventCh); err != nil {
 		return err
 	}
@@ -97,11 +108,71 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.Up
 		return err
 	}
 
+	supervisorOutput = withUpgradeJobID(supervisorOutput, upgradeInsertResponse.Job.ID)
+	if err := persistUpgradeToSupervisorOutput(ctx, client, job.ID, supervisorOutput); err != nil {
+		return err
+	}
+
 	if err := w.awaitCompletion(ctx, upgradeInsertResponse, eventCh); err != nil {
 		return err
 	}
 
 	// All done.
+	return nil
+}
+
+func loadUpgradeToSupervisorOutput(job *river.Job[rivertypes.UpgradeToArgs]) (rivertypes.UpgradeToSupervisorOutput, error) {
+	output := rivertypes.UpgradeToSupervisorOutput{
+		ModelUUID:            job.Args.ModelUUID,
+		TargetControllerName: job.Args.TargetControllerName,
+	}
+
+	if len(job.Output()) == 0 {
+		return output, nil
+	}
+
+	var stored rivertypes.UpgradeToSupervisorOutput
+	if err := json.Unmarshal(job.Output(), &stored); err != nil {
+		return output, fmt.Errorf("failed to decode existing supervisor output: %w", err)
+	}
+	if stored.ModelUUID != "" && stored.ModelUUID != job.Args.ModelUUID {
+		return output, fmt.Errorf("stored supervisor output model UUID %q does not match job args %q", stored.ModelUUID, job.Args.ModelUUID)
+	}
+	if stored.TargetControllerName != "" && stored.TargetControllerName != job.Args.TargetControllerName {
+		return output, fmt.Errorf("stored supervisor output target controller %q does not match job args %q", stored.TargetControllerName, job.Args.TargetControllerName)
+	}
+
+	if stored.ModelUUID != "" {
+		output.ModelUUID = stored.ModelUUID
+	}
+	if stored.TargetControllerName != "" {
+		output.TargetControllerName = stored.TargetControllerName
+	}
+	output.MigrationJobID = stored.MigrationJobID
+	output.UpgradeJobID = stored.UpgradeJobID
+	output.UpdatedAt = stored.UpdatedAt
+
+	return output, nil
+}
+
+func withMigrationJobID(output rivertypes.UpgradeToSupervisorOutput, jobID int64) rivertypes.UpgradeToSupervisorOutput {
+	migrationJobID := jobID
+	output.MigrationJobID = &migrationJobID
+	output.UpdatedAt = time.Now().UTC()
+	return output
+}
+
+func withUpgradeJobID(output rivertypes.UpgradeToSupervisorOutput, jobID int64) rivertypes.UpgradeToSupervisorOutput {
+	upgradeJobID := jobID
+	output.UpgradeJobID = &upgradeJobID
+	output.UpdatedAt = time.Now().UTC()
+	return output
+}
+
+func persistUpgradeToSupervisorOutput(ctx context.Context, client *river.Client[*sql.Tx], jobID int64, output rivertypes.UpgradeToSupervisorOutput) error {
+	if _, err := client.JobUpdate(ctx, jobID, &river.JobUpdateParams{Output: output}); err != nil {
+		return fmt.Errorf("failed to persist supervisor output: %w", err)
+	}
 	return nil
 }
 

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -121,6 +121,11 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.Up
 	return nil
 }
 
+// loadUpgradeToSupervisorOutput loads stored output from supervisor job, ensuring that any
+// existing output is consistent with the job args.
+//
+// The output is expected to contain the child job IDs of any previously started child jobs,
+// so that they can be tracked across restarts of the supervisor job.
 func loadUpgradeToSupervisorOutput(job *river.Job[rivertypes.UpgradeToArgs]) (rivertypes.UpgradeToSupervisorOutput, error) {
 	output := rivertypes.UpgradeToSupervisorOutput{
 		ModelUUID:            job.Args.ModelUUID,

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -287,6 +287,218 @@ func TestUpgradeToWorker_SuccessAfterTransientFailures(t *testing.T) {
 	c.Assert(row.Errors, qt.HasLen, 0)
 }
 
+func TestUpgradeToWorker_PersistsMigrationJobIDBeforeWaiting(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	migrationAwaitStarted := make(chan struct{})
+	allowMigrationAwait := make(chan struct{})
+	awaitCalls := 0
+
+	testDeps := setupIntegrationTest(
+		c,
+		setupWorkerParams{
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+				awaitCalls++
+				if awaitCalls == 1 {
+					close(migrationAwaitStarted)
+					<-allowMigrationAwait
+				}
+				return waitForJobToFinalise(ctx, result, eventCh)
+			},
+		},
+	)
+
+	riverClient := testDeps.riverClient
+	username := testDeps.identity
+	upgradeManager := testDeps.mockUpgradeManager
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	insRes, err := riverClient.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, nil)
+	c.Assert(err, qt.IsNil)
+
+	<-migrationAwaitStarted
+
+	output := getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.ModelUUID, qt.Equals, "model-uuid")
+	c.Assert(output.TargetControllerName, qt.Equals, "target-controller")
+	c.Assert(output.MigrationJobID, qt.IsNotNil)
+	c.Assert(output.UpgradeJobID, qt.IsNil)
+
+	migrateListRes, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrateListRes.Jobs, qt.HasLen, 1)
+	c.Assert(*output.MigrationJobID, qt.Equals, migrateListRes.Jobs[0].ID)
+
+	close(allowMigrationAwait)
+
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+	output = getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.MigrationJobID, qt.IsNotNil)
+	c.Assert(output.UpgradeJobID, qt.IsNotNil)
+}
+
+func TestUpgradeToWorker_PersistsBothChildJobIDsBeforeUpgradeWait(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	upgradeAwaitStarted := make(chan struct{})
+	allowUpgradeAwait := make(chan struct{})
+	awaitCalls := 0
+
+	testDeps := setupIntegrationTest(
+		c,
+		setupWorkerParams{
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+				awaitCalls++
+				if awaitCalls == 2 {
+					close(upgradeAwaitStarted)
+					<-allowUpgradeAwait
+				}
+				return waitForJobToFinalise(ctx, result, eventCh)
+			},
+		},
+	)
+
+	riverClient := testDeps.riverClient
+	username := testDeps.identity
+	upgradeManager := testDeps.mockUpgradeManager
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		Return(nil)
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	insRes, err := riverClient.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, nil)
+	c.Assert(err, qt.IsNil)
+
+	<-upgradeAwaitStarted
+
+	output := getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.MigrationJobID, qt.IsNotNil)
+	c.Assert(output.UpgradeJobID, qt.IsNotNil)
+
+	upgradeListRes, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(upgradeListRes.Jobs, qt.HasLen, 1)
+	c.Assert(*output.UpgradeJobID, qt.Equals, upgradeListRes.Jobs[0].ID)
+
+	close(allowUpgradeAwait)
+
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+}
+
+func TestUpgradeToWorker_RetryPreservesStoredUpgradeJobID(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	secondAttemptAfterMigratePersist := make(chan struct{})
+	allowSecondAttemptMigrateWait := make(chan struct{})
+	secondAttemptUpgradeAwaitStarted := make(chan struct{})
+	allowUpgradeToComplete := make(chan struct{})
+	awaitCalls := 0
+
+	testDeps := setupIntegrationTest(
+		c,
+		setupWorkerParams{
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+				awaitCalls++
+				switch awaitCalls {
+				case 2:
+					return errors.New("simulated crash after first upgrade insert")
+				case 3:
+					close(secondAttemptAfterMigratePersist)
+					<-allowSecondAttemptMigrateWait
+				case 4:
+					close(secondAttemptUpgradeAwaitStarted)
+				}
+				return waitForJobToFinalise(ctx, result, eventCh)
+			},
+		},
+	)
+
+	riverClient := testDeps.riverClient
+	username := testDeps.identity
+	upgradeManager := testDeps.mockUpgradeManager
+
+	upgradeManager.EXPECT().
+		MigrateModel(gomock.Any(), gomock.Any(), "model-uuid", "target-controller").
+		Return(nil).
+		Times(2)
+	upgradeManager.EXPECT().
+		UpgradeModel(gomock.Any(), "model-uuid", version.MustParse("2.0.0")).
+		DoAndReturn(func(context.Context, string, version.Number) error {
+			<-allowUpgradeToComplete
+			return nil
+		})
+
+	sub, cancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	c.Cleanup(cancel)
+
+	insRes, err := riverClient.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, nil)
+	c.Assert(err, qt.IsNil)
+
+	<-secondAttemptAfterMigratePersist
+
+	output := getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.MigrationJobID, qt.IsNotNil)
+	c.Assert(output.UpgradeJobID, qt.IsNotNil)
+
+	upgradeListRes, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(upgradeListRes.Jobs, qt.HasLen, 1)
+	c.Assert(*output.UpgradeJobID, qt.Equals, upgradeListRes.Jobs[0].ID)
+
+	close(allowSecondAttemptMigrateWait)
+	<-secondAttemptUpgradeAwaitStarted
+	close(allowUpgradeToComplete)
+
+	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
+	c.Assert(row.State, qt.Equals, rivertype.JobStateCompleted)
+
+	output = getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.MigrationJobID, qt.IsNotNil)
+	c.Assert(output.UpgradeJobID, qt.IsNotNil)
+	c.Assert(*output.UpgradeJobID, qt.Equals, upgradeListRes.Jobs[0].ID)
+}
+
 func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *testing.T) {
 	c := qt.New(t)
 	ctx := c.Context()

--- a/internal/river/utils_test.go
+++ b/internal/river/utils_test.go
@@ -5,6 +5,7 @@ package river
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	qt "github.com/frankban/quicktest"
@@ -16,6 +17,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/rivertypes"
 	"github.com/canonical/jimm/v3/internal/testutils/testdb"
 )
 
@@ -153,4 +155,17 @@ func waitForJobState(c *qt.C, ctx context.Context, riverClient *river.Client[*sq
 			c.Fatal("timed out waiting for job state")
 		}
 	}
+}
+
+func getUpgradeToSupervisorOutput(c *qt.C, ctx context.Context, riverClient *river.Client[*sql.Tx], jobID int64) rivertypes.UpgradeToSupervisorOutput {
+	job, err := riverClient.JobGet(ctx, jobID)
+	c.Assert(err, qt.IsNil)
+
+	var output rivertypes.UpgradeToSupervisorOutput
+	if len(job.Output()) == 0 {
+		return output
+	}
+
+	c.Assert(json.Unmarshal(job.Output(), &output), qt.IsNil)
+	return output
 }

--- a/internal/rivertypes/types.go
+++ b/internal/rivertypes/types.go
@@ -3,6 +3,8 @@
 package rivertypes
 
 import (
+	"time"
+
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/version/v2"
 	"github.com/riverqueue/river"
@@ -37,6 +39,16 @@ func (UpgradeToArgs) InsertOpts() river.InsertOpts {
 			},
 		},
 	}
+}
+
+// UpgradeToSupervisorOutput stores the child-job IDs discovered by the
+// UpgradeTo supervisor so later status lookups can traverse the full tree.
+type UpgradeToSupervisorOutput struct {
+	ModelUUID            string    `json:"model_uuid"`
+	TargetControllerName string    `json:"target_controller_name"`
+	MigrationJobID       *int64    `json:"migration_job_id,omitempty"`
+	UpgradeJobID         *int64    `json:"upgrade_job_id,omitempty"`
+	UpdatedAt            time.Time `json:"updated_at"`
 }
 
 // BootstrapArgs are the arguments for the bootstrap-controller worker.


### PR DESCRIPTION
## Description
This PR adds River ["output"](https://riverqueue.com/docs/recorded-output) information to the parent/supervisor upgrade-to job. Specifically the output information holds details on the child job IDs that will allow for reporting on their status later.

Fixes [JUJU-9547](https://warthogs.atlassian.net/browse/JUJU-9547)

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

[JUJU-9547]: https://warthogs.atlassian.net/browse/JUJU-9547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ