### PR TITLE
feat: add show-controller api method

### DIFF
--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -18,7 +18,7 @@ import (
 const defaultListJobsCount = 100
 const maxListJobsCount = 10_000
 
-var activeUpgradeToJobStates = []rivertype.JobState{
+var activeJobStates = []rivertype.JobState{
 	rivertype.JobStateAvailable,
 	rivertype.JobStatePending,
 	rivertype.JobStateRunning,
@@ -74,6 +74,31 @@ func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (JobInfo, erro
 		MaxAttempts:    jobRow.MaxAttempts,
 		FinishedAt:     jobRow.FinalizedAt,
 		Errors:         jobErrors,
+	}, nil
+}
+
+// GetActiveBootstrapStatusForController returns the status of the active bootstrap
+// job for the specified controller, if one exists.
+func (j *JobManager) GetActiveBootstrapStatusForController(ctx context.Context, controllerName string) (*apiparams.BootstrapJobStatus, error) {
+	jobListResult, err := j.jobQuerier.ListJobs(
+		ctx,
+		river.NewJobListParams().
+			Kinds(rivertypes.BootstrapJobKind).
+			First(1).
+			States(activeJobStates...).
+			Where(
+				"metadata->>'controller-name' = @controller_name",
+				river.NamedArgs{"controller_name": controllerName},
+			),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobListResult.Jobs) == 0 {
+		return nil, nil
+	}
+	return &apiparams.BootstrapJobStatus{
+		Bootstrap: toJobDetail(jobListResult.Jobs[0]),
 	}, nil
 }
 
@@ -231,7 +256,7 @@ func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string)
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(1).
-			States(activeUpgradeToJobStates...).
+			States(activeJobStates...).
 			Where(
 				"metadata->>'model-uuid' = @model_uuid",
 				river.NamedArgs{"model_uuid": modelUUID},

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 type testDeps struct {
@@ -81,6 +82,58 @@ func TestGetJobInfo_QueryError(t *testing.T) {
 	_, err := deps.jobManager.GetJobInfo(ctx, jobID)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err, qt.ErrorMatches, "query error")
+}
+
+func TestGetActiveBootstrapStatusForController_Success(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	ctx := context.Background()
+	controllerName := "controller-name"
+	attemptedAt := time.Now().Add(-time.Minute)
+	finalizedAt := time.Now()
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{{
+		ID:          123,
+		State:       rivertype.JobStateRunning,
+		Attempt:     2,
+		MaxAttempts: 5,
+		AttemptedAt: &attemptedAt,
+		FinalizedAt: &finalizedAt,
+		Errors: []rivertype.AttemptError{{
+			Error:   "test error",
+			At:      finalizedAt,
+			Attempt: 1,
+		}},
+	}}}, nil)
+
+	status, err := deps.jobManager.GetActiveBootstrapStatusForController(ctx, controllerName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.DeepEquals, &apiparams.BootstrapJobStatus{
+		Bootstrap: apiparams.JobDetail{
+			State:       string(rivertype.JobStateRunning),
+			Attempt:     2,
+			MaxAttempts: 5,
+			AttemptedAt: &attemptedAt,
+			FinalizedAt: &finalizedAt,
+			Errors: []apiparams.JobAttemptError{{
+				Attempt: 1,
+				At:      finalizedAt,
+				Error:   "test error",
+			}},
+		},
+	})
+}
+
+func TestGetActiveBootstrapStatusForController_NoJob(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{}, nil)
+
+	status, err := deps.jobManager.GetActiveBootstrapStatusForController(context.Background(), "controller-name")
+	c.Assert(err, qt.IsNil)
+	c.Assert(status, qt.IsNil)
 }
 
 func TestNewJobManager_NilQuerier(t *testing.T) {

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -55,15 +55,32 @@ func (j *JujuManager) forEachController(ctx context.Context, controllers []dbmod
 }
 
 // ControllerInfo returns info about a controller connected to JIMM.
-func (j *JujuManager) ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error) {
-
+func (j *JujuManager) ControllerInfo(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
 	ctl := dbmodel.Controller{
 		Name: name,
 	}
 	if err := j.Database.GetController(ctx, &ctl); err != nil {
 		return nil, err
 	}
+
+	canAddModel, err := user.IsAllowedAddModelToController(ctx, ctl.ResourceTag())
+	if err != nil {
+		zapctx.Error(ctx, "error checking user permissions for controller", zap.String("controller", ctl.Name), zap.Error(err))
+		return nil, errors.New("error checking user permissions for controller")
+	}
+	if !canAddModel {
+		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+	}
 	return &ctl, nil
+}
+
+// GetControllerBootstrap returns the pending bootstrap reservation for a controller.
+func (j *JujuManager) GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+	bootstrap := dbmodel.ControllerBootstrap{Name: name}
+	if err := j.Database.GetControllerBootstrap(ctx, &bootstrap); err != nil {
+		return nil, err
+	}
+	return &bootstrap, nil
 }
 
 // ListControllerBootstraps returns the currently pending controller bootstraps.

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -74,14 +74,60 @@ func TestControllerInfo(t *testing.T) {
 	j := newTestJujuManager(c, nil)
 
 	env := jimmtest.ParseEnvironment(c, testControllersEnv)
-	env.PopulateDB(c, j.Database)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
 
-	ctl, err := j.ControllerInfo(ctx, "test1")
-	c.Assert(err, qt.IsNil)
-	c.Assert(ctl.Name, qt.Equals, "test1")
+	alice := env.User("alice@canonical.com").DBObject(c, j.Database)
+	bob := env.User("bob@canonical.com").DBObject(c, j.Database)
+	notAllowed := env.User("notallowedanycontrollers@canonical.com").DBObject(c, j.Database)
 
-	_, err = j.ControllerInfo(ctx, "does-not-exist")
-	c.Assert(err, qt.ErrorMatches, "controller not found")
+	adminUser := openfga.NewUser(&alice, j.OpenFGAClient)
+	bobUser := openfga.NewUser(&bob, j.OpenFGAClient)
+	notAllowedUser := openfga.NewUser(&notAllowed, j.OpenFGAClient)
+
+	tests := []struct {
+		about         string
+		user          *openfga.User
+		controller    string
+		expectedName  string
+		expectedError string
+	}{
+		{
+			about:        "jimm admin can access controller",
+			user:         adminUser,
+			controller:   "test1",
+			expectedName: "test1",
+		},
+		{
+			about:        "user with add-model access can access controller",
+			user:         bobUser,
+			controller:   "test1",
+			expectedName: "test1",
+		},
+		{
+			about:         "user without add-model access is unauthorized",
+			user:          notAllowedUser,
+			controller:    "test1",
+			expectedError: "unauthorized",
+		},
+		{
+			about:         "non-existent controller returns not found",
+			user:          bobUser,
+			controller:    "does-not-exist",
+			expectedError: "controller not found",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.about, func(c *qt.C) {
+			ctl, err := j.ControllerInfo(ctx, test.user, test.controller)
+			if test.expectedError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(ctl.Name, qt.Equals, test.expectedName)
+		})
+	}
 }
 
 func TestListControllers(t *testing.T) {

--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -64,7 +64,8 @@ func init() {
 // ControllerService defines the methods used to manage controllers.
 type ControllerService interface {
 	AddController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
-	ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error)
+	GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error)
+	ControllerInfo(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error)
 	EarliestControllerVersion(ctx context.Context) (version.Number, error)
 	ListControllerBootstraps(ctx context.Context) ([]dbmodel.ControllerBootstrap, error)
 	ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -225,7 +225,8 @@ type JujuManager interface {
 	// Controller related methods
 
 	AddController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
-	ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error)
+	GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error)
+	ControllerInfo(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error)
 	EarliestControllerVersion(ctx context.Context) (version.Number, error)
 	ListControllerBootstraps(ctx context.Context) ([]dbmodel.ControllerBootstrap, error)
 	ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
