### PR TITLE
feat: allow add permission for idp-group

### DIFF
--- a/cmd/jaas/cmd/permission.go
+++ b/cmd/jaas/cmd/permission.go
@@ -61,6 +61,7 @@ Resources may be one of:
 
     user tag                = "user-<name>"
     group tag               = "group-<name>"
+	idp group tag           = "idpgroup-<id>"
 	role tag 			    = "role-<name>"
     controller tag          = "controller-<name>"
     model tag               = "model-<name>"
@@ -102,6 +103,10 @@ If the object is a group, a userset must be applied by adding #member as follows
 This will grant/revoke access to all users within TeamA:
 
     group-TeamA#member administrator controller-MyController
+
+IDP-owned groups use the idpgroup tag and also require the #member userset:
+
+	idpgroup-external-team-id#member administrator controller-MyController
 
 Similarly if the object is a role, a userset must be applied by adding #member as follows.
 

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -209,6 +209,7 @@ Resources may be one of:
 
     user tag                = "user-<name>"
     group tag               = "group-<name>"
+	idp group tag           = "idpgroup-&lt;id&gt;"
 	role tag 			    = "role-&lt;name&gt;"
     controller tag          = "controller-<name>"
     model tag               = "model-<name>"
@@ -250,6 +251,10 @@ If the object is a group, a userset must be applied by adding #member as follows
 This will grant/revoke access to all users within TeamA:
 
     group-TeamA#member administrator controller-MyController
+
+IDP-owned groups use the idpgroup tag and also require the #member userset:
+
+	idpgroup-external-team-id#member administrator controller-MyController
 
 Similarly if the object is a role, a userset must be applied by adding #member as follows.
 
@@ -1313,6 +1318,7 @@ Resources may be one of:
 
     user tag                = "user-<name>"
     group tag               = "group-<name>"
+	idp group tag           = "idpgroup-&lt;id&gt;"
 	role tag 			    = "role-&lt;name&gt;"
     controller tag          = "controller-<name>"
     model tag               = "model-<name>"
@@ -1354,6 +1360,10 @@ If the object is a group, a userset must be applied by adding #member as follows
 This will grant/revoke access to all users within TeamA:
 
     group-TeamA#member administrator controller-MyController
+
+IDP-owned groups use the idpgroup tag and also require the #member userset:
+
+	idpgroup-external-team-id#member administrator controller-MyController
 
 Similarly if the object is a role, a userset must be applied by adding #member as follows.
 

--- a/internal/common/pagination/entitlement.go
+++ b/internal/common/pagination/entitlement.go
@@ -23,6 +23,7 @@ var entitlementResources = []openfga.Kind{
 	openfga.ModelType,
 	openfga.ApplicationOfferType,
 	openfga.GroupType,
+	openfga.IdPGroupType,
 	openfga.RoleType,
 }
 

--- a/internal/jimm/permissions/access_test.go
+++ b/internal/jimm/permissions/access_test.go
@@ -1888,6 +1888,13 @@ func (s *permissionManagerSuite) TestParseAndValidateTag(c *qt.C) {
 	c.Assert(tag.ID, qt.Equals, "")
 	c.Assert(tag.Kind.String(), qt.Equals, names.ModelTagKind)
 
+	idpGroupTag := "idpgroup-engineering-team#member"
+	tag, err = s.manager.ParseAndValidateTag(ctx, idpGroupTag)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tag.ID, qt.Equals, "engineering-team")
+	c.Assert(tag.Kind.String(), qt.Equals, jimmnames.IdPGroupTagKind)
+	c.Assert(tag.Relation.String(), qt.Equals, "member")
+
 	// JIMM tag not valid
 	_, err = s.manager.ParseAndValidateTag(ctx, "")
 	c.Assert(err, qt.ErrorMatches, "unknown tag kind")
@@ -1919,6 +1926,10 @@ func (s *permissionManagerSuite) TestResolveTags(c *qt.C) {
 		desc:     "map group UUID with relation",
 		input:    "group-" + group.UUID + "#member",
 		expected: ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),
