### PR TITLE
feat: inject contextual tuples from jwt groups

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -77,6 +77,7 @@ const (
 )
 
 type sessionIdentityContextKey struct{}
+type sessionGroupsContextKey struct{}
 
 // ContextWithSessionIdentity adds the session identity id to the provided context.
 func ContextWithSessionIdentity(ctx context.Context, sessionIdentityId any) context.Context {
@@ -95,6 +96,38 @@ func SessionIdentityFromContext(ctx context.Context) string {
 		return ""
 	}
 	return s
+}
+
+// SessionGroupsFromContext returns the session groups from the context.
+func SessionGroupsFromContext(ctx context.Context) []string {
+	groups, _ := ctx.Value(sessionGroupsContextKey{}).([]string)
+	return append([]string(nil), groups...)
+}
+
+// ContextWithSessionGroups adds the session groups to the provided context.
+func ContextWithSessionGroups(ctx context.Context, groups []string) context.Context {
+	return context.WithValue(ctx, sessionGroupsContextKey{}, append([]string(nil), groups...))
+}
+
+func sessionGroupsFromValue(value any) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if groups, ok := value.([]string); ok {
+		return append([]string(nil), groups...), nil
+	}
+	if groups, ok := value.([]any); ok {
+		parsedGroups := make([]string, 0, len(groups))
+		for i, group := range groups {
+			groupStr, ok := group.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid session group entry type at index %d: got %T", i, group)
+			}
+			parsedGroups = append(parsedGroups, groupStr)
+		}
+		return parsedGroups, nil
+	}
+	return nil, fmt.Errorf("invalid session groups type: got %T", value)
 }
 
 // AuthenticationService handles authentication within JIMM.
@@ -708,6 +741,11 @@ func (as *AuthenticationService) AuthenticateBrowserSession(ctx context.Context,
 	}
 
 	ctx = ContextWithSessionIdentity(ctx, identityId)
