### PR TITLE
feat: deprecate AddGroup and AddMemberToGroup

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -55,7 +55,10 @@ const (
 
 	// migrationTokenExpiry is the expiry time for migration tokens.
 	migrationTokenExpiry = 3 * time.Hour
-	idpGroupLimit        = 20
+	// idpGroupLimit is the maximum number of groups that will be accepted from an identity provider
+	// in the configured group claim. Since we are handling idp groups as contextual tuples, and OpenFGA
+	// supports a max of 20 contextual tuples, this is the limit for now.
+	idpGroupLimit = 20
 )
 
 // AuthStyle determines how the client credentials are sent to the token endpoint.

--- a/internal/jimm/group/group.go
+++ b/internal/jimm/group/group.go
@@ -13,6 +13,9 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
+//nolint:gosec // This is a user-facing deprecation message, not a credential.
+const deprecatedJAASGroupWriteMessage = "JAAS-managed group writes are deprecated; group ownership is managed by the identity provider"
+
 // GroupManager provides a means to manage groups within JIMM.
 type GroupManager struct {
 	store   *db.Database
@@ -33,16 +36,7 @@ func NewGroupManager(store *db.Database, authSvc *openfga.OFGAClient) (*GroupMan
 
 // AddGroup creates a group within JIMMs DB for reference by OpenFGA.
 func (j *GroupManager) AddGroup(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
-
-	if !user.JimmAdmin {
-		return nil, errors.Codef(errors.CodeUnauthorized, "unauthorized")
-	}
-
-	ge, err := j.store.AddGroup(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-	return ge, nil
+	return nil, errors.Codef(errors.CodeNotSupported, deprecatedJAASGroupWriteMessage)
 }
 
 // CountGroups returns the number of groups that exist.
@@ -82,31 +76,7 @@ func (j *GroupManager) GetGroupByName(ctx context.Context, user *openfga.User, n
 
 // RenameGroup renames a group in JIMM's DB.
 func (j *GroupManager) RenameGroup(ctx context.Context, user *openfga.User, oldName, newName string) error {
-
-	if !user.JimmAdmin {
-		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
-	}
-
-	group := &dbmodel.GroupEntry{
-		Name: oldName,
-	}
-
-	err := j.store.Transaction(func(d *db.Database) error {
-		err := d.GetGroup(ctx, group)
-		if err != nil {
-			return err
-		}
-
-		if err := d.UpdateGroupName(ctx, group.UUID, newName); err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return errors.Codef(errors.CodeNotSupported, deprecatedJAASGroupWriteMessage)
 }
 
 // RemoveGroup removes a group within JIMMs DB for reference by OpenFGA.

--- a/internal/jimm/group/group_test.go
+++ b/internal/jimm/group/group_test.go
@@ -59,30 +59,15 @@ func (s *groupManagerSuite) Init(c *qt.C) {
 	s.user = openfga.NewUser(i2, ofgaClient)
 }
 
-func (s *groupManagerSuite) TestAddGroup(c *qt.C) {
-	c.Parallel()
-	ctx := context.Background()
-
-	g, err := s.manager.AddGroup(ctx, s.adminUser, "test-group-1")
-	c.Assert(err, qt.IsNil)
-	c.Assert(g.UUID, qt.Not(qt.Equals), "")
-	c.Assert(g.Name, qt.Equals, "test-group-1")
-
-	g, err = s.manager.AddGroup(ctx, s.adminUser, "test-group-2")
-	c.Assert(err, qt.IsNil)
-	c.Assert(g.UUID, qt.Not(qt.Equals), "")
-	c.Assert(g.Name, qt.Equals, "test-group-2")
-}
-
 func (s *groupManagerSuite) TestCountGroups(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	groupEntry, err := s.manager.AddGroup(ctx, s.adminUser, "test-group-1")
+	groupEntry, err := s.db.AddGroup(ctx, "test-group-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(groupEntry.UUID, qt.Not(qt.Equals), "")
 
-	_, err = s.manager.AddGroup(ctx, s.adminUser, "test-group-1")
+	_, err = s.db.AddGroup(ctx, "test-group-1")
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeAlreadyExists)
 }
 
@@ -90,7 +75,7 @@ func (s *groupManagerSuite) TestGetGroup(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
 
-	groupEntry, err := s.manager.AddGroup(ctx, s.adminUser, "test-group-1")
+	groupEntry, err := s.db.AddGroup(ctx, "test-group-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(groupEntry.UUID, qt.Not(qt.Equals), "")
 
@@ -187,81 +172,6 @@ func (s *groupManagerSuite) TestRemoveGroupRemovesTuples(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(remainingTuples, qt.HasLen, 0)
 }
-
-func (s *groupManagerSuite) TestRenameGroup(c *qt.C) {
-	c.Parallel()
-	ctx := context.Background()
-
-	user, group, controller, model, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
-
-	tuples := []openfga.Tuple{
-		{
-			Object:   ofganames.ConvertTag(user.ResourceTag()),
-			Relation: "member",
-			Target:   ofganames.ConvertTag(group.ResourceTag()),
-		},
-		{
-			Object:   ofganames.ConvertTagWithRelation(group.ResourceTag(), ofganames.MemberRelation),
-			Relation: "administrator",
-			Target:   ofganames.ConvertTag(controller.ResourceTag()),
-		},
-		{
-			Object:   ofganames.ConvertTagWithRelation(group.ResourceTag(), ofganames.MemberRelation),
-			Relation: "writer",
-			Target:   ofganames.ConvertTag(model.ResourceTag()),
-		},
-	}
-
-	err := s.ofgaClient.AddRelation(ctx, tuples...)
-	c.Assert(err, qt.IsNil)
-
-	err = s.manager.RenameGroup(ctx, s.adminUser, group.Name, "test-new-group")
-	c.Assert(err, qt.IsNil)
-
-	group.Name = "test-new-group"
-
-	// check the user still has member relation to the group
-	allowed, err := s.ofgaClient.CheckRelation(
-		ctx,
-		ofga.Tuple{
-			Object:   ofganames.ConvertTag(user.ResourceTag()),
-			Relation: "member",
-			Target:   ofganames.ConvertTag(group.ResourceTag()),
-		},
-		false,
-	)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.IsTrue)
-
-	// check the user still has writer relation to the model via the
-	// group membership
-	allowed, err = s.ofgaClient.CheckRelation(
-		ctx,
-		ofga.Tuple{
-			Object:   ofganames.ConvertTag(user.ResourceTag()),
-			Relation: "writer",
-			Target:   ofganames.ConvertTag(model.ResourceTag()),
-		},
-		false,
-	)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.IsTrue)
-
-	// check the user still has administrator relation to the controller
-	// via group membership
-	allowed, err = s.ofgaClient.CheckRelation(
-		ctx,
-		ofga.Tuple{
-			Object:   ofganames.ConvertTag(user.ResourceTag()),
-			Relation: "administrator",
-			Target:   ofganames.ConvertTag(controller.ResourceTag()),
-		},
-		false,
-	)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.IsTrue)
-}
-
 func (s *groupManagerSuite) TestListGroups(c *qt.C) {
 	c.Parallel()
 	ctx := context.Background()
@@ -284,7 +194,7 @@ func (s *groupManagerSuite) TestListGroups(c *qt.C) {
 	}
 
 	for _, name := range groupNames {
-		_, err := s.manager.AddGroup(ctx, u, name)
+		_, err := s.db.AddGroup(ctx, name)
 		c.Assert(err, qt.IsNil)
 	}
 	groups, err = s.manager.ListGroups(ctx, u, pagination, "")
@@ -301,6 +211,18 @@ func (s *groupManagerSuite) TestListGroups(c *qt.C) {
 	c.Assert(groups[2].Name, qt.Equals, "test-group0")
 	c.Assert(groups[3].Name, qt.Equals, "test-group1")
 	c.Assert(groups[4].Name, qt.Equals, "test-group2")
+}
+
+func (s *groupManagerSuite) TestAddGroupDeprecated(c *qt.C) {
+	c.Parallel()
+	_, err := s.manager.AddGroup(context.Background(), s.adminUser, "test-group-1")
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
+}
+
+func (s *groupManagerSuite) TestRenameGroupDeprecated(c *qt.C) {
+	c.Parallel()
+	err := s.manager.RenameGroup(context.Background(), s.adminUser, "old-group", "new-group")
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestGroupManager(t *testing.T) {

--- a/internal/jimm/permissions/relations.go
+++ b/internal/jimm/permissions/relations.go
@@ -54,6 +54,13 @@ var grantableObjectKinds = map[openfga.Kind]bool{
 	openfga.RoleType:     true,
 }
 
+//nolint:gosec // This is a user-facing deprecation message, not a credential.
+const deprecatedJAASGroupWriteMessage = "JAAS-managed group writes are deprecated; group ownership is managed by the identity provider"
+
+func isDeprecatedJAASGroupMembershipTuple(tuple openfga.Tuple) bool {
+	return tuple.Target != nil && tuple.Target.Kind == openfga.GroupType && tuple.Relation == ofganames.MemberRelation
+}
+
 // authorizeRelationTargetAdmin authorizes a non-JIMM-admin to manage the given
 // relation tuple. JIMM admins may manage any tuple. A non-admin may only grant
 // or revoke an access relation (resourceAdminRelations) to a grantee of an
@@ -115,6 +122,9 @@ func (j *PermissionManager) AddRelation(ctx context.Context, user *openfga.User,
 		return err
 	}
 	for _, tuple := range parsedTuples {
+		if isDeprecatedJAASGroupMembershipTuple(tuple) {
+			return errors.Codef(errors.CodeNotSupported, deprecatedJAASGroupWriteMessage)
+		}
 		if err := j.authorizeRelationTargetAdmin(ctx, user, tuple); err != nil {
 			return err
 		}

--- a/internal/jimm/permissions/relations_test.go
+++ b/internal/jimm/permissions/relations_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
 func (s *permissionManagerSuite) TestListRelationshipTuples(c *qt.C) {
@@ -253,7 +254,7 @@ func (s *permissionManagerSuite) TestListObjectRelations(c *qt.C) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, s.ofgaClient)
 	u.JimmAdmin = true
 
-	user, group, controller, model, _, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	user, _, controller, model, _, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 
 	err := s.manager.AddRelation(ctx, u, []apiparams.RelationshipTuple{
 		{
@@ -286,13 +287,7 @@ func (s *permissionManagerSuite) TestListObjectRelations(c *qt.C) {
 			Relation:     names.CanAddModelRelation.String(),
 			TargetObject: cloud.ResourceTag().String(),
 		},
-		{
-			Object:       user.Tag().String(),
-			Relation:     names.MemberRelation.String(),
-			TargetObject: group.ResourceTag().String(),
-		},
 	})
-
 	c.Assert(err, qt.IsNil)
 	type ExpectedTuple struct {
 		expectedRelation string
@@ -314,14 +309,14 @@ func (s *permissionManagerSuite) TestListObjectRelations(c *qt.C) {
 			object:               user.Tag().String(),
 			pageSize:             10,
 			expectNumPages:       1,
-			expectedTuplesLength: 7,
+			expectedTuplesLength: 6,
 		},
 		{
 			description:          "test listing all relations in multiple pages",
 			object:               user.Tag().String(),
 			pageSize:             2,
-			expectNumPages:       4,
-			expectedTuplesLength: 7,
+			expectNumPages:       3,
+			expectedTuplesLength: 6,
 		},
 		{
 			description:   "invalid initial token",
@@ -417,7 +412,7 @@ func (s *permissionManagerSuite) TestCheckPermissions(c *qt.C) {
 	u := openfga.NewUser(&dbmodel.Identity{Name: "admin@canonical.com"}, s.ofgaClient)
 	u.JimmAdmin = true
 
-	user, group, controller, model, _, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	user, _, controller, model, _, cloud, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
 	tuples := []apiparams.RelationshipTuple{
 		{
 			Object:       user.Tag().String(),
@@ -452,7 +447,7 @@ func (s *permissionManagerSuite) TestCheckPermissions(c *qt.C) {
 		{
 			Object:       user.Tag().String(),
 			Relation:     names.MemberRelation.String(),
-			TargetObject: group.ResourceTag().String(),
+			TargetObject: jimmnames.NewIdPGroupTag("engineering-team").String(),
 		},
 	}
 	err := s.manager.AddRelation(ctx, u, tuples)
@@ -644,7 +639,11 @@ func (s *permissionManagerSuite) TestGroupAndRoleRelationManagementRemainJimmAdm
 	for _, testCase := range testCases {
 		c.Run(testCase.description, func(c *qt.C) {
 			err := s.manager.AddRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
-			c.Assert(err, qt.ErrorMatches, "unauthorized")
+			if testCase.tuple.Relation == names.MemberRelation.String() {
+				c.Assert(err, qt.ErrorMatches, "JAAS-managed group writes are deprecated.*")
+			} else {
+				c.Assert(err, qt.ErrorMatches, "unauthorized")
+			}
 
 			_, err = s.manager.CheckRelation(ctx, grantor, testCase.tuple, false)
 			c.Assert(err, qt.ErrorMatches, "unauthorized")
@@ -657,6 +656,73 @@ func (s *permissionManagerSuite) TestGroupAndRoleRelationManagementRemainJimmAdm
 
 			err = s.manager.RemoveRelation(ctx, grantor, []apiparams.RelationshipTuple{testCase.tuple})
 			c.Assert(err, qt.ErrorMatches, "unauthorized")
+		})
+	}
+}
+
+func (s *permissionManagerSuite) TestJAASGroupMembershipAddsAreDeprecatedButRemovalsAreAllowed(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	userIdentity, err := dbmodel.NewIdentity(fmt.Sprintf("subject-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.Create(userIdentity).Error, qt.IsNil)
+
+	_, group, _, _, _, _, _, _ := jimmtest.CreateTestControllerEnvironment(ctx, c, s.db)
+	secondGroup, err := s.db.AddGroup(ctx, fmt.Sprintf("extra-group-%s", petname.Generate(2, "-")))
+	c.Assert(err, qt.IsNil)
+
+	testCases := []struct {
+		description string
+		apiTuple    apiparams.RelationshipTuple
+		seedTuple   openfga.Tuple
+	}{
+		{
+			description: "direct user membership write is deprecated",
+			apiTuple: apiparams.RelationshipTuple{
+				Object:       userIdentity.Tag().String(),
+				Relation:     names.MemberRelation.String(),
+				TargetObject: group.ResourceTag().String(),
+			},
+			seedTuple: openfga.Tuple{
+				Object:   names.ConvertGenericTag(userIdentity.Tag()),
+				Relation: names.MemberRelation,
+				Target:   names.ConvertTag(group.ResourceTag()),
+			},
+		},
+		{
+			description: "nested group membership write is deprecated",
+			apiTuple: apiparams.RelationshipTuple{
+				Object:       secondGroup.ResourceTag().String() + "#member",
+				Relation:     names.MemberRelation.String(),
+				TargetObject: group.ResourceTag().String(),
+			},
+			seedTuple: openfga.Tuple{
+				Object:   names.ConvertTagWithRelation(secondGroup.ResourceTag(), names.MemberRelation),
+				Relation: names.MemberRelation,
+				Target:   names.ConvertTag(group.ResourceTag()),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c.Run(testCase.description, func(c *qt.C) {
+			err := s.manager.AddRelation(ctx, s.adminUser, []apiparams.RelationshipTuple{testCase.apiTuple})
+			c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
+
+			err = s.ofgaClient.AddRelation(ctx, testCase.seedTuple)
+			c.Assert(err, qt.IsNil)
+
+			allowed, err := s.manager.CheckRelation(ctx, s.adminUser, testCase.apiTuple, false)
+			c.Assert(err, qt.IsNil)
+			c.Assert(allowed, qt.IsTrue)
+
+			err = s.manager.RemoveRelation(ctx, s.adminUser, []apiparams.RelationshipTuple{testCase.apiTuple})
+			c.Assert(err, qt.IsNil)
+
+			allowed, err = s.manager.CheckRelation(ctx, s.adminUser, testCase.apiTuple, false)
+			c.Assert(err, qt.IsNil)
+			c.Assert(allowed, qt.IsFalse)
 		})
 	}
 }

--- a/internal/jimmhttp/rebac_admin/groups.go
+++ b/internal/jimmhttp/rebac_admin/groups.go
@@ -20,6 +20,9 @@ import (
 	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
+//nolint:gosec // This is a user-facing deprecation message, not a credential.
+const deprecatedJAASGroupWriteMessage = "JAAS-managed group writes are deprecated; group ownership is managed by the identity provider"
+
 // groupsService implements the `GroupsService` interface.
 type groupsService struct {
 	jimm jujuapi.JIMM
@@ -191,48 +194,10 @@ func (s *groupsService) GetGroupIdentities(ctx context.Context, groupId string, 
 
 // PatchGroupIdentities performs addition or removal of identities to/from a Group identified by `groupId`.
 func (s *groupsService) PatchGroupIdentities(ctx context.Context, groupId string, identityPatches []resources.GroupIdentitiesPatchItem) (bool, error) {
-	user, err := utils.GetUserFromContext(ctx)
-	if err != nil {
+	if _, err := utils.GetUserFromContext(ctx); err != nil {
 		return false, err
 	}
-	if !jimmnames.IsValidGroupId(groupId) {
-		return false, v1.NewValidationError("invalid group ID")
-	}
-	groupTag := jimmnames.NewGroupTag(groupId)
-	tuple := apiparams.RelationshipTuple{
-		Relation:     ofganames.MemberRelation.String(),
-		TargetObject: groupTag.String(),
-	}
-	var toRemove []apiparams.RelationshipTuple
-	var toAdd []apiparams.RelationshipTuple
-	for _, identityPatch := range identityPatches {
-		if !names.IsValidUser(identityPatch.Identity) {
-			return false, v1.NewValidationError(fmt.Sprintf("invalid identity: %s", identityPatch.Identity))
-		}
-		identity := names.NewUserTag(identityPatch.Identity)
-		if identityPatch.Op == resources.GroupIdentitiesPatchItemOpAdd {
-			t := tuple
-			t.Object = identity.String()
-			toAdd = append(toAdd, t)
-		} else {
-			t := tuple
-			t.Object = identity.String()
-			toRemove = append(toRemove, t)
-		}
-	}
-	if toAdd != nil {
-		err := s.jimm.PermissionManager().AddRelation(ctx, user, toAdd)
-		if err != nil {
-			return false, err
-		}
-	}
-	if toRemove != nil {
-		err := s.jimm.PermissionManager().RemoveRelation(ctx, user, toRemove)
-		if err != nil {
-			return false, err
-		}
-	}
-	return true, nil
+	return false, v1.NewValidationError(deprecatedJAASGroupWriteMessage)
 }
 
 // GetGroupRoles returns a page of Roles for Group `groupId`.

--- a/internal/jimmhttp/rebac_admin/groups_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_integration_test.go
@@ -9,6 +9,7 @@ import (
 	rebac_handlers "github.com/canonical/rebac-admin-ui-handlers/v1"
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/jimmhttp/rebac_admin"
@@ -40,8 +41,7 @@ func TestListGroupsWithFilterIntegration(t *testing.T) {
 
 	ctx := c.Context()
 	for i := range 10 {
-		_, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, fmt.Sprintf("test-group-filter-%d", i))
-		c.Assert(err, qt.IsNil)
+		s.AddGroup(c, fmt.Sprintf("test-group-filter-%d", i))
 	}
 
 	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
@@ -73,8 +73,7 @@ func TestGetGroupIdentitiesIntegration(t *testing.T) {
 	s := SetupGroupsTest(c)
 
 	ctx := c.Context()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
-	c.Assert(err, qt.IsNil)
+	group := s.AddGroup(c, "test-group")
 	tuple := openfga.Tuple{
 		Relation: ofganames.MemberRelation,
 		Target:   ofganames.ConvertTag(jimmnames.NewGroupTag(group.UUID)),
@@ -85,7 +84,7 @@ func TestGetGroupIdentitiesIntegration(t *testing.T) {
 		t.Object = ofganames.ConvertTag(names.NewUserTag(fmt.Sprintf("foo%d@canonical.com", i)))
 		tuples = append(tuples, t)
 	}
-	err = s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
+	err := s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
 	c.Assert(err, qt.IsNil)
 	// Request Subset of items
 	pageSize := 5
@@ -124,44 +123,12 @@ func TestPatchGroupIdentitiesIntegration(t *testing.T) {
 	s := SetupGroupsTest(c)
 
 	ctx := c.Context()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
-	c.Assert(err, qt.IsNil)
-	tuple := openfga.Tuple{
-		Relation: ofganames.MemberRelation,
-		Target:   ofganames.ConvertTag(jimmnames.NewGroupTag(group.UUID)),
-	}
-	var tuples []openfga.Tuple
-	for i := range 2 {
-		t := tuple
-		t.Object = ofganames.ConvertTag(names.NewUserTag(fmt.Sprintf("foo%d@canonical.com", i)))
-		tuples = append(tuples, t)
-	}
-	err = s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
-	c.Assert(err, qt.IsNil)
-	allowed, err := s.JIMM.OpenFGAClient.CheckRelation(ctx, tuples[0], false)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.Equals, true)
-	// Above we have added 2 users to the group, below, we will request those 2 users to be removed
-	// and add 2 different users to the group, in the same request.
-	entitlementPatches := []resources.GroupIdentitiesPatchItem{
-		{Identity: "foo0@canonical.com", Op: resources.GroupIdentitiesPatchItemOpRemove},
-		{Identity: "foo1@canonical.com", Op: resources.GroupIdentitiesPatchItemOpRemove},
-		{Identity: "foo2@canonical.com", Op: resources.GroupIdentitiesPatchItemOpAdd},
-		{Identity: "foo3@canonical.com", Op: resources.GroupIdentitiesPatchItemOpAdd},
-	}
 	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
-	res, err := s.groupSvc.PatchGroupIdentities(ctx, group.UUID, entitlementPatches)
-	c.Assert(err, qt.IsNil)
-	c.Assert(res, qt.Equals, true)
-
-	allowed, err = s.JIMM.OpenFGAClient.CheckRelation(ctx, tuples[0], false)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.Equals, false)
-	newTuple := tuples[0]
-	newTuple.Object = ofganames.ConvertTag(names.NewUserTag("foo2@canonical.com"))
-	allowed, err = s.JIMM.OpenFGAClient.CheckRelation(ctx, newTuple, false)
-	c.Assert(err, qt.IsNil)
-	c.Assert(allowed, qt.Equals, true)
+	_, err := s.groupSvc.PatchGroupIdentities(ctx, uuid.NewString(), []resources.GroupIdentitiesPatchItem{{
+		Identity: "foo0@canonical.com",
+		Op:       resources.GroupIdentitiesPatchItemOpAdd,
+	}})
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestGetGroupRolesIntegration(t *testing.T) {
@@ -236,8 +203,7 @@ func TestGetGroupEntitlementsIntegration(t *testing.T) {
 	s := SetupGroupsTest(c)
 
 	ctx := c.Context()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
-	c.Assert(err, qt.IsNil)
+	group := s.AddGroup(c, "test-group")
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),
 		Relation: ofganames.AdministratorRelation,
@@ -253,7 +219,7 @@ func TestGetGroupEntitlementsIntegration(t *testing.T) {
 		t.Target = ofganames.ConvertTag(names.NewControllerTag(fmt.Sprintf("test-controller-%d", i)))
 		tuples = append(tuples, t)
 	}
-	err = s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
+	err := s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
 	c.Assert(err, qt.IsNil)
 
 	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
@@ -344,8 +310,7 @@ func TestPatchGroupEntitlementsIntegration(t *testing.T) {
 	oldModels := []string{env.Models[0].UUID, env.Models[1].UUID}
 	newModels := []string{env.Models[2].UUID, env.Models[3].UUID}
 
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, "test-group")
-	c.Assert(err, qt.IsNil)
+	group := s.AddGroup(c, "test-group")
 	tuple := openfga.Tuple{
 		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewGroupTag(group.UUID), ofganames.MemberRelation),
 		Relation: ofganames.AdministratorRelation,
@@ -357,7 +322,7 @@ func TestPatchGroupEntitlementsIntegration(t *testing.T) {
 		t.Target = ofganames.ConvertTag(names.NewModelTag(oldModels[i]))
 		tuples = append(tuples, t)
 	}
-	err = s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
+	err := s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
 	c.Assert(err, qt.IsNil)
 	allowed, err := s.JIMM.OpenFGAClient.CheckRelation(ctx, tuples[0], false)
 	c.Assert(err, qt.IsNil)

--- a/internal/jimmhttp/rebac_admin/groups_test.go
+++ b/internal/jimmhttp/rebac_admin/groups_test.go
@@ -27,10 +27,9 @@ import (
 
 func TestCreateGroup(t *testing.T) {
 	c := qt.New(t)
-	var addErr error
 	groupManager := mocks.GroupManager{
 		AddGroup_: func(ctx context.Context, user *openfga.User, name string) (*dbmodel.GroupEntry, error) {
-			return &dbmodel.GroupEntry{UUID: "test-uuid", Name: name}, addErr
+			return nil, errors.New("JAAS-managed group writes are deprecated; group ownership is managed by the identity provider")
 		},
 	}
 	jimm := jimmtest.JIMM{
@@ -42,28 +41,18 @@ func TestCreateGroup(t *testing.T) {
 	ctx := context.Background()
 	ctx = rebac_handlers.ContextWithIdentity(ctx, &user)
 	groupSvc := rebac_admin.NewGroupService(&jimm)
-	resp, err := groupSvc.CreateGroup(ctx, &resources.Group{Name: "new-group"})
-	c.Assert(err, qt.IsNil)
-	c.Assert(*resp.Id, qt.Equals, "test-uuid")
-	c.Assert(resp.Name, qt.Equals, "new-group")
-	addErr = errors.New("foo")
-	_, err = groupSvc.CreateGroup(ctx, &resources.Group{Name: "new-group"})
-	c.Assert(err, qt.ErrorMatches, "foo")
+	_, err := groupSvc.CreateGroup(ctx, &resources.Group{Name: "new-group"})
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestUpdateGroup(t *testing.T) {
 	c := qt.New(t)
-	groupID := "group-id"
-	var renameErr error
 	groupManager := mocks.GroupManager{
 		GetGroupByUUID_: func(ctx context.Context, user *openfga.User, uuid string) (*dbmodel.GroupEntry, error) {
-			return &dbmodel.GroupEntry{UUID: groupID, Name: "test-group"}, nil
+			return &dbmodel.GroupEntry{UUID: uuid, Name: "test-group"}, nil
 		},
 		RenameGroup_: func(ctx context.Context, user *openfga.User, oldName, newName string) error {
-			if oldName != "test-group" {
-				return errors.New("invalid old group name")
-			}
-			return renameErr
+			return errors.New("JAAS-managed group writes are deprecated; group ownership is managed by the identity provider")
 		},
 	}
 	jimm := jimmtest.JIMM{
@@ -75,14 +64,11 @@ func TestUpdateGroup(t *testing.T) {
 	ctx := context.Background()
 	ctx = rebac_handlers.ContextWithIdentity(ctx, &user)
 	groupSvc := rebac_admin.NewGroupService(&jimm)
+	groupID := "group-id"
 	_, err := groupSvc.UpdateGroup(ctx, &resources.Group{Name: "new-group"})
 	c.Assert(err, qt.ErrorMatches, ".*missing group ID")
-	resp, err := groupSvc.UpdateGroup(ctx, &resources.Group{Id: &groupID, Name: "new-group"})
-	c.Assert(err, qt.IsNil)
-	c.Assert(resp, qt.DeepEquals, &resources.Group{Id: &groupID, Name: "new-group"})
-	renameErr = errors.New("foo")
 	_, err = groupSvc.UpdateGroup(ctx, &resources.Group{Id: &groupID, Name: "new-group"})
-	c.Assert(err, qt.ErrorMatches, "foo")
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestListGroups(t *testing.T) {
@@ -220,46 +206,17 @@ func TestGetGroupIdentities(t *testing.T) {
 
 func TestPatchGroupIdentities(t *testing.T) {
 	c := qt.New(t)
-	var patchTuplesErr error
-	permissionManager := mocks.PermissionManager{
-		AddRelation_: func(ctx context.Context, user *openfga.User, tuples []params.RelationshipTuple) error {
-			return patchTuplesErr
-		},
-		RemoveRelation_: func(ctx context.Context, user *openfga.User, tuples []params.RelationshipTuple) error {
-			return patchTuplesErr
-		},
-	}
-	jimm := jimmtest.JIMM{
-		PermissionManager_: func() jujuapi.PermissionManager {
-			return &permissionManager
-		},
-	}
+	jimm := jimmtest.JIMM{}
 	user := openfga.User{}
 	ctx := context.Background()
 	ctx = rebac_handlers.ContextWithIdentity(ctx, &user)
 	groupSvc := rebac_admin.NewGroupService(&jimm)
 
-	_, err := groupSvc.PatchGroupIdentities(ctx, "invalid-group-id", nil)
-	c.Assert(err, qt.ErrorMatches, ".* invalid group ID")
-
-	newUUID := uuid.New()
-	operations := []resources.GroupIdentitiesPatchItem{
-		{Identity: "foo@canonical.com", Op: resources.GroupIdentitiesPatchItemOpAdd},
-		{Identity: "bar@canonical.com", Op: resources.GroupIdentitiesPatchItemOpRemove},
-	}
-	res, err := groupSvc.PatchGroupIdentities(ctx, newUUID.String(), operations)
-	c.Assert(err, qt.IsNil)
-	c.Assert(res, qt.IsTrue)
-
-	operationsWithInvalidIdentity := []resources.GroupIdentitiesPatchItem{
-		{Identity: "foo_", Op: resources.GroupIdentitiesPatchItemOpAdd},
-	}
-	_, err = groupSvc.PatchGroupIdentities(ctx, newUUID.String(), operationsWithInvalidIdentity)
-	c.Assert(err, qt.ErrorMatches, ".*invalid identity.*")
-
-	patchTuplesErr = errors.New("foo")
-	_, err = groupSvc.PatchGroupIdentities(ctx, newUUID.String(), operations)
-	c.Assert(err, qt.ErrorMatches, "foo")
+	_, err := groupSvc.PatchGroupIdentities(ctx, uuid.NewString(), []resources.GroupIdentitiesPatchItem{{
+		Identity: "foo@canonical.com",
+		Op:       resources.GroupIdentitiesPatchItemOpAdd,
+	}})
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestGetGroupRoles(t *testing.T) {

--- a/internal/jimmhttp/rebac_admin/identities.go
+++ b/internal/jimmhttp/rebac_admin/identities.go
@@ -248,48 +248,10 @@ func (s *identitiesService) GetIdentityGroups(ctx context.Context, identityId st
 
 // PatchIdentityGroups performs addition or removal of a Group to/from an Identity.
 func (s *identitiesService) PatchIdentityGroups(ctx context.Context, identityId string, groupPatches []resources.IdentityGroupsPatchItem) (bool, error) {
-	user, err := utils.GetUserFromContext(ctx)
-	if err != nil {
+	if _, err := utils.GetUserFromContext(ctx); err != nil {
 		return false, err
 	}
-
-	objUser, err := s.jimm.IdentityManager().FetchIdentity(ctx, identityId)
-	if err != nil {
-		return false, v1.NewNotFoundError(fmt.Sprintf("User with id %s not found", identityId))
-	}
-	additions := make([]apiparams.RelationshipTuple, 0)
-	deletions := make([]apiparams.RelationshipTuple, 0)
-	for _, p := range groupPatches {
-		if !jimmnames.IsValidGroupId(p.Group) {
-			return false, v1.NewValidationError(fmt.Sprintf("ID %s is not a valid group ID", p.Group))
-		}
-		t := apiparams.RelationshipTuple{
-			Object:       objUser.ResourceTag().String(),
-			Relation:     ofganames.MemberRelation.String(),
-			TargetObject: jimmnames.NewGroupTag(p.Group).String(),
-		}
-		switch p.Op {
-		case "add":
-			additions = append(additions, t)
-		case "remove":
-			deletions = append(deletions, t)
-		}
-	}
-	if len(additions) > 0 {
-		err = s.jimm.PermissionManager().AddRelation(ctx, user, additions)
-		if err != nil {
-			zapctx.Error(context.Background(), "cannot add relations", zap.Error(err))
-			return false, v1.NewUnknownError(err.Error())
-		}
-	}
-	if len(deletions) > 0 {
-		err = s.jimm.PermissionManager().RemoveRelation(ctx, user, deletions)
-		if err != nil {
-			zapctx.Error(context.Background(), "cannot remove relations", zap.Error(err))
-			return false, v1.NewUnknownError(err.Error())
-		}
-	}
-	return true, nil
+	return false, v1.NewValidationError(deprecatedJAASGroupWriteMessage)
 }
 
 // // GetIdentityEntitlements returns a page of Entitlements for identity `identityId`.

--- a/internal/jimmhttp/rebac_admin/identities_integration_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_integration_test.go
@@ -9,6 +9,7 @@ import (
 	rebac_handlers "github.com/canonical/rebac-admin-ui-handlers/v1"
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 	qt "github.com/frankban/quicktest"
+	"github.com/google/uuid"
 	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -63,44 +64,12 @@ func TestIdentityPatchGroups(t *testing.T) {
 
 	ctx = rebac_handlers.ContextWithIdentity(ctx, s.AdminUser)
 	identitySvc := rebac_admin.NewidentitiesService(jujuapi.NewJIMMAdapter(s.JIMM))
-	groupName := "group-test1"
 	username := s.AdminUser.Name
-	group := s.AddGroup(c, groupName)
-
-	// test add identity group
-	changed, err := identitySvc.PatchIdentityGroups(ctx, username, []resources.IdentityGroupsPatchItem{{
-		Group: group.UUID,
+	_, err := identitySvc.PatchIdentityGroups(ctx, username, []resources.IdentityGroupsPatchItem{{
+		Group: uuid.NewString(),
 		Op:    resources.IdentityGroupsPatchItemOpAdd,
 	}})
-	c.Assert(err, qt.IsNil)
-	c.Assert(changed, qt.Equals, true)
-
-	// test user added to groups
-	objUser, err := s.JIMM.IdentityManager.FetchIdentity(ctx, username)
-	c.Assert(err, qt.IsNil)
-	tuples, _, err := s.JIMM.PermissionManager.ListRelationshipTuples(ctx, s.AdminUser, params.RelationshipTuple{
-		Object:       objUser.ResourceTag().String(),
-		Relation:     ofganames.MemberRelation.String(),
-		TargetObject: group.ResourceTag().String(),
-	}, 10, "")
-	c.Assert(err, qt.IsNil)
-	c.Assert(len(tuples), qt.Equals, 1)
-	c.Assert(group.UUID, qt.Equals, tuples[0].Target.ID)
-
-	// test user remove from group
-	changed, err = identitySvc.PatchIdentityGroups(ctx, username, []resources.IdentityGroupsPatchItem{{
-		Group: group.UUID,
-		Op:    resources.IdentityGroupsPatchItemOpRemove,
-	}})
-	c.Assert(err, qt.IsNil)
-	c.Assert(changed, qt.Equals, true)
-	tuples, _, err = s.JIMM.PermissionManager.ListRelationshipTuples(ctx, s.AdminUser, params.RelationshipTuple{
-		Object:       objUser.ResourceTag().String(),
-		Relation:     ofganames.MemberRelation.String(),
-		TargetObject: group.ResourceTag().String(),
-	}, 10, "")
-	c.Assert(err, qt.IsNil)
-	c.Assert(len(tuples), qt.Equals, 0)
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestIdentityGetGroups(t *testing.T) {
@@ -113,21 +82,20 @@ func TestIdentityGetGroups(t *testing.T) {
 	identitySvc := rebac_admin.NewidentitiesService(jujuapi.NewJIMMAdapter(s.JIMM))
 	username := s.AdminUser.Name
 	groupsSize := 10
-	groupsToAdd := make([]resources.IdentityGroupsPatchItem, groupsSize)
 	groupTags := make([]jimmnames.GroupTag, groupsSize)
+	tuples := make([]openfga.Tuple, 0, groupsSize)
 	for i := range groupsSize {
 		groupName := fmt.Sprintf("group-test%d", i)
 		group := s.AddGroup(c, groupName)
 		groupTags[i] = group.ResourceTag()
-		groupsToAdd[i] = resources.IdentityGroupsPatchItem{
-			Group: group.UUID,
-			Op:    resources.IdentityGroupsPatchItemOpAdd,
-		}
-
+		tuples = append(tuples, openfga.Tuple{
+			Object:   ofganames.ConvertTag(s.AdminUser.ResourceTag()),
+			Relation: ofganames.MemberRelation,
+			Target:   ofganames.ConvertTag(group.ResourceTag()),
+		})
 	}
-	changed, err := identitySvc.PatchIdentityGroups(ctx, username, groupsToAdd)
+	err := s.JIMM.OpenFGAClient.AddRelation(ctx, tuples...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(changed, qt.Equals, true)
 
 	// test list identity's groups with token pagination
 	size := 3

--- a/internal/jimmhttp/rebac_admin/identities_test.go
+++ b/internal/jimmhttp/rebac_admin/identities_test.go
@@ -210,59 +210,17 @@ func TestGetIdentityGroups(t *testing.T) {
 
 func TestPatchIdentityGroups(t *testing.T) {
 	c := qt.New(t)
-	var patchTuplesErr error
-	identityManager := mocks.IdentityManager{
-		FetchIdentity_: func(ctx context.Context, id string) (*openfga.User, error) {
-			if id == "bob@canonical.com" {
-				return openfga.NewUser(&dbmodel.Identity{Name: "bob@canonical.com"}, nil), nil
-			}
-			return nil, dbmodel.ErrIdentityCreation
-		},
-	}
-	permissionManager := mocks.PermissionManager{
-		AddRelation_: func(ctx context.Context, user *openfga.User, tuples []params.RelationshipTuple) error {
-			return patchTuplesErr
-		},
-		RemoveRelation_: func(ctx context.Context, user *openfga.User, tuples []params.RelationshipTuple) error {
-			return patchTuplesErr
-		},
-	}
-	jimm := jimmtest.JIMM{
-		IdentityManager_: func() jujuapi.IdentityManager {
-			return &identityManager
-		},
-		PermissionManager_: func() jujuapi.PermissionManager {
-			return &permissionManager
-		},
-	}
+	jimm := jimmtest.JIMM{}
 	user := openfga.User{}
 	ctx := context.Background()
 	ctx = rebac_handlers.ContextWithIdentity(ctx, &user)
 	idSvc := rebac_admin.NewidentitiesService(&jimm)
 
-	_, err := idSvc.PatchIdentityGroups(ctx, "bob-not-found@canonical.com", nil)
-	c.Assert(err, qt.ErrorMatches, ".* not found")
-
-	username := "bob@canonical.com"
-	group1ID := uuid.New()
-	group2ID := uuid.New()
-	operations := []resources.IdentityGroupsPatchItem{
-		{Group: group1ID.String(), Op: resources.IdentityGroupsPatchItemOpAdd},
-		{Group: group2ID.String(), Op: resources.IdentityGroupsPatchItemOpRemove},
-	}
-	res, err := idSvc.PatchIdentityGroups(ctx, username, operations)
-	c.Assert(err, qt.IsNil)
-	c.Assert(res, qt.IsTrue)
-
-	patchTuplesErr = errors.New("foo")
-	_, err = idSvc.PatchIdentityGroups(ctx, username, operations)
-	c.Assert(err, qt.ErrorMatches, ".*foo")
-
-	invalidGroupName := []resources.IdentityGroupsPatchItem{
-		{Group: "test-group1", Op: resources.IdentityGroupsPatchItemOpAdd},
-	}
-	_, err = idSvc.PatchIdentityGroups(ctx, "bob@canonical.com", invalidGroupName)
-	c.Assert(err, qt.ErrorMatches, "Bad Request: ID test-group1 is not a valid group ID")
+	_, err := idSvc.PatchIdentityGroups(ctx, "bob@canonical.com", []resources.IdentityGroupsPatchItem{{
+		Group: uuid.NewString(),
+		Op:    resources.IdentityGroupsPatchItemOpAdd,
+	}})
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestGetIdentityRoles(t *testing.T) {

--- a/internal/testutils/jimmtest/setup_jimm.go
+++ b/internal/testutils/jimmtest/setup_jimm.go
@@ -384,7 +384,7 @@ func (s *JIMMEnv) RemoveCloud(c *qt.C, cloudName string) {
 
 func (s *JIMMEnv) AddGroup(c *qt.C, groupName string) dbmodel.GroupEntry {
 	ctx := context.Background()
-	group, err := s.JIMM.GroupManager.AddGroup(ctx, s.AdminUser, groupName)
+	group, err := s.JIMM.Database.AddGroup(ctx, groupName)
 	c.Assert(err, qt.Equals, nil)
 	return *group
 }

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -3,64 +3,68 @@
 package testing
 
 import (
-	"context"
 	"database/sql"
+	"encoding/base64"
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/uuid"
+	jujuapi "github.com/juju/juju/api"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/core/crossmodel"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 
+	"github.com/canonical/jimm/v3/internal/auth"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
 	"github.com/canonical/jimm/v3/pkg/api"
 	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
 
 /*
  Group facade related tests
 */
 
-func TestAddGroup(t *testing.T) {
+func TestAddGroupDeprecated(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
-	res, err := client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
-	c.Assert(err, qt.IsNil)
-	c.Assert(res.UUID, qt.Not(qt.Equals), "")
-
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
-	c.Assert(err, qt.ErrorMatches, ".*already exists.*")
+	_, err := client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestGetGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
 	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
 
-	created, err := client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
+	created, err := s.JIMM.Database.AddGroup(ctx, "test-group")
 	c.Assert(err, qt.IsNil)
 
-	retrievedUuid, err := client.GetGroup(&apiparams.GetGroupRequest{UUID: created.UUID})
+	retrievedUUID, err := client.GetGroup(&apiparams.GetGroupRequest{UUID: created.UUID})
 	c.Assert(err, qt.IsNil)
-	c.Assert(retrievedUuid.Group, qt.DeepEquals, created.Group)
+	c.Assert(retrievedUUID.UUID, qt.Equals, created.UUID)
+	c.Assert(retrievedUUID.Name, qt.Equals, created.Name)
 
 	retrievedName, err := client.GetGroup(&apiparams.GetGroupRequest{Name: created.Name})
 	c.Assert(err, qt.IsNil)
-	c.Assert(retrievedName.Group, qt.DeepEquals, created.Group)
+	c.Assert(retrievedName.UUID, qt.Equals, created.UUID)
+	c.Assert(retrievedName.Name, qt.Equals, created.Name)
 
 	_, err = client.GetGroup(&apiparams.GetGroupRequest{UUID: "non-existent"})
 	c.Assert(err, qt.ErrorMatches, ".*not found.*")
@@ -72,6 +76,7 @@ func TestGetGroup(t *testing.T) {
 func TestRemoveGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
 	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
@@ -82,7 +87,7 @@ func TestRemoveGroup(t *testing.T) {
 	})
 	c.Assert(err, qt.ErrorMatches, ".*not found.*")
 
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "test-group")
 	c.Assert(err, qt.IsNil)
 
 	err = client.RemoveGroup(&apiparams.RemoveGroupRequest{
@@ -94,7 +99,7 @@ func TestRemoveGroup(t *testing.T) {
 func TestRemoveGroupRemovesTuples(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	db := s.JIMM.Database
 
 	user, group, controller, model, _, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -144,7 +149,7 @@ func TestRemoveGroupRemovesTuples(t *testing.T) {
 	checkAccessTupleController := apiparams.RelationshipTuple{Object: u, Relation: "administrator", TargetObject: "controller-" + controller.UUID}
 	checkAccessTupleModel := apiparams.RelationshipTuple{Object: u, Relation: "writer", TargetObject: "model-" + model.UUID.String}
 
-	err = s.JIMM.OpenFGAClient.AddRelation(context.Background(), tuples...)
+	err = s.JIMM.OpenFGAClient.AddRelation(t.Context(), tuples...)
 	c.Assert(err, qt.IsNil)
 	// Check user has access to model and controller through group2
 	checkResp, err := client.CheckRelation(&apiparams.CheckRelationRequest{Tuple: checkAccessTupleController})
@@ -174,33 +179,24 @@ func TestRemoveGroupRemovesTuples(t *testing.T) {
 	c.Assert(checkResp.Allowed, qt.Equals, false)
 }
 
-func TestRenameGroup(t *testing.T) {
+func TestRenameGroupDeprecated(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	client := api.NewClient(conn)
-
 	err := client.RenameGroup(&apiparams.RenameGroupRequest{
 		Name:    "test-group",
 		NewName: "renamed-group",
 	})
-	c.Assert(err, qt.ErrorMatches, ".*not found.*")
-
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "test-group"})
-	c.Assert(err, qt.IsNil)
-
-	err = client.RenameGroup(&apiparams.RenameGroupRequest{
-		Name:    "test-group",
-		NewName: "renamed-group",
-	})
-	c.Assert(err, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, ".*JAAS-managed group writes are deprecated.*")
 }
 
 func TestListGroups(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
 	conn := s.Open(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
@@ -214,7 +210,7 @@ func TestListGroups(t *testing.T) {
 	}
 
 	for _, name := range groupNames {
-		_, err := client.AddGroup(&apiparams.AddGroupRequest{Name: name})
+		_, err := s.JIMM.Database.AddGroup(ctx, name)
 		c.Assert(err, qt.IsNil)
 	}
 	req := apiparams.ListGroupsRequest{Limit: 10, Offset: 0}
@@ -234,6 +230,8 @@ func TestListGroups(t *testing.T) {
  Relation facade related tests
 */
 
+const testIDPGroup = "engineering-team"
+
 // createTuple wraps the underlying ofga tuple into a convenient ease-of-use method
 func createTuple(object, relation, target string) openfga.Tuple {
 	objectEntity, _ := openfga.ParseTag(object)
@@ -245,11 +243,25 @@ func createTuple(object, relation, target string) openfga.Tuple {
 	}
 }
 
+func openClientWithIDPGroups(c *qt.C, s jimmtest.JimmWithControllers, username string, groups []string) (*api.Client, func()) {
+	token, err := jwt.NewBuilder().
+		Subject(username).
+		Claim(auth.SessionTokenGroupsClaimKey, groups).
+		Build()
+	c.Assert(err, qt.IsNil)
+	serialisedToken, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, []byte(jimmtest.JWTTestSecret)))
+	c.Assert(err, qt.IsNil)
+	b64Token := base64.StdEncoding.EncodeToString(serialisedToken)
+	conn, err := s.OpenCustomLoginProvider(c, nil, username, jujuapi.NewSessionTokenLoginProvider(b64Token, nil, nil))
+	c.Assert(err, qt.IsNil)
+	return api.NewClient(conn), func() { _ = conn.Close() }
+}
+
 // TestAddRelation currently verifies the following test cases,
 // when new relation control is to be added, please update this comment:
-// user -> group
 // user -> controller (name)
 // user -> controller (uuid)
+// user -> controller (jimm)
 // user -> model (name)
 // user -> model (uuid)
 // user -> applicationoffer (name)
@@ -260,27 +272,15 @@ func createTuple(object, relation, target string) openfga.Tuple {
 // group -> model (uuid)
 // group -> applicationoffer (name)
 // group -> applicationoffer (uuid)
-// group#member -> group
-// idpgroup#member -> model
+// idpgroup -> model (uuid)
 func TestAddRelation(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
-	db := s.JIMM.Database
+	ctx := t.Context()
 
 	user, group, controller, model, offer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
 
-	_, err := db.AddGroup(ctx, "test-group2")
-	c.Assert(err, qt.IsNil)
-
-	group2 := &dbmodel.GroupEntry{
-		Name: "test-group2",
-	}
-	err = db.GetGroup(ctx, group2)
-	c.Assert(err, qt.IsNil)
-
-	c.Assert(err, qt.IsNil)
 	type tuple struct {
 		object   string
 		relation string
@@ -321,39 +321,6 @@ func TestAddRelation(t *testing.T) {
 			input: tuple{"user-" + user.Name, "administrator", "controller-" + controller.UUID},
 			want: createTuple(
 				"user:"+user.Name,
-				"administrator",
-				"controller:"+controller.UUID,
-			),
-			err:         false,
-			changesType: "controller",
-		},
-		// Test user -> group
-		{
-			input: tuple{"user-" + user.Name, "member", "group-" + group.Name},
-			want: createTuple(
-				"user:"+user.Name,
-				"member",
-				"group:"+group.UUID,
-			),
-			err:         false,
-			changesType: "group",
-		},
-		// Test username with dots and @ -> group
-		{
-			input: tuple{"user-" + "kelvin.lina.test@canonical.com", "member", "group-" + group.Name},
-			want: createTuple(
-				"user:"+"kelvin.lina.test@canonical.com",
-				"member",
-				"group:"+group.UUID,
-			),
-			err:         false,
-			changesType: "group",
-		},
-		// Test group -> controller
-		{
-			input: tuple{"group-" + "test-group#member", "administrator", "controller-" + controller.UUID},
-			want: createTuple(
-				"group:"+group.UUID+"#member",
 				"administrator",
 				"controller:"+controller.UUID,
 			),
@@ -470,25 +437,14 @@ func TestAddRelation(t *testing.T) {
 			err:         false,
 			changesType: "applicationoffer",
 		},
-		// Test group -> group
+		// Test idpgroup -> model by UUID
 		{
-			input: tuple{"group-" + group.Name + "#member", "member", "group-" + group2.Name},
-			want: createTuple(
-				"group:"+group.UUID+"#member",
-				"member",
-				"group:"+group2.UUID,
-			),
-			err:         false,
-			changesType: "group",
-		},
-		// Test IDP group -> model by UUID.
-		{
-			input: tuple{"idpgroup-4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member", "reader", "model-" + model.UUID.String},
-			want: createTuple(
-				"idpgroup:4a8f49a8-df10-4a6d-a98f-f4df1d5a16ba#member",
-				"reader",
-				"model:"+model.UUID.String,
-			),
+			input: tuple{"idpgroup-" + testIDPGroup + "#member", "reader", "model-" + model.UUID.String},
+			want: openfga.Tuple{
+				Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(testIDPGroup), ofganames.MemberRelation),
+				Relation: "reader",
+				Target:   ofganames.ConvertTag(model.ResourceTag()),
+			},
 			err:         false,
 			changesType: "model",
 		},
@@ -544,10 +500,11 @@ func TestAddRelation(t *testing.T) {
 // group -> model (uuid)
 // group -> applicationoffer (name)
 // group -> applicationoffer (uuid)
+// idpgroup -> model (uuid)
 func TestRemoveRelation(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	user, group, controller, model, offer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
@@ -566,6 +523,22 @@ func TestRemoveRelation(t *testing.T) {
 	}
 
 	tagTests := []tagTest{
+		// Test user -> group
+		{
+			toAdd: openfga.Tuple{
+				Object:   ofganames.ConvertTag(user.ResourceTag()),
+				Relation: "member",
+				Target:   ofganames.ConvertTag(group.ResourceTag()),
+			},
+			toRemove: tuple{"user-" + user.Name, "member", "group-" + group.Name},
+			want: createTuple(
+				"user:"+user.Name,
+				"member",
+				"group:"+group.UUID,
+			),
+			err:         false,
+			changesType: "group",
+		},
 		// Test user -> controller by name
 		{
 			toAdd: openfga.Tuple{
@@ -592,38 +565,6 @@ func TestRemoveRelation(t *testing.T) {
 			toRemove: tuple{"user-" + user.Name, "administrator", "controller-" + controller.UUID},
 			want: createTuple(
 				"user:"+user.Name,
-				"administrator",
-				"controller:"+controller.UUID,
-			),
-			err:         false,
-			changesType: "controller",
-		},
-		// Test user -> group
-		{
-			toAdd: openfga.Tuple{
-				Object:   ofganames.ConvertTag(user.ResourceTag()),
-				Relation: "member",
-				Target:   ofganames.ConvertTag(group.ResourceTag()),
-			},
-			toRemove: tuple{"user-" + user.Name, "member", "group-" + group.Name},
-			want: createTuple(
-				"user:"+user.Name,
-				"member",
-				"group:"+group.UUID,
-			),
-			err:         false,
-			changesType: "group",
-		},
-		// Test group -> controller
-		{
-			toAdd: openfga.Tuple{
-				Object:   ofganames.ConvertTagWithRelation(group.ResourceTag(), ofganames.MemberRelation),
-				Relation: "administrator",
-				Target:   ofganames.ConvertTag(controller.ResourceTag()),
-			},
-			toRemove: tuple{"group-" + group.Name + "#member", "administrator", "controller-" + controller.UUID},
-			want: createTuple(
-				"group:"+group.UUID+"#member",
 				"administrator",
 				"controller:"+controller.UUID,
 			),
@@ -790,12 +731,28 @@ func TestRemoveRelation(t *testing.T) {
 			err:         false,
 			changesType: "applicationoffer",
 		},
+		// Test idpgroup -> model by UUID
+		{
+			toAdd: openfga.Tuple{
+				Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(testIDPGroup), ofganames.MemberRelation),
+				Relation: "reader",
+				Target:   ofganames.ConvertTag(model.ResourceTag()),
+			},
+			toRemove: tuple{"idpgroup-" + testIDPGroup + "#member", "reader", "model-" + model.UUID.String},
+			want: openfga.Tuple{
+				Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(testIDPGroup), ofganames.MemberRelation),
+				Relation: "reader",
+				Target:   ofganames.ConvertTag(model.ResourceTag()),
+			},
+			err:         false,
+			changesType: "model",
+		},
 	}
 
 	for i, tc := range tagTests {
 		c.Logf("running test %d", i)
 		ofgaClient := s.JIMM.OpenFGAClient
-		err := ofgaClient.AddRelation(context.Background(), tc.toAdd)
+		err := ofgaClient.AddRelation(t.Context(), tc.toAdd)
 		c.Check(err, qt.IsNil)
 		changes, err := s.COFGAClient.ReadChanges(ctx, tc.changesType, 99, "")
 		c.Assert(err, qt.IsNil)
@@ -834,6 +791,7 @@ func TestRemoveRelation(t *testing.T) {
 func TestListRelationshipTuples(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
 
 	user, _, controller, _, applicationOffer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
@@ -842,9 +800,16 @@ func TestListRelationshipTuples(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	initialTupleCount := len(response.Tuples)
 
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "yellow"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "yellow")
 	c.Assert(err, qt.IsNil)
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "orange")
+	c.Assert(err, qt.IsNil)
+
+	groupYellow := dbmodel.GroupEntry{Name: "yellow"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupYellow)
+	c.Assert(err, qt.IsNil)
+	groupOrange := dbmodel.GroupEntry{Name: "orange"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupOrange)
 	c.Assert(err, qt.IsNil)
 
 	tuples := []apiparams.RelationshipTuple{{
@@ -865,7 +830,28 @@ func TestListRelationshipTuples(t *testing.T) {
 		TargetObject: "applicationoffer-" + applicationOffer.URL,
 	}}
 
-	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	err = s.JIMM.OpenFGAClient.AddRelation(ctx,
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+			Relation: "member",
+			Target:   ofganames.ConvertTag(groupYellow.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTag(user.ResourceTag()),
+			Relation: "member",
+			Target:   ofganames.ConvertTag(groupOrange.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupYellow.ResourceTag(), ofganames.MemberRelation),
+			Relation: "administrator",
+			Target:   ofganames.ConvertTag(controller.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+			Relation: "administrator",
+			Target:   ofganames.ConvertTag(applicationOffer.ResourceTag()),
+		},
+	)
 	c.Assert(err, qt.IsNil)
 
 	response, err = client.ListRelationshipTuples(&apiparams.ListRelationshipTuplesRequest{ResolveUUIDs: true})
@@ -900,25 +886,24 @@ func TestListRelationshipTuples(t *testing.T) {
 func TestListRelationshipTuplesNoUUIDResolution(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, _, applicationOffer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
 
-	_, err := client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
-	c.Assert(err, qt.IsNil)
-
-	tuples := []apiparams.RelationshipTuple{{
-		Object:       "group-orange#member",
-		Relation:     "administrator",
-		TargetObject: "applicationoffer-" + applicationOffer.UUID,
-	}}
-
-	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	_, err := s.JIMM.Database.AddGroup(ctx, "orange")
 	c.Assert(err, qt.IsNil)
 
 	groupOrange := dbmodel.GroupEntry{Name: "orange"}
 	err = s.JIMM.Database.GetGroup(ctx, &groupOrange)
 	c.Assert(err, qt.IsNil)
+
+	err = s.JIMM.OpenFGAClient.AddRelation(ctx, openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+		Relation: "administrator",
+		Target:   ofganames.ConvertTag(applicationOffer.ResourceTag()),
+	})
+	c.Assert(err, qt.IsNil)
+
 	expected := []apiparams.RelationshipTuple{{
 		Object:       "group-" + groupOrange.UUID + "#member",
 		Relation:     "administrator",
@@ -938,6 +923,7 @@ func TestListRelationshipTuplesNoUUIDResolution(t *testing.T) {
 func TestListRelationshipTuplesAfterDeletingGroup(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
 
 	user, _, controller, _, applicationOffer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
@@ -946,9 +932,16 @@ func TestListRelationshipTuplesAfterDeletingGroup(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	initialTupleCount := len(response.Tuples)
 
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "yellow"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "yellow")
 	c.Assert(err, qt.IsNil)
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "orange")
+	c.Assert(err, qt.IsNil)
+
+	groupYellow := dbmodel.GroupEntry{Name: "yellow"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupYellow)
+	c.Assert(err, qt.IsNil)
+	groupOrange := dbmodel.GroupEntry{Name: "orange"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupOrange)
 	c.Assert(err, qt.IsNil)
 
 	tuples := []apiparams.RelationshipTuple{{
@@ -969,7 +962,28 @@ func TestListRelationshipTuplesAfterDeletingGroup(t *testing.T) {
 		TargetObject: "applicationoffer-" + applicationOffer.URL,
 	}}
 
-	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	err = s.JIMM.OpenFGAClient.AddRelation(ctx,
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+			Relation: "member",
+			Target:   ofganames.ConvertTag(groupYellow.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTag(user.ResourceTag()),
+			Relation: "member",
+			Target:   ofganames.ConvertTag(groupOrange.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupYellow.ResourceTag(), ofganames.MemberRelation),
+			Relation: "administrator",
+			Target:   ofganames.ConvertTag(controller.ResourceTag()),
+		},
+		openfga.Tuple{
+			Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+			Relation: "administrator",
+			Target:   ofganames.ConvertTag(applicationOffer.ResourceTag()),
+		},
+	)
 	c.Assert(err, qt.IsNil)
 
 	err = client.RemoveGroup(&apiparams.RemoveGroupRequest{Name: "yellow"})
@@ -996,7 +1010,7 @@ func TestListRelationshipTuplesAfterDeletingGroup(t *testing.T) {
 func TestListRelationshipTuplesWithMissingGroups(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	_, _, _, _, _, _, _, client, closeClient := createTestControllerEnvironment(c, s)
 	defer closeClient()
 
@@ -1004,9 +1018,16 @@ func TestListRelationshipTuplesWithMissingGroups(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	initialTupleCount := len(response.Tuples)
 
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "yellow"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "yellow")
 	c.Assert(err, qt.IsNil)
-	_, err = client.AddGroup(&apiparams.AddGroupRequest{Name: "orange"})
+	_, err = s.JIMM.Database.AddGroup(ctx, "orange")
+	c.Assert(err, qt.IsNil)
+
+	groupYellow := dbmodel.GroupEntry{Name: "yellow"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupYellow)
+	c.Assert(err, qt.IsNil)
+	groupOrange := dbmodel.GroupEntry{Name: "orange"}
+	err = s.JIMM.Database.GetGroup(ctx, &groupOrange)
 	c.Assert(err, qt.IsNil)
 
 	tuples := []apiparams.RelationshipTuple{{
@@ -1015,7 +1036,11 @@ func TestListRelationshipTuplesWithMissingGroups(t *testing.T) {
 		TargetObject: "group-yellow",
 	}}
 
-	err = client.AddRelation(&apiparams.AddRelationRequest{Tuples: tuples})
+	err = s.JIMM.OpenFGAClient.AddRelation(ctx, openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(groupOrange.ResourceTag(), ofganames.MemberRelation),
+		Relation: "member",
+		Target:   ofganames.ConvertTag(groupYellow.ResourceTag()),
+	})
 	c.Assert(err, qt.IsNil)
 
 	// Delete a group without going through the API.
@@ -1067,7 +1092,7 @@ func TestCheckRelationAsNonAdmin(t *testing.T) {
 func TestCheckRelationOfferReaderFlow(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	ofgaClient := s.JIMM.OpenFGAClient
 
 	user, group, _, _, offer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -1140,7 +1165,7 @@ func TestCheckRelationOfferReaderFlow(t *testing.T) {
 func TestCheckRelationOfferConsumerFlow(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	ofgaClient := s.JIMM.OpenFGAClient
 
 	user, group, _, _, offer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -1211,7 +1236,7 @@ func TestCheckRelationOfferConsumerFlow(t *testing.T) {
 func TestCheckRelationModelReaderFlow(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	ofgaClient := s.JIMM.OpenFGAClient
 
 	user, group, _, model, _, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -1284,7 +1309,7 @@ func TestCheckRelationModelReaderFlow(t *testing.T) {
 func TestCheckRelationModelWriterFlow(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	ofgaClient := s.JIMM.OpenFGAClient
 
 	user, group, _, model, _, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -1355,7 +1380,7 @@ func TestCheckRelationModelWriterFlow(t *testing.T) {
 func TestCheckRelationControllerAdministratorFlow(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
-	ctx := context.Background()
+	ctx := t.Context()
 	ofgaClient := s.JIMM.OpenFGAClient
 
 	user, group, controller, model, offer, _, _, client, closeClient := createTestControllerEnvironment(c, s)
@@ -1452,6 +1477,123 @@ func TestCheckRelationControllerAdministratorFlow(t *testing.T) {
 			want: true,
 		},
 		// Test user-> writer -> model (due to group#member -> controller#admin unioned to model #admin)
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "writer",
+				TargetObject: modelJAASKey,
+			},
+			want: true,
+		},
+		// Test user -> administrator -> offer
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "administrator",
+				TargetObject: offerJAASKey,
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		req := apiparams.CheckRelationRequest{Tuple: tc.input}
+		res, err := client.CheckRelation(&req)
+		c.Assert(err, qt.IsNil)
+		c.Assert(res.Allowed, qt.Equals, tc.want)
+	}
+	// Check that the same tuples can be checked via the CheckRelations API
+	tuplesToCheck := apiparams.CheckRelationsRequest{}
+	expected := apiparams.CheckRelationsResponse{}
+	for _, tc := range tests {
+		tuplesToCheck.Tuples = append(tuplesToCheck.Tuples, tc.input)
+		expected.Results = append(expected.Results, apiparams.CheckRelationResponse{
+			Allowed: tc.want,
+		})
+	}
+	results, err := client.CheckRelations(&tuplesToCheck)
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.DeepEquals, expected)
+}
+
+func TestCheckRelationIDPGroupControllerAdministratorFlow(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := t.Context()
+	ofgaClient := s.JIMM.OpenFGAClient
+
+	user, _, controller, model, offer, _, _, _, cleanup := createTestControllerEnvironment(c, s)
+	defer cleanup()
+	client, closeClient := openClientWithIDPGroups(c, s, user.Name, []string{testIDPGroup})
+	defer closeClient()
+	modelTag := ofganames.ConvertTag(model.ResourceTag())
+	controllerTag := ofganames.ConvertTag(controller.ResourceTag())
+	offerTag := ofganames.ConvertTag(offer.ResourceTag())
+
+	// JAAS style keys, to be translated and checked against UUIDs/users/groups
+	userJAASKey := "user-" + user.Name
+	controllerJAASKey := "controller-" + controller.Name
+	modelJAASKey := "model-" + user.Name + "/" + model.Name
+	offerJAASKey := "applicationoffer-" + offer.URL
+
+	idpGroupToControllerAdmin := openfga.Tuple{
+		Object:   ofganames.ConvertTagWithRelation(jimmnames.NewIdPGroupTag(testIDPGroup), ofganames.MemberRelation),
+		Relation: "administrator",
+		Target:   controllerTag,
+	}
+	controllerToModelAdmin := openfga.Tuple{
+		Object:   controllerTag,
+		Relation: "controller",
+		Target:   modelTag,
+	}
+	modelToAppOfferAdmin := openfga.Tuple{
+		Object:   modelTag,
+		Relation: "model",
+		Target:   offerTag,
+	}
+
+	err := ofgaClient.AddRelation(
+		ctx,
+		idpGroupToControllerAdmin,
+		controllerToModelAdmin,
+		modelToAppOfferAdmin,
+	)
+	c.Assert(err, qt.IsNil)
+
+	type test struct {
+		input apiparams.RelationshipTuple
+		want  bool
+	}
+
+	tests := []test{
+		// Test user-> member -> controller via contextual IDP group membership
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "administrator",
+				TargetObject: controllerJAASKey,
+			},
+			want: true,
+		},
+		// Test user-> administrator -> model via contextual IDP group membership
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "administrator",
+				TargetObject: modelJAASKey,
+			},
+			want: true,
+		},
+		// Test user -> reader -> model (due to idpgroup#member -> controller#admin unioned to model #admin)
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "reader",
+				TargetObject: modelJAASKey,
+			},
+			want: true,
+		},
+		// Test user-> writer -> model (due to idpgroup#member -> controller#admin unioned to model #admin)
 		{
 			input: apiparams.RelationshipTuple{
 				Object:       userJAASKey,
@@ -1688,7 +1830,7 @@ func createTestControllerEnvironment(c *qt.C, s jimmtest.JimmWithControllers) (
 		ModelID: model.ID,
 		URL:     offerURL.String(),
 	}
-	err = db.AddApplicationOffer(context.Background(), &offer)
+	err = db.AddApplicationOffer(c.Context(), &offer)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(offer.UUID), qt.Equals, 36)
 


### PR DESCRIPTION
## Description
- deprecate adding new groups and new members to group
- change the tests needing groups to not use client methods anymore by adding groups to the db directly
- add some tests for idp group permission propagation

Honestly for the rebac_admin i was wondering if we need all of that code to begin with, i guess nobody is really using it.
