### PR TITLE
feat: add ListModels to list models per users and their upgrade-to status

### DIFF
--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -161,9 +160,9 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 }
 
 // ListUpgradeToJobsForModels returns a lightweight per-model status for the most
-// recent relevant upgrade-to supervisor job.
-// The status is fetched from the latest supervisor job for each model, including
-// completed jobs.
+// relevant upgrade-to supervisor job for each requested model.
+// Active jobs are loaded first so in-flight work takes precedence, then the most
+// recent finalized jobs fill in any remaining models.
 func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
 	jobsByModelUUID := make(map[string]string, len(modelUUIDs))
 	if len(modelUUIDs) == 0 {
@@ -175,19 +174,19 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		requestedModelUUIDs[modelUUID] = struct{}{}
 	}
 
-	jobListResult, err := j.jobQuerier.ListJobs(
+	activeJobListResult, err := j.jobQuerier.ListJobs(
 		ctx,
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(maxListJobsCount).
-			States((append(activeJobStates, finalizedUpgradeToJobStates...))...),
+			States(activeJobStates...).
+			OrderBy(river.JobListOrderByTime, river.SortOrderDesc),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	latestJobByModelUUID := make(map[string]*rivertype.JobRow, len(modelUUIDs))
-	for _, job := range jobListResult.Jobs {
+	for _, job := range activeJobListResult.Jobs {
 		if job == nil {
 			continue
 		}
@@ -198,10 +197,36 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		if modelUUID == "" {
 			continue
 		}
-		latestJobByModelUUID[modelUUID] = laterJob(latestJobByModelUUID[modelUUID], job)
+		jobsByModelUUID[modelUUID] = UpgradeToModelStatusProgress
 	}
 
-	for modelUUID, job := range latestJobByModelUUID {
+	finalizedJobListResult, err := j.jobQuerier.ListJobs(
+		ctx,
+		river.NewJobListParams().
+			Kinds(rivertypes.UpgradeToJobKind).
+			First(maxListJobsCount).
+			States(finalizedUpgradeToJobStates...).
+			OrderBy(river.JobListOrderByTime, river.SortOrderDesc),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, job := range finalizedJobListResult.Jobs {
+		if job == nil {
+			continue
+		}
+		modelUUID, err := requestedUpgradeToModelUUID(job, requestedModelUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		if modelUUID == "" {
+			continue
+		}
+		if _, ok := jobsByModelUUID[modelUUID]; ok {
+			continue
+		}
+
 		switch job.State {
 		case rivertype.JobStateCancelled, rivertype.JobStateDiscarded:
 			jobsByModelUUID[modelUUID] = UpgradeToModelStatusError
@@ -229,26 +254,6 @@ func requestedUpgradeToModelUUID(job *rivertype.JobRow, requestedModelUUIDs map[
 		return "", nil
 	}
 	return metadata.ModelUUID, nil
-}
-
-// laterJob returns the later of the two jobs based on their attempted or created time. ù
-// If one of the jobs is nil, it returns the other job.
-func laterJob(current, candidate *rivertype.JobRow) *rivertype.JobRow {
-	if current == nil {
-		return candidate
-	}
-	if jobTime(candidate).After(jobTime(current)) {
-		return candidate
-	}
-	return current
-}
-
-// jobTime returns the attempted time of the job if available, otherwise it returns the created time.
-func jobTime(job *rivertype.JobRow) time.Time {
-	if job.AttemptedAt != nil {
-		return *job.AttemptedAt
-	}
-	return job.CreatedAt
 }
 
 // ListJobs returns a list of jobs based on the provided parameters. It converts the API parameters to the internal river job query parameters and retrieves the job list from the job querier.

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -31,6 +32,21 @@ var finalizedUpgradeToJobStates = []rivertype.JobState{
 	rivertype.JobStateCompleted,
 	rivertype.JobStateDiscarded,
 }
+
+var notCompletedStates = []rivertype.JobState{
+	rivertype.JobStateAvailable,
+	rivertype.JobStatePending,
+	rivertype.JobStateRunning,
+	rivertype.JobStateRetryable,
+	rivertype.JobStateScheduled,
+	rivertype.JobStateCancelled,
+	rivertype.JobStateDiscarded,
+}
+
+const (
+	UpgradeToModelStatusProgress = "progress"
+	UpgradeToModelStatusError    = "error"
+)
 
 // JobQuerier defines the interface for querying and managing jobs in JIMM.
 type JobQuerier interface {
@@ -147,10 +163,11 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 	return status, nil
 }
 
-// ListUpgradeToJobsForModels returns the set of model UUIDs that currently have
-// an active upgrade-to supervisor job.
-func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
-	jobsByModelUUID := make(map[string]bool, len(modelUUIDs))
+// ListUpgradeToJobsForModels returns a lightweight per-model status for the most
+// recent relevant upgrade-to supervisor job.
+// The status is fetched from the latest supervisor job for each model.
+func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
+	jobsByModelUUID := make(map[string]string, len(modelUUIDs))
 	if len(modelUUIDs) == 0 {
 		return jobsByModelUUID, nil
 	}
@@ -165,27 +182,70 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(maxListJobsCount).
-			States(activeJobStates...),
+			States(notCompletedStates...),
 	)
 	if err != nil {
 		return nil, err
 	}
 
+	latestJobByModelUUID := make(map[string]*rivertype.JobRow, len(modelUUIDs))
 	for _, job := range jobListResult.Jobs {
-		var metadata rivertypes.JobModelUUIDMetadata
-		if err := json.Unmarshal(job.Metadata, &metadata); err != nil {
-			return nil, fmt.Errorf("failed to decode upgrade-to metadata: %w", err)
+		modelUUID, err := requestedUpgradeToModelUUID(job, requestedModelUUIDs)
+		if err != nil {
+			return nil, err
 		}
-		if metadata.ModelUUID == "" {
+		if modelUUID == "" {
 			continue
 		}
-		if _, ok := requestedModelUUIDs[metadata.ModelUUID]; !ok {
-			continue
+		latestJobByModelUUID[modelUUID] = laterJob(latestJobByModelUUID[modelUUID], job)
+	}
+
+	for modelUUID, job := range latestJobByModelUUID {
+		switch job.State {
+		case rivertype.JobStateCancelled, rivertype.JobStateDiscarded:
+			jobsByModelUUID[modelUUID] = UpgradeToModelStatusError
+		case rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled:
+			jobsByModelUUID[modelUUID] = UpgradeToModelStatusProgress
 		}
-		jobsByModelUUID[metadata.ModelUUID] = true
 	}
 
 	return jobsByModelUUID, nil
+}
+
+// requestedUpgradeToModelUUID checks if the job has metadata indicating it is an upgrade-to job for one of the requested ù
+// model UUIDs. If so, it returns that model UUID; otherwise, it returns an empty string.
+func requestedUpgradeToModelUUID(job *rivertype.JobRow, requestedModelUUIDs map[string]struct{}) (string, error) {
+	var metadata rivertypes.JobModelUUIDMetadata
+	if err := json.Unmarshal(job.Metadata, &metadata); err != nil {
+		return "", fmt.Errorf("failed to decode upgrade-to metadata: %w", err)
+	}
+	if metadata.ModelUUID == "" {
+		return "", nil
+	}
+	if _, ok := requestedModelUUIDs[metadata.ModelUUID]; !ok {
+		return "", nil
+	}
+	return metadata.ModelUUID, nil
+}
+
+// laterJob returns the later of the two jobs based on their attempted or created time. ù
+// If one of the jobs is nil, it returns the other job.
+func laterJob(current, candidate *rivertype.JobRow) *rivertype.JobRow {
+	if current == nil {
+		return candidate
+	}
+	if jobTime(candidate).After(jobTime(current)) {
+		return candidate
+	}
+	return current
+}
+
+// jobTime returns the attempted time of the job if available, otherwise it returns the created time.
+func jobTime(job *rivertype.JobRow) time.Time {
+	if job.AttemptedAt != nil {
+		return *job.AttemptedAt
+	}
+	return job.CreatedAt
 }
 
 // ListJobs returns a list of jobs based on the provided parameters. It converts the API parameters to the internal river job query parameters and retrieves the job list from the job querier.

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -156,14 +155,17 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		return jobsByModelUUID, nil
 	}
 
-	whereClause, namedArgs := buildModelUUIDWhereClause(modelUUIDs)
+	requestedModelUUIDs := make(map[string]struct{}, len(modelUUIDs))
+	for _, modelUUID := range modelUUIDs {
+		requestedModelUUIDs[modelUUID] = struct{}{}
+	}
+
 	jobListResult, err := j.jobQuerier.ListJobs(
 		ctx,
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(maxListJobsCount).
-			States(activeJobStates...).
-			Where(whereClause, namedArgs),
+			States(activeJobStates...),
 	)
 	if err != nil {
 		return nil, err
@@ -175,6 +177,9 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 			return nil, fmt.Errorf("failed to decode upgrade-to metadata: %w", err)
 		}
 		if metadata.ModelUUID == "" {
+			continue
+		}
+		if _, ok := requestedModelUUIDs[metadata.ModelUUID]; !ok {
 			continue
 		}
 		jobsByModelUUID[metadata.ModelUUID] = true
@@ -325,17 +330,6 @@ func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string)
 	}
 
 	return finalizedJobs.Jobs[0], nil
-}
-
-func buildModelUUIDWhereClause(modelUUIDs []string) (string, river.NamedArgs) {
-	clauses := make([]string, 0, len(modelUUIDs))
-	namedArgs := river.NamedArgs{}
-	for i, modelUUID := range modelUUIDs {
-		argName := fmt.Sprintf("model_uuid_%d", i)
-		clauses = append(clauses, fmt.Sprintf("metadata->>'model-uuid' = @%s", argName))
-		namedArgs[argName] = modelUUID
-	}
-	return strings.Join(clauses, " OR "), namedArgs
 }
 
 func toJobDetail(jobRow *rivertype.JobRow) apiparams.JobDetail {

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -145,6 +146,41 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 	}
 
 	return status, nil
+}
+
+// ListUpgradeToJobsForModels returns the set of model UUIDs that currently have
+// an active upgrade-to supervisor job.
+func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+	jobsByModelUUID := make(map[string]bool, len(modelUUIDs))
+	if len(modelUUIDs) == 0 {
+		return jobsByModelUUID, nil
+	}
+
+	whereClause, namedArgs := buildModelUUIDWhereClause(modelUUIDs)
+	jobListResult, err := j.jobQuerier.ListJobs(
+		ctx,
+		river.NewJobListParams().
+			Kinds(rivertypes.UpgradeToJobKind).
+			First(maxListJobsCount).
+			States(activeJobStates...).
+			Where(whereClause, namedArgs),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, job := range jobListResult.Jobs {
+		var metadata rivertypes.JobModelUUIDMetadata
+		if err := json.Unmarshal(job.Metadata, &metadata); err != nil {
+			return nil, fmt.Errorf("failed to decode upgrade-to metadata: %w", err)
+		}
+		if metadata.ModelUUID == "" {
+			continue
+		}
+		jobsByModelUUID[metadata.ModelUUID] = true
+	}
+
+	return jobsByModelUUID, nil
 }
 
 // ListJobs returns a list of jobs based on the provided parameters. It converts the API parameters to the internal river job query parameters and retrieves the job list from the job querier.
@@ -289,6 +325,17 @@ func (j *JobManager) findUpgradeToRootJob(ctx context.Context, modelUUID string)
 	}
 
 	return finalizedJobs.Jobs[0], nil
+}
+
+func buildModelUUIDWhereClause(modelUUIDs []string) (string, river.NamedArgs) {
+	clauses := make([]string, 0, len(modelUUIDs))
+	namedArgs := river.NamedArgs{}
+	for i, modelUUID := range modelUUIDs {
+		argName := fmt.Sprintf("model_uuid_%d", i)
+		clauses = append(clauses, fmt.Sprintf("metadata->>'model-uuid' = @%s", argName))
+		namedArgs[argName] = modelUUID
+	}
+	return strings.Join(clauses, " OR "), namedArgs
 }
 
 func toJobDetail(jobRow *rivertype.JobRow) apiparams.JobDetail {

--- a/internal/jimm/jobs/jobs.go
+++ b/internal/jimm/jobs/jobs.go
@@ -33,19 +33,16 @@ var finalizedUpgradeToJobStates = []rivertype.JobState{
 	rivertype.JobStateDiscarded,
 }
 
-var notCompletedStates = []rivertype.JobState{
-	rivertype.JobStateAvailable,
-	rivertype.JobStatePending,
-	rivertype.JobStateRunning,
-	rivertype.JobStateRetryable,
-	rivertype.JobStateScheduled,
-	rivertype.JobStateCancelled,
-	rivertype.JobStateDiscarded,
-}
-
 const (
+	// UpgradeToModelStatusProgress indicates an upgrade-to job is currently in progress for the model.
+	// It maps to in-progress job states: available, pending, running, retryable, scheduled.
 	UpgradeToModelStatusProgress = "progress"
-	UpgradeToModelStatusError    = "error"
+	// UpgradeToModelStatusError indicates an upgrade-to job has encountered an error for the model.
+	// It maps to error job states: cancelled, discarded.
+	UpgradeToModelStatusError = "error"
+	// UpgradeToModelStatusCompleted indicates the latest upgrade-to job completed successfully.
+	// It maps to the completed job state.
+	UpgradeToModelStatusCompleted = "completed"
 )
 
 // JobQuerier defines the interface for querying and managing jobs in JIMM.
@@ -165,7 +162,8 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 
 // ListUpgradeToJobsForModels returns a lightweight per-model status for the most
 // recent relevant upgrade-to supervisor job.
-// The status is fetched from the latest supervisor job for each model.
+// The status is fetched from the latest supervisor job for each model, including
+// completed jobs.
 func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
 	jobsByModelUUID := make(map[string]string, len(modelUUIDs))
 	if len(modelUUIDs) == 0 {
@@ -182,7 +180,7 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		river.NewJobListParams().
 			Kinds(rivertypes.UpgradeToJobKind).
 			First(maxListJobsCount).
-			States(notCompletedStates...),
+			States((append(activeJobStates, finalizedUpgradeToJobStates...))...),
 	)
 	if err != nil {
 		return nil, err
@@ -190,6 +188,9 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 
 	latestJobByModelUUID := make(map[string]*rivertype.JobRow, len(modelUUIDs))
 	for _, job := range jobListResult.Jobs {
+		if job == nil {
+			continue
+		}
 		modelUUID, err := requestedUpgradeToModelUUID(job, requestedModelUUIDs)
 		if err != nil {
 			return nil, err
@@ -204,6 +205,8 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 		switch job.State {
 		case rivertype.JobStateCancelled, rivertype.JobStateDiscarded:
 			jobsByModelUUID[modelUUID] = UpgradeToModelStatusError
+		case rivertype.JobStateCompleted:
+			jobsByModelUUID[modelUUID] = UpgradeToModelStatusCompleted
 		case rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStateScheduled:
 			jobsByModelUUID[modelUUID] = UpgradeToModelStatusProgress
 		}
@@ -212,7 +215,7 @@ func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs 
 	return jobsByModelUUID, nil
 }
 
-// requestedUpgradeToModelUUID checks if the job has metadata indicating it is an upgrade-to job for one of the requested ù
+// requestedUpgradeToModelUUID checks if the job has metadata indicating it is an upgrade-to job for one of the requested
 // model UUIDs. If so, it returns that model UUID; otherwise, it returns an empty string.
 func requestedUpgradeToModelUUID(job *rivertype.JobRow, requestedModelUUIDs map[string]struct{}) (string, error) {
 	var metadata rivertypes.JobModelUUIDMetadata

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -413,3 +413,44 @@ func TestGetUpgradeToStatusForModel_UsesLatestFinalizedRoot(t *testing.T) {
 	c.Assert(status.Root.State, qt.Equals, string(rivertype.JobStateCompleted))
 	c.Assert(status.Root.Errors, qt.HasLen, 0)
 }
+
+func TestListUpgradeToJobsForModels_MultipleModels(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	jobManager, client := setupJobsIntegrationTest(c)
+
+	requestedModelUUID1 := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	requestedModelUUID2 := "93608db4-f1cb-4da5-9926-8233981aef0b"
+	nonRequestedModelUUID := "93608db4-f1cb-4da5-9926-8233981aef0c"
+
+	for _, testCase := range []struct {
+		modelUUID string
+		username  string
+		queue     string
+	}{
+		{modelUUID: requestedModelUUID1, username: "alice@canonical.com", queue: "inactive"},
+		{modelUUID: requestedModelUUID2, username: "bob@canonical.com", queue: "inactive"},
+		{modelUUID: nonRequestedModelUUID, username: "carol@canonical.com", queue: "inactive"},
+	} {
+		metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: testCase.modelUUID})
+		c.Assert(err, qt.IsNil)
+
+		_, err = client.Insert(ctx, rivertypes.UpgradeToArgs{
+			ModelUUID:            testCase.modelUUID,
+			Username:             testCase.username,
+			TargetControllerName: "target-controller",
+		}, &river.InsertOpts{Metadata: metadata, Queue: testCase.queue, MaxAttempts: 1})
+		c.Assert(err, qt.IsNil)
+	}
+
+	jobsByModelUUID, err := jobManager.ListUpgradeToJobsForModels(ctx, []string{
+		requestedModelUUID1,
+		requestedModelUUID2,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobsByModelUUID, qt.DeepEquals, map[string]bool{
+		requestedModelUUID1: true,
+		requestedModelUUID2: true,
+	})
+}

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -454,3 +454,29 @@ func TestListUpgradeToJobsForModels_MultipleModels(t *testing.T) {
 		requestedModelUUID2: UpgradeToModelStatusProgress,
 	})
 }
+
+func TestListUpgradeToJobsForModels_CompletedModel(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	jobManager, client := setupJobsIntegrationTest(c)
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: modelUUID})
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            modelUUID,
+		Username:             "complete-model",
+		TargetControllerName: "target-controller",
+	}, &river.InsertOpts{Metadata: metadata, MaxAttempts: 1})
+	c.Assert(err, qt.IsNil)
+
+	waitForJobs(c, client, 1, defaultTestTimeout)
+
+	jobsByModelUUID, err := jobManager.ListUpgradeToJobsForModels(ctx, []string{modelUUID})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobsByModelUUID, qt.DeepEquals, map[string]string{
+		modelUUID: UpgradeToModelStatusCompleted,
+	})
+}

