### PR TITLE
feat: add max of idp groups per user

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,6 +55,7 @@ const (
 
 	// migrationTokenExpiry is the expiry time for migration tokens.
 	migrationTokenExpiry = 3 * time.Hour
+	idpGroupLimit        = 20
 )
 
 // AuthStyle determines how the client credentials are sent to the token endpoint.
@@ -310,25 +311,32 @@ func (as *AuthenticationService) extractGroupsFromAccessToken(ctx context.Contex
 		return nil, nil
 	}
 
-	// Normalize the group claim into a slice of strings
-	switch groups := groupClaim.(type) {
+	var groups []string
+
+	// Normalize the group claim into a slice of strings.
+	switch typedGroups := groupClaim.(type) {
 	case string:
-		return splitGroupClaimString(groups), nil
+		groups = splitGroupClaimString(typedGroups)
 	case []string:
-		return groups, nil
+		groups = typedGroups
 	case []any:
-		var normalizedGroups []string
-		for i, group := range groups {
+		groups = make([]string, 0, len(typedGroups))
+		for i, group := range typedGroups {
 			groupStr, ok := group.(string)
 			if !ok {
 				return nil, fmt.Errorf("invalid group claim entry type at index %d: got %T", i, group)
 			}
-			normalizedGroups = append(normalizedGroups, groupStr)
+			groups = append(groups, groupStr)
 		}
-		return normalizedGroups, nil
 	default:
 		return nil, fmt.Errorf("invalid group claim type: got %T", groupClaim)
 	}
+
+	if len(groups) > idpGroupLimit {
+		return nil, errors.Codef(errors.CodeUnauthorized, "authorization denied: IDP group claim contains %d groups, maximum supported is %d", len(groups), idpGroupLimit)
+	}
+
+	return groups, nil
 }
 
 // AuthCodeURL returns a URL that will be used to redirect a browser to the identity provider.

--- a/internal/auth/auth_test_whitebox.go
+++ b/internal/auth/auth_test_whitebox.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"golang.org/x/oauth2"
+
+	"github.com/canonical/jimm/v3/internal/errors"
 )
 
 var OIDCGroupsTestGroupName = "canonical"
@@ -36,4 +40,28 @@ func TestSplitGroupClaimStringEmpty(t *testing.T) {
 
 	groups := splitGroupClaimString("  ")
 	c.Assert(groups, qt.IsNil)
+}
+
+func TestExtractGroupsFromAccessTokenRejectsTooManyGroups(t *testing.T) {
+	c := qt.New(t)
+
+	token, err := jwt.NewBuilder().
+		Claim("groups", []string{
+			"group-01", "group-02", "group-03", "group-04", "group-05",
+			"group-06", "group-07", "group-08", "group-09", "group-10",
+			"group-11", "group-12", "group-13", "group-14", "group-15",
+			"group-16", "group-17", "group-18", "group-19", "group-20",
+			"group-21",
+		}).
+		Build()
+	c.Assert(err, qt.IsNil)
+
+	serializedToken, err := jwt.NewSerializer().Serialize(token)
+	c.Assert(err, qt.IsNil)
+
+	authSvc := &AuthenticationService{groupClaimKey: "groups"}
+	groups, err := authSvc.extractGroupsFromAccessToken(t.Context(), &oauth2.Token{AccessToken: string(serializedToken)})
+	c.Assert(groups, qt.IsNil)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeUnauthorized)
+	c.Assert(err, qt.ErrorMatches, "authorization denied: IDP group claim contains 21 groups, maximum supported is 20")
 }


### PR DESCRIPTION
## Description

openfga supports max of 20 contextual tuples, so we need to return an error if there are >20 idp groups for a user. If somebody will complain about this we will find a solution, but for now we just return an error.

The only 2 path to check are:
- device flow
- client id and secret
- browser flow
Because those are the only place where we check the groups coming from the idp.

