### PR TITLE
feat: dialAll should return on the first successful connection

### DIFF
--- a/internal/rpc/dial.go
+++ b/internal/rpc/dial.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
-	"sync"
+	"sync/atomic"
 
 	"github.com/gorilla/websocket"
 	"github.com/juju/juju/core/network"
@@ -19,13 +20,17 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
-	"github.com/canonical/jimm/v3/internal/errors"
+	jimmerrors "github.com/canonical/jimm/v3/internal/errors"
 )
 
 // A Dialer is used to create client connections to an RPC URL.
 type Dialer struct {
 	// TLSConfig is used to configure TLS for the client connection.
 	TLSConfig *tls.Config
+}
+
+type websocketDialer interface {
+	DialWebsocket(context.Context, string, http.Header) (*websocket.Conn, error)
 }
 
 // Dial establishes a new client RPC connection to the given URL.
@@ -141,9 +146,9 @@ func websocketURL(s string, mt names.ModelTag, finalPath string, attrs url.Value
 
 // dialAll simultaneously dials all given urls and returns the first
 // connection.
-func dialAll(ctx context.Context, dialer *Dialer, urls []string, headers http.Header) (*websocket.Conn, error) {
+func dialAll(ctx context.Context, dialer websocketDialer, urls []string, headers http.Header) (*websocket.Conn, error) {
 	if len(urls) == 0 {
-		return nil, errors.New("no urls to dial")
+		return nil, jimmerrors.New("no urls to dial")
 	}
 	conn, err := dialAllHelper(ctx, dialer, urls, headers)
 	if err != nil {
@@ -152,40 +157,45 @@ func dialAll(ctx context.Context, dialer *Dialer, urls []string, headers http.He
 	return conn, nil
 }
 
+type dialResult struct {
+	url  string
+	conn *websocket.Conn
+	err  error
+}
+
 // dialAllHelper simultaneously dials all given urls and returns the first successful websocket connection.
-func dialAllHelper(ctx context.Context, dialer *Dialer, urls []string, headers http.Header) (*websocket.Conn, error) {
+func dialAllHelper(ctx context.Context, dialer websocketDialer, urls []string, headers http.Header) (*websocket.Conn, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var clientOnce, errOnce sync.Once
-	var err error
-	var wg sync.WaitGroup
-	var res *websocket.Conn
+	results := make(chan dialResult, len(urls))
+	var winnerSelected atomic.Bool
 	for _, url := range urls {
 		zapctx.Info(ctx, "dialing", zap.String("url", url))
 		url := url
-		wg.Go(func() {
-			conn, dErr := dialer.DialWebsocket(ctx, url, headers)
-			if dErr != nil {
-				errOnce.Do(func() {
-					err = dErr
-				})
-				return
+		go func() {
+			conn, err := dialer.DialWebsocket(ctx, url, headers)
+			if err == nil {
+				if !winnerSelected.CompareAndSwap(false, true) {
+					if conn != nil {
+						conn.Close()
+					}
+					return
+				}
 			}
-			var keep bool
-			clientOnce.Do(func() {
-				res = conn
-				keep = true
-				cancel()
-			})
-			if !keep {
-				conn.Close()
-			}
-		})
+			results <- dialResult{url: url, conn: conn, err: err}
+		}()
 	}
-	wg.Wait()
-	if res != nil {
-		return res, nil
+
+	var errs []error
+	for i := 0; i < len(urls); i++ {
+		result := <-results
+		if result.err != nil {
+			errs = append(errs, fmt.Errorf("dial %q: %w", result.url, result.err))
+			continue
+		}
+
+		return result.conn, nil
 	}
-	return nil, err
+	return nil, stderrors.Join(errs...)
 }

--- a/internal/rpc/dial_test.go
+++ b/internal/rpc/dial_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Canonical.
+
+package rpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestDialAllHelperReturnsAfterFirstSuccessfulDial(t *testing.T) {
+	fastURL := "wss://fast.example/api"
+	slowURL := "wss://slow.example/api"
+	slowCancelled := make(chan struct{}, 1)
+
+	dialer := &fakeWebsocketDialer{
+		responses: map[string]fakeDialResponse{
+			fastURL: {conn: &websocket.Conn{}},
+			slowURL: {
+				delay:     200 * time.Millisecond,
+				err:       errors.New("slow dial failed"),
+				cancelled: slowCancelled,
+			},
+		},
+	}
+
+	conn, err := dialAllHelper(context.Background(), dialer, []string{slowURL, fastURL}, nil)
+
+	if err != nil {
+		t.Fatalf("dialAllHelper returned error: %v", err)
+	}
+	if conn == nil {
+		t.Fatalf("expected winning connection")
+	}
+
+	select {
+	case <-slowCancelled:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("expected slow loser dial to be cancelled")
+	}
+}
+
+func TestDialAllHelperReturnsAllDialErrors(t *testing.T) {
+	firstURL := "wss://first.example/api"
+	secondURL := "wss://second.example/api"
+	firstErr := errors.New("first dial failed")
+	secondErr := errors.New("second dial failed")
+
+	dialer := &fakeWebsocketDialer{
+		responses: map[string]fakeDialResponse{
+			firstURL:  {err: firstErr},
+			secondURL: {err: secondErr},
+		},
+	}
+
+	conn, err := dialAllHelper(context.Background(), dialer, []string{firstURL, secondURL}, nil)
+
+	if conn != nil {
+		t.Fatalf("expected no connection, got %v", conn)
+	}
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !errors.Is(err, firstErr) {
+		t.Fatalf("expected error to include first dial error, got %v", err)
+	}
+	if !errors.Is(err, secondErr) {
+		t.Fatalf("expected error to include second dial error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), firstURL) {
+		t.Fatalf("expected error to include first URL, got %v", err)
+	}
+	if !strings.Contains(err.Error(), secondURL) {
+		t.Fatalf("expected error to include second URL, got %v", err)
+	}
+}
+
+type fakeWebsocketDialer struct {
+	responses map[string]fakeDialResponse
+}
+
+type fakeDialResponse struct {
+	conn      *websocket.Conn
+	err       error
+	delay     time.Duration
+	cancelled chan<- struct{}
+}
+
+func (d *fakeWebsocketDialer) DialWebsocket(ctx context.Context, url string, _ http.Header) (*websocket.Conn, error) {
+	response := d.responses[url]
+	if response.delay > 0 {
+		timer := time.NewTimer(response.delay)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if response.cancelled != nil {
+				select {
+				case response.cancelled <- struct{}{}:
+				default:
+				}
+			}
+			<-timer.C
+		}
+	}
+	return response.conn, response.err
+}


### PR DESCRIPTION
# Description
before dialAll was returning only after all dial goroutines have finished. The new implementation returns after the first successful one and cancel the other dials. In addition it joins the errors.

This came out of my tracing spike, i've noticed we are spending some time in the dial bit and looking at the code it seemed obvious we shouldn't wait for all the dial go routines to end.

Let me know what you think. This fix might be particular useful in production environment where one of the configure controller address is not reachable/timeout/or something.

# QA

I've used the old dialer with the same test and it was taking >200ms to return a connection, proving this fix is indeed needed.