--- a/internal/jimm/jobs/jobs_integration_test.go
+++ b/internal/jimm/jobs/jobs_integration_test.go
@@ -449,8 +449,8 @@ func TestListUpgradeToJobsForModels_MultipleModels(t *testing.T) {
 		requestedModelUUID2,
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(jobsByModelUUID, qt.DeepEquals, map[string]bool{
-		requestedModelUUID1: true,
-		requestedModelUUID2: true,
+	c.Assert(jobsByModelUUID, qt.DeepEquals, map[string]string{
+		requestedModelUUID1: UpgradeToModelStatusProgress,
+		requestedModelUUID2: UpgradeToModelStatusProgress,
 	})
 }

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -181,10 +181,13 @@ func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	metadataTwo, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-2"})
 	c.Assert(err, qt.IsNil)
+	metadataThree, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-3"})
+	c.Assert(err, qt.IsNil)
 
 	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
 		{Metadata: metadataOne},
 		{Metadata: metadataTwo},
+		{Metadata: metadataThree},
 	}}, nil)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1", "model-uuid-2"})

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -176,6 +176,8 @@ func TestGetUpgradeToStatusForModel_ActiveQueryError(t *testing.T) {
 func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 	c := qt.New(t)
 	deps := setupDeps(c)
+	now := time.Now()
+	earlier := now.Add(-time.Minute)
 
 	metadataOne, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
 	c.Assert(err, qt.IsNil)
@@ -183,18 +185,62 @@ func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	metadataThree, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-3"})
 	c.Assert(err, qt.IsNil)
+	metadataCompleted, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-2"})
+	c.Assert(err, qt.IsNil)
 
 	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
-		{Metadata: metadataOne},
-		{Metadata: metadataTwo},
-		{Metadata: metadataThree},
+		{Metadata: metadataOne, State: rivertype.JobStateRunning, AttemptedAt: &now},
+		{Metadata: metadataTwo, State: rivertype.JobStateRunning, AttemptedAt: &earlier},
+		{Metadata: metadataThree, State: rivertype.JobStateRunning, AttemptedAt: &now},
+		{Metadata: metadataTwo, State: rivertype.JobStateDiscarded, AttemptedAt: &now},
+		{Metadata: metadataCompleted, State: rivertype.JobStateCompleted, AttemptedAt: &earlier},
 	}}, nil)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1", "model-uuid-2"})
 	c.Assert(err, qt.IsNil)
