### PR TITLE
feat: upgrade-to details in show-model output

### DIFF
--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -4,17 +4,27 @@ package jobs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/rivertypes"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 const defaultListJobsCount = 100
 const maxListJobsCount = 10_000
+
+var activeUpgradeToJobStates = []rivertype.JobState{
+	rivertype.JobStateAvailable,
+	rivertype.JobStatePending,
+	rivertype.JobStateRunning,
+	rivertype.JobStateRetryable,
+	rivertype.JobStateScheduled,
+}
 
 // JobQuerier defines the interface for querying and managing jobs in JIMM.
 type JobQuerier interface {
@@ -59,6 +69,51 @@ func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (JobInfo, erro
 		FinishedAt:     jobRow.FinalizedAt,
 		Errors:         jobErrors,
 	}, nil
+}
+
+// GetUpgradeToStatusForModel returns the status of the current or most recent
+// discarded upgrade-to supervisor job for the specified model.
+func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*apiparams.UpgradeToJobStatus, error) {
+	rootJob, err := j.findUpgradeToRootJob(ctx, modelUUID)
+	if err != nil {
+		return nil, err
+	}
+	if rootJob == nil {
+		return nil, nil
+	}
+
+	status := &apiparams.UpgradeToJobStatus{
+		Root: toJobDetail(rootJob),
+	}
+
+	if len(rootJob.Output()) == 0 {
+		return status, nil
+	}
+
+	var output rivertypes.UpgradeToSupervisorOutput
+	if err := json.Unmarshal(rootJob.Output(), &output); err != nil {
+		return nil, fmt.Errorf("failed to decode upgrade-to supervisor output: %w", err)
+	}
+
+	if output.MigrationJobID != nil {
+		migrationJob, err := j.jobQuerier.GetJobInfo(ctx, *output.MigrationJobID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get migration job info: %w", err)
+		}
+		migration := toJobDetail(migrationJob)
+		status.Migration = &migration
+	}
+
+	if output.UpgradeJobID != nil {
+		upgradeJob, err := j.jobQuerier.GetJobInfo(ctx, *output.UpgradeJobID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get upgrade job info: %w", err)
+		}
+		upgrade := toJobDetail(upgradeJob)
+		status.Upgrade = &upgrade
+	}
+
+	return status, nil
 }
 
 // ListJobs returns a list of jobs based on the provided parameters. It converts the API parameters to the internal river job query parameters and retrieves the job list from the job querier.
@@ -155,6 +210,67 @@ func convertJobStates(statuses []apiparams.JobStatus) ([]rivertype.JobState, err
 	}
 
 	return riverStates, nil
