### PR TITLE
fix(jujumanager): close controller connections in PollModels

### DIFF
--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -15,6 +15,39 @@ import (
 	"github.com/canonical/jimm/v3/internal/servermon"
 )
 
+func (j *JujuManager) pollModels(ctx context.Context, models []*dbmodel.Model) error {
+	if len(models) == 0 {
+		return nil
+	}
+
+	ctrl := models[0].Controller
+
+	api, err := j.dialController(ctx, &ctrl, nil)
+	if err != nil {
+		zapctx.Error(ctx, "cannot dial controller", zap.String("controller", ctrl.UUID), zap.Error(err))
+		return nil
+	}
+	defer api.Close()
+
+	// Depending the model's migration mode, we either:
+	// - Check if the model exists (MigrationModeNone)
+	// - Check if the model has completed internal migration (MigrationModeMigrateInternal)
+	// - Do nothing if the model is in any other migration mode (MigrationModeImporting, MigrationModeExporting)
+	for _, m := range models {
+		ctx := zapctx.WithFields(ctx,
+			zap.String("model-owner", m.OwnerIdentityName),
+			zap.String("model-name", m.Name),
+			zap.String("migration-mode", string(m.MigrationMode)),
+		)
+
+		_, err := j.modelInfo(ctx, nil, m, api)
+		if err != nil {
+			zapctx.Error(ctx, "error getting model info", zap.Error(err))
+		}
+	}
+	return nil
+}
+
 // PollModels loops over models, contacting the respective controller
 // and checking, based on the model's migration mode, if the model exists.
 // If the model exists in JIMM's database, but not on the controller,
@@ -38,31 +71,11 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 
 	// Step 2: Loop over controllers and process their models
 	// This way we only dial each controller once.
-	for controllerUUID, models := range controllerModels {
+	for _, models := range controllerModels {
 		if len(models) == 0 {
 			continue
 		}
-		api, err := j.dialController(ctx, &models[0].Controller, nil)
-		if err != nil {
-			zapctx.Error(ctx, "cannot dial controller", zap.String("controller", controllerUUID), zap.Error(err))
-			continue
-		}
-		// Depending the model's migration mode, we either:
-		// - Check if the model exists (MigrationModeNone)
-		// - Check if the model has completed internal migration (MigrationModeMigrateInternal)
-		// - Do nothing if the model is in any other migration mode (MigrationModeImporting, MigrationModeExporting)
-		for _, m := range models {
-			ctx := zapctx.WithFields(ctx,
-				zap.String("model-owner", m.OwnerIdentityName),
-				zap.String("model-name", m.Name),
-				zap.String("migration-mode", string(m.MigrationMode)),
-			)
-
-			_, err := j.modelInfo(ctx, nil, m, api)
-			if err != nil {
-				zapctx.Error(ctx, "error getting model info", zap.Error(err))
-			}
-		}
+		_ = j.pollModels(ctx, models)
 	}
 	return nil
 }

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,74 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 )
+
+// perControllerDialer is a test juju.Dialer that records how many times each
+// controller was dialed and how many of those connections were subsequently
+// closed.  This lets tests assert that no connections are leaked.
+type perControllerDialer struct {
+	api juju.API
+
+	mu     sync.Mutex
+	opened map[string]int // controller name → dial count
+	closed map[string]int // controller name → close count
+}
+
+func newPerControllerDialer(api juju.API) *perControllerDialer {
+	return &perControllerDialer{
+		api:    api,
+		opened: make(map[string]int),
+		closed: make(map[string]int),
+	}
+}
+
+func (d *perControllerDialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelTag, _ *openfga.User) (juju.API, error) {
+	name := ctl.Name
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.opened[name]++
+	return &perControllerAPI{
+		API: d.api,
+		onClose: func() {
+			d.mu.Lock()
+			defer d.mu.Unlock()
+			d.closed[name]++
+		},
+	}, nil
+}
+
+// openedCounts returns a snapshot of the dial counts per controller.
+func (d *perControllerDialer) openedCounts() map[string]int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]int, len(d.opened))
+	for k, v := range d.opened {
+		out[k] = v
+	}
+	return out
+}
+
+// closedCounts returns a snapshot of the close counts per controller.
+func (d *perControllerDialer) closedCounts() map[string]int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]int, len(d.closed))
+	for k, v := range d.closed {
+		out[k] = v
+	}
+	return out
+}
+
+// perControllerAPI wraps a juju.API and calls onClose when the connection is
+// closed, allowing perControllerDialer to track the close event.
+type perControllerAPI struct {
+	juju.API
+	onClose func()
+}
+
+func (a *perControllerAPI) Close() error {
+	a.onClose()
+	return a.API.Close()
+}
 
 const modelPollerTestEnv = `clouds:
 - name: test-cloud
@@ -239,6 +308,33 @@ func TestInternalMigrationFailure(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(model.ControllerID, qt.Equals, sourceController.ID)
 	c.Assert(model.MigrationMode, qt.Equals, dbmodel.MigrationModeNone)
+}
+
+// TestPollModelsClosesControllerConnections ensures that the connection
+// dialled to each controller is closed once its models have been processed.
+// Otherwise every poll cycle leaks one connection per controller.
+func TestPollModelsClosesControllerConnections(t *testing.T) {
+	c := qt.New(t)
+	s := setupModelPollerTest(c)
+	ctx := context.Background()
+
+	dialer := newPerControllerDialer(&jimmtest.API{
+		ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
+			return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
+		},
+	})
+	s.jujuManager.Dialer = dialer
+
+	err := s.jujuManager.PollModels(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// controller-1 owns model-1, model-2, and model-3 so it must be dialed
+	// exactly once.  controller-2 has no models and must not be dialed at all.
+	c.Assert(dialer.openedCounts(), qt.DeepEquals, map[string]int{
+		"controller-1": 1,
+	})
+	// Every opened connection must have been closed – no leaks.
+	c.Assert(dialer.closedCounts(), qt.DeepEquals, dialer.openedCounts())
 }
 
 func TestPollModelsDyingControllerErrors(t *testing.T) {


### PR DESCRIPTION
## Description

PollModels dials each controller once to check its models, but never closes the resulting API connection. PollModels runs on a periodic schedule, so every cycle leaks one connection (a websocket plus its background receive goroutine) per controller, steadily accumulating until file descriptors are exhausted.

Process each controller inside a closure and `defer api.Close()` there, so the connection is released at the end of that controller's iteration. A bare `defer` in the loop body would instead hold every controller's connection open until PollModels returned, which is also undesirable when many controllers are polled.

Adds TestPollModelsClosesControllerConnections, which asserts via the test dialer's open-connection counter that no connection is left open after a poll.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