-	c.Assert(jobsByModel, qt.DeepEquals, map[string]bool{
-		"model-uuid-1": true,
-		"model-uuid-2": true,
+	c.Assert(jobsByModel, qt.DeepEquals, map[string]string{
+		"model-uuid-1": UpgradeToModelStatusProgress,
+		"model-uuid-2": UpgradeToModelStatusError,
+	})
+}
+
+func TestListUpgradeToJobsForModels_CompletedJobSuppressesOlderError(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+	now := time.Now()
+	earlier := now.Add(-time.Minute)
+
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
+	c.Assert(err, qt.IsNil)
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+		{Metadata: metadata, State: rivertype.JobStateCompleted, AttemptedAt: &now},
+		{Metadata: metadata, State: rivertype.JobStateDiscarded, AttemptedAt: &earlier},
+	}}, nil)
+
+	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobsByModel, qt.DeepEquals, map[string]string{})
+}
+
+func TestListUpgradeToJobsForModels_ActiveJobSuppressesOlderError(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+	now := time.Now()
+	earlier := now.Add(-time.Minute)
+
+	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
+	c.Assert(err, qt.IsNil)
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+		{Metadata: metadata, State: rivertype.JobStateRunning, AttemptedAt: &now},
+		{Metadata: metadata, State: rivertype.JobStateDiscarded, AttemptedAt: &earlier},
+	}}, nil)
+
+	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobsByModel, qt.DeepEquals, map[string]string{
+		"model-uuid-1": UpgradeToModelStatusProgress,
 	})
 }
 

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -220,7 +220,9 @@ func TestListUpgradeToJobsForModels_CompletedJobSuppressesOlderError(t *testing.
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1"})
 	c.Assert(err, qt.IsNil)
-	c.Assert(jobsByModel, qt.DeepEquals, map[string]string{})
+	c.Assert(jobsByModel, qt.DeepEquals, map[string]string{
+		"model-uuid-1": UpgradeToModelStatusCompleted,
+	})
 }
 
 func TestListUpgradeToJobsForModels_ActiveJobSuppressesOlderError(t *testing.T) {

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -4,6 +4,7 @@ package jobs
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/rivertypes"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
@@ -169,4 +171,37 @@ func TestGetUpgradeToStatusForModel_ActiveQueryError(t *testing.T) {
 	status, err := deps.jobManager.GetUpgradeToStatusForModel(ctx, "model-uuid")
 	c.Assert(err, qt.ErrorMatches, "query error")
 	c.Assert(status, qt.IsNil)
+}
+
+func TestListUpgradeToJobsForModels_Success(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	metadataOne, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
+	c.Assert(err, qt.IsNil)
+	metadataTwo, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-2"})
+	c.Assert(err, qt.IsNil)
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+		{Metadata: metadataOne},
+		{Metadata: metadataTwo},
+	}}, nil)
+
+	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1", "model-uuid-2"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jobsByModel, qt.DeepEquals, map[string]bool{
+		"model-uuid-1": true,
+		"model-uuid-2": true,
+	})
+}
+
+func TestListUpgradeToJobsForModels_QueryError(t *testing.T) {
+	c := qt.New(t)
+	deps := setupDeps(c)
+
+	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(nil, errors.New("query error"))
+
+	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid"})
+	c.Assert(err, qt.ErrorMatches, "query error")
+	c.Assert(jobsByModel, qt.IsNil)
 }

