### PR TITLE
test: fix flaky test by allowing multiple calls to `Stop()`

### DIFF
--- a/internal/jimm/juju/watcher_test.go
+++ b/internal/jimm/juju/watcher_test.go
@@ -273,7 +273,7 @@ func TestWatcherClearsControllerUnavailable(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	})
-	mockWatcher.EXPECT().Stop().Return(nil)
+	mockWatcher.EXPECT().Stop().Return(nil).AnyTimes()
 
 	w := juju.Watcher{
 		Database: &db.Database{


### PR DESCRIPTION
## Description

The reason the test is flaky is that it can happen a watcher is instanciate in the WatchAllModelSummaries for loop before it is cancelled.

# QA

Run the test with `stress` and now it's not flaky anymore.