+}
+
+func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string) (*rivertype.JobRow, error) {
+	activeJobs, err := j.jobQuerier.ListJobs(
+		ctx,
+		river.NewJobListParams().
+			Kinds(rivertypes.UpgradeToJobKind).
+			First(1).
+			States(activeUpgradeToJobStates...).
+			Where(
+				"metadata->>'model-uuid' = @model_uuid",
+				river.NamedArgs{"model_uuid": modelUUID},
+			),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(activeJobs.Jobs) > 0 {
+		return activeJobs.Jobs[0], nil
+	}
+
+	discardedJobs, err := j.jobQuerier.ListJobs(
+		ctx,
+		river.NewJobListParams().
+			Kinds(rivertypes.UpgradeToJobKind).
+			First(1).
+			States(rivertype.JobStateDiscarded).
+			Where(
+				"metadata->>'model-uuid' = @model_uuid",
+				river.NamedArgs{"model_uuid": modelUUID},
+			).
+			OrderBy(river.JobListOrderByTime, river.SortOrderDesc),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(discardedJobs.Jobs) == 0 {
+		return nil, nil
+	}
+
+	return discardedJobs.Jobs[0], nil
+}
+
+func toJobDetail(jobRow *rivertype.JobRow) apiparams.JobDetail {
+	var jobErrors []apiparams.JobAttemptError
+	for _, err := range jobRow.Errors {
+		jobErrors = append(jobErrors, apiparams.JobAttemptError{
+			Attempt: err.Attempt,
+			At:      err.At,
+			Error:   err.Error,
+		})
+	}
+
+	return apiparams.JobDetail{
+		State:       string(jobRow.State),
+		Attempt:     jobRow.Attempt,
+		MaxAttempts: jobRow.MaxAttempts,
+		AttemptedAt: jobRow.AttemptedAt,
+		FinalizedAt: jobRow.FinalizedAt,
+		Errors:      jobErrors,
+	}
 }
 
 // toJobStatus converts a rivertype.JobState to a params.JobStatus.

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -26,6 +26,12 @@ var activeUpgradeToJobStates = []rivertype.JobState{
 	rivertype.JobStateScheduled,
 }
 
+var finalizedUpgradeToJobStates = []rivertype.JobState{
+	rivertype.JobStateCancelled,
+	rivertype.JobStateCompleted,
+	rivertype.JobStateDiscarded,
+}
+
 // JobQuerier defines the interface for querying and managing jobs in JIMM.
 type JobQuerier interface {
 	GetJobInfo(ctx context.Context, jobID int64) (*rivertype.JobRow, error)
@@ -72,7 +78,7 @@ func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (JobInfo, erro
 }
 
 // GetUpgradeToStatusForModel returns the status of the current or most recent
-// discarded upgrade-to supervisor job for the specified model.
+// finalized upgrade-to supervisor job for the specified model.
 func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*apiparams.UpgradeToJobStatus, error) {
 	rootJob, err := j.findUpgradeToRootJob(ctx, modelUUID)
 	if err != nil {
@@ -212,6 +218,13 @@ func convertJobStates(statuses []apiparams.JobStatus) ([]rivertype.JobState, err
 	return riverStates, nil
 }
 
+// findUpgradeToRootJob finds the current active or most recently finalized
+// upgrade-to supervisor job for the specified model.
+//
+// This uses two queries so an in-flight supervisor job is preferred over any
+// older finalized job. If no active job exists, it falls back to the most
+// recently finalized supervisor so callers can still see the last terminal
+// upgrade-to status.
 func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string) (*rivertype.JobRow, error) {
 	activeJobs, err := j.jobQuerier.ListJobs(
 		ctx,
@@ -231,12 +244,12 @@ func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string)
 		return activeJobs.Jobs[0], nil
 	}
 
-	discardedJobs, err := j.jobQuerier.ListJobs(
+	finalizedJobs, err := j.jobQuerier.ListJobs(
 		ctx,
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(1).
-			States(rivertype.JobStateDiscarded).
+			States(finalizedUpgradeToJobStates...).
 			Where(
 				"metadata->>'model-uuid' = @model_uuid",
 				river.NamedArgs{"model_uuid": modelUUID},
@@ -246,11 +259,11 @@ func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string)
 	if err != nil {
 		return nil, err
 	}
-	if len(discardedJobs.Jobs) == 0 {
+	if len(finalizedJobs.Jobs) == 0 {
 		return nil, nil
 	}
 
-	return discardedJobs.Jobs[0], nil
+	return finalizedJobs.Jobs[0], nil
 }
 
 func toJobDetail(jobRow *rivertype.JobRow) apiparams.JobDetail {

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -367,7 +367,7 @@ func TestGetUpgradeToStatusForModel_InvalidSupervisorOutput(t *testing.T) {
 	c.Assert(status, qt.IsNil)
 }
 
-func TestGetUpgradeToStatusForModel_UsesLatestDiscardedRoot(t *testing.T) {
+func TestGetUpgradeToStatusForModel_UsesLatestFinalizedRoot(t *testing.T) {
 	c := qt.New(t)
 	ctx := c.Context()
 
@@ -398,4 +398,18 @@ func TestGetUpgradeToStatusForModel_UsesLatestDiscardedRoot(t *testing.T) {
 	c.Assert(status.Root.State, qt.Equals, string(rivertype.JobStateDiscarded))
 	c.Assert(status.Root.Errors, qt.HasLen, 1)
 	c.Assert(status.Root.Errors[0].Error, qt.Equals, "discarded upgrade root for discard-second")
+
+	_, err = client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "complete-third",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+	waitForJobs(c, client, 1, defaultTestTimeout)
+
+	status, err = jobManager.GetUpgradeToStatusForModel(ctx, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.IsNotNil)
+	c.Assert(status.Root.State, qt.Equals, string(rivertype.JobStateCompleted))
+	c.Assert(status.Root.Errors, qt.HasLen, 0)
 }

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -5,15 +5,20 @@ package jobs
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
+	"github.com/riverqueue/river/rivertype"
 
 	"github.com/canonical/jimm/v3/internal/db"
 	jimmriver "github.com/canonical/jimm/v3/internal/river"
+	"github.com/canonical/jimm/v3/internal/rivertypes"
 	"github.com/canonical/jimm/v3/internal/testutils/testdb"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
@@ -62,6 +67,19 @@ func (w *failureJobWorker) Work(ctx context.Context, job *river.Job[failureJobAr
 	return &river.JobCancelError{}
 }
 
+// upgradeToTestWorker exists only to register the upgrade-to kind with the test
+// client. Tests place root jobs on an unworked queue so this worker should not run.
+type upgradeToTestWorker struct {
+	river.WorkerDefaults[rivertypes.UpgradeToArgs]
+}
+
+func (w *upgradeToTestWorker) Work(ctx context.Context, job *river.Job[rivertypes.UpgradeToArgs]) error {
+	if strings.HasPrefix(job.Args.Username, "discard-") {
+		return fmt.Errorf("discarded upgrade root for %s", job.Args.Username)
+	}
+	return nil
+}
+
 // waitForJobs waits for the specified number of jobs to complete or fail.
 // Returns when all jobs have finalized or timeout occurs.
 func waitForJobs(c *qt.C, client *river.Client[*sql.Tx], expectedCount int, timeout time.Duration) {
@@ -102,6 +120,8 @@ func setupJobsIntegrationTest(c *qt.C) (*JobManager, *river.Client[*sql.Tx]) {
 	err = river.AddWorkerSafely(workers, &successJobWorker{})
 	c.Assert(err, qt.IsNil)
 	err = river.AddWorkerSafely(workers, &failureJobWorker{})
+	c.Assert(err, qt.IsNil)
+	err = river.AddWorkerSafely(workers, &upgradeToTestWorker{})
 	c.Assert(err, qt.IsNil)
 
 	// Start River client
@@ -277,4 +297,105 @@ func TestListJobs_FilterByKind(t *testing.T) {
 	}
 	c.Assert(successCount, qt.Equals, 3, qt.Commentf("Expected 3 success jobs, got %d", successCount))
 	c.Assert(failureCount, qt.Equals, 2, qt.Commentf("Expected 2 failure jobs, got %d", failureCount))
+}
+
+func TestGetUpgradeToStatusForModel_HydratesChildJobs(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	jobManager, client := setupJobsIntegrationTest(c)
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+
+	migrationRes, err := client.Insert(ctx, successJobArgs{Name: "migration"}, nil)
+	c.Assert(err, qt.IsNil)
+	upgradeRes, err := client.Insert(ctx, failureJobArgs{Name: "upgrade"}, nil)
+	c.Assert(err, qt.IsNil)
+
+	waitForJobs(c, client, 2, defaultTestTimeout)
+
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
+	c.Assert(err, qt.IsNil)
+	rootRes, err := client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "alice@canonical.com",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, Queue: "inactive"})
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.JobUpdate(ctx, rootRes.Job.ID, &river.JobUpdateParams{Output: rivertypes.UpgradeToSupervisorOutput{
+		ModelUUID:            modelUUID,
+		TargetControllerName: "target-controller",
+		MigrationJobID:       &migrationRes.Job.ID,
+		UpgradeJobID:         &upgradeRes.Job.ID,
+		UpdatedAt:            time.Now().UTC(),
+	}})
+	c.Assert(err, qt.IsNil)
+
+	status, err := jobManager.GetUpgradeToStatusForModel(ctx, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.IsNotNil)
+	c.Assert(status.Root.State, qt.Equals, string(rootRes.Job.State))
+	c.Assert(status.Migration, qt.IsNotNil)
+	c.Assert(status.Migration.State, qt.Equals, string(rivertype.JobStateCompleted))
+	c.Assert(status.Upgrade, qt.IsNotNil)
+	c.Assert(status.Upgrade.State, qt.Equals, string(rivertype.JobStateCancelled))
+	c.Assert(status.Upgrade.Errors, qt.HasLen, 1)
+	c.Assert(status.Upgrade.Errors[0].Error, qt.Not(qt.Equals), "")
+}
+
+func TestGetUpgradeToStatusForModel_InvalidSupervisorOutput(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	jobManager, client := setupJobsIntegrationTest(c)
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
+	c.Assert(err, qt.IsNil)
+	rootRes, err := client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "alice@canonical.com",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, Queue: "inactive"})
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.JobUpdate(ctx, rootRes.Job.ID, &river.JobUpdateParams{Output: "not-a-supervisor-output-object"})
+	c.Assert(err, qt.IsNil)
+
+	status, err := jobManager.GetUpgradeToStatusForModel(ctx, modelUUID)
+	c.Assert(err, qt.ErrorMatches, "failed to decode upgrade-to supervisor output: .*")
+	c.Assert(status, qt.IsNil)
+}
+
+func TestGetUpgradeToStatusForModel_UsesLatestDiscardedRoot(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	jobManager, client := setupJobsIntegrationTest(c)
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "discard-first",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+	waitForJobs(c, client, 1, defaultTestTimeout)
+
+	_, err = client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "discard-second",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+	waitForJobs(c, client, 1, defaultTestTimeout)
+
+	status, err := jobManager.GetUpgradeToStatusForModel(ctx, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.IsNotNil)
+	c.Assert(status.Root.State, qt.Equals, string(rivertype.JobStateDiscarded))
+	c.Assert(status.Root.Errors, qt.HasLen, 1)
+	c.Assert(status.Root.Errors[0].Error, qt.Equals, "discarded upgrade root for discard-second")
 }

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/frankban/quicktest"
+	qt "github.com/frankban/quicktest"
+	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ type testDeps struct {
 	jobQuerier *MockJobQuerier
 }
 
-func setupDeps(c *quicktest.C) testDeps {
+func setupDeps(c *qt.C) testDeps {
 	ctrl := gomock.NewController(c)
 	jobQuerier := NewMockJobQuerier(ctrl)
 	c.Cleanup(ctrl.Finish)
@@ -38,7 +39,7 @@ func setupDeps(c *quicktest.C) testDeps {
 }
 
 func TestGetJobInfo_Success(t *testing.T) {
-	c := quicktest.New(t)
+	c := qt.New(t)
 	deps := setupDeps(c)
 
 	ctx := context.Background()
@@ -68,7 +69,7 @@ func TestGetJobInfo_Success(t *testing.T) {
 }
 
 func TestGetJobInfo_QueryError(t *testing.T) {
-	c := quicktest.New(t)
+	c := qt.New(t)
 	deps := setupDeps(c)
 
 	ctx := context.Background()
@@ -78,13 +79,41 @@ func TestGetJobInfo_QueryError(t *testing.T) {
 		Return(nil, errors.New("query error"))
 
 	_, err := deps.jobManager.GetJobInfo(ctx, jobID)
-	c.Assert(err, quicktest.IsNotNil)
-	c.Assert(err, quicktest.ErrorMatches, "query error")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, "query error")
 }
 
 func TestNewJobManager_NilQuerier(t *testing.T) {
-	c := quicktest.New(t)
+	c := qt.New(t)
 
 	_, err := NewJobManager(nil)
-	c.Assert(err, quicktest.IsNotNil)
+	c.Assert(err, qt.IsNotNil)
+}
+
+func TestGetUpgradeToStatusForModel_NoJob(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	ctx := context.Background()
+	modelUUID := "model-uuid"
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{}, nil)
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{}, nil)
+
+	status, err := deps.jobManager.GetUpgradeToStatusForModel(ctx, modelUUID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.IsNil)
+}
+
+func TestGetUpgradeToStatusForModel_ActiveQueryError(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	ctx := context.Background()
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(nil, errors.New("query error"))
+
+	status, err := deps.jobManager.GetUpgradeToStatusForModel(ctx, "model-uuid")
+	c.Assert(err, qt.ErrorMatches, "query error")
+	c.Assert(status, qt.IsNil)
 }

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -344,5 +344,6 @@ type UpgradeManager interface {
 // JobManager provides methods to manage long-running jobs such as bootstrapping and upgrading.
 type JobManager interface {
 	GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error)
+	GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
 	ListJobs(ctx context.Context, params params.ListJobsRequest) (params.ListJobsResponse, error)
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -859,6 +859,12 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 		return apiparams.ModelControllerInfo{}, err
 	}
 
+	upgradeToStatus, err := r.jimm.JobManager().GetUpgradeToStatusForModel(ctx, response.ModelUUID)
+	if err != nil {
+		return apiparams.ModelControllerInfo{}, err
+	}
+	response.UpgradeToJobStatus = upgradeToStatus
+
 	return *response, nil
 }
 

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -812,6 +812,87 @@ func TestModelControllerInfo(t *testing.T) {
 	}
 }
 
+func TestModelControllerInfo_HydratesUpgradeToStatus(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	status := &apiparams.UpgradeToJobStatus{
+		Root: apiparams.JobDetail{
+			State:       "running",
+			Attempt:     1,
+			MaxAttempts: 3,
+		},
+	}
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					return &apiparams.ModelControllerInfo{
+						ModelName:      "test-model",
+						ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+						ControllerName: "test-controller",
+						ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+					}, nil
+				},
+			}
+		},
+		JobManager_: func() jujuapi.JobManager {
+			return &mocks.JobManager{
+				GetUpgradeToStatusForModel_: func(ctx context.Context, modelUUID string) (*apiparams.UpgradeToJobStatus, error) {
+					c.Assert(modelUUID, qt.Equals, "12345678-1234-1234-1234-123456789abc")
+					return status, nil
+				},
+			}
+		},
+	}
+
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	info, err := root.ModelControllerInfo(ctx, apiparams.ModelControllerInfoRequest{ModelQualifier: "12345678-1234-1234-1234-123456789abc"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(info, qt.DeepEquals, apiparams.ModelControllerInfo{
+		ModelName:          "test-model",
+		ModelUUID:          "12345678-1234-1234-1234-123456789abc",
+		ControllerName:     "test-controller",
+		ControllerUUID:     "87654321-4321-4321-4321-cba987654321",
+		UpgradeToJobStatus: status,
+	})
+}
+
+func TestModelControllerInfo_UpgradeStatusError(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelControllerInfo_: func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*apiparams.ModelControllerInfo, error) {
+					return &apiparams.ModelControllerInfo{
+						ModelName:      "test-model",
+						ModelUUID:      "12345678-1234-1234-1234-123456789abc",
+						ControllerName: "test-controller",
+						ControllerUUID: "87654321-4321-4321-4321-cba987654321",
+					}, nil
+				},
+			}
+		},
+		JobManager_: func() jujuapi.JobManager {
+			return &mocks.JobManager{
+				GetUpgradeToStatusForModel_: func(ctx context.Context, modelUUID string) (*apiparams.UpgradeToJobStatus, error) {
+					return nil, errors.New("river query failed")
+				},
+			}
+		},
+	}
+
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	_, err := root.ModelControllerInfo(ctx, apiparams.ModelControllerInfoRequest{ModelQualifier: "12345678-1234-1234-1234-123456789abc"})
+	c.Assert(err, qt.ErrorMatches, "river query failed")
+}
+
 func TestJobInfo(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -791,11 +791,20 @@ func TestModelControllerInfo(t *testing.T) {
 		expectedError: "model not found",
 	}}
 