--- a/internal/jimm/jobs/jobs_test.go
+++ b/internal/jimm/jobs/jobs_test.go
@@ -176,8 +176,6 @@ func TestGetUpgradeToStatusForModel_ActiveQueryError(t *testing.T) {
 func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 	c := qt.New(t)
 	deps := setupDeps(c)
-	now := time.Now()
-	earlier := now.Add(-time.Minute)
 
 	metadataOne, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
 	c.Assert(err, qt.IsNil)
@@ -188,13 +186,16 @@ func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 	metadataCompleted, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-2"})
 	c.Assert(err, qt.IsNil)
 
-	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
-		{Metadata: metadataOne, State: rivertype.JobStateRunning, AttemptedAt: &now},
-		{Metadata: metadataTwo, State: rivertype.JobStateRunning, AttemptedAt: &earlier},
-		{Metadata: metadataThree, State: rivertype.JobStateRunning, AttemptedAt: &now},
-		{Metadata: metadataTwo, State: rivertype.JobStateDiscarded, AttemptedAt: &now},
-		{Metadata: metadataCompleted, State: rivertype.JobStateCompleted, AttemptedAt: &earlier},
-	}}, nil)
+	gomock.InOrder(
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+			{Metadata: metadataOne, State: rivertype.JobStateRunning},
+			{Metadata: metadataThree, State: rivertype.JobStateRunning},
+		}}, nil),
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+			{Metadata: metadataTwo, State: rivertype.JobStateDiscarded},
+			{Metadata: metadataCompleted, State: rivertype.JobStateCompleted},
+		}}, nil),
+	)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1", "model-uuid-2"})
 	c.Assert(err, qt.IsNil)