+	}, {
+		desc:     "map IDP group ID with relation",
+		input:    "idpgroup-engineering-team#member",
+		expected: ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag("engineering-team"), ofganames.MemberRelation),
 	}, {
 		desc:     "map role UUID",
 		input:    "role-" + role.UUID,
@@ -2051,6 +2062,9 @@ func (s *permissionManagerSuite) TestToJAASTag(c *qt.C) {
 		tag:             ofganames.ConvertTag(group.ResourceTag()),
 		expectedJAASTag: "group-" + group.Name,
 	}, {
+		tag:             ofganames.ConvertTag(jimmnames.NewIdPGroupTag("engineering-team")),
+		expectedJAASTag: "idpgroup-engineering-team",
+	}, {
 		tag:             ofganames.ConvertTag(controller.ResourceTag()),
 		expectedJAASTag: "controller-" + controller.Name,
 	}, {
@@ -2100,6 +2114,9 @@ func (s *permissionManagerSuite) TestToJAASTagNoUUIDResolution(c *qt.C) {
 	}, {
 		tag:             ofganames.ConvertTag(group.ResourceTag()),
 		expectedJAASTag: "group-" + group.UUID,
+	}, {
+		tag:             ofganames.ConvertTag(jimmnames.NewIdPGroupTag("engineering-team")),
+		expectedJAASTag: "idpgroup-engineering-team",
 	}, {
 		tag:             ofganames.ConvertTag(controller.ResourceTag()),
 		expectedJAASTag: "controller-" + controller.UUID,
@@ -2213,4 +2230,25 @@ func (s *permissionManagerSuite) TestOpenFGACleanup(c *qt.C) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(ok, qt.IsFalse)
 	}
+}
+
+func (s *permissionManagerSuite) TestOpenFGACleanupPreservesIdPGroupTuples(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	_, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	tuple := openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag("engineering-team"), ofganames.MemberRelation),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(model.ResourceTag()),
+	}
+	err := s.ofgaClient.AddRelation(ctx, tuple)
+	c.Assert(err, qt.IsNil)
+
+	err = s.manager.OpenFGACleanup(ctx)
+	c.Assert(err, qt.IsNil)
+
+	ok, err := s.ofgaClient.CheckRelation(ctx, tuple, false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
 }

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -48,9 +48,10 @@ var resourceAdminRelations = map[ofga.Relation]bool{
 // restricting grantees to these kinds independently prevents a non-admin from
 // writing a structural tuple.
 var grantableObjectKinds = map[openfga.Kind]bool{
-	openfga.UserType:  true,
-	openfga.GroupType: true,
-	openfga.RoleType:  true,
+	openfga.UserType:     true,
+	openfga.GroupType:    true,
+	openfga.IdPGroupType: true,
+	openfga.RoleType:     true,
 }
 
 // authorizeRelationTargetAdmin authorizes a non-JIMM-admin to manage the given

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -475,6 +475,17 @@ func (s *permissionManagerSuite) TestRelationManagementAsResourceAdministrator(c
 			},
 		},
 		{
+			description: "model administrator can manage IDP group relations",
+			grantAdmin: func() error {
+				return grantor.SetModelAccess(ctx, model.ResourceTag(), names.AdministratorRelation)
+			},
+			tuple: apiparams.RelationshipTuple{
+				Object:       "idpgroup-engineering-team#member",
+				Relation:     names.ReaderRelation.String(),
+				TargetObject: model.ResourceTag().String(),
+			},
+		},
+		{
 			description: "application offer administrator can manage relations",
 			grantAdmin: func() error {
 				return grantor.SetApplicationOfferAccess(ctx, offer.ResourceTag(), names.AdministratorRelation)

--- a/internal/jimm/permissions/tagresolver.go
+++ b/internal/jimm/permissions/tagresolver.go
@@ -112,6 +112,8 @@ func (j *PermissionManager) ToJAASTag(ctx context.Context, tag *ofganames.Tag, r
 			return "", fmt.Errorf("failed to fetch group information: %s: %w", group.UUID, err)
 		}
 		return tagToString(jimmnames.GroupTagKind, group.Name), nil
+	case jimmnames.IdPGroupTagKind:
+		return tagToString(jimmnames.IdPGroupTagKind, tag.ID), nil
 	case jimmnames.RoleTagKind:
 		role := dbmodel.RoleEntry{
 			UUID: tag.ID,
@@ -201,6 +203,26 @@ func (t *tagResolver) groupTag(ctx context.Context, db *db.Database) (*ofga.Enti
 	}
 
 	return ofganames.ConvertTagWithRelation(entry.ResourceTag(), t.relation), nil
+}
+
+func (t *tagResolver) idpGroupTag(ctx context.Context) (*ofga.Entity, error) {
+	idpGroupID := t.trailer
+	if idpGroupID == "" {
+		idpGroupID = t.resourceUUID
+	}
+	zapctx.Debug(
+		ctx,
+		"Resolving JIMM tags to Juju tags for tag kind: idpgroup",
+		zap.String("idp-group-id", idpGroupID),
+	)
+	if !jimmnames.IsValidIdPGroupId(idpGroupID) {
+		return nil, errors.New("invalid idp group")
+	}
+	return &ofga.Entity{
+		ID:       idpGroupID,
+		Kind:     ofga.Kind(jimmnames.IdPGroupTagKind),
+		Relation: t.relation,
+	}, nil
 }
 
 func (t *tagResolver) controllerTag(ctx context.Context, jimmUUID string, db *db.Database) (*ofga.Entity, error) {
@@ -326,6 +348,8 @@ func resolveTag(jimmUUID string, db *db.Database, tag string) (*ofganames.Tag, e
 		return resolver.userTag(ctx)
 	case jimmnames.GroupTagKind:
 		return resolver.groupTag(ctx, db)
+	case jimmnames.IdPGroupTagKind:
+		return resolver.idpGroupTag(ctx)
 	case jimmnames.RoleTagKind:
 		return resolver.roleTag(ctx, db)
 	case names.ControllerTagKind:

--- a/internal/openfga/names/names.go
+++ b/internal/openfga/names/names.go
@@ -56,6 +56,7 @@ type Tag = cofga.Entity
 type ResourceTagger interface {
 	names.UserTag |
 		jimmnames.GroupTag |
+		jimmnames.IdPGroupTag |
 		names.ControllerTag |
 		names.ModelTag |
 		names.ApplicationOfferTag |
@@ -105,6 +106,7 @@ func BlankKindTag(kind string) (*Tag, error) {
 	switch kind {
 	case names.UserTagKind,
 		jimmnames.GroupTagKind,
+		jimmnames.IdPGroupTagKind,
 		jimmnames.RoleTagKind,
 		names.ControllerTagKind,
 		names.ModelTagKind,

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// resourceTypes contains a list of all resource kinds (i.e. tags) used throughout JIMM.
-	resourceTypes = [...]string{names.UserTagKind, names.ModelTagKind, names.ControllerTagKind, names.ApplicationOfferTagKind, jimmnames.GroupTagKind, jimmnames.RoleTagKind}
+	resourceTypes = [...]string{names.UserTagKind, names.ModelTagKind, names.ControllerTagKind, names.ApplicationOfferTagKind, jimmnames.GroupTagKind, jimmnames.IdPGroupTagKind, jimmnames.RoleTagKind}
 )
 
 // Tuple represents a relation between an object and a target.
@@ -45,6 +45,8 @@ var (
 	ModelType Kind = names.ModelTagKind
 	// GroupType represents a group object.
 	GroupType Kind = jimmnames.GroupTagKind
+	// IdPGroupType represents an IDP-owned group object.
+	IdPGroupType Kind = jimmnames.IdPGroupTagKind
 	// RoleType represents a role object.
 	RoleType Kind = jimmnames.RoleTagKind
 	// ApplicationOfferType represents an application offer object.

--- a/openfga/authorisation_model.fga
+++ b/openfga/authorisation_model.fga
@@ -5,35 +5,39 @@ type user
 
 type role
  relations
-   define assignee: [user, user:*, group#member]
+   define assignee: [user, user:*, group#member, idpgroup#member]
 
 type group
   relations
     define member: [user, user:*, group#member]
 
+type idpgroup
+  relations
+    define member: [user, user:*]
+
 type controller
   relations
     define controller: [controller]
-    define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
-    define audit_log_viewer: [user, user:*, group#member, role#assignee] or administrator
-    define can_addmodel: [user, user:*, group#member, role#assignee] or administrator
+    define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from controller
+    define audit_log_viewer: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
+    define can_addmodel: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
 
 type model
   relations
     define controller: [controller]
-    define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
-    define reader: [user, user:*, group#member, role#assignee] or writer
-    define writer: [user, user:*, group#member, role#assignee] or administrator
+    define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from controller
+    define reader: [user, user:*, group#member, idpgroup#member, role#assignee] or writer
+    define writer: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
 
 type applicationoffer
   relations
     define model: [model]
-    define administrator: [user, user:*, group#member, role#assignee] or administrator from model
-    define consumer: [user, user:*, group#member, role#assignee] or administrator
-    define reader: [user, user:*, group#member, role#assignee] or consumer
+    define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from model
+    define consumer: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
+    define reader: [user, user:*, group#member, idpgroup#member, role#assignee] or consumer
 
 type cloud
   relations
     define controller: [controller]
-    define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
-    define can_addmodel: [user, user:*, group#member, role#assignee] or administrator
+    define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from controller
+    define can_addmodel: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator

--- a/openfga/tests.fga.yaml
+++ b/openfga/tests.fga.yaml
@@ -140,6 +140,12 @@ tuples:
     - user: group:mo-group-3#member
       relation: writer
       object: model:mo-model-1
+    - user: user:mo-user-6
+      relation: member
+      object: idpgroup:mo-idpgroup-1
+    - user: idpgroup:mo-idpgroup-1#member
+      relation: reader
+      object: model:mo-model-1
     
     # Cloud (cl)
     - user: user:cl-user-1
@@ -414,6 +420,12 @@ tests:
             writer:
               - model:mo-model-1
               - model:mo-model-2
+            reader:
+              - model:mo-model-1
+              - model:mo-model-2
+        - user: user:mo-user-6
+          type: model
+          assertions:
             reader:
               - model:mo-model-1
               - model:mo-model-2

--- a/pkg/names/idp_group.go
+++ b/pkg/names/idp_group.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Canonical.
+
+package names
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	IdPGroupTagKind = "idpgroup"
+)
+
+// IdPGroupTag represents a group owned by an external identity provider.
+// Implements juju names.Tag.
+type IdPGroupTag struct {
+	id string
+}
+
+// Id implements juju names.Tag.
+func (t IdPGroupTag) Id() string { return t.id }
+
+// Kind implements juju names.Tag.
+func (t IdPGroupTag) Kind() string { return IdPGroupTagKind }
+
+// String implements juju names.Tag.
+func (t IdPGroupTag) String() string { return IdPGroupTagKind + "-" + t.Id() }
+
+// NewIdPGroupTag creates an IdPGroupTag from the provided external group identifier.
+func NewIdPGroupTag(groupId string) IdPGroupTag {
+	if !IsValidIdPGroupId(groupId) {
+		panic(fmt.Sprintf("invalid idp group tag %q", groupId))
+	}
+
+	return IdPGroupTag{id: groupId}
+}
+
+// ParseIdPGroupTag parses an IDP group string.
+func ParseIdPGroupTag(tag string) (IdPGroupTag, error) {
+	t, err := ParseTag(tag)
+	if err != nil {
+		return IdPGroupTag{}, err
+	}
+	gt, ok := t.(IdPGroupTag)
+	if !ok {
+		return IdPGroupTag{}, invalidTagError(tag, IdPGroupTagKind)
+	}
+	return gt, nil
+}
+
+// IsValidIdPGroupId verifies the id is non-empty and does not contain multiple relation separators.
+func IsValidIdPGroupId(id string) bool {
+	if id == "" {
+		return false
+	}
+	parts := strings.Split(id, "#")
+	if len(parts) > 2 {
+		return false
+	}
+	if parts[0] == "" {
+		return false
+	}
+	return len(parts) == 1 || parts[1] != ""
+}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -42,6 +42,11 @@ func ParseTag(tag string) (names.Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewGroupTag(id), nil
+	case IdPGroupTagKind:
+		if !IsValidIdPGroupId(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewIdPGroupTag(id), nil
 	case RoleTagKind:
 		if !IsValidRoleId(id) {
 			return nil, invalidTagError(tag, kind)

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -32,7 +32,21 @@ func TestParseTag(t *testing.T) {
 			expectedValid: true,
 		},
 		{
+			tagString:     "idpgroup-engineering",
+			expectedTag:   names.NewIdPGroupTag("engineering"),
+			expectedValid: true,
+		},
+		{
+			tagString:     "idpgroup-4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member",
+			expectedTag:   names.NewIdPGroupTag("4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member"),
+			expectedValid: true,
+		},
+		{
 			tagString:     "group1",
+			expectedValid: false,
+		},
+		{
+			tagString:     "idpgroup-",
 			expectedValid: false,
 		},
 	}

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -261,6 +261,7 @@ func createTuple(object, relation, target string) openfga.Tuple {
 // group -> applicationoffer (name)
 // group -> applicationoffer (uuid)
 // group#member -> group
+// idpgroup#member -> model
 func TestAddRelation(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
@@ -479,6 +480,17 @@ func TestAddRelation(t *testing.T) {
 			),
 			err:         false,
 			changesType: "group",
+		},
+		// Test IDP group -> model by UUID.
+		{
+			input: tuple{"idpgroup-4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member", "reader", "model-" + model.UUID.String},
+			want: createTuple(
+				"idpgroup:4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member",
+				"reader",
+				"model:"+model.UUID.String,
+			),
+			err:         false,
+			changesType: "model",
 		},
 	}
 


### PR DESCRIPTION
## Description

add idp-group tag and entity handling, the idea is to allow juju jaas add-permission and the corresponding terraform resource to work with idp-group tags.

So:
`juju jaas add-permission idp-group:engineering audit_log_viewer controller-jimm`

and
```
resource "juju_jaas_access_controller" "devops" {
  access  = "administrator"
  idp_groups  = [local.devops_group_id]
}
```

Adding a new entity and a new tag instead of relying on the preexisting group tag makes it easier to:
- handle the future migrations when we will remove group entirely, from jaas and openfga tuples
- don't special case idp groups in our OpenFgaCleanup logic
- more clarity in the code
- at one point we can remove the group-tag and all tests associated to it

The new UX has been shared with Niko from IS and he said he doesn't change much for them.
See https://docs.google.com/document/d/1hUl5QFyPQ8IP4VZSR1fKMRGZ9e8ATE62nRfJfRmVYFI/edit?disco=AAAB9Ff8l14