+	groups, err := sessionGroupsFromValue(session.Values[SessionGroupsKey])
+	if err != nil {
+		return ctx, err
+	}
+	ctx = ContextWithSessionGroups(ctx, groups)
 
 	if err := as.extendSession(session, w, req); err != nil {
 		return ctx, err

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -20,14 +20,19 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	qt "github.com/frankban/quicktest"
 	"github.com/gorilla/sessions"
+	jujunames "github.com/juju/names/v5"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/login"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/internal/testutils/testdb"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
 const (
@@ -415,6 +420,52 @@ func TestBrowserLoginStoresExtractedGroups(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(session.Values[auth.SessionIdentityKey], qt.Equals, jimmtest.HardcodedGroupEmail)
 	c.Assert(session.Values[auth.SessionGroupsKey], qt.DeepEquals, []string{jimmtest.OIDCGroupsTestGroupName})
+}
+
+func TestKeycloakGroupUserAuthorisesViaIDPGroupContextualTuple(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	authSvc, db, sessionStore, cleanup := setupTestAuthSvcWithGroupClaimKey(ctx, c, time.Hour, testGroupClaimKey)
+	defer cleanup()
+
+	ofgaClient, _, _, err := jimmtest.SetupTestOFGAClient(c.Name())
+	c.Assert(err, qt.IsNil)
+
+	loginManager, err := login.NewLoginManager(db, ofgaClient, authSvc, jujunames.NewControllerTag("jimm"))
+	c.Assert(err, qt.IsNil)
+
+	cookie, err := jimmtest.RunBrowserLogin(
+		db,
+		sessionStore,
+		jimmtest.HardcodedGroupUsername,
+		jimmtest.HardcodedGroupPassword,
+	)
+	c.Assert(err, qt.IsNil)
+
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "", nil)
+	c.Assert(err, qt.IsNil)
+	req.AddCookie(jimmtest.ParseCookies(cookie)[0])
+
+	ctx, err = authSvc.AuthenticateBrowserSession(ctx, rec, req)
+	c.Assert(err, qt.IsNil)
+
+	user, err := loginManager.LoginWithSessionCookie(ctx, jimmtest.HardcodedGroupEmail)
+	c.Assert(err, qt.IsNil)
+	c.Assert(user.IDPGroupIDs, qt.DeepEquals, []string{jimmtest.OIDCGroupsTestGroupName})
+
+	modelTag := jujunames.NewModelTag("00000002-0000-0000-0000-000000000001")
+	err = ofgaClient.AddRelation(ctx, openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(jimmtest.OIDCGroupsTestGroupName), ofganames.MemberRelation),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(modelTag),
+	})
+	c.Assert(err, qt.IsNil)
+
+	allowed, err := user.IsModelReader(ctx, modelTag)
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowed, qt.IsTrue)
 }
 
 func TestCreateBrowserSessionWithGroups(t *testing.T) {

--- a/internal/jimm/login/login.go
+++ b/internal/jimm/login/login.go
@@ -155,7 +155,7 @@ func (j *LoginManager) LoginClientCredentials(ctx context.Context, clientID stri
 		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 
-	_, err = j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
+	groups, err := j.oAuthAuthenticator.VerifyClientCredentials(ctx, clientID, clientSecret)
 	if err != nil {
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
 		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
@@ -165,6 +165,7 @@ func (j *LoginManager) LoginClientCredentials(ctx context.Context, clientID stri
 		logger.LogFailedLogin(ctx, clientIdWithDomain)
 		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
+	user.SetIDPGroups(groups)
 	logger.LogSuccessfulLogin(ctx, clientIdWithDomain)
 	return user, nil
 }
@@ -181,12 +182,19 @@ func (j *LoginManager) LoginWithSessionToken(ctx context.Context, sessionToken s
 		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
 
+	groups, err := auth.SessionGroupsFromToken(jwtToken)
+	if err != nil {
+		logger.LogFailedLogin(ctx, jwtToken.Subject())
+		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
+	}
+
 	email := jwtToken.Subject()
 	user, err := j.UserLogin(ctx, email)
 	if err != nil {
 		logger.LogFailedLogin(ctx, email)
 		return nil, errors.Codef(errors.CodeFatalLoginError, "%w", err)
 	}
+	user.SetIDPGroups(groups)
 	logger.LogSuccessfulLogin(ctx, email)
 	return user, nil
 }
@@ -207,6 +215,7 @@ func (j *LoginManager) LoginWithSessionCookie(ctx context.Context, identityID st
 		logger.LogFailedLogin(ctx, identityID)
 		return nil, err
 	}
+	user.SetIDPGroups(auth.SessionGroupsFromContext(ctx))
 	logger.LogSuccessfulLogin(ctx, identityID)
 	return user, nil
 }
@@ -216,7 +225,6 @@ func (j *LoginManager) LoginWithSessionCookie(ctx context.Context, identityID st
 // It will create a new identity if one does not exist.
 // The identity's last login time is updated.
 func (j *LoginManager) UserLogin(ctx context.Context, identifier string) (*openfga.User, error) {
-
 	ofgaUser, err := j.GetOrCreateIdentity(ctx, identifier)
 	if err != nil {
 		return nil, errors.Codef(errors.CodeUnauthorized, "%w", err)
@@ -229,7 +237,6 @@ func (j *LoginManager) UserLogin(ctx context.Context, identifier string) (*openf
 }
 
 func (j *LoginManager) GetOrCreateIdentity(ctx context.Context, identifier string) (*openfga.User, error) {
-
 	identity, err := dbmodel.NewIdentity(identifier)
 	if err != nil {
 		return nil, err

--- a/internal/jimm/login/login_test.go
+++ b/internal/jimm/login/login_test.go
@@ -167,9 +167,11 @@ func (s *loginManagerSuite) TestLoginClientCredentials(c *qt.C) {
 func (s *loginManagerSuite) TestLoginWithSessionToken(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
+	groups := []string{"engineering", "platform"}
 
 	token, err := jwt.NewBuilder().
 		Subject("alice@canonical.com").
+		Claim(auth.SessionTokenGroupsClaimKey, groups).
 		Build()
 	c.Assert(err, qt.IsNil)
 	serialisedToken, err := jwt.NewSerializer().Serialize(token)
@@ -182,6 +184,7 @@ func (s *loginManagerSuite) TestLoginWithSessionToken(c *qt.C) {
 	user, err := s.manager.LoginWithSessionToken(ctx, b64Token)
 	c.Assert(err, qt.IsNil)
 	c.Assert(user.Name, qt.Equals, "alice@canonical.com")
+	c.Assert(user.IDPGroupIDs, qt.DeepEquals, groups)
 }
 
 func (s *loginManagerSuite) TestLoginWithSessionCookie(c *qt.C) {

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -82,11 +82,15 @@ func (j *PermissionManager) authorizeRelationTargetAdmin(ctx context.Context, us
 
 	switch tuple.Target.Kind {
 	case openfga.ControllerType, openfga.ModelType, openfga.ApplicationOfferType, openfga.CloudType:
+		contextualTuples, err := user.ContextualTuples()
+		if err != nil {
+			return err
+		}
 		allowed, err := j.authSvc.CheckRelation(ctx, openfga.Tuple{
 			Object:   ofganames.ConvertTag(user.ResourceTag()),
 			Relation: ofganames.AdministratorRelation,
 			Target:   tuple.Target,
-		}, false)
+		}, false, contextualTuples...)
 		if err != nil {
 			return errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 		}
@@ -172,7 +176,11 @@ func (j *PermissionManager) CheckRelation(ctx context.Context, user *openfga.Use
 		}
 	}
 
-	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace)
+	contextualTuples, err := user.ContextualTuples()
+	if err != nil {
+		return allowed, err
+	}
+	allowed, err = j.authSvc.CheckRelation(ctx, *parsedTuple, trace, contextualTuples...)
 	if err != nil {
 		return allowed, errors.Codef(errors.CodeOpenFGARequestFailed, "%w", err)
 	}

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -178,6 +178,74 @@ func (s *permissionManagerSuite) TestListRelationshipTuples(c *qt.C) {
 	}
 }
 
+func (s *permissionManagerSuite) TestCheckRelationUsesUserIDPGroupsAsContextualTuples(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	userIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("subject-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(userIdentity).Error, qt.IsNil)
+	user := openfga.NewUser(userIdentity, s.ofgaClient)
+	user.SetIDPGroups([]string{"engineering-team"})
+
+	_, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	err = s.manager.AddRelation(ctx, s.adminUser, []apiparams.RelationshipTuple{{
+		Object:       "idpgroup-engineering-team#member",
+		Relation:     names.ReaderRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}})
+	c.Assert(err, qt.IsNil)
+
+	checkTuple := apiparams.RelationshipTuple{
+		Object:       userIdentity.Tag().String(),
+		Relation:     names.ReaderRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}
+
+	allowed, err := s.manager.CheckRelation(ctx, openfga.NewUser(userIdentity, s.ofgaClient), checkTuple, false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowed, qt.IsFalse)
+
+	allowed, err = s.manager.CheckRelation(ctx, user, checkTuple, false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowed, qt.IsTrue)
+}
+
+func (s *permissionManagerSuite) TestResourceAdminCheckUsesUserIDPGroupsAsContextualTuples(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	grantorIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("grantor-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(grantorIdentity).Error, qt.IsNil)
+	grantor := openfga.NewUser(grantorIdentity, s.ofgaClient)
+	grantor.SetIDPGroups([]string{"model-admins"})
+
+	subjectIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("subject-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(subjectIdentity).Error, qt.IsNil)
+
+	_, _, _, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	err = s.manager.AddRelation(ctx, s.adminUser, []apiparams.RelationshipTuple{{
+		Object:       "idpgroup-model-admins#member",
+		Relation:     names.AdministratorRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}})
+	c.Assert(err, qt.IsNil)
+
+	tuples := []apiparams.RelationshipTuple{{
+		Object:       subjectIdentity.Tag().String(),
+		Relation:     names.ReaderRelation.String(),
+		TargetObject: model.ResourceTag().String(),
+	}}
+
+	err = s.manager.AddRelation(ctx, openfga.NewUser(grantorIdentity, s.ofgaClient), tuples)
+	c.Assert(err, qt.ErrorMatches, "unauthorized")
+
+	err = s.manager.AddRelation(ctx, grantor, tuples)
+	c.Assert(err, qt.IsNil)
+}
+
 func (s *permissionManagerSuite) TestListObjectRelations(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -45,8 +45,12 @@ func (s streamControllerProxier) Authenticate(ctx context.Context, w http.Respon
 	if err != nil {
 		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
-	email := jwtToken.Subject()
-	ctx = auth.ContextWithSessionIdentity(ctx, email)
+	groups, err := auth.SessionGroupsFromToken(jwtToken)
+	if err != nil {
+		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
+	}
+	ctx = auth.ContextWithSessionIdentity(ctx, jwtToken.Subject())
+	ctx = auth.ContextWithSessionGroups(ctx, groups)
 	return ctx, nil
 }
 
@@ -76,6 +80,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		writeError(err.Error(), errors.CodeUnauthorized)
 		return
 	}
+	user.SetIDPGroups(auth.SessionGroupsFromContext(ctx))
 
 	if !user.JimmAdmin {
 		logger.LogUnauthorizedAccess(

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -40,8 +40,12 @@ func (s streamModelProxier) Authenticate(ctx context.Context, w http.ResponseWri
 	if err != nil {
 		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
 	}
-	email := jwtToken.Subject()
-	ctx = auth.ContextWithSessionIdentity(ctx, email)
+	groups, err := auth.SessionGroupsFromToken(jwtToken)
+	if err != nil {
+		return ctx, errors.Codef(errors.CodeUnauthorized, "%w", err)
+	}
+	ctx = auth.ContextWithSessionIdentity(ctx, jwtToken.Subject())
+	ctx = auth.ContextWithSessionGroups(ctx, groups)
 	return ctx, nil
 }
 
@@ -69,6 +73,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		writeError(err.Error(), errors.CodeUnauthorized)
 		return
 	}
+	user.SetIDPGroups(auth.SessionGroupsFromContext(ctx))
 
 	uuid, finalPath, err := modelInfoFromPath(jimmhttp.PathElementFromContext(ctx))
 	if err != nil {

--- a/internal/openfga/openfga.go
+++ b/internal/openfga/openfga.go
@@ -233,7 +233,7 @@ func (o *OFGAClient) ReadRelatedObjects(ctx context.Context, tuple Tuple, pageSi
 // CheckRelation verifies that a user (or object) is allowed to access the target object by the specified relation.
 //
 // It will return a bool of simply true or false, denoting authorisation, and an error.
-func (o *OFGAClient) CheckRelation(ctx context.Context, tuple Tuple, trace bool) (_ bool, err error) {
+func (o *OFGAClient) CheckRelation(ctx context.Context, tuple Tuple, trace bool, contextualTuples ...Tuple) (_ bool, err error) {
 	const op = "openfga.CheckRelation"
 
 	durationObserver := servermon.DurationObserver(servermon.OpenFGACallDurationHistogram, op)
@@ -241,9 +241,9 @@ func (o *OFGAClient) CheckRelation(ctx context.Context, tuple Tuple, trace bool)
 	defer servermon.ErrorCounter(servermon.OpenFGACallErrorCount, &err, op)
 
 	if trace {
-		return o.cofgaClient.CheckRelationWithTracing(ctx, tuple)
+		return o.cofgaClient.CheckRelationWithTracing(ctx, tuple, contextualTuples...)
 	}
-	return o.cofgaClient.CheckRelation(ctx, tuple)
+	return o.cofgaClient.CheckRelation(ctx, tuple, contextualTuples...)
 }
 
 // removeTuples iteratively reads through all the tuples with the parameters as supplied by tuple and deletes them.

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -653,6 +653,40 @@ func TestListObjectsWithContextualTuples(t *testing.T) {
 	), qt.Equals, true)
 }
 
+func TestCheckRelationWithContextualTuples(t *testing.T) {
+	c := qt.New(t)
+	s := SetupTest(c)
+	ctx := context.TODO()
+
+	groupID := uuid.NewString()
+	modelID := uuid.NewString()
+
+	err := s.ofgaClient.AddRelation(ctx, openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(groupID), ofganames.MemberRelation),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag(modelID)),
+	})
+	c.Assert(err, qt.IsNil)
+
+	check := openfga.Tuple{
+		Object:   ofganames.ConvertTag(names.NewUserTag("alice")),
+		Relation: ofganames.ReaderRelation,
+		Target:   ofganames.ConvertTag(names.NewModelTag(modelID)),
+	}
+
+	allowed, err := s.ofgaClient.CheckRelation(ctx, check, false)
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowed, qt.IsFalse)
+
+	allowed, err = s.ofgaClient.CheckRelation(ctx, check, false, openfga.Tuple{
+		Object:   ofganames.ConvertTag(names.NewUserTag("alice")),
+		Relation: ofganames.MemberRelation,
+		Target:   ofganames.ConvertTag(jimmnames.NewIdPGroupTag(groupID)),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(allowed, qt.IsTrue)
+}
+
 func TestListObjectsWithPeristedTuples(t *testing.T) {
 	c := qt.New(t)
 	s := SetupTest(c)

--- a/internal/openfga/user.go
+++ b/internal/openfga/user.go
@@ -15,7 +15,10 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
+
+const maxContextualTuples = 20
 
 // NewUser returns a new user structure that can be used to check
 // user's access rights to various resources.
@@ -30,8 +33,35 @@ func NewUser(u *dbmodel.Identity, client *OFGAClient) *User {
 // to check user's access rights to various resources.
 type User struct {
 	*dbmodel.Identity
-	client    *OFGAClient
-	JimmAdmin bool
+	client      *OFGAClient
+	JimmAdmin   bool
+	IDPGroupIDs []string
+}
+
+// SetIDPGroups stores the opaque IDP group identifiers associated with the user.
+func (u *User) SetIDPGroups(groups []string) {
+	u.IDPGroupIDs = append([]string(nil), groups...)
+}
+
+// ContextualTuples returns the ephemeral OpenFGA tuples representing the user's
+// IDP group memberships.
+func (u *User) ContextualTuples() ([]Tuple, error) {
+	if len(u.IDPGroupIDs) > maxContextualTuples {
+		return nil, errors.Codef(errors.CodeUnauthorized, "too many IDP groups in session: got %d, maximum is %d", len(u.IDPGroupIDs), maxContextualTuples)
+	}
+
+	contextualTuples := make([]Tuple, 0, len(u.IDPGroupIDs))
+	for _, group := range u.IDPGroupIDs {
+		if !jimmnames.IsValidIdPGroupId(group) {
+			return nil, errors.Codef(errors.CodeUnauthorized, "invalid IDP group identifier in session: %q", group)
+		}
+		contextualTuples = append(contextualTuples, Tuple{
+			Object:   ofganames.ConvertTag(u.ResourceTag()),
+			Relation: ofganames.MemberRelation,
+			Target:   ofganames.ConvertTag(jimmnames.NewIdPGroupTag(group)),
+		})
+	}
+	return contextualTuples, nil
 }
 
 // IsAllowedAddModelToController returns true if the user is allowed to add a model on the
@@ -267,7 +297,11 @@ func (u *User) UnsetApplicationOfferAccess(ctx context.Context, resource names.A
 
 // ListModels returns a slice of model UUIDs that this user has the relation <relation> to.
 func (u *User) ListModels(ctx context.Context, relation ofga.Relation) ([]string, error) {
-	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ModelType, nil)
+	contextualTuples, err := u.ContextualTuples()
+	if err != nil {
+		return nil, err
+	}
+	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ModelType, contextualTuples)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +314,11 @@ func (u *User) ListModels(ctx context.Context, relation ofga.Relation) ([]string
 
 // ListApplicationOffers returns a slice of application offer UUIDs that a user has the relation <relation> to.
 func (u *User) ListApplicationOffers(ctx context.Context, relation ofga.Relation) ([]string, error) {
-	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ApplicationOfferType, nil)
+	contextualTuples, err := u.ContextualTuples()
+	if err != nil {
+		return nil, err
+	}
+	entities, err := u.client.ListObjects(ctx, ofganames.ConvertTag(u.ResourceTag()), relation, ApplicationOfferType, contextualTuples)
 	if err != nil {
 		return nil, err
 	}
@@ -315,6 +353,11 @@ func (u *User) CheckPermission(ctx context.Context, resourceTag string, permissi
 		relation = ofganames.CanAddModelRelation
 	}
 
+	contextualTuples, err := u.ContextualTuples()
+	if err != nil {
+		return err
+	}
+
 	allowed, err := u.client.CheckRelation(
 		ctx,
 		Tuple{
@@ -323,6 +366,7 @@ func (u *User) CheckPermission(ctx context.Context, resourceTag string, permissi
 			Target:   ofganames.ConvertGenericTag(resource),
 		},
 		true,
+		contextualTuples...,
 	)
 	if err != nil {
 		return err
@@ -343,6 +387,11 @@ type administratorT interface {
 }
 
 func checkRelation[T ofganames.ResourceTagger](ctx context.Context, u *User, resource T, relation Relation) (bool, error) {
+	contextualTuples, err := u.ContextualTuples()
+	if err != nil {
+		return false, err
+	}
+
 	isAllowed, err := u.client.CheckRelation(
 		ctx,
 		Tuple{
@@ -351,6 +400,7 @@ func checkRelation[T ofganames.ResourceTagger](ctx context.Context, u *User, res
 			Target:   ofganames.ConvertTag(resource),
 		},
 		true,
+		contextualTuples...,
 	)
 	if err != nil {
 		return false, err
@@ -366,6 +416,11 @@ func CheckRelation(ctx context.Context, u *User, resource names.Tag, relation Re
 	var tag *ofganames.Tag
 	var err error
 	tag = ofganames.ConvertGenericTag(resource)
+	contextualTuples, err := u.ContextualTuples()
+	if err != nil {
+		return false, err
+	}
+
 	isAllowed, err := u.client.CheckRelation(
 		ctx,
 		Tuple{
@@ -374,6 +429,7 @@ func CheckRelation(ctx context.Context, u *User, resource names.Tag, relation Re
 			Target:   tag,
 		},
 		true,
+		contextualTuples...,
 	)
 	if err != nil {
 		return false, err

--- a/internal/openfga/user_test.go
+++ b/internal/openfga/user_test.go
@@ -52,6 +52,61 @@ func TestIsAdministrator(t *testing.T) {
 	c.Assert(allowed, qt.Equals, true)
 }
 
+func TestUserContextualTuples(c *testing.T) {
+	assert := qt.New(c)
+	identity, err := dbmodel.NewIdentity("eve")
+	assert.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(identity, nil)
+	groups := []string{"engineering", "platform"}
+	user.SetIDPGroups(groups)
+	groups[0] = "mutated"
+
+	tuples, err := user.ContextualTuples()
+	assert.Assert(err, qt.IsNil)
+	assert.Assert(tuples, qt.DeepEquals, []openfga.Tuple{{
+		Object:   ofganames.ConvertTag(names.NewUserTag("eve")),
+		Relation: ofganames.MemberRelation,
+		Target:   ofganames.ConvertTag(jimmnames.NewIdPGroupTag("engineering")),
+	}, {
+		Object:   ofganames.ConvertTag(names.NewUserTag("eve")),
+		Relation: ofganames.MemberRelation,
+		Target:   ofganames.ConvertTag(jimmnames.NewIdPGroupTag("platform")),
+	}})
+}
+
+func TestUserContextualTuplesRejectsTooManyGroups(c *testing.T) {
+	assert := qt.New(c)
+	identity, err := dbmodel.NewIdentity("eve")
+	assert.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(identity, nil)
+	user.SetIDPGroups([]string{
+		"group-01", "group-02", "group-03", "group-04", "group-05",
+		"group-06", "group-07", "group-08", "group-09", "group-10",
+		"group-11", "group-12", "group-13", "group-14", "group-15",
+		"group-16", "group-17", "group-18", "group-19", "group-20",
+		"group-21",
+	})
+
+	tuples, err := user.ContextualTuples()
+	assert.Assert(tuples, qt.IsNil)
+	assert.Assert(err, qt.ErrorMatches, "too many IDP groups in session: got 21, maximum is 20")
+}
+
+func TestUserContextualTuplesRejectsInvalidGroup(c *testing.T) {
+	assert := qt.New(c)
+	identity, err := dbmodel.NewIdentity("eve")
+	assert.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(identity, nil)
+	user.SetIDPGroups([]string{""})
+
+	tuples, err := user.ContextualTuples()
+	assert.Assert(tuples, qt.IsNil)
+	assert.Assert(err, qt.ErrorMatches, `invalid IDP group identifier in session: ""`)
+}
+
 func TestModelAccess(t *testing.T) {
 	c := qt.New(t)
 	s := SetupTest(c)


### PR DESCRIPTION
## Description

idp groups are injected into the user obj to then use it as contextual tuples.

The groups are injected in the ctx in the auth path, and the groups are injected in the `openfga.User` at login time.

Then those idp-groups are used as contextual tuples during openfga evaluation.