@@ -207,16 +208,17 @@ func TestListUpgradeToJobsForModels_Success(t *testing.T) {
 func TestListUpgradeToJobsForModels_CompletedJobSuppressesOlderError(t *testing.T) {
 	c := qt.New(t)
 	deps := setupDeps(c)
-	now := time.Now()
-	earlier := now.Add(-time.Minute)
 
 	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
 	c.Assert(err, qt.IsNil)
 
-	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
-		{Metadata: metadata, State: rivertype.JobStateCompleted, AttemptedAt: &now},
-		{Metadata: metadata, State: rivertype.JobStateDiscarded, AttemptedAt: &earlier},
-	}}, nil)
+	gomock.InOrder(
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{}, nil),
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+			{Metadata: metadata, State: rivertype.JobStateCompleted},
+			{Metadata: metadata, State: rivertype.JobStateDiscarded},
+		}}, nil),
+	)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1"})
 	c.Assert(err, qt.IsNil)
@@ -228,16 +230,18 @@ func TestListUpgradeToJobsForModels_CompletedJobSuppressesOlderError(t *testing.
 func TestListUpgradeToJobsForModels_ActiveJobSuppressesOlderError(t *testing.T) {
 	c := qt.New(t)
 	deps := setupDeps(c)
-	now := time.Now()
-	earlier := now.Add(-time.Minute)
 
 	metadata, err := json.Marshal(rivertypes.JobModelUUIDMetadata{ModelUUID: "model-uuid-1"})
 	c.Assert(err, qt.IsNil)
 
-	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
-		{Metadata: metadata, State: rivertype.JobStateRunning, AttemptedAt: &now},
-		{Metadata: metadata, State: rivertype.JobStateDiscarded, AttemptedAt: &earlier},
-	}}, nil)
+	gomock.InOrder(
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+			{Metadata: metadata, State: rivertype.JobStateRunning},
+		}}, nil),
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{Jobs: []*rivertype.JobRow{
+			{Metadata: metadata, State: rivertype.JobStateDiscarded},
+		}}, nil),
+	)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid-1"})
 	c.Assert(err, qt.IsNil)
@@ -250,7 +254,10 @@ func TestListUpgradeToJobsForModels_QueryError(t *testing.T) {
 	c := qt.New(t)
 	deps := setupDeps(c)
 
-	deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(nil, errors.New("query error"))
+	gomock.InOrder(
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(&river.JobListResult{}, nil),
+		deps.jobQuerier.EXPECT().ListJobs(gomock.Any(), gomock.Any()).Return(nil, errors.New("query error")),
+	)
 
 	jobsByModel, err := deps.jobManager.ListUpgradeToJobsForModels(context.Background(), []string{"model-uuid"})
 	c.Assert(err, qt.ErrorMatches, "query error")

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -453,13 +452,6 @@ func (j *JujuManager) ListModelControllerInfo(ctx context.Context, user *openfga
 			ControllerUUID: model.Controller.UUID,
 		})
 	}
-
-	slices.SortFunc(info, func(a, b apiparams.ModelControllerInfoListItem) int {
-		if cmp := strings.Compare(a.ModelName, b.ModelName); cmp != 0 {
-			return cmp
-		}
-		return strings.Compare(a.ModelUUID, b.ModelUUID)
-	})
 
 	return info, nil
 }

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -21,6 +22,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/credentials"
 	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
@@ -424,4 +426,40 @@ func (j *JujuManager) ModelControllerInfo(ctx context.Context, user *openfga.Use
 		ControllerName: model.Controller.Name,
 		ControllerUUID: model.Controller.UUID,
 	}, nil
+}
+
+// ListModelControllerInfo returns lightweight controller information for all
+// models the user can read.
+func (j *JujuManager) ListModelControllerInfo(ctx context.Context, user *openfga.User) ([]apiparams.ModelControllerInfoListItem, error) {
+	modelUUIDs, err := user.ListModels(ctx, ofganames.ReaderRelation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user models: %w", err)
+	}
+	if len(modelUUIDs) == 0 {
+		return []apiparams.ModelControllerInfoListItem{}, nil
+	}
+
+	models, err := j.Database.GetModelsByUUID(ctx, modelUUIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get models by uuid: %w", err)
+	}
+
+	info := make([]apiparams.ModelControllerInfoListItem, 0, len(models))
+	for _, model := range models {
+		info = append(info, apiparams.ModelControllerInfoListItem{
+			ModelName:      model.Name,
+			ModelUUID:      model.UUID.String,
+			ControllerName: model.Controller.Name,
+			ControllerUUID: model.Controller.UUID,
+		})
+	}
+
+	slices.SortFunc(info, func(a, b apiparams.ModelControllerInfoListItem) int {
+		if cmp := strings.Compare(a.ModelName, b.ModelName); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.ModelUUID, b.ModelUUID)
+	})
+
+	return info, nil
 }

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -1317,3 +1317,26 @@ func TestModelControllerInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestListModelControllerInfo(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testModelControllerInfoEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	userIdentity := env.User("bob@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&userIdentity, j.OpenFGAClient)
+
+	info, err := j.ListModelControllerInfo(ctx, user)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info, qt.DeepEquals, []params.ModelControllerInfoListItem{{
+		ModelName:      "model-2",
+		ModelUUID:      "00000002-0000-0000-0000-000000000002",
+		ControllerName: "controller-2",
+		ControllerUUID: "00000001-0000-0000-0000-000000000002",
+	}})
+}

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -249,6 +249,7 @@ type JujuManager interface {
 	ModelDefaultsForCloud(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag) (jujuparams.ModelDefaultsResult, error)
 	ModelInfo(ctx context.Context, u *openfga.User, mt names.ModelTag) (jujuclient.ModelInfo, error)
 	ModelControllerInfo(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error)
+	ListModelControllerInfo(ctx context.Context, user *openfga.User) ([]params.ModelControllerInfoListItem, error)
 	ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) ([]base.UserModelSummary, error)
 	ModelStatus(ctx context.Context, u *openfga.User, mt names.ModelTag) (base.ModelStatus, error)
 	QueryModelsJq(ctx context.Context, models []string, jqQuery string) (params.CrossModelQueryResponse, error)
