### PR TITLE
fix: clean up controllerRoot watchers on websocket disconnect

### DIFF
--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -37,9 +37,8 @@ const (
 
 // An apiServer is a jimmhttp.WSServer that serves the controller API.
 type apiServer struct {
-	jimm    *jimm.JIMM
-	cleanup func()
-	params  Params
+	jimm   *jimm.JIMM
+	params Params
 }
 
 // Authenticate implements jimmhttp.Authenticate and handles browser authentication
@@ -84,16 +83,13 @@ func (s *apiServer) Authenticate(ctx context.Context, w http.ResponseWriter, req
 func (s *apiServer) ServeWS(ctx context.Context, conn *websocket.Conn) {
 	identityId := auth.SessionIdentityFromContext(ctx)
 	controllerRoot := newControllerRoot(&JIMMAdapter{j: s.jimm}, s.params, identityId)
-	s.cleanup = controllerRoot.cleanup
+	// cleanup releases the controllerRoot's resources (e.g. model summary
+	// watcher goroutines and their pubsub subscriptions) when the
+	// connection is torn down. serveRoot blocks until the connection is
+	// dead, so this runs at teardown.
+	defer controllerRoot.cleanup()
 	Dblogger := controllerRoot.newAuditLogger()
 	serveRoot(ctx, controllerRoot, Dblogger, conn)
-}
-
-// Kill implements the rpc.Killer interface.
-func (s *apiServer) Kill() {
-	if s.cleanup != nil {
-		s.cleanup()
-	}
 }
 
 // serveRoot serves an RPC root object on a websocket connection.

--- a/internal/pubsub/hub.go
+++ b/internal/pubsub/hub.go
@@ -87,6 +87,14 @@ func (h *Hub) Subscribe(model string, handler HandlerFunc) (func(), error) {
 	return h.SubscribeMatch(modelMatches(model), handler)
 }
 
+// SubscriberCount returns the number of currently active subscribers.
+func (h *Hub) SubscriberCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return len(h.subscribers)
+}
+
 // SubscribeMatch takes a function that determines whether the
 // handler function should be called for a specific model.
 // The matcher function should not do any "expensive" operations (ie

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -302,3 +302,45 @@ func TestWatchAllModelSummaries(t *testing.T) {
 	err = conn.APICall("ModelSummaryWatcher", 1, "unknown-id", "Next", nil, &summaries)
 	c.Assert(err, qt.ErrorMatches, `not found \(not found\)`)
 }
+
+// TestModelSummaryWatcherCleanupOnDisconnect ensures that a model summary
+// watcher started on a connection is torn down when the client disconnects
+// without explicitly stopping it. The watcher's pubsub subscription must be
+// removed, otherwise the watcher goroutine and subscription leak for the
+// lifetime of the process.
+func TestModelSummaryWatcherCleanupOnDisconnect(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	s.CreateModelForBob(c)
+
+	// Capture the baseline subscriber count: other components may hold
+	// subscriptions, so assert relative to this value.
+	baseline := s.JIMM.Pubsub.SubscriberCount()
+
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
+
+	var watcherID jujuparams.SummaryWatcherID
+	err := conn.APICall("Controller", 12, "", "WatchAllModelSummaries", nil, &watcherID)
+	c.Assert(err, qt.IsNil)
+
+	// Starting the watcher must have added exactly one subscriber.
+	c.Assert(s.JIMM.Pubsub.SubscriberCount(), qt.Equals, baseline+1)
+
+	// Disconnect without calling ModelSummaryWatcherStop. The server must
+	// clean up the watcher when the connection is torn down.
+	err = conn.Close()
+	c.Assert(err, qt.IsNil)
+
+	// The cleanup happens asynchronously once the connection is dead, so
+	// poll until the subscriber count returns to the baseline.
+	for i := 0; ; i++ {
+		count := s.JIMM.Pubsub.SubscriberCount()
+		if count == baseline {
+			break
+		}
+		if i >= 100 {
+			c.Fatalf("watcher subscription was not cleaned up after disconnect: got %d subscribers, want %d", count, baseline)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Description

The controllerRoot's cleanup was only reachable via apiServer.Kill, but the WSServer interface never declares Kill and the websocket handler never calls it, so cleanup never ran. 

Any client that started a WatchAllModelSummaries/WatchModelSummaries watcher and disconnected without an explicit stop leaked the modelAccessWatcher goroutine and its subscription permanently. 

Assigning controllerRoot.cleanup to apiServer.cleanup also raced: apiServer is shared across all connections on the handler, so each connection assigned the field concurrently.

Added an test that asserts that the subscriber count decrements after the connection is closed.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