@@ -344,6 +345,7 @@ type UpgradeManager interface {
 // JobManager provides methods to manage long-running jobs such as bootstrapping and upgrading.
 type JobManager interface {
 	GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error)
+	GetActiveBootstrapStatusForController(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
 	GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
 	ListJobs(ctx context.Context, params params.ListJobsRequest) (params.ListJobsResponse, error)
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -77,6 +77,7 @@ func init() {
 		upgradeToMethod := rpc.Method(r.UpgradeTo)
 		listUserCloudsMethod := rpc.Method(r.ListUserClouds)
 		modelControllerInfoMethod := rpc.Method(r.ModelControllerInfo)
+		showControllerMethod := rpc.Method(r.ShowController)
 		jobInfoMethod := rpc.Method(r.JobInfo)
 		listJobsMethod := rpc.Method(r.ListJobs)
 		supportedVersionMethd := rpc.Method(r.SupportedJujuVersions)
@@ -99,6 +100,7 @@ func init() {
 		r.AddMethod("JIMM", 4, "RemoveController", removeControllerMethod)
 		r.AddMethod("JIMM", 4, "RevokeAuditLogAccess", revokeAuditLogAccessMethod)
 		r.AddMethod("JIMM", 4, "SetControllerDeprecated", setControllerDeprecatedMethod)
+		r.AddMethod("JIMM", 4, "ShowController", showControllerMethod)
 		r.AddMethod("JIMM", 4, "UpdateMigratedModel", updateMigratedModelMethod)
 
 		// JIMM ReBAC RPC
@@ -313,7 +315,7 @@ func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.Rem
 		return apiparams.ControllerInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
+	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, r.user, req.Name)
 	if err != nil {
 		return apiparams.ControllerInfo{}, err
 	}
@@ -330,7 +332,7 @@ func (r *controllerRoot) SetControllerDeprecated(ctx context.Context, req apipar
 	if err := r.jimm.JujuManager().SetControllerDeprecated(ctx, r.user, req.Name, req.Deprecated); err != nil {
 		return apiparams.ControllerInfo{}, err
 	}
-	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.Name)
+	ctl, err := r.jimm.JujuManager().ControllerInfo(ctx, r.user, req.Name)
 	if err != nil {
 		return apiparams.ControllerInfo{}, err
 	}
@@ -743,7 +745,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 		return apiparams.StartBootstrapResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, req.ControllerName)
+	ctrl, err := r.jimm.JujuManager().ControllerInfo(ctx, r.user, req.ControllerName)
 	if err != nil {
 		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to fetch controller info: %w", err)
 	}
@@ -866,6 +868,36 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 	response.UpgradeToJobStatus = upgradeToStatus
 
 	return *response, nil
+}
+
+// ShowController returns information about a controller or an in-progress bootstrap reservation.
+func (r *controllerRoot) ShowController(ctx context.Context, req apiparams.ShowControllerRequest) (apiparams.ControllerInfo, error) {
+	controller, err := r.jimm.JujuManager().ControllerInfo(ctx, r.user, req.ControllerName)
+	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
+		return apiparams.ControllerInfo{}, err
+	}
+	if err == nil {
+		return controller.ToAPIControllerInfo(), nil
+	}
+	// If the user is not a JIMM admin, return the not found error.
+	// Only JIMM admins can see controllers undergoing bootstrap.
+	if !r.user.JimmAdmin {
+		return apiparams.ControllerInfo{}, err
+	}
+
+	bootstrap, err := r.jimm.JujuManager().GetControllerBootstrap(ctx, req.ControllerName)
+	if err != nil {
+		return apiparams.ControllerInfo{}, err
+	}
+
+	response := bootstrap.ToAPIControllerInfo()
+	status, err := r.jimm.JobManager().GetActiveBootstrapStatusForController(ctx, req.ControllerName)
+	if err != nil {
+		return apiparams.ControllerInfo{}, err
+	}
+	response.BootstrapJobStatus = status
+
+	return response, nil
 }
 
 // JobInfo returns information about a job given its ID.

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -160,6 +160,273 @@ func TestListControllers_AdminIncludesPendingBootstraps(t *testing.T) {
 	}})
 }
 