@@ -347,5 +348,6 @@ type JobManager interface {
 	GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error)
 	GetActiveBootstrapStatusForController(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
 	GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
+	ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error)
 	ListJobs(ctx context.Context, params params.ListJobsRequest) (params.ListJobsResponse, error)
 }

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -348,6 +348,6 @@ type JobManager interface {
 	GetJobInfo(ctx context.Context, jobID int64) (jobs.JobInfo, error)
 	GetActiveBootstrapStatusForController(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
 	GetUpgradeToStatusForModel(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
-	ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error)
+	ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]string, error)
 	ListJobs(ctx context.Context, params params.ListJobsRequest) (params.ListJobsResponse, error)
 }

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -149,8 +149,6 @@ func init() {
 	}
 }
 
-const upgradeToInProgressStatus = "upgrade-to in progress"
-
 // DisableControllerUUIDMasking ensures that the controller UUID returned
 // with any model information is the UUID of the juju controller that is
 // hosting the model, and not JAAS.
@@ -893,8 +891,8 @@ func (r *controllerRoot) ListModelControllerInfo(ctx context.Context) (apiparams
 	}
 
 	for i := range models {
-		if activeUpgradeJobs[models[i].ModelUUID] {
-			models[i].UpgradeToJobStatus = upgradeToInProgressStatus
+		if status, ok := activeUpgradeJobs[models[i].ModelUUID]; ok {
+			models[i].UpgradeToJobStatus = status
 		}
 	}
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -76,6 +76,7 @@ func init() {
 		removeControllerProfile := rpc.Method(r.RemoveControllerProfile)
 		upgradeToMethod := rpc.Method(r.UpgradeTo)
 		listUserCloudsMethod := rpc.Method(r.ListUserClouds)
+		listModelsMethod := rpc.Method(r.ListModelControllerInfo)
 		modelControllerInfoMethod := rpc.Method(r.ModelControllerInfo)
 		showControllerMethod := rpc.Method(r.ShowController)
 		jobInfoMethod := rpc.Method(r.JobInfo)
@@ -92,6 +93,7 @@ func init() {
 		r.AddMethod("JIMM", 4, "GrantAuditLogAccess", grantAuditLogAccessMethod)
 		r.AddMethod("JIMM", 4, "ImportModel", importModelMethod)
 		r.AddMethod("JIMM", 4, "ListControllers", listControllersMethod)
+		r.AddMethod("JIMM", 4, "ListModels", listModelsMethod)
 		r.AddMethod("JIMM", 4, "ListUserClouds", listUserCloudsMethod)
 		r.AddMethod("JIMM", 4, "MigrateModel", migrateModel)
 		r.AddMethod("JIMM", 4, "ModelControllerInfo", modelControllerInfoMethod)
@@ -146,6 +148,8 @@ func init() {
 		return []int{4}
 	}
 }
+
+const upgradeToInProgressStatus = "upgrade-to in progress"
 
 // DisableControllerUUIDMasking ensures that the controller UUID returned
 // with any model information is the UUID of the juju controller that is
@@ -868,6 +872,33 @@ func (r *controllerRoot) ModelControllerInfo(ctx context.Context, req apiparams.
 	response.UpgradeToJobStatus = upgradeToStatus
 
 	return *response, nil
+}
+
+// ListModelControllerInfo returns controller information for all models the
+// authenticated user can access.
+func (r *controllerRoot) ListModelControllerInfo(ctx context.Context) (apiparams.ListModelsResponse, error) {
+	models, err := r.jimm.JujuManager().ListModelControllerInfo(ctx, r.user)
+	if err != nil {
+		return apiparams.ListModelsResponse{}, err
+	}
+
+	modelUUIDs := make([]string, 0, len(models))
+	for _, model := range models {
+		modelUUIDs = append(modelUUIDs, model.ModelUUID)
+	}
+
+	activeUpgradeJobs, err := r.jimm.JobManager().ListUpgradeToJobsForModels(ctx, modelUUIDs)
+	if err != nil {
+		return apiparams.ListModelsResponse{}, err
+	}
+
+	for i := range models {
+		if activeUpgradeJobs[models[i].ModelUUID] {
+			models[i].UpgradeToJobStatus = upgradeToInProgressStatus
+		}
+	}
+
+	return apiparams.ListModelsResponse{Models: models}, nil
 }
 
 // ShowController returns information about a controller or an in-progress bootstrap reservation.

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -1198,13 +1198,13 @@ func TestListModelControllerInfo(t *testing.T) {
 		},
 		JobManager_: func() jujuapi.JobManager {
 			return &mocks.JobManager{
-				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
 					c.Assert(modelUUIDs, qt.DeepEquals, []string{
 						"00000000-0000-0000-0000-000000000001",
 						"00000000-0000-0000-0000-000000000002",
 					})
-					return map[string]bool{
-						"00000000-0000-0000-0000-000000000002": true,
+					return map[string]string{
+						"00000000-0000-0000-0000-000000000002": jobs.UpgradeToModelStatusProgress,
 					}, nil
 				},
 			}
@@ -1225,7 +1225,50 @@ func TestListModelControllerInfo(t *testing.T) {
 		ModelUUID:          "00000000-0000-0000-0000-000000000002",
 		ControllerName:     "controller-b",
 		ControllerUUID:     "10000000-0000-0000-0000-000000000002",
-		UpgradeToJobStatus: "upgrade-to in progress",
+		UpgradeToJobStatus: jobs.UpgradeToModelStatusProgress,
+	}}})
+}
+
+func TestListModelControllerInfo_UpgradeJobFailed(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	models := []apiparams.ModelControllerInfoListItem{{
+		ModelName:      "alpha",
+		ModelUUID:      "00000000-0000-0000-0000-000000000001",
+		ControllerName: "controller-a",
+		ControllerUUID: "10000000-0000-0000-0000-000000000001",
+	}}
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ListModelControllerInfo_: func(ctx context.Context, user *openfga.User) ([]apiparams.ModelControllerInfoListItem, error) {
+					return append([]apiparams.ModelControllerInfoListItem(nil), models...), nil
+				},
+			}
+		},
+		JobManager_: func() jujuapi.JobManager {
+			return &mocks.JobManager{
+				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
+					return map[string]string{
+						"00000000-0000-0000-0000-000000000001": jobs.UpgradeToModelStatusError,
+					}, nil
+				},
+			}
+		},
+	}
+
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	resp, err := root.ListModelControllerInfo(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp, qt.DeepEquals, apiparams.ListModelsResponse{Models: []apiparams.ModelControllerInfoListItem{{
+		ModelName:          "alpha",
+		ModelUUID:          "00000000-0000-0000-0000-000000000001",
+		ControllerName:     "controller-a",
+		ControllerUUID:     "10000000-0000-0000-0000-000000000001",
+		UpgradeToJobStatus: jobs.UpgradeToModelStatusError,
 	}}})
 }
 