+	jobManagerMock := &mocks.JobManager{
+		GetUpgradeToStatusForModel_: func(ctx context.Context, modelUUID string) (*apiparams.UpgradeToJobStatus, error) {
+			return nil, nil
+		},
+	}
+
 	for _, test := range testCases {
 		c.Log(test.about)
 		jimm := &jimmtest.JIMM{
 			JujuManager_: func() jujuapi.JujuManager {
 				return test.jujuManager(c)
+			},
+			JobManager_: func() jujuapi.JobManager {
+				return jobManagerMock
 			},
 		}
 		root := newTestControllerRoot(jimm, "alice@canonical.com", test.admin)

--- a/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
@@ -11,8 +11,9 @@ import (
 )
 
 type JobManager struct {
-	GetJobInfo_ func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
-	ListJobs_   func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
+	GetJobInfo_                 func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
+	GetUpgradeToStatusForModel_ func(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
+	ListJobs_                   func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
 }
 
 func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error) {
@@ -20,6 +21,13 @@ func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo,
 		return jobs.JobInfo{}, errors.New("not implemented")
 	}
 	return j.GetJobInfo_(ctx, jobID)
+}
+
+func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error) {
+	if j.GetUpgradeToStatusForModel_ == nil {
+		return nil, errors.New("not implemented")
+	}
+	return j.GetUpgradeToStatusForModel_(ctx, modelUUID)
 }
 
 func (j *JobManager) ListJobs(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error) {


### PR DESCRIPTION
## Description
This change wires up recent work done for tracking the status of the upgrade-to job and its child jobs into the output of `juju show-model`. We query the River for any active upgrade-to jobs or the most recently completely job and return the parent and child job details.

Fixes [JUJU-9548](https://warthogs.atlassian.net/browse/JUJU-9548)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->


[JUJU-9548]: https://warthogs.atlassian.net/browse/JUJU-9548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