### PR TITLE
feat: jaas show-controller command

### DIFF
--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -35,6 +35,7 @@ type JIMMAPI interface {
 	RemoveController(req *params.RemoveControllerRequest) (params.ControllerInfo, error)
 	RemoveControllerProfile(req *params.RemoveControllerProfileRequest) error
 	SetControllerDeprecated(req *params.SetControllerDeprecatedRequest) (params.ControllerInfo, error)
+	ShowController(controllerName string) (*params.ControllerInfo, error)
 
 	// Migration operations
 	ListMigrationTargets(req *params.ListMigrationTargetsRequest) ([]params.ControllerInfo, error)

--- a/cmd/jaas/cmd/listcontrollers.go
+++ b/cmd/jaas/cmd/listcontrollers.go
@@ -13,6 +13,8 @@ import (
 const (
 	listControllersCommandDoc = `
 Displays controller information for all controllers known to JIMM.
+
+For JAAS admins, this will also display controllers that are in the process of being bootstrapped.
 `
 	listControllersCommandExample = `
     juju controllers

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -1590,6 +1590,45 @@ func (c *MockJIMMAPISetControllerDeprecatedCall) DoAndReturn(f func(*params.SetC
 	return c
 }
 
+// ShowController mocks base method.
+func (m *MockJIMMAPI) ShowController(controllerName string) (*params.ControllerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShowController", controllerName)
+	ret0, _ := ret[0].(*params.ControllerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShowController indicates an expected call of ShowController.
+func (mr *MockJIMMAPIMockRecorder) ShowController(controllerName any) *MockJIMMAPIShowControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShowController", reflect.TypeOf((*MockJIMMAPI)(nil).ShowController), controllerName)
+	return &MockJIMMAPIShowControllerCall{Call: call}
+}
+
+// MockJIMMAPIShowControllerCall wrap *gomock.Call
+type MockJIMMAPIShowControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIShowControllerCall) Return(arg0 *params.ControllerInfo, arg1 error) *MockJIMMAPIShowControllerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIShowControllerCall) Do(f func(string) (*params.ControllerInfo, error)) *MockJIMMAPIShowControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIShowControllerCall) DoAndReturn(f func(string) (*params.ControllerInfo, error)) *MockJIMMAPIShowControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // StartBootstrap mocks base method.
 func (m *MockJIMMAPI) StartBootstrap(req *params.BootstrapParams) (*params.StartBootstrapResponse, error) {
 	m.ctrl.T.Helper()

--- a/cmd/jaas/cmd/showcontroller.go
+++ b/cmd/jaas/cmd/showcontroller.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Canonical.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+)
+
+const (
+	showControllerCommandDoc = `
+Displays information about a controller known to JIMM.
+
+The output includes the controller name, UUID, addresses, cloud placement,
+agent version, status, and any active bootstrap status tracked by JIMM.
+`
+	showControllerCommandExample = `
+    juju jaas show-controller my-controller
+    juju jaas show-controller my-controller --format json
+`
+)
+
+// NewShowControllerCommand returns a command to display controller information.
+func NewShowControllerCommand() cmd.Command {
+	cmd := &showControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
+
+	return modelcmd.WrapBase(cmd)
+}
+
+// showControllerCommand displays information about a controller known to JIMM.
+type showControllerCommand struct {
+	jaasCommandBase
+	out cmd.Output
+
+	controllerName string
+}
+
+func (c *showControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "show-controller",
+		Args:     "<controller name>",
+		Purpose:  "Displays information about a controller",
+		Doc:      showControllerCommandDoc,
+		Examples: showControllerCommandExample,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *showControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements the cmd.Command interface.
+func (c *showControllerCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("missing controller name")
+	}
+	c.controllerName, args = args[0], args[1:]
+	if len(args) > 0 {
+		return fmt.Errorf("unknown arguments: %v", args)
+	}
+	return nil
+}
+
+// Run implements Command.Run.
+func (c *showControllerCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.getJIMMAPI()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	info, err := client.ShowController(c.controllerName)
+	if err != nil {
+		return err
+	}
+
+	return c.out.Write(ctxt, info)
+}

--- a/cmd/jaas/cmd/showcontroller.go
+++ b/cmd/jaas/cmd/showcontroller.go
@@ -16,8 +16,7 @@ const (
 	showControllerCommandDoc = `
 Displays information about a controller known to JIMM.
 
-The output includes the controller name, UUID, addresses, cloud placement,
-agent version, status, and any active bootstrap status tracked by JIMM.
+For controllers with an active bootstrap status, some fields will be empty/missing.
 `
 	showControllerCommandExample = `
     juju jaas show-controller my-controller

--- a/cmd/jaas/cmd/showcontroller_test.go
+++ b/cmd/jaas/cmd/showcontroller_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Canonical.
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"gopkg.in/yaml.v2"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+func runShowControllerCommand(c *qt.C, mocks *cmdMocks, args ...string) (string, error) {
+	showCmd := showControllerCommand{}
+	showCmd.SetClientStore(mocks.store)
+	showCmd.setJIMMAPI(mocks.client)
+
+	ctx := newTestContext(c)
+	err := initCommandWithError(&showCmd, args...)
+	if err != nil {
+		return "", err
+	}
+
+	err = showCmd.Run(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return cmdtesting.Stdout(ctx), nil
+}
+
+func TestShowControllerOutput(t *testing.T) {
+	c := qt.New(t)
+
+	attemptedAt := time.Date(2026, time.May, 29, 10, 45, 0, 0, time.UTC)
+	errAt := attemptedAt.Add(-2 * time.Minute)
+	controllerInfo := &apiparams.ControllerInfo{
+		Name:          "test-controller",
+		UUID:          "87654321-4321-4321-4321-cba987654321",
+		PublicAddress: "test-controller.example.com:443",
+		APIAddresses:  []string{"10.0.0.1:17070", "10.0.0.2:17070"},
+		CACertificate: "-----BEGIN CERTIFICATE-----\ntest-cert\n-----END CERTIFICATE-----",
+		CloudTag:      "cloud-test-cloud",
+		CloudRegion:   "test-region",
+		AgentVersion:  "3.6.8",
+		Status: jujuparams.EntityStatus{
+			Status: "available",
+			Info:   "controller is healthy",
+		},
+		BootstrapJobStatus: &apiparams.BootstrapJobStatus{
+			Bootstrap: apiparams.JobDetail{
+				State:       "running",
+				Attempt:     2,
+				MaxAttempts: 5,
+				AttemptedAt: &attemptedAt,
+				Errors: []apiparams.JobAttemptError{{
+					Attempt: 1,
+					At:      errAt,
+					Error:   "temporary network issue",
+				}},
+			},
+		},
+	}
+
+	mocks := setupCmdMocks(c)
+	mocks.client.EXPECT().Close().AnyTimes()
+	mocks.client.EXPECT().ShowController("test-controller").Return(controllerInfo, nil).AnyTimes()
+
+	expectedJSON := *controllerInfo
+	expectedJSON.Status.Data = nil
+	expectedYAML := *controllerInfo
+	expectedYAML.Status.Data = map[string]any{}
+
+	tests := []struct {
+		name   string
+		args   []string
+		want   apiparams.ControllerInfo
+		decode func(string) (apiparams.ControllerInfo, error)
+	}{
+		{
+			name: "json",
+			args: []string{"test-controller", "--format", "json"},
+			want: expectedJSON,
+			decode: func(output string) (apiparams.ControllerInfo, error) {
+				var actual apiparams.ControllerInfo
+				err := json.Unmarshal([]byte(strings.TrimSpace(output)), &actual)
+				return actual, err
+			},
+		},
+		{
+			name: "yaml",
+			args: []string{"test-controller", "--format", "yaml"},
+			want: expectedYAML,
+			decode: func(output string) (apiparams.ControllerInfo, error) {
+				var actual apiparams.ControllerInfo
+				err := yaml.Unmarshal([]byte(output), &actual)
+				return actual, err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			output, err := runShowControllerCommand(c, mocks, test.args...)
+			c.Assert(err, qt.IsNil)
+
+			actual, err := test.decode(output)
+			c.Assert(err, qt.IsNil)
+			c.Assert(actual, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestShowControllerError(t *testing.T) {
+	c := qt.New(t)
+
+	mocks := setupCmdMocks(c)
+	mocks.client.EXPECT().Close().AnyTimes()
+	mocks.client.EXPECT().ShowController("test-controller").Return(nil, errors.New("not found")).AnyTimes()
+
+	_, err := runShowControllerCommand(c, mocks, "test-controller")
+	c.Assert(err, qt.ErrorMatches, "not found")
+}
+
+func TestShowControllerArgsError(t *testing.T) {
+	c := qt.New(t)
+
+	mocks := setupCmdMocks(c)
+
+	_, err := runShowControllerCommand(c, mocks)
+	c.Assert(err, qt.ErrorMatches, "missing controller name")
+
+	_, err = runShowControllerCommand(c, mocks, "test-controller", "extra-arg")
+	c.Assert(err, qt.ErrorMatches, `unknown arguments: \[extra-arg\]`)
+}

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -59,6 +59,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewRenameRoleCommand())
 	jaasCmd.Register(cmd.NewRevokeAuditLogAccessCommand())
 	jaasCmd.Register(cmd.NewSetControllerDeprecatedCommand())
+	jaasCmd.Register(cmd.NewShowControllerCommand())
 	jaasCmd.Register(cmd.NewShowControllerProfileCommand())
 	jaasCmd.Register(cmd.NewShowModelCommand())
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -1454,6 +1454,36 @@ Sets controller deprecated status.
 Sets the deprecated status of a controller.
 
 
+(command-jaas-show-controller)=
+# jaas show-controller
+
+## Summary
+Displays information about a controller
+
+## Usage
+```juju jaas show-controller [options] <controller name>```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--format` | yaml | Specify output format (json&#x7c;yaml) |
+| `-o`, `--output` |  | Specify an output file |
+
+## Examples
+
+    juju jaas show-controller my-controller
+    juju jaas show-controller my-controller --format json
+
+
+## Details
+
+Displays information about a controller known to JIMM.
+
+The output includes the controller name, UUID, addresses, cloud placement,
+agent version, status, and any active bootstrap status tracked by JIMM.
+
+
 (command-jaas-show-controller-profile)=
 # jaas show-controller-profile
 

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -479,6 +479,8 @@ Lists all controllers known to JIMM.
 
 Displays controller information for all controllers known to JIMM.
 
+For JAAS admins, this will also display controllers that are in the process of being bootstrapped.
+
 
 (command-jaas-destroy-controller)=
 # jaas destroy-controller
@@ -1480,8 +1482,7 @@ Displays information about a controller
 
 Displays information about a controller known to JIMM.
 
-The output includes the controller name, UUID, addresses, cloud placement,
-agent version, status, and any active bootstrap status tracked by JIMM.
+For controllers with an active bootstrap status, some fields will be empty/missing.
 
 
 (command-jaas-show-controller-profile)=

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -87,3 +87,4 @@ parts:
       ln -sf jaas bin/juju-remove-controller-profile
       ln -sf jaas bin/juju-show-controller-profile
       ln -sf jaas bin/juju-update-controller-profile
+      ln -sf jaas bin/juju-show-controller      


### PR DESCRIPTION
## Description
This change adds a new JAAS CLI command `show-controller` that shows the details for a single controller.

Fixes [JUJU-9553](https://warthogs.atlassian.net/browse/JUJU-9553)

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


[JUJU-9553]: https://warthogs.atlassian.net/browse/JUJU-9553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