+func TestShowController(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	testCases := []struct {
+		about         string
+		admin         bool
+		controller    string
+		jujuManager   func(*qt.C) jujuapi.JujuManager
+		jobManager    func(*qt.C) jujuapi.JobManager
+		expectedInfo  apiparams.ControllerInfo
+		expectedError string
+	}{
+		{
+			about:      "non-admin user with add-model access can view controller",
+			admin:      false,
+			controller: "test-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, false)
+							c.Assert(name, qt.Equals, "test-controller")
+							return &dbmodel.Controller{
+								Name:      "test-controller",
+								UUID:      "982b16d9-a945-4762-b684-fd4fd885aa11",
+								CloudName: "aws",
+							}, nil
+						},
+					},
+				}
+			},
+			expectedInfo: apiparams.ControllerInfo{
+				Name:     "test-controller",
+				UUID:     "982b16d9-a945-4762-b684-fd4fd885aa11",
+				CloudTag: names.NewCloudTag("aws").String(),
+				Status:   jujuparams.EntityStatus{Status: "available"},
+			},
+		},
+		{
+			about:      "non-admin user without add-model access is unauthorized",
+			admin:      false,
+			controller: "test-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, false)
+							return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+						},
+					},
+				}
+			},
+			expectedError: "unauthorized",
+		},
+		{
+			about:      "non-admin user cannot see bootstrapping controller",
+			admin:      false,
+			controller: "bootstrapping-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, false)
+							return nil, errors.Codef(errors.CodeNotFound, "controller not found")
+						},
+					},
+				}
+			},
+			expectedError: "controller not found",
+		},
+		{
+			about:      "returns persisted controller info",
+			admin:      true,
+			controller: "test-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, true)
+							c.Assert(name, qt.Equals, "test-controller")
+							return &dbmodel.Controller{
+								Name:      "test-controller",
+								UUID:      "982b16d9-a945-4762-b684-fd4fd885aa11",
+								CloudName: "aws",
+							}, nil
+						},
+					},
+				}
+			},
+			jobManager: func(c *qt.C) jujuapi.JobManager {
+				return &mocks.JobManager{}
+			},
+			expectedInfo: apiparams.ControllerInfo{
+				Name:     "test-controller",
+				UUID:     "982b16d9-a945-4762-b684-fd4fd885aa11",
+				CloudTag: names.NewCloudTag("aws").String(),
+				Status:   jujuparams.EntityStatus{Status: "available"},
+			},
+		},
+		{
+			about:      "returns bootstrapping controller with job status",
+			admin:      true,
+			controller: "bootstrapping-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, true)
+							return nil, errors.Codef(errors.CodeNotFound, "controller not found")
+						},
+						GetControllerBootstrap_: func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+							c.Assert(name, qt.Equals, "bootstrapping-controller")
+							return &dbmodel.ControllerBootstrap{
+								Name:        "bootstrapping-controller",
+								CloudName:   "aws",
+								CloudRegion: "eu-west-1",
+							}, nil
+						},
+					},
+				}
+			},
+			jobManager: func(c *qt.C) jujuapi.JobManager {
+				return &mocks.JobManager{
+					GetActiveBootstrapStatusForController_: func(ctx context.Context, controllerName string) (*apiparams.BootstrapJobStatus, error) {
+						c.Assert(controllerName, qt.Equals, "bootstrapping-controller")
+						return &apiparams.BootstrapJobStatus{
+							Bootstrap: apiparams.JobDetail{
+								State:       "running",
+								Attempt:     1,
+								MaxAttempts: 3,
+							},
+						}, nil
+					},
+				}
+			},
+			expectedInfo: apiparams.ControllerInfo{
+				Name:        "bootstrapping-controller",
+				CloudTag:    names.NewCloudTag("aws").String(),
+				CloudRegion: "eu-west-1",
+				Status:      jujuparams.EntityStatus{Status: "bootstrapping"},
+				BootstrapJobStatus: &apiparams.BootstrapJobStatus{
+					Bootstrap: apiparams.JobDetail{
+						State:       "running",
+						Attempt:     1,
+						MaxAttempts: 3,
+					},
+				},
+			},
+		},
+		{
+			about:      "propagates bootstrap lookup error",
+			admin:      true,
+			controller: "bootstrapping-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, true)
+							return nil, errors.Codef(errors.CodeNotFound, "controller not found")
+						},
+						GetControllerBootstrap_: func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+							return nil, errors.New("bootstrap query failed")
+						},
+					},
+				}
+			},
+			jobManager: func(c *qt.C) jujuapi.JobManager {
+				return &mocks.JobManager{}
+			},
+			expectedError: "bootstrap query failed",
+		},
+		{
+			about:      "returns bootstrapping controller without status when no active job exists",
+			admin:      true,
+			controller: "bootstrapping-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, true)
+							return nil, errors.Codef(errors.CodeNotFound, "controller not found")
+						},
+						GetControllerBootstrap_: func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+							return &dbmodel.ControllerBootstrap{
+								Name:        "bootstrapping-controller",
+								CloudName:   "aws",
+								CloudRegion: "eu-west-1",
+							}, nil
+						},
+					},
+				}
+			},
+			jobManager: func(c *qt.C) jujuapi.JobManager {
+				return &mocks.JobManager{
+					GetActiveBootstrapStatusForController_: func(ctx context.Context, controllerName string) (*apiparams.BootstrapJobStatus, error) {
+						c.Assert(controllerName, qt.Equals, "bootstrapping-controller")
+						return nil, nil
+					},
+				}
+			},
+			expectedInfo: apiparams.ControllerInfo{
+				Name:        "bootstrapping-controller",
+				CloudTag:    names.NewCloudTag("aws").String(),
+				CloudRegion: "eu-west-1",
+				Status:      jujuparams.EntityStatus{Status: "bootstrapping"},
+			},
+		},
+		{
+			about:      "propagates bootstrap job status error",
+			admin:      true,
+			controller: "bootstrapping-controller",
+			jujuManager: func(c *qt.C) jujuapi.JujuManager {
+				return &mocks.JujuManager{
+					ControllerService: mocks.ControllerService{
+						ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+							c.Assert(user.JimmAdmin, qt.Equals, true)
+							return nil, errors.Codef(errors.CodeNotFound, "controller not found")
+						},
+						GetControllerBootstrap_: func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+							return &dbmodel.ControllerBootstrap{
+								Name: "bootstrapping-controller",
+							}, nil
+						},
+					},
+				}
+			},
+			jobManager: func(c *qt.C) jujuapi.JobManager {
+				return &mocks.JobManager{
+					GetActiveBootstrapStatusForController_: func(ctx context.Context, controllerName string) (*apiparams.BootstrapJobStatus, error) {
+						c.Assert(controllerName, qt.Equals, "bootstrapping-controller")
+						return nil, errors.New("job query failed")
+					},
+				}
+			},
+			expectedError: "job query failed",
+		},
+	}
+
+	for _, test := range testCases {
+		c.Run(test.about, func(c *qt.C) {
+			jimm := &jimmtest.JIMM{
+				JujuManager_: func() jujuapi.JujuManager {
+					return test.jujuManager(c)
+				},
+				JobManager_: func() jujuapi.JobManager {
+					if test.jobManager == nil {
+						return &mocks.JobManager{}
+					}
+					return test.jobManager(c)
+				},
+			}
+
+			root := newTestControllerRoot(jimm, "alice@canonical.com", test.admin)
+			info, err := root.ShowController(ctx, apiparams.ShowControllerRequest{ControllerName: test.controller})
+
+			if test.expectedError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(info, qt.DeepEquals, test.expectedInfo)
+		})
+	}
+}
+
 func TestRemoveController_UnauthorizedUser(t *testing.T) {
 	c := qt.New(t)
 
@@ -186,8 +453,9 @@ func TestRemoveController_Success(t *testing.T) {
 		JujuManager_: func() jujuapi.JujuManager {
 			return &mocks.JujuManager{
 				ControllerService: mocks.ControllerService{
-					ControllerInfo_: func(ctx context.Context, name string) (*dbmodel.Controller, error) {
+					ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
 						infoCalled = true
+						c.Check(user.JimmAdmin, qt.Equals, true)
 						return &dbmodel.Controller{
 							Name:          testControllerName,
 							UUID:          "982b16d9-a945-4762-b684-fd4fd885aa11",
@@ -547,7 +815,8 @@ func TestStartDestroyControllerJob(t *testing.T) {
 		JujuManager_: func() jujuapi.JujuManager {
 			return &mocks.JujuManager{
 				ControllerService: mocks.ControllerService{
-					ControllerInfo_: func(ctx context.Context, name string) (*dbmodel.Controller, error) {
+					ControllerInfo_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
+						c.Check(user.JimmAdmin, qt.Equals, true)
 						return ctrlInfo, nil
 					},
 				},

--- a/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
@@ -11,9 +11,10 @@ import (
 )
 
 type JobManager struct {
-	GetJobInfo_                 func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
-	GetUpgradeToStatusForModel_ func(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
-	ListJobs_                   func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
+	GetJobInfo_                            func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
+	GetActiveBootstrapStatusForController_ func(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
+	GetUpgradeToStatusForModel_            func(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
+	ListJobs_                              func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
 }
 
 func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error) {
@@ -21,6 +22,13 @@ func (j *JobManager) GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo,
 		return jobs.JobInfo{}, errors.New("not implemented")
 	}
 	return j.GetJobInfo_(ctx, jobID)
+}
+
+func (j *JobManager) GetActiveBootstrapStatusForController(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error) {
+	if j.GetActiveBootstrapStatusForController_ == nil {
+		return nil, errors.New("not implemented")
+	}
+	return j.GetActiveBootstrapStatusForController_(ctx, controllerName)
 }
 
 func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -19,7 +19,8 @@ type ControllerService struct {
 	AddController_                     func(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
 	ControllerDetailsForModel_         func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
 	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
-	ControllerInfo_                    func(ctx context.Context, name string) (*dbmodel.Controller, error)
+	GetControllerBootstrap_            func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error)
+	ControllerInfo_                    func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error)
 	EarliestControllerVersion_         func(ctx context.Context) (version.Number, error)
 	ListControllerBootstraps_          func(ctx context.Context) ([]dbmodel.ControllerBootstrap, error)
 	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
@@ -49,11 +50,18 @@ func (j *ControllerService) ControllerDetailsForIncomingModel(ctx context.Contex
 	return j.ControllerDetailsForIncomingModel_(ctx, modelUUID)
 }
 
-func (j *ControllerService) ControllerInfo(ctx context.Context, name string) (*dbmodel.Controller, error) {
+func (j *ControllerService) ControllerInfo(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error) {
 	if j.ControllerInfo_ == nil {
 		return nil, errors.New("not implemented")
 	}
-	return j.ControllerInfo_(ctx, name)
+	return j.ControllerInfo_(ctx, user, name)
+}
+
+func (j *ControllerService) GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
+	if j.GetControllerBootstrap_ == nil {
+		return nil, errors.New("not implemented")
+	}
+	return j.GetControllerBootstrap_(ctx, name)
 }
 
 func (j *ControllerService) EarliestControllerVersion(ctx context.Context) (version.Number, error) {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -365,6 +365,14 @@ func (c *Client) ModelControllerInfo(modelQualifier string) (*params.ModelContro
 	return &resp, err
 }
 
+// ShowController returns information about a controller or a pending bootstrap reservation.
+func (c *Client) ShowController(controllerName string) (*params.ControllerInfo, error) {
+	req := params.ShowControllerRequest{ControllerName: controllerName}
+	var resp params.ControllerInfo
+	err := c.caller.APICall("JIMM", 4, "", "ShowController", req, &resp)
+	return &resp, err
+}
+
 func cloudFromParams(cloudName string, p jujuparams.Cloud) jujucloud.Cloud {
 	authTypes := make([]jujucloud.AuthType, len(p.AuthTypes))
 	for i, authType := range p.AuthTypes {

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -190,6 +190,63 @@ func TestListControllersUnauthorized(t *testing.T) {
 	c.Check(cis, qt.DeepEquals, []apiparams.ControllerInfo{})
 }
 
+func TestShowController(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	controllerName, conf := s.GetOneControllerConfig(c)
+	expectedController := apiparams.ControllerInfo{
+		Name:          controllerName,
+		UUID:          conf.UUID,
+		APIAddresses:  conf.ToAPIInfo().Addrs,
+		CACertificate: conf.ToAPIInfo().CACert,
+		CloudTag:      names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion:   jimmtest.TestE2ECloudRegionName,
+		Status: jujuparams.EntityStatus{
+			Status: "available",
+		},
+	}
+
+	adminConn := s.Open(c, nil, "alice@canonical.com", nil)
+	defer adminConn.Close()
+	adminClient := api.NewClient(adminConn)
+
+	ci, err := adminClient.ShowController(controllerName)
+	c.Assert(err, qt.IsNil)
+	assertControllerInfos(c, []apiparams.ControllerInfo{*ci}, []apiparams.ControllerInfo{expectedController}, s.GetControllersConfig(c))
+
+	bobConn := s.Open(c, nil, "bob@canonical.com", nil)
+	defer bobConn.Close()
+	bobClient := api.NewClient(bobConn)
+
+	ci, err = bobClient.ShowController(controllerName)
+	c.Assert(err, qt.IsNil)
+	assertControllerInfos(c, []apiparams.ControllerInfo{*ci}, []apiparams.ControllerInfo{expectedController}, s.GetControllersConfig(c))
+
+	bootstrap := &dbmodel.ControllerBootstrap{
+		Name:        "bootstrapping-controller",
+		CloudName:   jimmtest.TestE2ECloudName,
+		CloudRegion: jimmtest.TestE2ECloudRegionName,
+	}
+	err = s.JIMM.Database.AddControllerBootstrap(c.Context(), bootstrap)
+	c.Assert(err, qt.IsNil)
+
+	ci, err = adminClient.ShowController(bootstrap.Name)
+	c.Assert(err, qt.IsNil)
+	c.Check(*ci, qt.DeepEquals, apiparams.ControllerInfo{
+		Name:        bootstrap.Name,
+		CloudTag:    names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		CloudRegion: jimmtest.TestE2ECloudRegionName,
+		Status: jujuparams.EntityStatus{
+			Status: "bootstrapping",
+		},
+	})
+
+	ci, err = bobClient.ShowController(bootstrap.Name)
+	c.Check(jujuparams.IsCodeNotFound(err), qt.Equals, true)
+	c.Check(*ci, qt.DeepEquals, apiparams.ControllerInfo{})
+}
+
 func TestAddControllerPublicAddressWithoutPort(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)


### PR DESCRIPTION
## Description
This PR implements a new `ShowController` API method. The method allows a user to view the details on a single controller. It follows the same permissions as ListControllers, showing users any controllers they have AddModel access to and only shows bootstrapping controllers to admins.

I'm not particularly happy with the incosistent locations of our permission checks. E.g. in the API layer we check if the user is an admin to determine whether they can see bootstrapping controllers, but we check in the service layer whether the user has AddModel permissions on the controller they are trying to view.

Fixes [JUJU-9552](https://warthogs.atlassian.net/browse/JUJU-9552)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9552]: https://warthogs.atlassian.net/browse/JUJU-9552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