### PR TITLE
feat: broaden use of JAAS permissions

### DIFF
--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -25,16 +25,45 @@ import (
 // requests according to the deployed OpenFGA instance configuration.
 const BATCH_SIZE_OPENFGA = 100
 
-// AddRelation checks user permission and add given relations tuples.
-// At the moment user is required be admin.
-func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
-
-	if !user.JimmAdmin {
-		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
+func (j *PermissionManager) authorizeRelationTargetAdmin(ctx context.Context, user *openfga.User, tuple openfga.Tuple) error {
+	if user.JimmAdmin {
+		return nil
 	}
+
+	switch tuple.Target.Kind {
+	case openfga.ControllerType, openfga.ModelType, openfga.ApplicationOfferType, openfga.CloudType:
+		allowed, err := j.authSvc.CheckRelation(ctx, openfga.Tuple{
+			Object:   ofganames.ConvertTag(user.ResourceTag()),
+			Relation: ofganames.AdministratorRelation,
+			Target:   tuple.Target,
+		}, false)
+		if err != nil {
+			return errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
+		}
+		if allowed {
+			return nil
+		}
+	case openfga.GroupType, openfga.RoleType:
+		// Membership changes for groups and roles are restricted to JIMM admins.
+	default:
+		// Unsupported relation-management targets are rejected for non-admins.
+	}
+
+	return errors.Codef(errors.CodeUnauthorized, "unauthorized")
+}
+
+// AddRelation checks user permission and adds the given relation tuples.
+// JIMM admins can update any relation, while resource administrators can update
+// relations on supported resource targets.
+func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
 		return err
+	}
+	for _, tuple := range parsedTuples {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple); err != nil {
+			return err
+		}
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
 		end := min(i+BATCH_SIZE_OPENFGA, len(parsedTuples))
@@ -49,16 +78,18 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 	return nil
 }
 
-// RemoveRelation checks user permission and remove given relations tuples.
-// At the moment user is required be admin.
+// RemoveRelation checks user permission and removes the given relation tuples.
+// JIMM admins can update any relation, while resource administrators can update
+// relations on supported resource targets.
 func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.User, tuples []apiparams.RelationshipTuple) error {
-
-	if !user.JimmAdmin {
-		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
-	}
 	parsedTuples, err := j.parseTuples(ctx, tuples)
 	if err != nil {
 		return err
+	}
+	for _, tuple := range parsedTuples {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple); err != nil {
+			return err
+		}
 	}
 	for i := 0; i < len(parsedTuples); i += BATCH_SIZE_OPENFGA {
 		end := min(i+BATCH_SIZE_OPENFGA, len(parsedTuples))
@@ -73,8 +104,9 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 	return nil
 }
 
-// CheckRelation checks user permission and return true if the given tuple exists.
-// At the moment user is required be admin or checking its own relations.
+// CheckRelation checks user permission and returns true if the given tuple exists.
+// JIMM admins can inspect any relation, while non-admins can inspect their own
+// relations or relations on supported resources they administer.
 func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.User, tuple apiparams.RelationshipTuple, trace bool) (_ bool, err error) {
 
 	allowed := false
@@ -83,9 +115,11 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 		return false, err
 	}
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
-	// Admins can check any relation, non-admins can only check their own.
-	if !user.JimmAdmin && !userCheckingSelf {
-		return allowed, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+	// Admins can check any relation, and non-admins can check their own or relations on resources they administer.
+	if !userCheckingSelf {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, *parsedTuple); err != nil {
+			return allowed, err
+		}
 	}
 
 	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace)

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/canonical/ofga"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -25,17 +26,17 @@ import (
 // requests according to the deployed OpenFGA instance configuration.
 const BATCH_SIZE_OPENFGA = 100
 
