### PR TITLE
feat: add controller details struct

### DIFF
--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -35,7 +35,7 @@ type JIMMAPI interface {
 	RemoveController(req *params.RemoveControllerRequest) (params.ControllerInfo, error)
 	RemoveControllerProfile(req *params.RemoveControllerProfileRequest) error
 	SetControllerDeprecated(req *params.SetControllerDeprecatedRequest) (params.ControllerInfo, error)
-	ShowController(controllerName string) (*params.ControllerInfo, error)
+	ShowController(controllerName string) (*params.ControllerDetails, error)
 
 	// Migration operations
 	ListMigrationTargets(req *params.ListMigrationTargetsRequest) ([]params.ControllerInfo, error)

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -1630,10 +1630,10 @@ func (c *MockJIMMAPISetControllerDeprecatedCall) DoAndReturn(f func(*params.SetC
 }
 
 // ShowController mocks base method.
-func (m *MockJIMMAPI) ShowController(controllerName string) (*params.ControllerInfo, error) {
+func (m *MockJIMMAPI) ShowController(controllerName string) (*params.ControllerDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShowController", controllerName)
-	ret0, _ := ret[0].(*params.ControllerInfo)
+	ret0, _ := ret[0].(*params.ControllerDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1651,19 +1651,19 @@ type MockJIMMAPIShowControllerCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockJIMMAPIShowControllerCall) Return(arg0 *params.ControllerInfo, arg1 error) *MockJIMMAPIShowControllerCall {
+func (c *MockJIMMAPIShowControllerCall) Return(arg0 *params.ControllerDetails, arg1 error) *MockJIMMAPIShowControllerCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJIMMAPIShowControllerCall) Do(f func(string) (*params.ControllerInfo, error)) *MockJIMMAPIShowControllerCall {
+func (c *MockJIMMAPIShowControllerCall) Do(f func(string) (*params.ControllerDetails, error)) *MockJIMMAPIShowControllerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJIMMAPIShowControllerCall) DoAndReturn(f func(string) (*params.ControllerInfo, error)) *MockJIMMAPIShowControllerCall {
+func (c *MockJIMMAPIShowControllerCall) DoAndReturn(f func(string) (*params.ControllerDetails, error)) *MockJIMMAPIShowControllerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/jaas/cmd/showcontroller_test.go
+++ b/cmd/jaas/cmd/showcontroller_test.go
@@ -41,7 +41,7 @@ func TestShowControllerOutput(t *testing.T) {
 
 	attemptedAt := time.Date(2026, time.May, 29, 10, 45, 0, 0, time.UTC)
 	errAt := attemptedAt.Add(-2 * time.Minute)
-	controllerInfo := &apiparams.ControllerInfo{
+	controllerInfo := &apiparams.ControllerDetails{
 		Name:          "test-controller",
 		UUID:          "87654321-4321-4321-4321-cba987654321",
 		PublicAddress: "test-controller.example.com:443",
@@ -81,15 +81,15 @@ func TestShowControllerOutput(t *testing.T) {
 	tests := []struct {
 		name   string
 		args   []string
-		want   apiparams.ControllerInfo
-		decode func(string) (apiparams.ControllerInfo, error)
+		want   apiparams.ControllerDetails
+		decode func(string) (apiparams.ControllerDetails, error)
 	}{
 		{
 			name: "json",
 			args: []string{"test-controller", "--format", "json"},
 			want: expectedJSON,
-			decode: func(output string) (apiparams.ControllerInfo, error) {
-				var actual apiparams.ControllerInfo
+			decode: func(output string) (apiparams.ControllerDetails, error) {
+				var actual apiparams.ControllerDetails
 				err := json.Unmarshal([]byte(strings.TrimSpace(output)), &actual)
 				return actual, err
 			},
@@ -98,8 +98,8 @@ func TestShowControllerOutput(t *testing.T) {
 			name: "yaml",
 			args: []string{"test-controller", "--format", "yaml"},
 			want: expectedYAML,
-			decode: func(output string) (apiparams.ControllerInfo, error) {
-				var actual apiparams.ControllerInfo
+			decode: func(output string) (apiparams.ControllerDetails, error) {
+				var actual apiparams.ControllerDetails
 				err := yaml.Unmarshal([]byte(output), &actual)
 				return actual, err
 			},

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -98,9 +98,9 @@ func (c *Controller) SetTag(t names.ControllerTag) {
 	c.UUID = t.Id()
 }
 
-// ToAPIControllerInfo converts a controller entry to a JIMM API
+// ToControllerInfo converts a controller entry to a JIMM API
 // ControllerInfo.
-func (c Controller) ToAPIControllerInfo() apiparams.ControllerInfo {
+func (c Controller) ToControllerInfo() apiparams.ControllerInfo {
 	var ci apiparams.ControllerInfo
 	ci.Name = c.Name
 	ci.UUID = c.UUID
@@ -132,10 +132,9 @@ func (c Controller) ToAPIControllerInfo() apiparams.ControllerInfo {
 	return ci
 }
 
-// ToAPIShowControllerInfo converts a controller entry to a JIMM API
-// ShowControllerInfo.
-func (c Controller) ToAPIShowControllerInfo() apiparams.ControllerDetails {
-	info := c.ToAPIControllerInfo()
+// ToControllerDetails returns a ControllerDetails struct for this controller.
+func (c Controller) ToControllerDetails() apiparams.ControllerDetails {
+	info := c.ToControllerInfo()
 	return apiparams.ControllerDetails{
 		Name:          info.Name,
 		UUID:          info.UUID,

--- a/internal/dbmodel/controller.go
+++ b/internal/dbmodel/controller.go
@@ -132,6 +132,23 @@ func (c Controller) ToAPIControllerInfo() apiparams.ControllerInfo {
 	return ci
 }
 
+// ToAPIShowControllerInfo converts a controller entry to a JIMM API
+// ShowControllerInfo.
+func (c Controller) ToAPIShowControllerInfo() apiparams.ControllerDetails {
+	info := c.ToAPIControllerInfo()
+	return apiparams.ControllerDetails{
+		Name:          info.Name,
+		UUID:          info.UUID,
+		PublicAddress: info.PublicAddress,
+		APIAddresses:  info.APIAddresses,
+		CACertificate: info.CACertificate,
+		CloudTag:      info.CloudTag,
+		CloudRegion:   info.CloudRegion,
+		AgentVersion:  info.AgentVersion,
+		Status:        info.Status,
+	}
+}
+
 const (
 	// CloudRegionControllerPriorityDeployed is the priority given to the
 	// controller when deploying to a cloud region to which the controller

--- a/internal/dbmodel/controller_bootstrap.go
+++ b/internal/dbmodel/controller_bootstrap.go
@@ -24,7 +24,7 @@ type ControllerBootstrap struct {
 	JobID       sql.NullInt64 `gorm:"column:job_id;uniqueIndex"`
 }
 
-// ToAPIControllerInfo converts a pending bootstrap entry to controller info for list/show APIs.
+// ToAPIControllerInfo converts a pending bootstrap entry to controller info for list-style APIs.
 func (c ControllerBootstrap) ToAPIControllerInfo() apiparams.ControllerInfo {
 	ci := apiparams.ControllerInfo{
 		Name:        c.Name,
@@ -37,4 +37,20 @@ func (c ControllerBootstrap) ToAPIControllerInfo() apiparams.ControllerInfo {
 		ci.CloudTag = names.NewCloudTag(c.CloudName).String()
 	}
 	return ci
+}
+
+// ToAPIControllerDetails converts a pending bootstrap entry to controller info for show APIs.
+func (c ControllerBootstrap) ToAPIControllerDetails() apiparams.ControllerDetails {
+	info := c.ToAPIControllerInfo()
+	return apiparams.ControllerDetails{
+		Name:          info.Name,
+		UUID:          info.UUID,
+		PublicAddress: info.PublicAddress,
+		APIAddresses:  info.APIAddresses,
+		CACertificate: info.CACertificate,
+		CloudTag:      info.CloudTag,
+		CloudRegion:   info.CloudRegion,
+		AgentVersion:  info.AgentVersion,
+		Status:        info.Status,
+	}
 }

--- a/internal/dbmodel/controller_bootstrap.go
+++ b/internal/dbmodel/controller_bootstrap.go
@@ -24,8 +24,8 @@ type ControllerBootstrap struct {
 	JobID       sql.NullInt64 `gorm:"column:job_id;uniqueIndex"`
 }
 
-// ToAPIControllerInfo converts a pending bootstrap entry to controller info for list-style APIs.
-func (c ControllerBootstrap) ToAPIControllerInfo() apiparams.ControllerInfo {
+// ToControllerInfo converts a pending bootstrap entry to controller info for list-style APIs.
+func (c ControllerBootstrap) ToControllerInfo() apiparams.ControllerInfo {
 	ci := apiparams.ControllerInfo{
 		Name:        c.Name,
 		CloudRegion: c.CloudRegion,
@@ -39,9 +39,9 @@ func (c ControllerBootstrap) ToAPIControllerInfo() apiparams.ControllerInfo {
 	return ci
 }
 
-// ToAPIControllerDetails converts a pending bootstrap entry to controller info for show APIs.
-func (c ControllerBootstrap) ToAPIControllerDetails() apiparams.ControllerDetails {
-	info := c.ToAPIControllerInfo()
+// ToControllerDetails converts a pending bootstrap entry to controller info for show APIs.
+func (c ControllerBootstrap) ToControllerDetails() apiparams.ControllerDetails {
+	info := c.ToControllerInfo()
 	return apiparams.ControllerDetails{
 		Name:          info.Name,
 		UUID:          info.UUID,

--- a/internal/dbmodel/controller_bootstrap_test.go
+++ b/internal/dbmodel/controller_bootstrap_test.go
@@ -20,7 +20,7 @@ func TestControllerBootstrapToAPIControllerInfo(t *testing.T) {
 		Name:        "test-controller",
 		CloudName:   "test-cloud",
 		CloudRegion: "test-region",
-	}.ToAPIControllerInfo()
+	}.ToControllerInfo()
 
 	c.Check(ci, qt.DeepEquals, apiparams.ControllerInfo{
 		Name:        "test-controller",

--- a/internal/dbmodel/controller_test.go
+++ b/internal/dbmodel/controller_test.go
@@ -166,7 +166,7 @@ func TestToAPIControllerInfo(t *testing.T) {
 	}}
 	ctl.AgentVersion = "1.2.3"
 
-	ci := ctl.ToAPIControllerInfo()
+	ci := ctl.ToControllerInfo()
 	c.Check(ci, qt.DeepEquals, apiparams.ControllerInfo{
 		Name:          "test-controller",
 		UUID:          "00000000-0000-0000-0000-0000-0000000000001",

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -231,7 +231,7 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 		return jujuparams.MigrationTargetInfo{}, 0, errors.New("missing target controller credentials")
 	}
 	// Should we verify controller can access the cloud where the model is currently hosted?
-	apiControllerInfo := dbController.ToAPIControllerInfo()
+	apiControllerInfo := dbController.ToControllerInfo()
 	targetInfo := jujuparams.MigrationTargetInfo{
 		ControllerAlias: dbController.Name, // This value will be returned to us on successful migration.
 		ControllerTag:   dbController.ResourceTag().String(),

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -900,29 +900,29 @@ func (r *controllerRoot) ListModelControllerInfo(ctx context.Context) (apiparams
 }
 
 // ShowController returns information about a controller or an in-progress bootstrap reservation.
-func (r *controllerRoot) ShowController(ctx context.Context, req apiparams.ShowControllerRequest) (apiparams.ControllerInfo, error) {
+func (r *controllerRoot) ShowController(ctx context.Context, req apiparams.ShowControllerRequest) (apiparams.ControllerDetails, error) {
 	controller, err := r.jimm.JujuManager().ControllerInfo(ctx, r.user, req.ControllerName)
 	if err != nil && errors.ErrorCode(err) != errors.CodeNotFound {
-		return apiparams.ControllerInfo{}, err
+		return apiparams.ControllerDetails{}, err
 	}
 	if err == nil {
-		return controller.ToAPIControllerInfo(), nil
+		return controller.ToAPIShowControllerInfo(), nil
 	}
 	// If the user is not a JIMM admin, return the not found error.
 	// Only JIMM admins can see controllers undergoing bootstrap.
 	if !r.user.JimmAdmin {
-		return apiparams.ControllerInfo{}, err
+		return apiparams.ControllerDetails{}, err
 	}
 
 	bootstrap, err := r.jimm.JujuManager().GetControllerBootstrap(ctx, req.ControllerName)
 	if err != nil {
-		return apiparams.ControllerInfo{}, err
+		return apiparams.ControllerDetails{}, err
 	}
 
-	response := bootstrap.ToAPIControllerInfo()
+	response := bootstrap.ToAPIControllerDetails()
 	status, err := r.jimm.JobManager().GetActiveBootstrapStatusForController(ctx, req.ControllerName)
 	if err != nil {
-		return apiparams.ControllerInfo{}, err
+		return apiparams.ControllerDetails{}, err
 	}
 	response.BootstrapJobStatus = status
 

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -279,7 +279,7 @@ func (r *controllerRoot) AddController(ctx context.Context, req apiparams.AddCon
 	if err := r.jimm.JujuManager().AddController(ctx, r.user, &ctl, ctlCreds); err != nil {
 		return apiparams.ControllerInfo{}, fmt.Errorf("failed to add controller: %w", err)
 	}
-	return ctl.ToAPIControllerInfo(), nil
+	return ctl.ToControllerInfo(), nil
 }
 
 // ListControllers returns the list of juju controllers the user has can_addmodel access to on the controller.
@@ -291,7 +291,7 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
-		controllersInfo = append(controllersInfo, ctl.ToAPIControllerInfo())
+		controllersInfo = append(controllersInfo, ctl.ToControllerInfo())
 	}
 	if r.user.JimmAdmin {
 		bootstraps, err := r.jimm.JujuManager().ListControllerBootstraps(ctx)
@@ -299,7 +299,7 @@ func (r *controllerRoot) ListControllers(ctx context.Context) (apiparams.ListCon
 			return apiparams.ListControllersResponse{}, err
 		}
 		for _, bootstrap := range bootstraps {
-			controllersInfo = append(controllersInfo, bootstrap.ToAPIControllerInfo())
+			controllersInfo = append(controllersInfo, bootstrap.ToControllerInfo())
 		}
 		slices.SortFunc(controllersInfo, func(a, b apiparams.ControllerInfo) int {
 			return strings.Compare(a.Name, b.Name)
@@ -325,7 +325,7 @@ func (r *controllerRoot) RemoveController(ctx context.Context, req apiparams.Rem
 	if err := r.jimm.JujuManager().RemoveController(ctx, r.user, req.Name, req.Force); err != nil {
 		return apiparams.ControllerInfo{}, err
 	}
-	return ctl.ToAPIControllerInfo(), nil
+	return ctl.ToControllerInfo(), nil
 }
 
 // SetControllerDeprecated sets the deprecated status of a controller.
@@ -338,7 +338,7 @@ func (r *controllerRoot) SetControllerDeprecated(ctx context.Context, req apipar
 	if err != nil {
 		return apiparams.ControllerInfo{}, err
 	}
-	return ctl.ToAPIControllerInfo(), nil
+	return ctl.ToControllerInfo(), nil
 }
 
 // maxLimit is the maximum number of audit-log entries that will be
@@ -628,7 +628,7 @@ func (r *controllerRoot) ListMigrationTargets(ctx context.Context, req apiparams
 	}
 	controllersInfo := make([]apiparams.ControllerInfo, 0, len(dbControllers))
 	for _, ctl := range dbControllers {
-		controllersInfo = append(controllersInfo, ctl.ToAPIControllerInfo())
+		controllersInfo = append(controllersInfo, ctl.ToControllerInfo())
 	}
 
 	return apiparams.ListControllersResponse{
@@ -762,7 +762,7 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 		AgentVersion:   ctrl.AgentVersion,
 		CloudName:      ctrl.CloudName,
 		CloudRegion:    ctrl.CloudRegion,
-		APIEndpoints:   ctrl.ToAPIControllerInfo().APIAddresses,
+		APIEndpoints:   ctrl.ToControllerInfo().APIAddresses,
 		PublicAddress:  ctrl.PublicAddress,
 		CACertificate:  ctrl.CACertificate,
 	})
@@ -906,7 +906,7 @@ func (r *controllerRoot) ShowController(ctx context.Context, req apiparams.ShowC
 		return apiparams.ControllerDetails{}, err
 	}
 	if err == nil {
-		return controller.ToAPIShowControllerInfo(), nil
+		return controller.ToControllerDetails(), nil
 	}
 	// If the user is not a JIMM admin, return the not found error.
 	// Only JIMM admins can see controllers undergoing bootstrap.
@@ -919,7 +919,7 @@ func (r *controllerRoot) ShowController(ctx context.Context, req apiparams.ShowC
 		return apiparams.ControllerDetails{}, err
 	}
 
-	response := bootstrap.ToAPIControllerDetails()
+	response := bootstrap.ToControllerDetails()
 	status, err := r.jimm.JobManager().GetActiveBootstrapStatusForController(ctx, req.ControllerName)
 	if err != nil {
 		return apiparams.ControllerDetails{}, err

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -170,7 +170,7 @@ func TestShowController(t *testing.T) {
 		controller    string
 		jujuManager   func(*qt.C) jujuapi.JujuManager
 		jobManager    func(*qt.C) jujuapi.JobManager
-		expectedInfo  apiparams.ControllerInfo
+		expectedInfo  apiparams.ControllerDetails
 		expectedError string
 	}{
 		{
@@ -192,7 +192,7 @@ func TestShowController(t *testing.T) {
 					},
 				}
 			},
-			expectedInfo: apiparams.ControllerInfo{
+			expectedInfo: apiparams.ControllerDetails{
 				Name:     "test-controller",
 				UUID:     "982b16d9-a945-4762-b684-fd4fd885aa11",
 				CloudTag: names.NewCloudTag("aws").String(),
@@ -253,7 +253,7 @@ func TestShowController(t *testing.T) {
 			jobManager: func(c *qt.C) jujuapi.JobManager {
 				return &mocks.JobManager{}
 			},
-			expectedInfo: apiparams.ControllerInfo{
+			expectedInfo: apiparams.ControllerDetails{
 				Name:     "test-controller",
 				UUID:     "982b16d9-a945-4762-b684-fd4fd885aa11",
 				CloudTag: names.NewCloudTag("aws").String(),
@@ -296,7 +296,7 @@ func TestShowController(t *testing.T) {
 					},
 				}
 			},
-			expectedInfo: apiparams.ControllerInfo{
+			expectedInfo: apiparams.ControllerDetails{
 				Name:        "bootstrapping-controller",
 				CloudTag:    names.NewCloudTag("aws").String(),
 				CloudRegion: "eu-west-1",
@@ -361,7 +361,7 @@ func TestShowController(t *testing.T) {
 					},
 				}
 			},
-			expectedInfo: apiparams.ControllerInfo{
+			expectedInfo: apiparams.ControllerDetails{
 				Name:        "bootstrapping-controller",
 				CloudTag:    names.NewCloudTag("aws").String(),
 				CloudRegion: "eu-west-1",

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -374,9 +374,9 @@ func (c *Client) ListModels() ([]params.ModelControllerInfoListItem, error) {
 }
 
 // ShowController returns information about a controller or a pending bootstrap reservation.
-func (c *Client) ShowController(controllerName string) (*params.ControllerInfo, error) {
+func (c *Client) ShowController(controllerName string) (*params.ControllerDetails, error) {
 	req := params.ShowControllerRequest{ControllerName: controllerName}
-	var resp params.ControllerInfo
+	var resp params.ControllerDetails
 	err := c.caller.APICall("JIMM", 4, "", "ShowController", req, &resp)
 	return &resp, err
 }

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -149,8 +149,45 @@ type AuditEvents struct {
 	Events []AuditEvent `json:"events"`
 }
 
-// A ControllerInfo describes a controller on a JIMM system.
+// ControllerInfo describes controller fields returned by list-style APIs.
 type ControllerInfo struct {
+	// Name is the name of the controller.
+	Name string `json:"name"`
+
+	// UUID is the UUID of the controller.
+	UUID string `json:"uuid"`
+
+	// PublicAddress is the public address of the controller. This is
+	// normally a DNS name and port which provide the controller endpoints.
+	// This address should not change even if the controller units
+	// themselves are migrated.
+	PublicAddress string `json:"public-address,omitempty"`
+
+	// APIAddresses contains the currently known API addresses for the
+	// controller.
+	APIAddresses []string `json:"api-addresses,omitempty"`
+
+	// CACertificate contains the CA certificate to use to validate the
+	// connection to the controller. This is not needed if certificate is
+	// signed by a public CA.
+	CACertificate string `json:"ca-certificate,omitempty"`
+
+	// CloudTag is the tag of the cloud this controller is running in.
+	CloudTag string `json:"cloud-tag,omitempty"`
+
+	// CloudRegion is the region that this controller is running in.
+	CloudRegion string `json:"cloud-region,omitempty"`
+
+	// The version of the juju agent running on the controller.
+	AgentVersion string `json:"agent-version"`
+
+	// Status contains the current status of the controller. The status
+	// will either be "available", "deprecated", or "unavailable".
+	Status jujuparams.EntityStatus `json:"status"`
+}
+
+// ControllerDetails describes a controller details returned by ShowController.
+type ControllerDetails struct {
 	// Name is the name of the controller.
 	Name string `json:"name"`
 

--- a/testing/jimm_test.go
+++ b/testing/jimm_test.go
@@ -69,6 +69,20 @@ func assertControllerInfos(c *qt.C, actual []apiparams.ControllerInfo, expected 
 	), expected)
 
 	// Verify all configured addresses are present in the response
+	checkControllerInfoAddresses(actual, confs, c)
+}
+
+// assertControllerDetail verifies that the controller detail match expectations, including API addresses.
+func assertControllerDetail(c *qt.C, actual apiparams.ControllerDetails, expected apiparams.ControllerDetails, confs *jimmtest.ControllersConfig) {
+	c.Check(actual, qt.CmpEquals(
+		cmpopts.IgnoreFields(apiparams.ControllerDetails{}, "AgentVersion", "APIAddresses"),
+	), expected)
+
+	// Verify all configured addresses are present in the response
+	checkControllerDetailAddresses(actual, confs, c)
+}
+
+func checkControllerInfoAddresses(actual []apiparams.ControllerInfo, confs *jimmtest.ControllersConfig, c *qt.C) {
 	for _, ci := range actual {
 		for name, conf := range confs.Controllers {
 			if conf.UUID == ci.UUID {
@@ -80,6 +94,22 @@ func assertControllerInfos(c *qt.C, actual []apiparams.ControllerInfo, expected 
 						name, expectedAddr, ci.APIAddresses))
 				}
 			}
+		}
+	}
+}
+
+func checkControllerDetailAddresses(actual apiparams.ControllerDetails, confs *jimmtest.ControllersConfig, c *qt.C) {
+	for name, conf := range confs.Controllers {
+		if conf.UUID != actual.UUID {
+			continue
+		}
+
+		expectedAddrs := conf.ToAPIInfo().Addrs
+		for _, expectedAddr := range expectedAddrs {
+			found := slices.Contains(actual.APIAddresses, expectedAddr)
+			c.Assert(found, qt.Equals, true, qt.Commentf(
+				"controller %q: expected address %q not found in APIAddresses %v",
+				name, expectedAddr, actual.APIAddresses))
 		}
 	}
 }
@@ -195,7 +225,7 @@ func TestShowController(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 
 	controllerName, conf := s.GetOneControllerConfig(c)
-	expectedController := apiparams.ControllerInfo{
+	expectedController := apiparams.ControllerDetails{
 		Name:          controllerName,
 		UUID:          conf.UUID,
 		APIAddresses:  conf.ToAPIInfo().Addrs,
@@ -213,7 +243,7 @@ func TestShowController(t *testing.T) {
 
 	ci, err := adminClient.ShowController(controllerName)
 	c.Assert(err, qt.IsNil)
-	assertControllerInfos(c, []apiparams.ControllerInfo{*ci}, []apiparams.ControllerInfo{expectedController}, s.GetControllersConfig(c))
+	assertControllerDetail(c, *ci, expectedController, s.GetControllersConfig(c))
 
 	bobConn := s.Open(c, nil, "bob@canonical.com", nil)
 	defer bobConn.Close()
@@ -221,7 +251,7 @@ func TestShowController(t *testing.T) {
 
 	ci, err = bobClient.ShowController(controllerName)
 	c.Assert(err, qt.IsNil)
-	assertControllerInfos(c, []apiparams.ControllerInfo{*ci}, []apiparams.ControllerInfo{expectedController}, s.GetControllersConfig(c))
+	assertControllerDetail(c, *ci, expectedController, s.GetControllersConfig(c))
 
 	bootstrap := &dbmodel.ControllerBootstrap{
 		Name:        "bootstrapping-controller",
@@ -233,7 +263,7 @@ func TestShowController(t *testing.T) {
 
 	ci, err = adminClient.ShowController(bootstrap.Name)
 	c.Assert(err, qt.IsNil)
-	c.Check(*ci, qt.DeepEquals, apiparams.ControllerInfo{
+	c.Check(*ci, qt.DeepEquals, apiparams.ControllerDetails{
 		Name:        bootstrap.Name,
 		CloudTag:    names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
 		CloudRegion: jimmtest.TestE2ECloudRegionName,
@@ -244,7 +274,7 @@ func TestShowController(t *testing.T) {
 
 	ci, err = bobClient.ShowController(bootstrap.Name)
 	c.Check(jujuparams.IsCodeNotFound(err), qt.Equals, true)
-	c.Check(*ci, qt.DeepEquals, apiparams.ControllerInfo{})
+	c.Check(*ci, qt.DeepEquals, apiparams.ControllerDetails{})
 }
 
 func TestAddControllerPublicAddressWithoutPort(t *testing.T) {


### PR DESCRIPTION
## Description
This PR addresses a previous oversight on my part. I added the `BootstrapJobStatus` field to the `ControllerInfo` struct, but we only populate it in calls to `ShowController` and not `ListController` yet both methods return the same type. The newly added `ShowController` struct should use a new type to avoid leaving the `BootstrapJobStatus` field nil.

This PR adds a new type called  `ControllerDetails` that is only returned from `ShowController`. It's best to leave `ControllerInfo` as-is to avoid a breaking change. The newly introduced field (`BootstrapJobStatus`) and the `ShowController` method have not been release yet.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests