### PR TITLE
feat: add bootstrap metadata to be queried later

### DIFF
--- a/internal/jimm/bootstrap/bootstrap.go
+++ b/internal/jimm/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ package bootstrap
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"runtime"
@@ -62,11 +63,15 @@ type Store interface {
 
 // JobQueue defines the method to enqueue a bootstrap/destroy-controller job.
 type JobQueue interface {
-	EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)
+	EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs, metadata []byte) (*rivertype.JobInsertResult, error)
 	EnqueueDestroyController(ctx context.Context, args rivertypes.DestroyControllerArgs) (*rivertype.JobInsertResult, error)
 	WaitForJobCompletion(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
 	GetJobInfo(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
 	CancelJob(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
+}
+
+type bootstrapJobMetadata struct {
+	ControllerName string `json:"controller-name"`
 }
 
 // JujuManager defines the juju manager methods required by the job.
@@ -312,7 +317,12 @@ func (b *BootstrapManager) StartBootstrapJob(ctx context.Context, user *openfga.
 			ControllerModelConfig: params.BootstrapOptions.ControllerModelConfig,
 		},
 	}
-	job, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs)
+	metadata, err := json.Marshal(bootstrapJobMetadata{ControllerName: params.ControllerName})
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal bootstrap job metadata: %w", err)
+	}
+
+	job, err := b.jobQueue.EnqueueBootstrap(ctx, bootstrapArgs, metadata)
 	if err != nil {
 		return 0, fmt.Errorf("failed to enqueue bootstrap job: %w", err)
 	}

--- a/internal/jimm/bootstrap/bootstrap_test.go
+++ b/internal/jimm/bootstrap/bootstrap_test.go
@@ -4,6 +4,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"runtime"
@@ -214,6 +215,8 @@ func (s *bootstrapManagerSuite) TestStartBootstrapJob_EnqueuesJob(c *qt.C) {
 		gomock.Any(),
 		&dbmodel.Controller{Name: requested.ControllerName},
 	).Return(errors.Codef(errors.CodeNotFound, "test err"))
+	expectedMetadata, err := json.Marshal(map[string]string{"controller-name": requested.ControllerName})
+	c.Assert(err, qt.IsNil)
 
 	mocks.jobQueue.EXPECT().EnqueueBootstrap(gomock.Any(), rivertypes.BootstrapArgs{
 		Username:             "bob@canonical.com",
@@ -225,7 +228,7 @@ func (s *bootstrapManagerSuite) TestStartBootstrapJob_EnqueuesJob(c *qt.C) {
 		Cloud:                requested.Cloud,
 		LoginTokenRefreshURL: loginTokenRefreshURLParam,
 		BootstrapOptions:     expectedRiverBootstrapOptions(requested.BootstrapOptions),
-	}).Return(&rivertype.JobInsertResult{
+	}, expectedMetadata).Return(&rivertype.JobInsertResult{
 		Job: &rivertype.JobRow{
 			ID: 99,
 		},

--- a/internal/jimm/bootstrap/mocks/queue.go
+++ b/internal/jimm/bootstrap/mocks/queue.go
@@ -82,18 +82,18 @@ func (c *MockJobQueueCancelJobCall) DoAndReturn(f func(context.Context, int64) (
 }
 
 // EnqueueBootstrap mocks base method.
-func (m *MockJobQueue) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error) {
+func (m *MockJobQueue) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs, metadata []byte) (*rivertype.JobInsertResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueBootstrap", ctx, args)
+	ret := m.ctrl.Call(m, "EnqueueBootstrap", ctx, args, metadata)
 	ret0, _ := ret[0].(*rivertype.JobInsertResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnqueueBootstrap indicates an expected call of EnqueueBootstrap.
-func (mr *MockJobQueueMockRecorder) EnqueueBootstrap(ctx, args any) *MockJobQueueEnqueueBootstrapCall {
+func (mr *MockJobQueueMockRecorder) EnqueueBootstrap(ctx, args, metadata any) *MockJobQueueEnqueueBootstrapCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueBootstrap", reflect.TypeOf((*MockJobQueue)(nil).EnqueueBootstrap), ctx, args)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueBootstrap", reflect.TypeOf((*MockJobQueue)(nil).EnqueueBootstrap), ctx, args, metadata)
 	return &MockJobQueueEnqueueBootstrapCall{Call: call}
 }
 
@@ -109,13 +109,13 @@ func (c *MockJobQueueEnqueueBootstrapCall) Return(arg0 *rivertype.JobInsertResul
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJobQueueEnqueueBootstrapCall) Do(f func(context.Context, rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
+func (c *MockJobQueueEnqueueBootstrapCall) Do(f func(context.Context, rivertypes.BootstrapArgs, []byte) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJobQueueEnqueueBootstrapCall) DoAndReturn(f func(context.Context, rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
+func (c *MockJobQueueEnqueueBootstrapCall) DoAndReturn(f func(context.Context, rivertypes.BootstrapArgs, []byte) (*rivertype.JobInsertResult, error)) *MockJobQueueEnqueueBootstrapCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/river/client.go
+++ b/internal/river/client.go
@@ -46,8 +46,8 @@ func (c *Client) EnqueueUpgradeTo(ctx context.Context, args rivertypes.UpgradeTo
 }
 
 // EnqueueBootstrap inserts a River job to bootstrap a new controller.
-func (c *Client) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs) (*rivertype.JobInsertResult, error) {
-	job, err := c.client.Insert(ctx, args, nil)
+func (c *Client) EnqueueBootstrap(ctx context.Context, args rivertypes.BootstrapArgs, metadata []byte) (*rivertype.JobInsertResult, error) {
+	job, err := c.client.Insert(ctx, args, &river.InsertOpts{Metadata: metadata})
 	return job, err
 }
 

--- a/internal/river/client_test.go
+++ b/internal/river/client_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Canonical.
+
+package river
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
+	"github.com/riverqueue/river/rivertype"
+)
+
+const metadataQueryTestJobKind = "metadata-query-test"
+
+type metadataQueryTestArgs struct{}
+
+func (metadataQueryTestArgs) Kind() string { return metadataQueryTestJobKind }
+
+func TestInsert_MetadataQueryable_WithoutWorkers(t *testing.T) {
+	c := qt.New(t)
+
+	_, sqlDB := setupTestDB(c)
+	riverClient, err := river.NewClient(riverdatabasesql.New(sqlDB), &river.Config{})
+	c.Assert(err, qt.IsNil)
+
+	controllerName := "controller-queryable"
+	metadata := map[string]any{
+		"controller-name": controllerName,
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	c.Assert(err, qt.IsNil)
+
+	insRes, err := riverClient.Insert(c.Context(), metadataQueryTestArgs{}, &river.InsertOpts{Metadata: metadataBytes})
+	c.Assert(err, qt.IsNil)
+
+	jobs, err := riverClient.JobList(
+		c.Context(),
+		river.NewJobListParams().
+			Kinds(metadataQueryTestJobKind).
+			First(1).
+			States(
+				rivertype.JobStateAvailable,
+			).
+			Where(
+				"metadata->>'controller-name' = @controller_name",
+				river.NamedArgs{"controller_name": controllerName},
+			),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobs.Jobs, qt.HasLen, 1)
+	c.Assert(jobs.Jobs[0].ID, qt.Equals, insRes.Job.ID)
+	c.Assert(jobs.Jobs[0].State, qt.Equals, rivertype.JobStateAvailable)
+	c.Assert(jobs.Jobs[0].FinalizedAt, qt.IsNil)
+
+	var gotMetadata map[string]any
+	err = json.Unmarshal(jobs.Jobs[0].Metadata, &gotMetadata)
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotMetadata, qt.DeepEquals, metadata)
+}


### PR DESCRIPTION
## Description

Fixes https://warthogs.atlassian.net/browse/JUJU-9552

Add bootstrap name to river job metadata, so later-on can be queried.


Althougth this seems very simple the godoc for `Metadata` is:
```
// Metadata is a JSON object blob of arbitrary data that will be stored with
// the job. Users should not overwrite or remove anything stored in this
// field by River.
Metadata []byte
```

@ale8k are we sure we are supposed to use this field?

Reading other features:
[ResumableStep](https://pkg.go.dev/github.com/riverqueue/river#ResumableStep) wraps a named unit of work. On the first attempt, all steps run in order. If a step returns an error, River records the last successfully completed step in the job's metadata

Are we sure we are supposed to write in here? are we at risk of compromising other features?

Edit: after a bit of digging through the code, the insertion is fine because no other metadata are written yet.
However if you collide with River metadata they will be overriden, so it would be better to have very specific names for metadata field.
In our case "controller-name" i think it's perfectly fine