-func (j *PermissionManager) authorizeRelationTargetAdmin(ctx context.Context, user *openfga.User, tuple openfga.Tuple) error {
+func (j *PermissionManager) authorizeRelationTargetAdmin(ctx context.Context, user *openfga.User, target *ofga.Entity) error {
 	if user.JimmAdmin {
 		return nil
 	}
 
-	switch tuple.Target.Kind {
+	switch target.Kind {
 	case openfga.ControllerType, openfga.ModelType, openfga.ApplicationOfferType, openfga.CloudType:
 		allowed, err := j.authSvc.CheckRelation(ctx, openfga.Tuple{
 			Object:   ofganames.ConvertTag(user.ResourceTag()),
 			Relation: ofganames.AdministratorRelation,
-			Target:   tuple.Target,
+			Target:   target,
 		}, false)
 		if err != nil {
 			return errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
@@ -61,7 +62,7 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 		return err
 	}
 	for _, tuple := range parsedTuples {
-		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple); err != nil {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple.Target); err != nil {
 			return err
 		}
 	}
@@ -87,7 +88,7 @@ func (j *PermissionManager) RemoveRelation(ctx context.Context, user *openfga.Us
 		return err
 	}
 	for _, tuple := range parsedTuples {
-		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple); err != nil {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple.Target); err != nil {
 			return err
 		}
 	}
@@ -117,7 +118,7 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 	userCheckingSelf := parsedTuple.Object.Kind == openfga.UserType && parsedTuple.Object.ID == user.Name
 	// Admins can check any relation, and non-admins can check their own or relations on resources they administer.
 	if !userCheckingSelf {
-		if err := j.authorizeRelationTargetAdmin(ctx, user, *parsedTuple); err != nil {
+		if err := j.authorizeRelationTargetAdmin(ctx, user, parsedTuple.Target); err != nil {
 			return allowed, err
 		}
 	}

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -432,6 +432,156 @@ func (s *permissionManagerSuite) TestCheckRelationsWithErrors(c *qt.C) {
 	c.Assert(results[1].Error, qt.IsNotNil)
 }
 
+func (s *permissionManagerSuite) TestRelationManagementAsResourceAdministrator(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	grantorIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("grantor-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(grantorIdentity).Error, qt.IsNil)
+	grantor := openfga.NewUser(grantorIdentity, s.ofgaClient)
+
+	subjectIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("subject-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(subjectIdentity).Error, qt.IsNil)
+
+	_, _, controller, model, offer, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+
+	testCases := []struct {
+		description string
+		grantAdmin  func() error
+		tuple       apiparams.RelationshipTuple
+	}{
+		{
+			description: "controller administrator can manage relations",
+			grantAdmin: func() error {
+				return grantor.SetControllerAccess(ctx, controller.ResourceTag(), names.AdministratorRelation)
+			},
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.AuditLogViewerRelation.String(),
+				TargetObject: controller.ResourceTag().String(),
+			},
+		},
+		{
+			description: "model administrator can manage relations",
+			grantAdmin: func() error {
+				return grantor.SetModelAccess(ctx, model.ResourceTag(), names.AdministratorRelation)
+			},
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.ReaderRelation.String(),
+				TargetObject: model.ResourceTag().String(),
+			},
+		},
+		{
+			description: "application offer administrator can manage relations",
+			grantAdmin: func() error {
+				return grantor.SetApplicationOfferAccess(ctx, offer.ResourceTag(), names.AdministratorRelation)
+			},
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.ReaderRelation.String(),
+				TargetObject: offer.ResourceTag().String(),
+			},
+		},
+		{
+			description: "cloud administrator can manage relations",
+			grantAdmin: func() error {
+				return grantor.SetCloudAccess(ctx, cloud.ResourceTag(), names.AdministratorRelation)
+			},
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.CanAddModelRelation.String(),
+				TargetObject: cloud.ResourceTag().String(),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c.Run(testCase.description, func(c *qt.C) {
+			c.Assert(testCase.grantAdmin(), qt.IsNil)
+
+			err := s.manager.AddRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.IsNil)
+
+			allowed, err := s.manager.CheckRelation(ctx, grantor, testCase.tuple, false)
+			c.Assert(err, qt.IsNil)
+			c.Assert(allowed, qt.IsTrue)
+
+			results, err := s.manager.CheckRelations(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.IsNil)
+			c.Assert(results, qt.HasLen, 1)
+			c.Assert(results[0].Allowed, qt.IsTrue)
+			c.Assert(results[0].Error, qt.IsNil)
+
+			err = s.manager.RemoveRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.IsNil)
+
+			allowed, err = s.manager.CheckRelation(ctx, grantor, testCase.tuple, false)
+			c.Assert(err, qt.IsNil)
+			c.Assert(allowed, qt.IsFalse)
+		})
+	}
+}
+
+func (s *permissionManagerSuite) TestGroupAndRoleRelationManagementRemainJimmAdminOnly(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	grantorIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("grantor-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(grantorIdentity).Error, qt.IsNil)
+	grantor := openfga.NewUser(grantorIdentity, s.ofgaClient)
+
+	subjectIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("subject-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(subjectIdentity).Error, qt.IsNil)
+
+	_, group, _, _, _, _, _, role := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+
+	testCases := []struct {
+		description string
+		tuple       apiparams.RelationshipTuple
+	}{
+		{
+			description: "group membership changes remain restricted",
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.MemberRelation.String(),
+				TargetObject: group.ResourceTag().String(),
+			},
+		},
+		{
+			description: "role assignment changes remain restricted",
+			tuple: apiparams.RelationshipTuple{
+				Object:       subjectIdentity.Tag().String(),
+				Relation:     names.AssigneeRelation.String(),
+				TargetObject: role.ResourceTag().String(),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c.Run(testCase.description, func(c *qt.C) {
+			err := s.manager.AddRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.ErrorMatches, "unauthorized")
+
+			_, err = s.manager.CheckRelation(ctx, grantor, testCase.tuple, false)
+			c.Assert(err, qt.ErrorMatches, "unauthorized")
+
+			results, err := s.manager.CheckRelations(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.IsNil)
+			c.Assert(results, qt.HasLen, 1)
+			c.Assert(results[0].Allowed, qt.IsFalse)
+			c.Assert(results[0].Error, qt.ErrorMatches, "unauthorized")
+
+			err = s.manager.RemoveRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
+			c.Assert(err, qt.ErrorMatches, "unauthorized")
+		})
+	}
+}
+
 func (s *permissionManagerSuite) TestRelationshipLogUserUpdated(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## Description
Allow a subset of JIMM's broader permission endpoints to be used by non-admins provided the user has admin access to the resource they want to modify. E.g. a model admin can use JIMM's AddRelation endpoint to grant access to a model for a group or role or another user.

For groups and roles, the user must still be an admin to list them or view a specific one.

Fixes [JUJU-9926](https://warthogs.atlassian.net/browse/JUJU-9926)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-9926]: https://warthogs.atlassian.net/browse/JUJU-9926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