### PR TITLE
feat: improve river teardown and upgrade-to errors

### DIFF
--- a/cmd/jaas/cmd/upgradeto.go
+++ b/cmd/jaas/cmd/upgradeto.go
@@ -24,7 +24,7 @@ and upgrades the models to the controller's version.
 `
 	upgradeToExample = `
     juju upgrade-to myController 2cb433a6-04eb-4ec4-9567-90426d20a004
-	juju upgrade-to myController 2cb433a6-04eb-4ec4-9567-90426d20a004 83cf3d62-ab16-4cb2-8e2f-df111fca1a32
+    juju upgrade-to myController 2cb433a6-04eb-4ec4-9567-90426d20a004 83cf3d62-ab16-4cb2-8e2f-df111fca1a32
 `
 )
 

--- a/cmd/jimmsrv/main.go
+++ b/cmd/jimmsrv/main.go
@@ -270,6 +270,24 @@ func start(ctx context.Context, s *service.Service) error {
 		HostKey:                  []byte(hostKeyRaw),
 		MaxConcurrentConnections: maxConcurrentConnections,
 	}, jimmsvc.JIMM().SSHManager)
+	if err != nil {
+		return err
+	}
+
+	err = river.MigrateRiver(ctx, jimmsvc.JIMM().Database)
+	if err != nil {
+		return err
+	}
+	riverClient, err := river.StartWorkers(
+		ctx,
+		jimmsvc.JIMM().Database,
+		jimmsvc.JIMM().OpenFGAClient,
+		jimmsvc.JIMM().UpgradeManager,
+		jimmsvc.JIMM().BootstrapManager,
+	)
+	if err != nil {
+		return err
+	}
 
 	s.OnShutdown(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -295,22 +313,14 @@ func start(ctx context.Context, s *service.Service) error {
 			zapctx.Error(ctx, "failed to shutdown SSH server gracefully", zap.Error(err))
 		}
 
+		zapctx.Warn(ctx, "River client shutdown triggered")
+		if err := riverClient.StopAndCancel(ctx); err != nil {
+			zapctx.Error(ctx, "failed to shutdown River client", zap.Error(err))
+		}
+
 		jimmsvc.Cleanup()
 	})
-	err = river.MigrateRiver(ctx, jimmsvc.JIMM().Database)
-	if err != nil {
-		return err
-	}
-	err = river.StartWorkers(
-		ctx,
-		jimmsvc.JIMM().Database,
-		jimmsvc.JIMM().OpenFGAClient,
-		jimmsvc.JIMM().UpgradeManager,
-		jimmsvc.JIMM().BootstrapManager,
-	)
-	if err != nil {
-		return err
-	}
+
 	zapctx.Info(ctx, "Registered all River workers")
 	s.Go(httpsrv.ListenAndServe)
 	zapctx.Info(ctx, "Started JIMM HTTP server")

--- a/internal/river/migrationworker.go
+++ b/internal/river/migrationworker.go
@@ -42,8 +42,10 @@ type migrationWorkerArgs struct {
 	TargetControllerName string `json:"target_controller_name"`
 }
 
+const migrationWorkerJobKind = "migrate-model"
+
 // Kind implements the [river.JobArgs] interface.
-func (migrationWorkerArgs) Kind() string { return "migrate-model" }
+func (migrationWorkerArgs) Kind() string { return migrationWorkerJobKind }
 
 // InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
 //

--- a/internal/river/retry_policy.go
+++ b/internal/river/retry_policy.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Canonical.
+
+package river
+
+import (
+	"time"
+
+	riverqueue "github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/canonical/jimm/v3/internal/rivertypes"
+)
+
+const (
+	upgradeFlowRetryAfterFirstFailure  = 30 * time.Second
+	upgradeFlowRetryAfterSecondFailure = 2 * time.Minute
+)
+
+type upgradeFlowRetryPolicy struct {
+	defaultPolicy riverqueue.ClientRetryPolicy
+	timeNow       func() time.Time
+}
+
+// newUpgradeFlowRetryPolicy creates a new upgradeFlowRetryPolicy
+// which retries upgrade-to style jobs with a fixed delay, and falls back
+// to the default retry policy for other jobs.
+func newUpgradeFlowRetryPolicy() *upgradeFlowRetryPolicy {
+	return &upgradeFlowRetryPolicy{
+		defaultPolicy: &riverqueue.DefaultClientRetryPolicy{},
+		timeNow:       time.Now,
+	}
+}
+
+func (p *upgradeFlowRetryPolicy) NextRetry(job *rivertype.JobRow) time.Time {
+	if !isUpgradeFlowJobKind(job.Kind) {
+		return p.defaultRetryPolicy().NextRetry(job)
+	}
+
+	delay, ok := upgradeFlowRetryDelay(job.Attempt)
+	if !ok {
+		return p.defaultRetryPolicy().NextRetry(job)
+	}
+
+	return p.timeNowUTC().Add(delay)
+}
+
+func (p *upgradeFlowRetryPolicy) defaultRetryPolicy() riverqueue.ClientRetryPolicy {
+	if p.defaultPolicy != nil {
+		return p.defaultPolicy
+	}
+	return &riverqueue.DefaultClientRetryPolicy{}
+}
+
+func (p *upgradeFlowRetryPolicy) timeNowUTC() time.Time {
+	if p.timeNow != nil {
+		return p.timeNow().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func isUpgradeFlowJobKind(kind string) bool {
+	switch kind {
+	case rivertypes.UpgradeToJobKind, migrationWorkerJobKind, upgradeWorkerJobKind:
+		return true
+	default:
+		return false
+	}
+}
+
+func upgradeFlowRetryDelay(attempt int) (time.Duration, bool) {
+	switch attempt {
+	case 1:
+		return upgradeFlowRetryAfterFirstFailure, true
+	case 2:
+		return upgradeFlowRetryAfterSecondFailure, true
+	default:
+		return upgradeFlowRetryAfterSecondFailure, false
+	}
+}

--- a/internal/river/retry_policy_test.go
+++ b/internal/river/retry_policy_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Canonical.
+
+package river
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/canonical/jimm/v3/internal/rivertypes"
+)
+
+type stubRetryPolicy struct {
+	nextRetry time.Time
+}
+
+func (p stubRetryPolicy) NextRetry(*rivertype.JobRow) time.Time {
+	return p.nextRetry
+}
+
+func TestUpgradeFlowRetryPolicy_NextRetry(t *testing.T) {
+	c := qt.New(t)
+	now := time.Date(2026, time.June, 4, 12, 0, 0, 0, time.UTC)
+	fallbackRetry := now.Add(10 * time.Minute)
+	policy := &upgradeFlowRetryPolicy{
+		defaultPolicy: stubRetryPolicy{nextRetry: fallbackRetry},
+		timeNow: func() time.Time {
+			return now
+		},
+	}
+
+	testCases := []struct {
+		about   string
+		jobKind string
+		attempt int
+		want    time.Time
+	}{
+		{
+			about:   "supervisor first retry",
+			jobKind: rivertypes.UpgradeToJobKind,
+			attempt: 1,
+			want:    now.Add(30 * time.Second),
+		},
+		{
+			about:   "migration second retry",
+			jobKind: migrationWorkerArgs{}.Kind(),
+			attempt: 2,
+			want:    now.Add(2 * time.Minute),
+		},
+		{
+			about:   "upgrade first retry",
+			jobKind: upgradeWorkerArgs{}.Kind(),
+			attempt: 1,
+			want:    now.Add(30 * time.Second),
+		},
+		{
+			about:   "other jobs keep default policy",
+			jobKind: "bootstrap-controller",
+			attempt: 1,
+			want:    fallbackRetry,
+		},
+	}
+
+	for _, testCase := range testCases {
+		c.Run(testCase.about, func(c *qt.C) {
+			got := policy.NextRetry(&rivertype.JobRow{Kind: testCase.jobKind, Attempt: testCase.attempt})
+			c.Assert(got, qt.DeepEquals, testCase.want)
+		})
+	}
+}

--- a/internal/river/river.go
+++ b/internal/river/river.go
@@ -4,6 +4,7 @@ package river
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/juju/version/v2"
 	"github.com/juju/zaputil/zapctx"
@@ -48,13 +49,14 @@ type Store interface {
 
 // StartWorkers sets up and starts the river workers.
 // Start() is a non-blocking call; it starts a background goroutine to process jobs, and maintainance tasks.
+// The started River client is returned so callers can wait for shutdown to complete.
 func StartWorkers(
 	ctx context.Context,
 	db *db.Database,
 	openfgaClient *openfga.OFGAClient,
 	upgradeManager UpgradeManager,
 	bootstrapManager BootstrapManager,
-) error {
+) (*river.Client[*sql.Tx], error) {
 	workerParams := workerParams{
 		migrateRetryCount: defaultMigrateRetries,
 		upgradeRetryCount: defaultUpgradeRetries,
@@ -66,12 +68,12 @@ func StartWorkers(
 	}
 	workers, err := newWorkers(workerParams)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	sqlDb, err := db.SqlDB()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	riverClient, err := river.NewClient(riverdatabasesql.New(sqlDb), &river.Config{
@@ -79,12 +81,16 @@ func StartWorkers(
 			river.QueueDefault: {MaxWorkers: defaultQueueMaxWorkers},
 		},
 		Workers:      workers,
+		RetryPolicy:  newUpgradeFlowRetryPolicy(),
 		ErrorHandler: &errorHandler{},
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return riverClient.Start(ctx)
+	if err := riverClient.Start(ctx); err != nil {
+		return nil, err
+	}
+	return riverClient, nil
 }
 
 type workerParams struct {

--- a/internal/river/upgradetoworker.go
+++ b/internal/river/upgradetoworker.go
@@ -19,6 +19,25 @@ import (
 // awaitCompletionFunc is a function that waits for a job to finalise.
 type awaitCompletionFunc func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error
 
+type childStageError struct {
+	stage string
+	err   error
+}
+
+// Error implements the error interface.
+func (e childStageError) Error() string {
+	return e.stage + " failed: " + e.err.Error()
+}
+
+// wrapChildStageFailure wraps an error from a child job stage,
+// annotating it with the stage that failed.
+func wrapChildStageFailure(stage string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return childStageError{stage: stage, err: err}
+}
+
 func newUpgradeToWorker(migrateRetries int, upgradeRetries int, awaitFunc awaitCompletionFunc) *upgradeToWorker {
 	return &upgradeToWorker{
 		migrateRetries:  migrateRetries,
@@ -91,7 +110,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.Up
 	}
 
 	if err := w.awaitCompletion(ctx, migrateInsertResponse, eventCh); err != nil {
-		return err
+		return wrapChildStageFailure("migration", err)
 	}
 
 	upgradeInsertResponse, err := client.Insert(
@@ -114,7 +133,7 @@ func (w *upgradeToWorker) Work(ctx context.Context, job *river.Job[rivertypes.Up
 	}
 
 	if err := w.awaitCompletion(ctx, upgradeInsertResponse, eventCh); err != nil {
-		return err
+		return wrapChildStageFailure("upgrade", err)
 	}
 
 	// All done.

--- a/internal/river/upgradetoworker_test.go
+++ b/internal/river/upgradetoworker_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/juju/version/v2"
@@ -175,9 +176,15 @@ func TestUpgradeToWorker_MigrationFails(t *testing.T) {
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
-	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
+	// The supervisor should surface a wrapped error mentioning the stage
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
-	c.Assert(upgradeToJobFinalError, qt.Equals, "unexpected-error-3")
+	c.Assert(upgradeToJobFinalError, qt.Equals, "migration failed: unexpected-error-3")
+
+	migrationJobs, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(migrationWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationJobs.Jobs, qt.HasLen, 1)
+	migrationJobFinalError := migrationJobs.Jobs[0].Errors[len(migrationJobs.Jobs[0].Errors)-1].Error
+	c.Assert(migrationJobFinalError, qt.Equals, "unexpected-error-3")
 }
 
 func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
@@ -223,9 +230,15 @@ func TestUpgradeToWorker_UpgradeFails(t *testing.T) {
 
 	row := waitForFinalisedJob(c, ctx, sub, insRes.Job.ID)
 	c.Assert(row.State, qt.Equals, rivertype.JobStateDiscarded)
-	// Ensure we capture the last error only from the migrate job, and that it is surfaced to the upgrade to job.
+	// The supervisor should surface a wrapped error mentioning the stage
 	upgradeToJobFinalError := row.Errors[len(row.Errors)-1].Error
-	c.Assert(upgradeToJobFinalError, qt.Equals, "unexpected-error-3")
+	c.Assert(upgradeToJobFinalError, qt.Equals, "upgrade failed: unexpected-error-3")
+
+	upgradeJobs, err := riverClient.JobList(ctx, river.NewJobListParams().Kinds(upgradeWorkerArgs{}.Kind()).First(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(upgradeJobs.Jobs, qt.HasLen, 1)
+	upgradeJobFinalError := upgradeJobs.Jobs[0].Errors[len(upgradeJobs.Jobs[0].Errors)-1].Error
+	c.Assert(upgradeJobFinalError, qt.Equals, "unexpected-error-3")
 }
 
 // This test is particularly valuable because it ensures we're checking the jobs finalised state AND event kind.
@@ -560,6 +573,51 @@ func TestUpgradeToWorker_EnsureCancellingSupervisorCancelsSpawnedMigrateJob(t *t
 	// Check the nested migrate job has finalised successfully because the context
 	// was cancelled for the root job.
 	c.Assert(listRes.Jobs[0].FinalizedAt, qt.IsNotNil)
+}
+
+func TestUpgradeToWorker_StopAndCancelDoesNotLeaveSupervisorRunning(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+
+	awaitStarted := make(chan struct{})
+
+	testDeps := setupIntegrationTest(
+		c,
+		setupWorkerParams{
+			migrateRetryCount: 1,
+			upgradeRetryCount: 1,
+			awaitFunc: func(ctx context.Context, result *rivertype.JobInsertResult, eventCh <-chan *river.Event) error {
+				close(awaitStarted)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+	)
+
+	riverClient := testDeps.riverClient
+	username := testDeps.identity
+
+	insRes, err := riverClient.Insert(ctx, rivertypes.UpgradeToArgs{
+		ModelUUID:            "model-uuid",
+		TargetVersion:        version.MustParse("2.0.0"),
+		Username:             username,
+		TargetControllerName: "target-controller",
+	}, nil)
+	c.Assert(err, qt.IsNil)
+
+	<-awaitStarted
+	waitForJobState(c, ctx, riverClient, insRes.Job.ID, rivertype.JobStateRunning, rivertypes.UpgradeToJobKind)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c.Assert(riverClient.StopAndCancel(shutdownCtx), qt.IsNil)
+
+	rootJob, err := riverClient.JobGet(ctx, insRes.Job.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(rootJob.State, qt.Not(qt.Equals), rivertype.JobStateRunning)
+
+	output := getUpgradeToSupervisorOutput(c, ctx, riverClient, insRes.Job.ID)
+	c.Assert(output.MigrationJobID, qt.Not(qt.IsNil))
 }
 
 // The aim of this test is to ensure that only 1 migrate job is inserted, even after a crash.

--- a/internal/river/upgradeworker.go
+++ b/internal/river/upgradeworker.go
@@ -31,8 +31,10 @@ type upgradeWorkerArgs struct {
 	TargetVersion version.Number `json:"target-version"`
 }
 
+const upgradeWorkerJobKind = "upgrade-model"
+
 // Kind returns the kind of the job.
-func (upgradeWorkerArgs) Kind() string { return "upgrade-model" }
+func (upgradeWorkerArgs) Kind() string { return upgradeWorkerJobKind }
 
 // InsertOpts implements the [river.JobArgsWithInsertOpts] interface.
 //


### PR DESCRIPTION
## Description
This PR addresses some bits around River that needed improvement when QA'ing the upgrade-to logic.
1. The upgrade-to process did retries with River's default retry policy [which is](https://riverqueue.com/docs/job-retries) `attempts ^ 4 + rand(±10%) seconds (0s, 1s, 16s, ...)`. This is too quick for the upgrade-to logic.
2. The River client did not get shutdown if JIMM received a stop signal so a running job would not be cleanly killed and could be left in a `running` state in the DB, eventually getting cleaned up by River's rescuer process. Now we call StopAndCancel() on the River client when JIMM is stopped, cancelling any current jobs. Note that StopAndCancel() still waits for active jobs to return, but cancels the active context.
3. The error surfaced in the root job did not include the step that was being executed.

There are still some remaining issues:
- The root job has a retry count of 3 as do the child jobs. This means child jobs can execute up to 9 times, with the first 2 rounds of errors behind masked. 
- If the root job is cancelled (say by a restart) while a child job is waiting to retry, the root job's attempt count will tick up by one but the child job's won't. That means on restart, the root job might never retry but the child job will get picked up again.

These two issues seem to be solved by River's new [resumable-jobs](https://riverqueue.com/docs/resumable-jobs) feature which covers our short-comings.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
