### PR TITLE
feat(jujuapi): add params36 package for 3.6<->4.x wire conversion

### DIFF
--- a/internal/jujuapi/params36/params36.go
+++ b/internal/jujuapi/params36/params36.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Canonical.
+
+// Package params36 converts between the current (Juju 4.x) jujuparams types,
+// which identify a model by its qualifier, and the legacy (Juju 3.6) "*Legacy"
+// types, which identify a model by its owner tag.
+//
+// JIMM serves multiple facade versions so that both Juju 3.6 and Juju 4.x
+// clients can talk to it directly.
+// Where a facade method's wire format changed between the two majors — almost
+// entirely the model owner-tag -> qualifier rename — JIMM's lower-version
+// handler speaks the 3.6 wire format using these conversions.
+//
+// This package is intended to be the ONLY place in JIMM that imports juju's
+// "*Legacy" params structs. Those structs are temporary upstream (juju will
+// remove them once it stops managing 3.6 controllers); keeping their use
+// localised here means a future copy-into-JIMM is a single-file change.
+//
+// The owner-tag <-> qualifier transform is lossless for qualifiers that name a
+// user: a qualifier in user-id form ("alice@external") maps to the owner-tag
+// form ("user-alice@external") and back. A qualifier that is not a valid Juju
+// user has no faithful owner-tag representation; the response-direction
+// converters surface this as an error (single-item) or a per-result error
+// (bulk). Handlers serving such models to a 3.6 client decide how to handle
+// them — preferring JIMM's own record of the model owner, which for
+// JIMM-created models is always a user.
+package params36
+
+import (
+	"github.com/juju/juju/core/crossmodel"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+// qualifierToOwnerTag converts a model qualifier in user-id form (e.g.
+// "alice@external") into the owner-tag form expected by 3.6 clients (e.g.
+// "user-alice@external"). It returns an error for a qualifier that does not
+// name a valid Juju user, which therefore has no owner-tag representation.
+func qualifierToOwnerTag(qualifier string) (string, error) {
+	if !names.IsValidUser(qualifier) {
+		return "", errors.Codef(errors.CodeBadRequest, "model qualifier %q is not a user and has no owner-tag representation", qualifier)
+	}
+	return names.NewUserTag(qualifier).String(), nil
+}
+
+// ownerTagToQualifier converts an owner tag sent by a 3.6 client (e.g.
+// "user-alice@external") into the qualifier form (e.g. "alice@external") used
+// by the current API. It is the inverse of qualifierToOwnerTag for user owners.
+func ownerTagToQualifier(ownerTag string) (string, error) {
+	ut, err := names.ParseUserTag(ownerTag)
+	if err != nil {
+		return "", errors.Codef(errors.CodeBadRequest, "%w", err)
+	}
+	return ut.Id(), nil
+}
+
+// toParamsError renders a conversion error as a *jujuparams.Error, preserving
+// JIMM's error code where one is set, so it can be returned in a per-result
+// error slot.
+func toParamsError(err error) *jujuparams.Error {
+	return &jujuparams.Error{
+		Message: err.Error(),
+		Code:    string(errors.ErrorCode(err)),
+	}
+}
+
+// ModelCreateArgs converts a 3.6 ModelCreateArgsLegacy (owner-tag) into
+// the current ModelCreateArgs (qualifier). An empty owner tag yields an empty
+// qualifier, mirroring the existing behaviour where the model owner defaults to
+// the authenticated user downstream. The legacy form has no TargetController
+// field, so it is left unset.
+func ModelCreateArgs(in jujuparams.ModelCreateArgsLegacy) (jujuparams.ModelCreateArgs, error) {
+	out := jujuparams.ModelCreateArgs{
+		Name:               in.Name,
+		Config:             in.Config,
+		CloudTag:           in.CloudTag,
+		CloudRegion:        in.CloudRegion,
+		CloudCredentialTag: in.CloudCredentialTag,
+	}
+	if in.OwnerTag != "" {
+		qualifier, err := ownerTagToQualifier(in.OwnerTag)
+		if err != nil {
+			return jujuparams.ModelCreateArgs{}, err
+		}
+		out.Qualifier = qualifier
+	}
+	return out, nil
+}
+
+// OfferFilters converts 3.6 OfferFiltersLegacy (model owner name) into
+// the current OfferFilters (model qualifier). It mirrors juju's own
+// legacyFiltersToFilters: the model owner name maps directly onto the
+// qualifier.
+func OfferFilters(in jujuparams.OfferFiltersLegacy) jujuparams.OfferFilters {
+	out := jujuparams.OfferFilters{
+		Filters: make([]jujuparams.OfferFilter, len(in.Filters)),
+	}
+	for i, f := range in.Filters {
+		out.Filters[i] = jujuparams.OfferFilter{
+			ModelName:              f.ModelName,
+			OfferName:              f.OfferName,
+			ApplicationName:        f.ApplicationName,
+			ApplicationDescription: f.ApplicationDescription,
+			ApplicationUser:        f.ApplicationUser,
+			Endpoints:              f.Endpoints,
+			ConnectedUserTags:      f.ConnectedUserTags,
+			AllowedConsumerTags:    f.AllowedConsumerTags,
+		}
+		if f.OwnerName != "" {
+			out.Filters[i].ModelQualifier = f.OwnerName
+		}
+	}
+	return out
+}
+
+// TransformOfferURLs rewrites any model-owner segment in the given offer URLs
+// into the model-qualifier form used by the current API, mirroring juju's own
+// transformOfferURLs. URLs that do not parse, or that carry no qualifier, are
+// passed through unchanged so the downstream handler produces the error.
+func TransformOfferURLs(in []string) []string {
+	out := make([]string, len(in))
+	for i, urlStr := range in {
+		url, err := crossmodel.ParseOfferURL(urlStr)
+		if err != nil || url.ModelQualifier == "" {
+			out[i] = urlStr
+			continue
+		}
+		out[i] = url.String()
+	}
+	return out
+}
+
+// LegacyModelInfo converts a current ModelInfo (qualifier) into the 3.6
+// ModelInfoLegacy (owner-tag). The JAAS-specific TargetController field has no
+// legacy equivalent and is dropped.
+func LegacyModelInfo(in jujuparams.ModelInfo) (jujuparams.ModelInfoLegacy, error) {
+	ownerTag, err := qualifierToOwnerTag(in.Qualifier)
+	if err != nil {
+		return jujuparams.ModelInfoLegacy{}, err
+	}
+	return jujuparams.ModelInfoLegacy{
+		Name:                    in.Name,
+		Type:                    in.Type,
+		UUID:                    in.UUID,
+		ControllerUUID:          in.ControllerUUID,
+		IsController:            in.IsController,
+		ProviderType:            in.ProviderType,
+		CloudTag:                in.CloudTag,
+		CloudRegion:             in.CloudRegion,
+		CloudCredentialTag:      in.CloudCredentialTag,
+		CloudCredentialValidity: in.CloudCredentialValidity,
+		OwnerTag:                ownerTag,
+		Life:                    in.Life,
+		Status:                  in.Status,
+		Users:                   in.Users,
+		Machines:                in.Machines,
+		SecretBackends:          in.SecretBackends,
+		Migration:               in.Migration,
+		AgentVersion:            in.AgentVersion,
+		SupportedFeatures:       in.SupportedFeatures,
+	}, nil
+}
+
+// LegacyModelInfoResults converts a bulk ModelInfoResults into its legacy form.
+// A result whose qualifier has no owner-tag representation is converted into a
+// result-level error rather than failing the whole batch.
+func LegacyModelInfoResults(in jujuparams.ModelInfoResults) jujuparams.ModelInfoResultsLegacy {
+	out := jujuparams.ModelInfoResultsLegacy{
+		Results: make([]jujuparams.ModelInfoResultLegacy, len(in.Results)),
+	}
+	for i, r := range in.Results {
+		if r.Result == nil {
+			out.Results[i] = jujuparams.ModelInfoResultLegacy{Error: r.Error}
+			continue
+		}
+		mi, err := LegacyModelInfo(*r.Result)
+		if err != nil {
+			out.Results[i] = jujuparams.ModelInfoResultLegacy{Error: toParamsError(err)}
+			continue
+		}
+		out.Results[i] = jujuparams.ModelInfoResultLegacy{Result: &mi}
+	}
+	return out
+}
+
+// legacyModel converts a current Model (qualifier) into the 3.6 ModelLegacy
+// (owner-tag).
+func legacyModel(in jujuparams.Model) (jujuparams.ModelLegacy, error) {
+	ownerTag, err := qualifierToOwnerTag(in.Qualifier)
+	if err != nil {
+		return jujuparams.ModelLegacy{}, err
+	}
+	return jujuparams.ModelLegacy{
+		Name:     in.Name,
+		UUID:     in.UUID,
+		Type:     in.Type,
+		OwnerTag: ownerTag,
+	}, nil
+}
+
+// LegacyUserModelList converts a current UserModelList (qualifier) into the 3.6
+// UserModelListLegacy (owner-tag). UserModel has no per-item error slot, so a
+// model whose qualifier has no owner-tag representation fails the whole
+// conversion; callers should ensure model owners are users (they are for
+// JIMM-created models) or pre-filter.
+func LegacyUserModelList(in jujuparams.UserModelList) (jujuparams.UserModelListLegacy, error) {
+	out := jujuparams.UserModelListLegacy{
+		UserModels: make([]jujuparams.UserModelLegacy, len(in.UserModels)),
+	}
+	for i, um := range in.UserModels {
+		ml, err := legacyModel(um.Model)
+		if err != nil {
+			return jujuparams.UserModelListLegacy{}, err
+		}
+		out.UserModels[i] = jujuparams.UserModelLegacy{
+			ModelLegacy:    ml,
+			LastConnection: um.LastConnection,
+		}
+	}
+	return out, nil
+}
+
+// legacyModelStatus converts a single current ModelStatus into its legacy form.
+// A ModelStatus that already carries an error is passed through unchanged; a
+// qualifier with no owner-tag representation is recorded as the item's error.
+func legacyModelStatus(in jujuparams.ModelStatus) jujuparams.ModelStatusLegacy {
+	out := jujuparams.ModelStatusLegacy{
+		ModelTag:           in.ModelTag,
+		Life:               in.Life,
+		Type:               in.Type,
+		HostedMachineCount: in.HostedMachineCount,
+		ApplicationCount:   in.ApplicationCount,
+		UnitCount:          in.UnitCount,
+		Applications:       in.Applications,
+		Machines:           in.Machines,
+		Volumes:            in.Volumes,
+		Filesystems:        in.Filesystems,
+		Error:              in.Error,
+	}
+	if in.Error != nil {
+		return out
+	}
+	ownerTag, err := qualifierToOwnerTag(in.Qualifier)
+	if err != nil {
+		out.Error = toParamsError(err)
+		return out
+	}
+	out.OwnerTag = ownerTag
+	return out
+}
+
+// LegacyModelStatusResults converts a bulk ModelStatusResults into its legacy
+// form, recording any per-model conversion failure in that model's error.
+func LegacyModelStatusResults(in jujuparams.ModelStatusResults) jujuparams.ModelStatusResultsLegacy {
+	out := jujuparams.ModelStatusResultsLegacy{
+		Results: make([]jujuparams.ModelStatusLegacy, len(in.Results)),
+	}
+	for i, ms := range in.Results {
+		out.Results[i] = legacyModelStatus(ms)
+	}
+	return out
+}
+
+// legacyModelSummary converts a single current ModelSummary into its legacy
+// form.
+func legacyModelSummary(in jujuparams.ModelSummary) (jujuparams.ModelSummaryLegacy, error) {
+	ownerTag, err := qualifierToOwnerTag(in.Qualifier)
+	if err != nil {
+		return jujuparams.ModelSummaryLegacy{}, err
+	}
+	return jujuparams.ModelSummaryLegacy{
+		Name:               in.Name,
+		UUID:               in.UUID,
+		Type:               in.Type,
+		ControllerUUID:     in.ControllerUUID,
+		IsController:       in.IsController,
+		ProviderType:       in.ProviderType,
+		CloudTag:           in.CloudTag,
+		CloudRegion:        in.CloudRegion,
+		CloudCredentialTag: in.CloudCredentialTag,
+		OwnerTag:           ownerTag,
+		Life:               in.Life,
+		Status:             in.Status,
+		UserAccess:         in.UserAccess,
+		UserLastConnection: in.UserLastConnection,
+		Counts:             in.Counts,
+		Migration:          in.Migration,
+		AgentVersion:       in.AgentVersion,
+	}, nil
+}
+
+// LegacyModelSummaryResults converts a bulk ModelSummaryResults into its legacy
+// form. A result whose qualifier has no owner-tag representation is converted
+// into a result-level error rather than failing the whole batch.
+func LegacyModelSummaryResults(in jujuparams.ModelSummaryResults) jujuparams.ModelSummaryResultsLegacy {
+	out := jujuparams.ModelSummaryResultsLegacy{
+		Results: make([]jujuparams.ModelSummaryResultLegacy, len(in.Results)),
+	}
+	for i, r := range in.Results {
+		if r.Result == nil {
+			out.Results[i] = jujuparams.ModelSummaryResultLegacy{Error: r.Error}
+			continue
+		}
+		ms, err := legacyModelSummary(*r.Result)
+		if err != nil {
+			out.Results[i] = jujuparams.ModelSummaryResultLegacy{Error: toParamsError(err)}
+			continue
+		}
+		out.Results[i] = jujuparams.ModelSummaryResultLegacy{Result: &ms}
+	}
+	return out
+}

--- a/internal/jujuapi/params36/params36_test.go
+++ b/internal/jujuapi/params36/params36_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Canonical.
+
+package params36
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/semversion"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+func TestOwnerTagQualifierRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		qualifier string
+		ownerTag  string
+	}{
+		{qualifier: "alice@external", ownerTag: "user-alice@external"},
+		{qualifier: "admin", ownerTag: "user-admin"},
+		{qualifier: "bob@canonical.com", ownerTag: "user-bob@canonical.com"},
+	}
+	for _, test := range tests {
+		ownerTag, err := qualifierToOwnerTag(test.qualifier)
+		c.Assert(err, qt.IsNil)
+		c.Check(ownerTag, qt.Equals, test.ownerTag)
+
+		qualifier, err := ownerTagToQualifier(test.ownerTag)
+		c.Assert(err, qt.IsNil)
+		c.Check(qualifier, qt.Equals, test.qualifier)
+
+		// The transform is an exact inverse for users.
+		roundTripped, err := qualifierToOwnerTag(qualifier)
+		c.Assert(err, qt.IsNil)
+		c.Check(roundTripped, qt.Equals, test.ownerTag)
+	}
+}
+
+func TestQualifierToOwnerTagInvalid(t *testing.T) {
+	c := qt.New(t)
+
+	for _, qualifier := range []string{"", "a b", "Not-A-User!"} {
+		_, err := qualifierToOwnerTag(qualifier)
+		c.Check(err, qt.IsNotNil, qt.Commentf("qualifier %q", qualifier))
+		c.Check(errors.ErrorCode(err), qt.Equals, errors.CodeBadRequest)
+	}
+}
+
+func TestOwnerTagToQualifierInvalid(t *testing.T) {
+	c := qt.New(t)
+
+	for _, ownerTag := range []string{"", "not-a-tag", "machine-0"} {
+		_, err := ownerTagToQualifier(ownerTag)
+		c.Check(err, qt.IsNotNil, qt.Commentf("owner tag %q", ownerTag))
+	}
+}
+
+func TestModelCreateArgs(t *testing.T) {
+	c := qt.New(t)
+
+	in := jujuparams.ModelCreateArgsLegacy{
+		Name:               "mymodel",
+		OwnerTag:           "user-alice@external",
+		Config:             map[string]any{"key": "value"},
+		CloudTag:           "cloud-aws",
+		CloudRegion:        "eu-west-1",
+		CloudCredentialTag: "cloudcred-aws_alice@external_cred",
+	}
+	got, err := ModelCreateArgs(in)
+	c.Assert(err, qt.IsNil)
+	c.Check(got, qt.DeepEquals, jujuparams.ModelCreateArgs{
+		Name:               "mymodel",
+		Qualifier:          "alice@external",
+		Config:             map[string]any{"key": "value"},
+		CloudTag:           "cloud-aws",
+		CloudRegion:        "eu-west-1",
+		CloudCredentialTag: "cloudcred-aws_alice@external_cred",
+	})
+
+	// An empty owner tag yields an empty qualifier (owner defaults downstream).
+	got, err = ModelCreateArgs(jujuparams.ModelCreateArgsLegacy{Name: "m"})
+	c.Assert(err, qt.IsNil)
+	c.Check(got.Qualifier, qt.Equals, "")
+
+	// An invalid owner tag is an error.
+	_, err = ModelCreateArgs(jujuparams.ModelCreateArgsLegacy{Name: "m", OwnerTag: "not-a-tag"})
+	c.Check(err, qt.IsNotNil)
+}
+
+func TestLegacyModelInfo(t *testing.T) {
+	c := qt.New(t)
+
+	valid := true
+	agentVersion := semversion.MustParse("4.0.0")
+	in := jujuparams.ModelInfo{
+		Name:                    "mymodel",
+		Type:                    "iaas",
+		UUID:                    "00000000-0000-0000-0000-000000000001",
+		ControllerUUID:          "00000000-0000-0000-0000-0000000000ff",
+		IsController:            false,
+		ProviderType:            "ec2",
+		CloudTag:                "cloud-aws",
+		CloudRegion:             "eu-west-1",
+		CloudCredentialTag:      "cloudcred-aws_alice@external_cred",
+		CloudCredentialValidity: &valid,
+		Qualifier:               "alice@external",
+		Life:                    life.Alive,
+		Status:                  jujuparams.EntityStatus{Status: "available"},
+		AgentVersion:            &agentVersion,
+		// TargetController has no legacy equivalent and must be dropped.
+		TargetController: "controller-prod",
+	}
+	got, err := LegacyModelInfo(in)
+	c.Assert(err, qt.IsNil)
+	c.Check(got, qt.CmpEquals(cmp.AllowUnexported()), jujuparams.ModelInfoLegacy{
+		Name:                    "mymodel",
+		Type:                    "iaas",
+		UUID:                    "00000000-0000-0000-0000-000000000001",
+		ControllerUUID:          "00000000-0000-0000-0000-0000000000ff",
+		IsController:            false,
+		ProviderType:            "ec2",
+		CloudTag:                "cloud-aws",
+		CloudRegion:             "eu-west-1",
+		CloudCredentialTag:      "cloudcred-aws_alice@external_cred",
+		CloudCredentialValidity: &valid,
+		OwnerTag:                "user-alice@external",
+		Life:                    life.Alive,
+		Status:                  jujuparams.EntityStatus{Status: "available"},
+		AgentVersion:            &agentVersion,
+	})
+
+	// A non-user qualifier has no owner-tag representation.
+	_, err = LegacyModelInfo(jujuparams.ModelInfo{Qualifier: "a b"})
+	c.Check(err, qt.IsNotNil)
+}
+
+func TestLegacyModelInfoResults(t *testing.T) {
+	c := qt.New(t)
+
+	in := jujuparams.ModelInfoResults{
+		Results: []jujuparams.ModelInfoResult{
+			{Result: &jujuparams.ModelInfo{Name: "m1", Qualifier: "alice@external"}},
+			{Error: &jujuparams.Error{Message: "boom", Code: "not found"}},
+			{Result: &jujuparams.ModelInfo{Name: "m3", Qualifier: "a b"}},
+		},
+	}
+	got := LegacyModelInfoResults(in)
+	c.Assert(got.Results, qt.HasLen, 3)
+
+	// Converted result.
+	c.Assert(got.Results[0].Result, qt.IsNotNil)
+	c.Check(got.Results[0].Result.OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.Results[0].Error == nil, qt.IsTrue)
+
+	// Existing error is passed through untouched.
+	c.Check(got.Results[1].Result, qt.IsNil)
+	c.Check(got.Results[1].Error, qt.DeepEquals, &jujuparams.Error{Message: "boom", Code: "not found"})
+
+	// Unconvertible qualifier becomes a result-level error, not a batch failure.
+	c.Check(got.Results[2].Result, qt.IsNil)
+	c.Check(got.Results[2].Error, qt.IsNotNil)
+}
+
+func TestLegacyUserModelList(t *testing.T) {
+	c := qt.New(t)
+
+	now := time.Unix(1700000000, 0).UTC()
+	in := jujuparams.UserModelList{
+		UserModels: []jujuparams.UserModel{{
+			Model: jujuparams.Model{
+				Name:      "mymodel",
+				Qualifier: "alice@external",
+				UUID:      "00000000-0000-0000-0000-000000000001",
+				Type:      "iaas",
+			},
+			LastConnection: &now,
+		}},
+	}
+	got, err := LegacyUserModelList(in)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.UserModels, qt.HasLen, 1)
+	c.Check(got.UserModels[0].ModelLegacy, qt.DeepEquals, jujuparams.ModelLegacy{
+		Name:     "mymodel",
+		UUID:     "00000000-0000-0000-0000-000000000001",
+		Type:     "iaas",
+		OwnerTag: "user-alice@external",
+	})
+	c.Check(got.UserModels[0].LastConnection, qt.DeepEquals, &now)
+
+	// A non-user qualifier fails the conversion (no per-item error slot).
+	_, err = LegacyUserModelList(jujuparams.UserModelList{
+		UserModels: []jujuparams.UserModel{{Model: jujuparams.Model{Qualifier: "a b"}}},
+	})
+	c.Check(err, qt.IsNotNil)
+}
+
+func TestLegacyModelStatusResults(t *testing.T) {
+	c := qt.New(t)
+
+	in := jujuparams.ModelStatusResults{
+		Results: []jujuparams.ModelStatus{
+			{ModelTag: "model-1", Qualifier: "alice@external", UnitCount: 3},
+			{Error: &jujuparams.Error{Message: "boom"}},
+			{ModelTag: "model-3", Qualifier: "a b"},
+		},
+	}
+	got := LegacyModelStatusResults(in)
+	c.Assert(got.Results, qt.HasLen, 3)
+
+	// Converted.
+	c.Check(got.Results[0].OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.Results[0].UnitCount, qt.Equals, 3)
+	c.Check(got.Results[0].Error == nil, qt.IsTrue)
+
+	// Existing error passes through; no qualifier conversion attempted.
+	c.Check(got.Results[1].OwnerTag, qt.Equals, "")
+	c.Check(got.Results[1].Error, qt.DeepEquals, &jujuparams.Error{Message: "boom"})
+
+	// Unconvertible qualifier becomes the item's error.
+	c.Check(got.Results[2].OwnerTag, qt.Equals, "")
+	c.Check(got.Results[2].Error, qt.IsNotNil)
+}
+
+func TestLegacyModelSummaryResults(t *testing.T) {
+	c := qt.New(t)
+
+	in := jujuparams.ModelSummaryResults{
+		Results: []jujuparams.ModelSummaryResult{
+			{Result: &jujuparams.ModelSummary{Name: "m1", Qualifier: "alice@external"}},
+			{Error: &jujuparams.Error{Message: "boom"}},
+			{Result: &jujuparams.ModelSummary{Name: "m3", Qualifier: "a b"}},
+		},
+	}
+	got := LegacyModelSummaryResults(in)
+	c.Assert(got.Results, qt.HasLen, 3)
+
+	c.Assert(got.Results[0].Result, qt.IsNotNil)
+	c.Check(got.Results[0].Result.OwnerTag, qt.Equals, "user-alice@external")
+
+	c.Check(got.Results[1].Result, qt.IsNil)
+	c.Check(got.Results[1].Error, qt.DeepEquals, &jujuparams.Error{Message: "boom"})
+
+	c.Check(got.Results[2].Result, qt.IsNil)
+	c.Check(got.Results[2].Error, qt.IsNotNil)
+}
+
+func TestOfferFilters(t *testing.T) {
+	c := qt.New(t)
+
+	in := jujuparams.OfferFiltersLegacy{
+		Filters: []jujuparams.OfferFilterLegacy{
+			{
+				OwnerName:       "alice@external",
+				ModelName:       "mymodel",
+				OfferName:       "myoffer",
+				ApplicationName: "myapp",
+			},
+			{ModelName: "othermodel"}, // empty owner name stays empty
+		},
+	}
+	got := OfferFilters(in)
+	c.Assert(got.Filters, qt.HasLen, 2)
+	c.Check(got.Filters[0], qt.DeepEquals, jujuparams.OfferFilter{
+		ModelQualifier:  "alice@external",
+		ModelName:       "mymodel",
+		OfferName:       "myoffer",
+		ApplicationName: "myapp",
+	})
+	c.Check(got.Filters[1].ModelQualifier, qt.Equals, "")
+	c.Check(got.Filters[1].ModelName, qt.Equals, "othermodel")
+}
+
+func TestTransformOfferURLs(t *testing.T) {
+	c := qt.New(t)
+
+	got := TransformOfferURLs([]string{
+		"alice@external/mymodel.myoffer",
+		"this is not a valid offer url",
+	})
+	c.Assert(got, qt.HasLen, 2)
+
+	// A valid URL is rewritten into qualifier form (here, already canonical).
+	url, err := crossmodel.ParseOfferURL(got[0])
+	c.Assert(err, qt.IsNil)
+	c.Check(url.ModelQualifier, qt.Equals, "alice@external")
+	c.Check(url.ModelName, qt.Equals, "mymodel")
+	c.Check(url.Name, qt.Equals, "myoffer")
+
+	// An unparseable URL is passed through unchanged.
+	c.Check(got[1], qt.Equals, "this is not a valid offer url")
+}


### PR DESCRIPTION
## Description

Add internal/jujuapi/params36, the single place that converts between the current (Juju 4.x) jujuparams types, which identify a model by its qualifier, and the legacy (Juju 3.6) "*Legacy" types, which identify a model by its owner tag.

This is groundwork for serving Juju 3.6 clients from a juju-4-based JIMM: lower-version facade handlers will use these conversions to speak the 3.6 owner-tag wire format while reusing the existing 4.x business logic.

Provides:
- owner-tag <-> qualifier transforms (lossless for user owners; a non-user qualifier has no owner-tag representation and is surfaced as an error, single-item, or a per-result error, bulk)
- request direction: ModelCreateArgsLegacy, OfferFiltersLegacy, offer URLs
- response direction: ModelInfo(Results), UserModelList, ModelStatusResults, ModelSummaryResults

Isolating juju's temporary *Legacy structs in this one package keeps their eventual upstream removal a single-file change.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
