### PR TITLE
fix(jujuapi): check for models before destroying a controller

### DIFF
--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -75,6 +75,16 @@ func (j *JujuManager) ControllerInfo(ctx context.Context, user *openfga.User, na
 	return &ctl, nil
 }
 
+// ControllerModelCount returns the number of models hosted on the given
+// controller.
+func (j *JujuManager) ControllerModelCount(ctx context.Context, ctl dbmodel.Controller) (int, error) {
+	models, err := j.Database.GetModelsByController(ctx, ctl)
+	if err != nil {
+		return 0, err
+	}
+	return len(models), nil
+}
+
 // GetControllerBootstrap returns the pending bootstrap reservation for a controller.
 func (j *JujuManager) GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {
 	bootstrap := dbmodel.ControllerBootstrap{Name: name}

--- a/internal/jimm/juju/jimm_test.go
+++ b/internal/jimm/juju/jimm_test.go
@@ -1340,3 +1340,59 @@ func TestListModelControllerInfo(t *testing.T) {
 		ControllerUUID: "00000001-0000-0000-0000-000000000002",
 	}})
 }
+
+const testControllerModelCountEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region
+cloud-credentials:
+- name: test-cred
+  cloud: test-cloud
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: controller-with-models
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-region
+- name: controller-without-models
+  uuid: 00000001-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-region
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: controller-with-models
+  cloud: test-cloud
+  region: test-region
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+- name: model-2
+  uuid: 00000002-0000-0000-0000-000000000002
+  controller: controller-with-models
+  cloud: test-cloud
+  region: test-region
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+`
+
+func TestControllerModelCount(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	j := newTestJujuManager(c, nil)
+
+	env := jimmtest.ParseEnvironment(c, testControllerModelCountEnv)
+	env.PopulateDB(c, j.Database)
+
+	withModels := env.Controllers[0].DBObject(c, j.Database)
+	count, err := j.ControllerModelCount(ctx, withModels)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 2)
+
+	withoutModels := env.Controllers[1].DBObject(c, j.Database)
+	count, err = j.ControllerModelCount(ctx, withoutModels)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -227,6 +227,7 @@ type JujuManager interface {
 	AddController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, creds juju.ControllerCreds) error
 	GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error)
 	ControllerInfo(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error)
+	ControllerModelCount(ctx context.Context, ctl dbmodel.Controller) (int, error)
 	EarliestControllerVersion(ctx context.Context) (version.Number, error)
 	ListControllerBootstraps(ctx context.Context) ([]dbmodel.ControllerBootstrap, error)
 	ListControllers(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -752,7 +752,14 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to fetch controller info: %w", err)
 	}
 
-	if len(ctrl.Models) != 0 {
+	// ControllerInfo does not preload the controller's models, so query them
+	// explicitly; relying on ctrl.Models would always see an empty slice and
+	// silently allow destroying a controller that still hosts models.
+	modelCount, err := r.jimm.JujuManager().ControllerModelCount(ctx, *ctrl)
+	if err != nil {
+		return apiparams.StartBootstrapResponse{}, fmt.Errorf("failed to check controller models: %w", err)
+	}
+	if modelCount != 0 {
 		return apiparams.StartBootstrapResponse{}, errors.Codef(errors.CodeBadRequest, "cannot destroy controller with models")
 	}
 

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -801,9 +801,13 @@ func TestStartDestroyControllerJob(t *testing.T) {
 		AgentVersion:  "not-a-version",
 		PublicAddress: "not-an-address",
 		CACertificate: "not-even-close",
-		Models:        []dbmodel.Model{},
 	}
 
+	// modelCount is the number of models the controller is reported to host.
+	// The guard must consult the database (via ControllerModelCount) rather
+	// than the Controller.Models association, which ControllerInfo never
+	// preloads.
+	modelCount := 0
 	jimm := &jimmtest.JIMM{
 		BootstapManager_: func() jujuapi.BootstrapManager {
 			return &mocks.BootstapManager{
@@ -819,6 +823,10 @@ func TestStartDestroyControllerJob(t *testing.T) {
 						c.Check(user.JimmAdmin, qt.Equals, true)
 						return ctrlInfo, nil
 					},
+					ControllerModelCount_: func(ctx context.Context, ctl dbmodel.Controller) (int, error) {
+						c.Check(ctl.Name, qt.Equals, ctrlInfo.Name)
+						return modelCount, nil
+					},
 				},
 			}
 		},
@@ -831,7 +839,7 @@ func TestStartDestroyControllerJob(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Refuse to destroy controller with models
-	ctrlInfo.Models = append(ctrlInfo.Models, dbmodel.Model{})
+	modelCount = 1
 	_, err = root.StartDestroyController(ctx, req)
 	c.Assert(err, qt.ErrorMatches, "cannot destroy controller with models")
 }

--- a/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_controller_mock.go
@@ -21,6 +21,7 @@ type ControllerService struct {
 	ControllerDetailsForIncomingModel_ func(ctx context.Context, modelUUID string) (juju.ControllerConnectionDetails, error)
 	GetControllerBootstrap_            func(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error)
 	ControllerInfo_                    func(ctx context.Context, user *openfga.User, name string) (*dbmodel.Controller, error)
+	ControllerModelCount_              func(ctx context.Context, ctl dbmodel.Controller) (int, error)
 	EarliestControllerVersion_         func(ctx context.Context) (version.Number, error)
 	ListControllerBootstraps_          func(ctx context.Context) ([]dbmodel.ControllerBootstrap, error)
 	ListControllers_                   func(ctx context.Context, user *openfga.User) ([]dbmodel.Controller, error)
@@ -55,6 +56,13 @@ func (j *ControllerService) ControllerInfo(ctx context.Context, user *openfga.Us
 		return nil, errors.New("not implemented")
 	}
 	return j.ControllerInfo_(ctx, user, name)
+}
+
+func (j *ControllerService) ControllerModelCount(ctx context.Context, ctl dbmodel.Controller) (int, error) {
+	if j.ControllerModelCount_ == nil {
+		return 0, errors.New("not implemented")
+	}
+	return j.ControllerModelCount_(ctx, ctl)
 }
 
 func (j *ControllerService) GetControllerBootstrap(ctx context.Context, name string) (*dbmodel.ControllerBootstrap, error) {


### PR DESCRIPTION
## Description

StartDestroyController guards against tearing down a controller that still hosts models with `if len(ctrl.Models) != 0`. The controller comes from ControllerInfo, which loads it via GetController; that query only preloads CloudRegions, never the Models association. ctrl.Models is therefore always an empty slice, so the guard never fires and a JIMM admin can start a destroy job for a controller that still hosts models.

Add a ControllerModelCount method to the juju manager that queries the models for a controller via GetModelsByController (the same query the RemoveController path already uses), and have StartDestroyController call it instead of inspecting the never-populated association.

TestStartDestroyControllerJob now drives the model count through the manager rather than ctrl.Models, and fails against the old guard.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
