### PR TITLE
Migrate v3

### DIFF
--- a/docs/.sphinx/_static/js/overwrite_links.js
+++ b/docs/.sphinx/_static/js/overwrite_links.js
@@ -1,15 +1,37 @@
+// Replace oldDomain with newDomain
 const oldDomain = 'canonical-jaas-1.readthedocs-hosted.com';
 const newDomain = 'canonical.com/juju/docs/jaas';
 
-function overwriteURL(el) {
-	if (!el) return;
-	el.querySelectorAll('a').forEach(function (anchor) {
-		const href = anchor.getAttribute('href');
-		if (href && href.includes(oldDomain)) {
-			anchor.href = href.replace(oldDomain, newDomain);
-		}
-	});
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-overwriteURL(document.querySelector('header'));
-overwriteURL(document.querySelector('.rst-versions'));
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/.sphinx/_static/js/overwrite_links.js
+++ b/docs/.sphinx/_static/js/overwrite_links.js
@@ -1,0 +1,15 @@
+const oldDomain = 'canonical-jaas-1.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/jaas';
+
+function overwriteURL(el) {
+	if (!el) return;
+	el.querySelectorAll('a').forEach(function (anchor) {
+		const href = anchor.getAttribute('href');
+		if (href && href.includes(oldDomain)) {
+			anchor.href = href.replace(oldDomain, newDomain);
+		}
+	});
+}
+
+overwriteURL(document.querySelector('header'));
+overwriteURL(document.querySelector('.rst-versions'));

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,9 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical.com/juju/docs/jaas/"
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+
+ogp_site_url = f"https://canonical.com/juju/docs/jaas/{version_slug}/"
 
 
 # Preview name of the documentation website
@@ -148,7 +150,7 @@ slug = 'juju/docs/jaas'
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://canonical.com/juju/docs/jaas/'
+html_baseurl = f'https://canonical.com/juju/docs/jaas/{version_slug}/'
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-jaas-documentation.readthedocs-hosted.com/"
+ogp_site_url = "https://canonical.com/juju/docs/jaas/"
 
 
 # Preview name of the documentation website
@@ -139,7 +139,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = 'jaas'
+slug = 'juju/docs/jaas'
 
 
 #######################
@@ -148,7 +148,7 @@ slug = 'jaas'
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://documentation.ubuntu.com/jaas/'
+html_baseurl = 'https://canonical.com/juju/docs/jaas/'
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
@@ -158,6 +158,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
     sitemap_url_scheme = '{version}{link}'
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
+
+sitemap_filename = "doc-sitemap.xml"
 
 sitemap_show_lastmod = True
 
@@ -303,6 +305,7 @@ html_css_files = [
 
 html_js_files = [
 	'js/bundle.js',
+	'js/overwrite_links.js',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,11 +153,7 @@ html_baseurl = 'https://canonical.com/juju/docs/jaas/'
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+sitemap_url_scheme = '{link}'
 
 sitemap_filename = "doc-sitemap.xml"
 


### PR DESCRIPTION
Part of our docs migration to canonical.com/juju/docs/jaas.


For reference see https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/ 

The changes to the content files are about spellcheck or linkcheck fixes (so the CI tests pass). The `.customwordlist` temporarily includes spelling errors that occur in the `jaas` plugin and which we should try to fix at source.