@@ -1245,7 +1288,7 @@ func TestListModelControllerInfo_UpgradeJobError(t *testing.T) {
 		},
 		JobManager_: func() jujuapi.JobManager {
 			return &mocks.JobManager{
-				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
 					return nil, errors.New("river query failed")
 				},
 			}

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -1171,6 +1171,93 @@ func TestModelControllerInfo_UpgradeStatusError(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "river query failed")
 }
 
+func TestListModelControllerInfo(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	models := []apiparams.ModelControllerInfoListItem{{
+		ModelName:      "alpha",
+		ModelUUID:      "00000000-0000-0000-0000-000000000001",
+		ControllerName: "controller-a",
+		ControllerUUID: "10000000-0000-0000-0000-000000000001",
+	}, {
+		ModelName:      "beta",
+		ModelUUID:      "00000000-0000-0000-0000-000000000002",
+		ControllerName: "controller-b",
+		ControllerUUID: "10000000-0000-0000-0000-000000000002",
+	}}
+
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ListModelControllerInfo_: func(ctx context.Context, user *openfga.User) ([]apiparams.ModelControllerInfoListItem, error) {
+					c.Assert(user.JimmAdmin, qt.Equals, false)
+					return append([]apiparams.ModelControllerInfoListItem(nil), models...), nil
+				},
+			}
+		},
+		JobManager_: func() jujuapi.JobManager {
+			return &mocks.JobManager{
+				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+					c.Assert(modelUUIDs, qt.DeepEquals, []string{
+						"00000000-0000-0000-0000-000000000001",
+						"00000000-0000-0000-0000-000000000002",
+					})
+					return map[string]bool{
+						"00000000-0000-0000-0000-000000000002": true,
+					}, nil
+				},
+			}
+		},
+	}
+
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	resp, err := root.ListModelControllerInfo(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(resp, qt.DeepEquals, apiparams.ListModelsResponse{Models: []apiparams.ModelControllerInfoListItem{{
+		ModelName:      "alpha",
+		ModelUUID:      "00000000-0000-0000-0000-000000000001",
+		ControllerName: "controller-a",
+		ControllerUUID: "10000000-0000-0000-0000-000000000001",
+	}, {
+		ModelName:          "beta",
+		ModelUUID:          "00000000-0000-0000-0000-000000000002",
+		ControllerName:     "controller-b",
+		ControllerUUID:     "10000000-0000-0000-0000-000000000002",
+		UpgradeToJobStatus: "upgrade-to in progress",
+	}}})
+}
+
+func TestListModelControllerInfo_UpgradeJobError(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ListModelControllerInfo_: func(ctx context.Context, user *openfga.User) ([]apiparams.ModelControllerInfoListItem, error) {
+					return []apiparams.ModelControllerInfoListItem{{
+						ModelUUID: "00000000-0000-0000-0000-000000000001",
+					}}, nil
+				},
+			}
+		},
+		JobManager_: func() jujuapi.JobManager {
+			return &mocks.JobManager{
+				ListUpgradeToJobsForModels_: func(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+					return nil, errors.New("river query failed")
+				},
+			}
+		},
+	}
+
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	_, err := root.ListModelControllerInfo(ctx)
+	c.Assert(err, qt.ErrorMatches, "river query failed")
+}
+
 func TestJobInfo(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
@@ -14,7 +14,7 @@ type JobManager struct {
 	GetJobInfo_                            func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
 	GetActiveBootstrapStatusForController_ func(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
 	GetUpgradeToStatusForModel_            func(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
-	ListUpgradeToJobsForModels_            func(ctx context.Context, modelUUIDs []string) (map[string]bool, error)
+	ListUpgradeToJobsForModels_            func(ctx context.Context, modelUUIDs []string) (map[string]string, error)
 	ListJobs_                              func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
 }
 
@@ -39,7 +39,7 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 	return j.GetUpgradeToStatusForModel_(ctx, modelUUID)
 }
 
-func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]string, error) {
 	if j.ListUpgradeToJobsForModels_ == nil {
 		return nil, errors.New("not implemented")
 	}

--- a/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_jobmanager_mock.go
@@ -14,6 +14,7 @@ type JobManager struct {
 	GetJobInfo_                            func(ctx context.Context, jobID int64) (jobs.JobInfo, error)
 	GetActiveBootstrapStatusForController_ func(ctx context.Context, controllerName string) (*params.BootstrapJobStatus, error)
 	GetUpgradeToStatusForModel_            func(ctx context.Context, modelUUID string) (*params.UpgradeToJobStatus, error)
+	ListUpgradeToJobsForModels_            func(ctx context.Context, modelUUIDs []string) (map[string]bool, error)
 	ListJobs_                              func(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error)
 }
 
@@ -36,6 +37,13 @@ func (j *JobManager) GetUpgradeToStatusForModel(ctx context.Context, modelUUID s
 		return nil, errors.New("not implemented")
 	}
 	return j.GetUpgradeToStatusForModel_(ctx, modelUUID)
+}
+
+func (j *JobManager) ListUpgradeToJobsForModels(ctx context.Context, modelUUIDs []string) (map[string]bool, error) {
+	if j.ListUpgradeToJobsForModels_ == nil {
+		return nil, errors.New("not implemented")
+	}
+	return j.ListUpgradeToJobsForModels_(ctx, modelUUIDs)
 }
 
 func (j *JobManager) ListJobs(ctx context.Context, req params.ListJobsRequest) (params.ListJobsResponse, error) {

--- a/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_mock.go
@@ -50,6 +50,7 @@ type JujuManager struct {
 	InitiateInternalMigration_         func(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
 	InitiateMigration_                 func(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error)
 	ListApplicationOffers_             func(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error)
+	ListModelControllerInfo_           func(ctx context.Context, user *openfga.User) ([]params.ModelControllerInfoListItem, error)
 	ListModels_                        func(ctx context.Context, user *openfga.User) ([]base.UserModel, error)
 	ListResources_                     func(ctx context.Context, user *openfga.User, filter pagination.LimitOffsetPagination, namePrefixFilter, typeFilter string) ([]db.Resource, error)
 	ModelControllerInfo_               func(ctx context.Context, user *openfga.User, qualifier juju.ModelControllerInfoQualifier) (*params.ModelControllerInfo, error)
@@ -246,6 +247,12 @@ func (j *JujuManager) ListModels(ctx context.Context, user *openfga.User) ([]bas
 		return nil, errors.New("not implemented")
 	}
 	return j.ListModels_(ctx, user)
+}
+func (j *JujuManager) ListModelControllerInfo(ctx context.Context, user *openfga.User) ([]params.ModelControllerInfoListItem, error) {
+	if j.ListModelControllerInfo_ == nil {
+		return nil, errors.New("not implemented")
+	}
+	return j.ListModelControllerInfo_(ctx, user)
 }
 func (j *JujuManager) UpdateMetrics(ctx context.Context) {
 	if j.UpdateMetrics_ == nil {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -365,6 +365,14 @@ func (c *Client) ModelControllerInfo(modelQualifier string) (*params.ModelContro
 	return &resp, err
 }
 
+// ListModels returns controller information for all models visible to the
+// authenticated user, including a lightweight upgrade-to status when present.
+func (c *Client) ListModels() ([]params.ModelControllerInfoListItem, error) {
+	var resp params.ListModelsResponse
+	err := c.caller.APICall("JIMM", 4, "", "ListModels", nil, &resp)
+	return resp.Models, err
+}
+
 // ShowController returns information about a controller or a pending bootstrap reservation.
 func (c *Client) ShowController(controllerName string) (*params.ControllerInfo, error) {
 	req := params.ShowControllerRequest{ControllerName: controllerName}

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -839,6 +839,28 @@ type ModelControllerInfo struct {
 	UpgradeToJobStatus *UpgradeToJobStatus `json:"upgrade-to-job-status,omitempty" yaml:"upgrade-to-job-status,omitempty"`
 }
 
+// ModelControllerInfoListItem holds lightweight controller information about a
+// model as returned by ListModels.
+type ModelControllerInfoListItem struct {
+	// ModelName is the name of the model.
+	ModelName string `json:"model-name" yaml:"model-name"`
+	// ModelUUID is the UUID of the model.
+	ModelUUID string `json:"model-uuid" yaml:"model-uuid"`
+	// ControllerName is the name of the controller hosting the model.
+	ControllerName string `json:"controller-name" yaml:"controller-name"`
+	// ControllerUUID is the UUID of the controller hosting the model.
+	ControllerUUID string `json:"controller-uuid" yaml:"controller-uuid"`
+
+	// UpgradeToJobStatus holds a lightweight status string when an upgrade-to job
+	// is currently associated with the model.
+	UpgradeToJobStatus string `json:"upgrade-to-job-status,omitempty" yaml:"upgrade-to-job-status,omitempty"`
+}
+
+// ListModelsResponse holds the response for the JIMM ListModels method.
+type ListModelsResponse struct {
+	Models []ModelControllerInfoListItem `json:"models" yaml:"models"`
+}
+
 // JobInfoRequest holds the request to get information about a job.
 type JobInfoRequest struct {
 	// JobID is the ID of the job to get information about.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -852,7 +852,7 @@ type ModelControllerInfoListItem struct {
 	ControllerUUID string `json:"controller-uuid" yaml:"controller-uuid"`
 
 	// UpgradeToJobStatus holds a lightweight status string for the latest relevant
-	// upgrade-to job associated with the model, such as progress or error.
+	// upgrade-to job associated with the model, such as progress, error, or completed.
 	UpgradeToJobStatus string `json:"upgrade-to-job-status,omitempty" yaml:"upgrade-to-job-status,omitempty"`
 }
 

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -851,8 +851,8 @@ type ModelControllerInfoListItem struct {
 	// ControllerUUID is the UUID of the controller hosting the model.
 	ControllerUUID string `json:"controller-uuid" yaml:"controller-uuid"`
 
-	// UpgradeToJobStatus holds a lightweight status string when an upgrade-to job
-	// is currently associated with the model.
+	// UpgradeToJobStatus holds a lightweight status string for the latest relevant
+	// upgrade-to job associated with the model, such as progress or error.
 	UpgradeToJobStatus string `json:"upgrade-to-job-status,omitempty" yaml:"upgrade-to-job-status,omitempty"`
 }
 


### PR DESCRIPTION
## Description

The implementation is:
- list models per user
- check if river contains any of the model-uuid in metadata of jobs
- add a simple "in-progress" status for said models, it contains less info than `show-model` but it's a lighter query, and you can always gather more details targeting a specific model

I've added an integration test for this multiple-metadata query to make sure it was actually working as expected.