### PR TITLE
refactor: re-organise model proxy

### DIFF
--- a/internal/rpcproxy/controller_response.go
+++ b/internal/rpcproxy/controller_response.go
@@ -36,7 +36,7 @@ func (h controllerResponseHandler) handle(ctx context.Context, msg *message) err
 		h.handleError(ctx, msg, err)
 		return fmt.Errorf("error modifying controller response: %w", err)
 	}
-	h.proxy.msgs.removeMessage(msg.RequestID)
+	h.proxy.inflight.finish(msg.RequestID)
 	if err := h.proxy.auditLogMessage(msg, true); err != nil {
 		zapctx.Error(context.Background(), "failed to audit log message", zap.Error(err))
 	}
@@ -83,7 +83,7 @@ func (h controllerResponseHandler) processControllerErrors(ctx context.Context, 
 			return false
 		}
 		// Write back to the controller.
-		msg := h.proxy.msgs.getMessage(msg.RequestID)
+		msg := h.proxy.inflight.request(msg.RequestID)
 		if msg != nil {
 			if err := h.proxy.src.writeJson(msg); err != nil {
 				zapctx.Error(context.Background(), "failed to write back to controller", zap.Error(err))
@@ -96,7 +96,7 @@ func (h controllerResponseHandler) processControllerErrors(ctx context.Context, 
 
 func (h controllerResponseHandler) handleError(ctx context.Context, msg *message, err error) {
 	h.proxy.sendError(ctx, h.proxy.dst, msg, err)
-	h.proxy.msgs.removeMessage(msg.RequestID)
+	h.proxy.inflight.finish(msg.RequestID)
 }
 
 // checkPermissionsRequired returns a nil map if no permissions are required.
@@ -151,7 +151,7 @@ func (h controllerResponseHandler) redoLogin(ctx context.Context, permissions ma
 	if h.proxy.anonymousLogin {
 		return errors.Codef(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
 	}
-	loginMsg := h.proxy.msgs.getLoginMessage()
+	loginMsg := h.proxy.inflight.login()
 	if loginMsg == nil {
 		return errors.Codef(errors.CodeUnauthorized, "Haven't received login yet")
 	}

--- a/internal/rpcproxy/controller_response.go
+++ b/internal/rpcproxy/controller_response.go
@@ -1,0 +1,212 @@
+// Copyright 2025 Canonical.
+
+package rpcproxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+)
+
+// controllerResponseHandler keeps controller->client response handling in one place
+// so the proxy loop stays focused on transport orchestration.
+type controllerResponseHandler struct {
+	proxy *controllerProxy
+}
+
+func newControllerResponseHandler(proxy *controllerProxy) controllerResponseHandler {
+	return controllerResponseHandler{proxy: proxy}
+}
+
+func (h controllerResponseHandler) handle(ctx context.Context, msg *message) error {
+	if !h.processControllerErrors(ctx, msg) {
+		return nil
+	}
+
+	if err := modifyControllerResponse(msg); err != nil {
+		zapctx.Error(ctx, "Failed to modify message", zap.Error(err))
+		h.handleError(ctx, msg, err)
+		return fmt.Errorf("error modifying controller response: %w", err)
+	}
+	h.proxy.msgs.removeMessage(msg.RequestID)
+	if err := h.proxy.auditLogMessage(msg, true); err != nil {
+		zapctx.Error(context.Background(), "failed to audit log message", zap.Error(err))
+	}
+	if err := h.proxy.dst.writeJson(msg); err != nil {
+		zapctx.Error(ctx, "controllerProxy error writing to dst", zap.Error(err))
+		return fmt.Errorf("error writing message to client: %w", err)
+	}
+	return nil
+}
+
+// processControllerErrors checks for errors in the message from the controller
+// and decides how to handle them. It returns true if the message should be
+// returned to the client, false if it should not.
+func (h controllerResponseHandler) processControllerErrors(ctx context.Context, msg *message) bool {
+	// Check if the model is migrating. When it has completed its migration, we will receive
+	// an unauthorized error from the controller and we want to mask that error and inform
+	// clients to try again as JIMM will eventually update the model's controller.
+	// See internal/jimm/juju/model_poller.go.
+	modelMigrating := h.proxy.modelMigrationMode == dbmodel.MigrationModeMigrateInternal || h.proxy.modelMigrationMode == dbmodel.MigrationModeExporting
+	if modelMigrating && msg.ErrorCode == string(errors.CodeUnauthorized) {
+		msg.ErrorCode = string(errors.CodeModelMigrating)
+		msg.Error = "model is finishing migration, please retry later"
+		return true
+	}
+
+	// Next we check for permission required errors where the Juju controller is informing us
+	// that the user needs more permissions to perform the requested operation.
+	// If so, we attempt to redo the login with the required permissions (if the user has them)
+	// and then resend the original login request.
+	//
+	// It's ideally unlikely we'll hit this code path often because JIMM sets a broad scope
+	// of permissions on the initial login request.
+	permissionsRequired, err := checkPermissionsRequired(ctx, msg)
+	if err != nil {
+		zapctx.Error(ctx, "failed to determine if more permissions required", zap.Error(err))
+		h.handleError(ctx, msg, err)
+		return false
+	}
+	if permissionsRequired != nil {
+		zapctx.Error(ctx, "Access Required error")
+		if err := h.redoLogin(ctx, permissionsRequired); err != nil {
+			zapctx.Error(ctx, "Failed to redo login", zap.Error(err))
+			h.handleError(ctx, msg, err)
+			return false
+		}
+		// Write back to the controller.
+		msg := h.proxy.msgs.getMessage(msg.RequestID)
+		if msg != nil {
+			if err := h.proxy.src.writeJson(msg); err != nil {
+				zapctx.Error(context.Background(), "failed to write back to controller", zap.Error(err))
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func (h controllerResponseHandler) handleError(ctx context.Context, msg *message, err error) {
+	h.proxy.sendError(ctx, h.proxy.dst, msg, err)
+	h.proxy.msgs.removeMessage(msg.RequestID)
+}
+
+// checkPermissionsRequired returns a nil map if no permissions are required.
+func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any, error) {
+	// Instantiate later because we won't always need the map.
+	var permissionMap map[string]any
+
+	// Check for errors that may be a result of a normal request.
+	if msg.ErrorCode == accessRequiredErrorCode {
+		permissionMap = msg.ErrorInfo
+		return permissionMap, nil
+	}
+
+	// if the message response is empty, this is clearly not a permission
+	// check required error and we return an empty map of required
+	// permissions
+	if msg.Response == nil || string(msg.Response) == "" {
+		return permissionMap, nil
+	}
+
+	var er jujuparams.ErrorResults
+	err := json.Unmarshal(msg.Response, &er)
+	if err != nil {
+		zapctx.Error(ctx, "failed to read response error", zap.Error(err))
+		return permissionMap, nil
+	}
+
+	// Check for errors that may be a result of a bulk request.
+	for _, e := range er.Results {
+		if e.Error != nil && e.Error.Code == accessRequiredErrorCode {
+			zapctx.Debug(ctx, "received error", zap.Any("error", e.Error))
+			for k, v := range e.Error.Info {
+				accessLevel, ok := v.(string)
+				if !ok {
+					return nil, errors.New("unknown permission level")
+				}
+				if permissionMap == nil {
+					permissionMap = make(map[string]any)
+				}
+				permissionMap[k] = accessLevel
+			}
+		}
+	}
+	return permissionMap, nil
+}
+
+// redoLogin sends a new login request to the controller after checking for
+// the provided permissions. This is sometimes necessary if Juju requires
+// extra permission checks for an operation. If the client performed anonymous
+// login, an error is always returned since we cannot authorize an anonymous user.
+func (h controllerResponseHandler) redoLogin(ctx context.Context, permissions map[string]any) error {
+	if h.proxy.anonymousLogin {
+		return errors.Codef(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
+	}
+	loginMsg := h.proxy.msgs.getLoginMessage()
+	if loginMsg == nil {
+		return errors.Codef(errors.CodeUnauthorized, "Haven't received login yet")
+	}
+	err := addJWT(ctx, loginMsg, permissions, h.proxy.tokenGen)
+	if err != nil {
+		return err
+	}
+	zapctx.Info(ctx, "Performing new login", zap.Any("message", loginMsg))
+	if err := h.proxy.src.writeJson(loginMsg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// addJWT adds a JWT token to the the provided message.
+func addJWT(ctx context.Context, msg *message, permissions map[string]any, tokenGen TokenGenerator) error {
+	// First we unmarshal the existing LoginRequest.
+	if msg == nil {
+		return errors.New("nil messsage")
+	}
+	var lr jujuparams.LoginRequest
+	if err := json.Unmarshal(msg.Params, &lr); err != nil {
+		return err
+	}
+
+	jwt, err := tokenGen.MakeToken(ctx, permissions)
+	if err != nil {
+		return err
+	}
+
+	jwtString := base64.StdEncoding.EncodeToString(jwt)
+	// Add the JWT as base64 encoded string.
+	lr.Token = jwtString
+	// Marshal it again to JSON.
+	data, err := json.Marshal(lr)
+	if err != nil {
+		return err
+	}
+	// And add it to the message.
+	msg.Params = data
+	return nil
+}
+
+func modifyControllerResponse(msg *message) error {
+	var response map[string]any
+	err := json.Unmarshal(msg.Response, &response)
+	if err != nil {
+		return err
+	}
+	// Delete servers block so that juju clients don't get redirected.
+	delete(response, "servers")
+	newResp, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	msg.Response = newResp
+	return nil
+}

--- a/internal/rpcproxy/controller_response_test.go
+++ b/internal/rpcproxy/controller_response_test.go
@@ -87,9 +87,12 @@ func TestControllerResponseHandlerRedoLoginReplaysOriginalRequest(t *testing.T) 
 	}
 	writes := &captureWebsocketConnection{}
 	tokenGen := &recordingTokenGenerator{}
+	tracker := newInflightTracker()
+	tracker.rememberLogin(loginMsg)
+	tracker.track(originalMsg)
 	proxy := &controllerProxy{modelProxy: modelProxy{
 		src:      &writeLockConn{conn: writes},
-		msgs:     &inflightMsgs{loginMessage: loginMsg, messages: map[uint64]*message{2: originalMsg}},
+		inflight: tracker,
 		tokenGen: tokenGen,
 	}}
 	handler := newControllerResponseHandler(proxy)

--- a/internal/rpcproxy/controller_response_test.go
+++ b/internal/rpcproxy/controller_response_test.go
@@ -1,0 +1,187 @@
+// Copyright 2025 Canonical.
+
+package rpcproxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+func TestCheckPermissionsRequiredTopLevelError(t *testing.T) {
+	c := qt.New(t)
+
+	msg := &message{
+		ErrorCode: accessRequiredErrorCode,
+		ErrorInfo: map[string]any{
+			"model-test": "write",
+		},
+	}
+
+	permissions, err := checkPermissionsRequired(context.Background(), msg)
+	c.Assert(err, qt.IsNil)
+	c.Assert(permissions, qt.DeepEquals, msg.ErrorInfo)
+}
+
+func TestCheckPermissionsRequiredBulkErrors(t *testing.T) {
+	c := qt.New(t)
+
+	response, err := json.Marshal(jujuparams.ErrorResults{
+		Results: []jujuparams.ErrorResult{{
+			Error: &jujuparams.Error{
+				Code: accessRequiredErrorCode,
+				Info: map[string]any{
+					"model-test": "write",
+				},
+			},
+		}, {
+			Error: &jujuparams.Error{
+				Code: accessRequiredErrorCode,
+				Info: map[string]any{
+					"controller-test": "superuser",
+				},
+			},
+		}},
+	})
+	c.Assert(err, qt.IsNil)
+
+	permissions, err := checkPermissionsRequired(context.Background(), &message{Response: response})
+	c.Assert(err, qt.IsNil)
+	c.Assert(permissions, qt.DeepEquals, map[string]any{
+		"model-test":      "write",
+		"controller-test": "superuser",
+	})
+}
+
+func TestControllerResponseHandlerRedoLoginReplaysOriginalRequest(t *testing.T) {
+	c := qt.New(t)
+
+	loginParams, err := json.Marshal(jujuparams.LoginRequest{
+		AuthTag: names.NewUserTag("alice@example.com").String(),
+		Token:   "old-token",
+	})
+	c.Assert(err, qt.IsNil)
+
+	loginMsg := &message{
+		RequestID: 1,
+		Type:      "Admin",
+		Version:   3,
+		Request:   "Login",
+		Params:    loginParams,
+	}
+	originalMsg := &message{
+		RequestID: 2,
+		Type:      "Client",
+		Version:   7,
+		Request:   "DoThing",
+		Params:    json.RawMessage(`{"key":"value"}`),
+	}
+	writes := &captureWebsocketConnection{}
+	tokenGen := &recordingTokenGenerator{}
+	proxy := &controllerProxy{modelProxy: modelProxy{
+		src:      &writeLockConn{conn: writes},
+		msgs:     &inflightMsgs{loginMessage: loginMsg, messages: map[uint64]*message{2: originalMsg}},
+		tokenGen: tokenGen,
+	}}
+	handler := newControllerResponseHandler(proxy)
+
+	shouldForward := handler.processControllerErrors(context.Background(), &message{
+		RequestID: 2,
+		ErrorCode: accessRequiredErrorCode,
+		ErrorInfo: map[string]any{
+			"model-test": "write",
+		},
+	})
+
+	c.Assert(shouldForward, qt.IsFalse)
+	c.Assert(tokenGen.permissionMaps, qt.HasLen, 1)
+	c.Assert(tokenGen.permissionMaps[0], qt.DeepEquals, map[string]any{"model-test": "write"})
+	c.Assert(writes.writes, qt.HasLen, 2)
+
+	var wroteLogin message
+	err = json.Unmarshal(writes.writes[0], &wroteLogin)
+	c.Assert(err, qt.IsNil)
+	c.Assert(wroteLogin.RequestID, qt.Equals, uint64(1))
+	c.Assert(wroteLogin.Type, qt.Equals, "Admin")
+	c.Assert(wroteLogin.Request, qt.Equals, "Login")
+
+	var retriedLogin jujuparams.LoginRequest
+	err = json.Unmarshal(wroteLogin.Params, &retriedLogin)
+	c.Assert(err, qt.IsNil)
+	c.Assert(retriedLogin.Token, qt.Equals, base64.StdEncoding.EncodeToString([]byte("test token")))
+
+	var wroteOriginal message
+	err = json.Unmarshal(writes.writes[1], &wroteOriginal)
+	c.Assert(err, qt.IsNil)
+	c.Assert(wroteOriginal.RequestID, qt.Equals, uint64(2))
+	c.Assert(wroteOriginal.Type, qt.Equals, "Client")
+	c.Assert(wroteOriginal.Request, qt.Equals, "DoThing")
+	var retriedParams map[string]any
+	err = json.Unmarshal(wroteOriginal.Params, &retriedParams)
+	c.Assert(err, qt.IsNil)
+	c.Assert(retriedParams, qt.DeepEquals, map[string]any{"key": "value"})
+}
+
+func TestModifyControllerResponseStripsServers(t *testing.T) {
+	c := qt.New(t)
+
+	msg := &message{Response: json.RawMessage(`{"results":[],"servers":[{"value":"controller-1"}]}`)}
+	err := modifyControllerResponse(msg)
+	c.Assert(err, qt.IsNil)
+	var response map[string]any
+	err = json.Unmarshal(msg.Response, &response)
+	c.Assert(err, qt.IsNil)
+	c.Assert(response, qt.DeepEquals, map[string]any{"results": []any{}})
+}
+
+type captureWebsocketConnection struct {
+	writes [][]byte
+}
+
+func (c *captureWebsocketConnection) ReadJSON(any) error {
+	return fmt.Errorf("unexpected ReadJSON call")
+}
+
+func (c *captureWebsocketConnection) WriteJSON(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.writes = append(c.writes, data)
+	return nil
+}
+
+func (c *captureWebsocketConnection) Close() error {
+	return nil
+}
+
+type recordingTokenGenerator struct {
+	permissionMaps []map[string]any
+}
+
+func (r *recordingTokenGenerator) MakeLoginToken(context.Context, *openfga.User) ([]byte, error) {
+	return []byte("test token"), nil
+}
+
+func (r *recordingTokenGenerator) MakeToken(_ context.Context, permissionMap map[string]any) ([]byte, error) {
+	copyMap := make(map[string]any, len(permissionMap))
+	maps.Copy(copyMap, permissionMap)
+	r.permissionMaps = append(r.permissionMaps, copyMap)
+	return []byte("test token"), nil
+}
+
+func (r *recordingTokenGenerator) SetTags(names.ModelTag, names.ControllerTag) {
+}
+
+func (r *recordingTokenGenerator) GetUser() names.UserTag {
+	return names.NewUserTag("test-user")
+}

--- a/internal/rpcproxy/inflight.go
+++ b/internal/rpcproxy/inflight.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Canonical.
+
+package rpcproxy
+
+import (
+	"sync"
+	"time"
+
+	"github.com/canonical/jimm/v3/internal/servermon"
+)
+
+// inflightTracker holds only request messages that are still pending a response
+// from a Juju controller, plus the replayable login message used for access-required retries.
+type inflightTracker struct {
+	controllerUUID string
+
+	mu           sync.Mutex
+	loginMessage *message
+	requests     map[uint64]*message
+}
+
+func newInflightTracker() *inflightTracker {
+	return &inflightTracker{requests: make(map[uint64]*message)}
+}
+
+func (tracker *inflightTracker) setControllerUUID(uuid string) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	tracker.controllerUUID = uuid
+}
+
+func (tracker *inflightTracker) controllerID() string {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	return tracker.controllerUUID
+}
+
+func (tracker *inflightTracker) rememberLogin(msg *message) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	tracker.loginMessage = msg
+}
+
+func (tracker *inflightTracker) login() *message {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	return tracker.loginMessage
+}
+
+func (tracker *inflightTracker) track(msg *message) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	msg.start = time.Now()
+	tracker.requests[msg.RequestID] = msg
+}
+
+func (tracker *inflightTracker) request(requestID uint64) *message {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	msg, ok := tracker.requests[requestID]
+	if !ok {
+		return nil
+	}
+	return msg
+}
+
+// finish deletes the request message that corresponds to the response message ID.
+func (tracker *inflightTracker) finish(requestID uint64) {
+	tracker.mu.Lock()
+	req, ok := tracker.requests[requestID]
+	if ok {
+		delete(tracker.requests, requestID)
+	}
+	controllerUUID := tracker.controllerUUID
+	tracker.mu.Unlock()
+
+	if ok {
+		servermon.JujuCallDurationHistogram.WithLabelValues(
+			req.Type,
+			req.Request,
+			controllerUUID,
+		).Observe(time.Since(req.start).Seconds())
+	}
+}

--- a/internal/rpcproxy/lifecycle.go
+++ b/internal/rpcproxy/lifecycle.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Canonical.
+
+package rpcproxy
+
+import (
+	"context"
+
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/utils"
+)
+
+type proxySession struct {
+	clientConn WebsocketConnection
+	proxy      *clientProxy
+	errChan    chan error
+}
+
+func newProxySession(helpers ProxyHelpers) (*proxySession, error) {
+	if err := helpers.validate(); err != nil {
+		return nil, err
+	}
+
+	errChan := make(chan error, 2)
+	tracker := newInflightTracker()
+	client := &writeLockConn{conn: helpers.ConnClient}
+	proxy := &clientProxy{
+		modelProxy: modelProxy{
+			src:                     client,
+			inflight:                tracker,
+			tokenGen:                helpers.TokenGen,
+			auditLog:                helpers.AuditLog,
+			conversationId:          utils.NewConversationID(),
+			loginService:            helpers.LoginService,
+			authenticatedIdentityID: helpers.AuthenticatedIdentityID,
+			redirectInfo:            helpers.RedirectInfo,
+		},
+		errChan:              errChan,
+		createControllerConn: helpers.ConnectController,
+	}
+
+	return &proxySession{
+		clientConn: helpers.ConnClient,
+		proxy:      proxy,
+		errChan:    errChan,
+	}, nil
+}
+
+func (session *proxySession) run(ctx context.Context) error {
+	session.proxy.wg.Go(func() {
+		session.errChan <- session.proxy.start(ctx)
+	})
+
+	err := session.wait(ctx)
+	// Close the client connection to ensure everything is cleaned up.
+	// Normally the client would do this but we also do it here in case the
+	// connection to the controller fails and we want to trigger cleanup.
+	session.clientConn.Close()
+	session.proxy.wg.Wait()
+	return err
+}
+
+func (session *proxySession) wait(ctx context.Context) error {
+	select {
+	case err := <-session.errChan:
+		if err != nil {
+			zapctx.Debug(ctx, "Proxy error", zap.Error(err))
+		}
+		return err
+	case <-ctx.Done():
+		zapctx.Debug(ctx, "Context cancelled")
+		return errors.New("Context cancelled")
+	}
+}
+
+func (helpers ProxyHelpers) validate() error {
+	if helpers.ConnectController == nil {
+		return errors.New("missing controller connect function")
+	}
+	if helpers.AuditLog == nil {
+		return errors.New("missing audit log function")
+	}
+	if helpers.LoginService == nil {
+		return errors.New("missing login service function")
+	}
+	if helpers.RedirectInfo == nil {
+		return errors.New("missing redirect info function")
+	}
+	return nil
+}

--- a/internal/rpcproxy/login_dispatch.go
+++ b/internal/rpcproxy/login_dispatch.go
@@ -1,0 +1,187 @@
+// Copyright 2025 Canonical.
+
+package rpcproxy
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/juju/juju/api"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v5"
+	"github.com/juju/zaputil/zapctx"
+	"go.uber.org/zap"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+// adminLoginDispatcher isolates Admin facade login handling from the proxy loop.
+type adminLoginDispatcher struct {
+	proxy *clientProxy
+}
+
+func newAdminLoginDispatcher(proxy *clientProxy) adminLoginDispatcher {
+	return adminLoginDispatcher{proxy: proxy}
+}
+
+// handle processes the admin facade call and returns:
+// a message to be returned to the source
+// a message to be sent to the destination
+// an error
+func (h adminLoginDispatcher) handle(ctx context.Context, msg *message) (clientResponse *message, controllerMessage *message, err error) {
+	errorFnc := func(err error) (*message, *message, error) {
+		return nil, nil, err
+	}
+	controllerLoginMessageFnc := func(user *openfga.User) (*message, *message, error) {
+		jwt, err := h.proxy.tokenGen.MakeLoginToken(ctx, user)
+		if err != nil {
+			return errorFnc(err)
+		}
+		data, err := json.Marshal(jujuparams.LoginRequest{
+			AuthTag: names.NewUserTag(user.Name).String(),
+			Token:   base64.StdEncoding.EncodeToString(jwt),
+		})
+		if err != nil {
+			return errorFnc(err)
+		}
+		m := *msg
+		m.Type = "Admin"
+		m.Request = "Login"
+		m.Version = 3
+		m.Params = data
+		return nil, &m, nil
+	}
+
+	switch msg.Request {
+	case "LoginDevice":
+		deviceResponse, err := h.proxy.loginService.LoginDevice(ctx)
+		if err != nil {
+			return errorFnc(err)
+		}
+		h.proxy.deviceOAuthResponse = deviceResponse
+
+		data, err := json.Marshal(apiparams.LoginDeviceResponse{
+			VerificationURI: deviceResponse.VerificationURI,
+			UserCode:        deviceResponse.UserCode,
+		})
+		if err != nil {
+			return errorFnc(err)
+		}
+		msg.Response = data
+		return msg, nil, nil
+	case "GetDeviceSessionToken":
+		sessionToken, err := h.proxy.loginService.GetDeviceSessionToken(ctx, h.proxy.deviceOAuthResponse)
+		if err != nil {
+			return errorFnc(err)
+		}
+		// #nosec G117 session token is sensitive but the data object is not logged.
+		data, err := json.Marshal(apiparams.GetDeviceSessionTokenResponse{
+			SessionToken: sessionToken,
+		})
+		if err != nil {
+			return errorFnc(err)
+		}
+		msg.Response = data
+		return msg, nil, nil
+	case "LoginWithSessionToken":
+		var request apiparams.LoginWithSessionTokenRequest
+		err := json.Unmarshal(msg.Params, &request)
+		if err != nil {
+			return errorFnc(err)
+		}
+
+		user, err := h.proxy.loginService.LoginWithSessionToken(ctx, request.SessionToken)
+		if err != nil {
+			return errorFnc(err)
+		}
+
+		return controllerLoginMessageFnc(user)
+	case "LoginWithClientCredentials":
+		var request apiparams.LoginWithClientCredentialsRequest
+		err := json.Unmarshal(msg.Params, &request)
+		if err != nil {
+			return errorFnc(err)
+		}
+		user, err := h.proxy.loginService.LoginClientCredentials(ctx, request.ClientID, request.ClientSecret)
+		if err != nil {
+			return errorFnc(err)
+		}
+
+		return controllerLoginMessageFnc(user)
+	case "LoginWithSessionCookie":
+		user, err := h.proxy.loginService.LoginWithSessionCookie(ctx, h.proxy.authenticatedIdentityID)
+		if err != nil {
+			return errorFnc(err)
+		}
+
+		return controllerLoginMessageFnc(user)
+	case "Login":
+		controllerMessage, err := h.handleLegacyLogin(ctx, msg)
+		return nil, controllerMessage, err
+	default:
+		return nil, nil, nil
+	}
+}
+
+// handleLegacyLogin handles old style username+password/macaroon login
+// requests and decides what to do based on the client's auth tag.
+//
+// If the request is an "anonymous login" request (i.e., the auth tag is
+// api.AnonymousUsername), it sets the anonymousLogin flag to true and returns
+// the message verbatim to the controller, allowing it to handle the login.
+// This supports login from a Juju controller during model migration.
+//
+// If the auth tag is a non-user entity e.g. a machine/unit then we return
+// a redirect to the backing Juju controller. This is also used for model migrations
+// but specifically for directing agents to speak to the backing Juju controller.
+//
+// Legacy login requests from users (i.e., those with a user tag) are not supported
+// in JIMM and will return an error.
+func (h adminLoginDispatcher) handleLegacyLogin(ctx context.Context, msg *message) (*message, error) {
+	var request jujuparams.LoginRequest
+	err := json.Unmarshal(msg.Params, &request)
+	if err != nil {
+		return nil, err
+	}
+	tag, err := names.ParseTag(request.AuthTag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user tag: %v", err)
+	}
+	switch tag := tag.(type) {
+	case names.UserTag:
+		if tag.Id() == api.AnonymousUsername {
+			h.proxy.anonymousLogin = true
+			// return the client's login message verbatim to the controller.
+			return msg, nil
+		}
+		return nil, errors.Codef(errors.CodeNotSupported, "JIMM does not support login from old clients")
+	case names.ModelTag, names.MachineTag, names.UnitTag:
+		zapctx.Debug(ctx, "Legacy login request from agent", zap.String("tag", tag.String()))
+
+		redirectInfo, err := h.proxy.redirectInfo.GetRedirectInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get redirect info: %w", err)
+		}
+
+		// This is a legacy login request from an agent.
+		// We return a redirect to the backing Juju controller.
+		info := jujuparams.RedirectErrorInfo{
+			Servers: redirectInfo.Addresses,
+			CACert:  redirectInfo.CACert,
+		}.AsMap()
+		errRedirect := &errors.Error{
+			Code:    errors.CodeRedirect,
+			Message: "redirection to alternative server required",
+			Info:    info,
+		}
+
+		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Addresses))
+		return nil, errRedirect
+	default:
+		return nil, fmt.Errorf("unsupported login request for tag %s", tag)
+	}
+}

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	accessRequiredErrorCode = "access required"
-	unauthorizedErrorCode   = "unauthorized"
 )
 
 // ControllerDetails holds information about the controller

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/servermon"
-	"github.com/canonical/jimm/v3/internal/utils"
 )
 
 const (
@@ -107,57 +106,11 @@ type ProxyHelpers struct {
 // tokenGen is used to authenticate the user and generate JWT token.
 // connectController provides the function to return a connection to the desired controller endpoint.
 func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
-
-	if helpers.ConnectController == nil {
-		return errors.New("missing controller connect function")
+	session, err := newProxySession(helpers)
+	if err != nil {
+		return err
 	}
-	if helpers.AuditLog == nil {
-		return errors.New("missing audit log function")
-	}
-	if helpers.LoginService == nil {
-		return errors.New("missing login service function")
-	}
-	if helpers.RedirectInfo == nil {
-		return errors.New("missing redirect info function")
-	}
-	errChan := make(chan error, 2)
-	msgInFlight := inflightMsgs{messages: make(map[uint64]*message)}
-	client := writeLockConn{conn: helpers.ConnClient}
-	// Note that the clProxy start method will create the connection to the desired controller only
-	// after the first message has been received so that any errors can be properly sent back to the client.
-	clProxy := clientProxy{
-		modelProxy: modelProxy{
-			src:                     &client,
-			msgs:                    &msgInFlight,
-			tokenGen:                helpers.TokenGen,
-			auditLog:                helpers.AuditLog,
-			conversationId:          utils.NewConversationID(),
-			loginService:            helpers.LoginService,
-			authenticatedIdentityID: helpers.AuthenticatedIdentityID,
-			redirectInfo:            helpers.RedirectInfo,
-		},
-		errChan:              errChan,
-		createControllerConn: helpers.ConnectController,
-	}
-	clProxy.wg.Go(func() {
-		errChan <- clProxy.start(ctx)
-	})
-	var err error
-	select {
-	case err = <-errChan:
-		if err != nil {
-			zapctx.Debug(ctx, "Proxy error", zap.Error(err))
-		}
-	case <-ctx.Done():
-		err = errors.New("Context cancelled")
-		zapctx.Debug(ctx, "Context cancelled")
-	}
-	// Close the client connection to ensure everything is cleaned up.
-	// Normally the client would do this but we also do it here in case the
-	// connection to the controller fails and we want to trigger cleanup.
-	helpers.ConnClient.Close()
-	clProxy.wg.Wait()
-	return err
+	return session.run(ctx)
 }
 
 // writeLockConn provides a websocket connection that is safe for concurrent writes.
@@ -198,71 +151,10 @@ func (c *writeLockConn) sendMessage(responseObject any, request *message) {
 	}
 }
 
-// inflightMsgs holds only request messages that are
-// still pending a response from a Juju controller.
-type inflightMsgs struct {
-	controllerUUID string
-
-	mu           sync.Mutex
-	loginMessage *message
-	messages     map[uint64]*message
-}
-
-func (msgs *inflightMsgs) addLoginMessage(msg *message) {
-	msgs.mu.Lock()
-	defer msgs.mu.Unlock()
-
-	msgs.loginMessage = msg
-}
-
-func (msgs *inflightMsgs) getLoginMessage() *message {
-	msgs.mu.Lock()
-	defer msgs.mu.Unlock()
-
-	return msgs.loginMessage
-}
-
-func (msgs *inflightMsgs) addMessage(msg *message) {
-	msgs.mu.Lock()
-	defer msgs.mu.Unlock()
-
-	msg.start = time.Now()
-	msgs.messages[msg.RequestID] = msg
-}
-
-// removeMessage deletes the request message that corresponds
-// to the responses message ID.
-func (msgs *inflightMsgs) removeMessage(msgID uint64) {
-	msgs.mu.Lock()
-	req, ok := msgs.messages[msgID]
-	if ok {
-		delete(msgs.messages, msgID)
-	}
-	msgs.mu.Unlock()
-
-	if ok {
-		servermon.JujuCallDurationHistogram.WithLabelValues(
-			req.Type,
-			req.Request,
-			msgs.controllerUUID,
-		).Observe(time.Since(req.start).Seconds())
-	}
-}
-
-func (msgs *inflightMsgs) getMessage(key uint64) *message {
-	msgs.mu.Lock()
-	defer msgs.mu.Unlock()
-	msg, ok := msgs.messages[key]
-	if !ok {
-		return nil
-	}
-	return msg
-}
-
 type modelProxy struct {
 	src                     *writeLockConn
 	dst                     *writeLockConn
-	msgs                    *inflightMsgs
+	inflight                *inflightTracker
 	anonymousLogin          bool // anonymousLogin is true if the client is not authenticated.
 	auditLog                func(*dbmodel.AuditLogEntry)
 	tokenGen                TokenGenerator
@@ -296,7 +188,7 @@ func (p *modelProxy) sendError(ctx context.Context, socket *writeLockConn, req *
 		}
 	}
 	// An error message is a response back to the client.
-	servermon.JujuCallErrorCount.WithLabelValues(req.Type, req.Request, p.msgs.controllerUUID)
+	servermon.JujuCallErrorCount.WithLabelValues(req.Type, req.Request, p.inflight.controllerID())
 	if err := p.auditLogMessage(msg, true); err != nil {
 		zapctx.Error(context.Background(), "failed to audit log message", zap.Error(err))
 	}
@@ -413,14 +305,14 @@ func (p *clientProxy) start(ctx context.Context) error {
 				continue
 			} else if toController != nil {
 				msg = toController
-				p.msgs.addLoginMessage(toController)
+				p.inflight.rememberLogin(toController)
 			}
 		}
-		p.msgs.addMessage(msg)
+		p.inflight.track(msg)
 		if err := p.dst.writeJson(msg); err != nil {
 			zapctx.Error(ctx, "clientProxy error writing to dst", zap.Error(err))
 			p.sendError(ctx, p.src, msg, err)
-			p.msgs.removeMessage(msg.RequestID)
+			p.inflight.finish(msg.RequestID)
 			continue
 		}
 	}
@@ -429,38 +321,45 @@ func (p *clientProxy) start(ctx context.Context) error {
 // makeControllerConnection dials a controller and starts a go routine for
 // proxying requests from the controller to the client.
 func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
-
 	var createConnErr error
 	// Create the controller connection once.
 	p.connectController.Do(func() {
-		connWithMetadata, err := p.createControllerConn(ctx)
-		if err != nil {
-			createConnErr = err
-			return
-		}
-
-		p.msgs.controllerUUID = connWithMetadata.ControllerUUID
-		p.modelName = connWithMetadata.ModelName
-		p.modelUUID = connWithMetadata.ModelUUID
-		p.modelMigrationMode = connWithMetadata.MigrationMode
-		p.dst = &writeLockConn{conn: connWithMetadata.Conn}
-		controllerToClient := controllerProxy{
-			modelProxy: modelProxy{
-				src:                p.dst,
-				dst:                p.src,
-				msgs:               p.msgs,
-				auditLog:           p.auditLog,
-				tokenGen:           p.tokenGen,
-				modelName:          p.modelName,
-				conversationId:     p.conversationId,
-				modelMigrationMode: p.modelMigrationMode,
-			},
-		}
-		p.wg.Go(func() {
-			p.errChan <- controllerToClient.start(ctx)
-		})
+		createConnErr = p.attachController(ctx)
 	})
 	return createConnErr
+}
+
+func (p *clientProxy) attachController(ctx context.Context) error {
+	connWithMetadata, err := p.createControllerConn(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.inflight.setControllerUUID(connWithMetadata.ControllerUUID)
+	p.modelName = connWithMetadata.ModelName
+	p.modelUUID = connWithMetadata.ModelUUID
+	p.modelMigrationMode = connWithMetadata.MigrationMode
+	p.dst = &writeLockConn{conn: connWithMetadata.Conn}
+	p.startControllerProxy(ctx)
+	return nil
+}
+
+func (p *clientProxy) startControllerProxy(ctx context.Context) {
+	controllerToClient := controllerProxy{
+		modelProxy: modelProxy{
+			src:                p.dst,
+			dst:                p.src,
+			inflight:           p.inflight,
+			auditLog:           p.auditLog,
+			tokenGen:           p.tokenGen,
+			modelName:          p.modelName,
+			conversationId:     p.conversationId,
+			modelMigrationMode: p.modelMigrationMode,
+		},
+	}
+	p.wg.Go(func() {
+		p.errChan <- controllerToClient.start(ctx)
+	})
 }
 
 // controllerProxy proxies messages from controller->client with the caveat that

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -7,14 +7,12 @@ package rpcproxy
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/juju/juju/api"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
@@ -27,7 +25,6 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/servermon"
 	"github.com/canonical/jimm/v3/internal/utils"
-	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
 )
 
 const (
@@ -370,6 +367,7 @@ type clientProxy struct {
 
 // start begins the client->controller proxier.
 func (p *clientProxy) start(ctx context.Context) error {
+	loginDispatcher := newAdminLoginDispatcher(p)
 	defer func() {
 		if p.dst != nil {
 			p.dst.conn.Close()
@@ -402,7 +400,7 @@ func (p *clientProxy) start(ctx context.Context) error {
 		// All requests should be proxied as transparently as possible through to the controller
 		// except for auth related requests like Login because JIMM is auth gateway.
 		if msg.Type == "Admin" {
-			toClient, toController, err := p.handleAdminFacade(ctx, msg)
+			toClient, toController, err := loginDispatcher.handle(ctx, msg)
 			if err != nil {
 				p.sendError(ctx, p.src, msg, err)
 				continue
@@ -473,6 +471,7 @@ type controllerProxy struct {
 
 // start implements the controller->client proxier.
 func (p *controllerProxy) start(ctx context.Context) error {
+	responseHandler := newControllerResponseHandler(p)
 	for {
 		msg := new(message)
 		if err := p.src.readJson(msg); err != nil {
@@ -483,177 +482,10 @@ func (p *controllerProxy) start(ctx context.Context) error {
 			return nil
 		}
 
-		returnMsgToClient := p.processControllerErrors(ctx, msg)
-		if !returnMsgToClient {
-			continue
-		}
-
-		if err := modifyControllerResponse(msg); err != nil {
-			zapctx.Error(ctx, "Failed to modify message", zap.Error(err))
-			p.handleError(ctx, msg, err)
-			// An error when modifying the message is a show stopper.
-			return fmt.Errorf("error modifying controller response: %w", err)
-		}
-		p.msgs.removeMessage(msg.RequestID)
-		if err := p.auditLogMessage(msg, true); err != nil {
-			zapctx.Error(context.Background(), "failed to audit log message", zap.Error(err))
-		}
-		if err := p.dst.writeJson(msg); err != nil {
-			zapctx.Error(ctx, "controllerProxy error writing to dst", zap.Error(err))
-			return fmt.Errorf("error writing message to client: %w", err)
+		if err := responseHandler.handle(ctx, msg); err != nil {
+			return err
 		}
 	}
-}
-
-// processControllerErrors checks for errors in the message from the controller
-// and decides how to handle them. It returns true if the message should be
-// returned to the client, false if it should not.
-func (p *controllerProxy) processControllerErrors(ctx context.Context, msg *message) bool {
-
-	// Check if the model is migrating. When it has completed its migration, we will receive
-	// an unauthorized error from the controller and we want to mask that error and inform
-	// clients to try again as JIMM will eventually update the model's controller.
-	// See internal/jimm/juju/model_poller.go.
-	modelMigrating := p.modelMigrationMode == dbmodel.MigrationModeMigrateInternal || p.modelMigrationMode == dbmodel.MigrationModeExporting
-	if modelMigrating && msg.ErrorCode == string(errors.CodeUnauthorized) {
-		msg.ErrorCode = string(errors.CodeModelMigrating)
-		msg.Error = "model is finishing migration, please retry later"
-		return true
-	}
-
-	// Next we check for permission required errors where the Juju controller is informing us
-	// that the user needs more permissions to perform the requested operation.
-	// If so, we attempt to redo the login with the required permissions (if the user has them)
-	// and then resend the original login request.
-	//
-	// It's ideally unlikely we'll hit this code path often because JIMM sets a broad scope
-	// of permissions on the initial login request.
-	permissionsRequired, err := checkPermissionsRequired(ctx, msg)
-	if err != nil {
-		zapctx.Error(ctx, "failed to determine if more permissions required", zap.Error(err))
-		p.handleError(ctx, msg, err)
-		return false
-	}
-	if permissionsRequired != nil {
-		zapctx.Error(ctx, "Access Required error")
-		if err := p.redoLogin(ctx, permissionsRequired); err != nil {
-			zapctx.Error(ctx, "Failed to redo login", zap.Error(err))
-			p.handleError(ctx, msg, err)
-			return false
-		}
-		// Write back to the controller.
-		msg := p.msgs.getMessage(msg.RequestID)
-		if msg != nil {
-			if err := p.src.writeJson(msg); err != nil {
-				zapctx.Error(context.Background(), "failed to write back to controller", zap.Error(err))
-			}
-		}
-		return false
-	}
-	return true
-}
-
-func (p *controllerProxy) handleError(ctx context.Context, msg *message, err error) {
-	p.sendError(ctx, p.dst, msg, err)
-	p.msgs.removeMessage(msg.RequestID)
-}
-
-// checkPermissionsRequired returns a nil map if no permissions are required.
-func checkPermissionsRequired(ctx context.Context, msg *message) (map[string]any, error) {
-	// Instantiate later because we won't always need the map.
-	var permissionMap map[string]any
-
-	// Check for errors that may be a result of a normal request.
-	if msg.ErrorCode == accessRequiredErrorCode {
-		permissionMap = msg.ErrorInfo
-		return permissionMap, nil
-	}
-
-	// if the message response is empty, this is clearly not a permission
-	// check required error and we return an empty map of required
-	// permissions
-	if msg.Response == nil || string(msg.Response) == "" {
-		return permissionMap, nil
-	}
-
-	var er jujuparams.ErrorResults
-	err := json.Unmarshal(msg.Response, &er)
-	if err != nil {
-		zapctx.Error(ctx, "failed to read response error", zap.Error(err))
-		return permissionMap, nil
-	}
-
-	// Check for errors that may be a result of a bulk request.
-	for _, e := range er.Results {
-		if e.Error != nil && e.Error.Code == accessRequiredErrorCode {
-			zapctx.Debug(ctx, "received error", zap.Any("error", e.Error))
-			for k, v := range e.Error.Info {
-				accessLevel, ok := v.(string)
-				if !ok {
-					return nil, errors.New("unknown permission level")
-				}
-				if permissionMap == nil {
-					permissionMap = make(map[string]any)
-				}
-				permissionMap[k] = accessLevel
-			}
-		}
-	}
-	return permissionMap, nil
-}
-
-// redoLogin sends a new login request to the controller after checking for
-// the provided permissions. This is sometimes necessary if Juju requires
-// extra permission checks for an operation. If the client performed anonymous
-// login, an error is always returned since we cannot authorize an anonymous user.
-func (p *controllerProxy) redoLogin(ctx context.Context, permissions map[string]any) error {
-
-	if p.anonymousLogin {
-		return errors.Codef(errors.CodeUnauthorized, "Anonymous login does not support re-authentication")
-	}
-	loginMsg := p.msgs.getLoginMessage()
-	if loginMsg == nil {
-		return errors.Codef(errors.CodeUnauthorized, "Haven't received login yet")
-	}
-	err := addJWT(ctx, loginMsg, permissions, p.tokenGen)
-	if err != nil {
-		return err
-	}
-	zapctx.Info(ctx, "Performing new login", zap.Any("message", loginMsg))
-	if err := p.src.writeJson(loginMsg); err != nil {
-		return err
-	}
-	return nil
-}
-
-// addJWT adds a JWT token to the the provided message.
-func addJWT(ctx context.Context, msg *message, permissions map[string]any, tokenGen TokenGenerator) error {
-
-	// First we unmarshal the existing LoginRequest.
-	if msg == nil {
-		return errors.New("nil messsage")
-	}
-	var lr jujuparams.LoginRequest
-	if err := json.Unmarshal(msg.Params, &lr); err != nil {
-		return err
-	}
-
-	jwt, err := tokenGen.MakeToken(ctx, permissions)
-	if err != nil {
-		return err
-	}
-
-	jwtString := base64.StdEncoding.EncodeToString(jwt)
-	// Add the JWT as base64 encoded string.
-	lr.Token = jwtString
-	// Marshal it again to JSON.
-	data, err := json.Marshal(lr)
-	if err != nil {
-		return err
-	}
-	// And add it to the message.
-	msg.Params = data
-	return nil
 }
 
 func createErrResponse(err error, req *message) *message {
@@ -663,177 +495,4 @@ func createErrResponse(err error, req *message) *message {
 	errMsg.Error = err.Error()
 	errMsg.ErrorCode = string(errors.ErrorCode(err))
 	return errMsg
-}
-
-func modifyControllerResponse(msg *message) error {
-	var response map[string]any
-	err := json.Unmarshal(msg.Response, &response)
-	if err != nil {
-		return err
-	}
-	// Delete servers block so that juju clients don't get redirected.
-	delete(response, "servers")
-	newResp, err := json.Marshal(response)
-	if err != nil {
-		return err
-	}
-	msg.Response = newResp
-	return nil
-}
-
-// handleAdminFacade processes the admin facade call and returns:
-// a message to be returned to the source
-// a message to be sent to the destination
-// an error
-func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clientResponse *message, controllerMessage *message, err error) {
-	errorFnc := func(err error) (*message, *message, error) {
-		return nil, nil, err
-	}
-	controllerLoginMessageFnc := func(user *openfga.User) (*message, *message, error) {
-		jwt, err := p.tokenGen.MakeLoginToken(ctx, user)
-		if err != nil {
-			return errorFnc(err)
-		}
-		data, err := json.Marshal(jujuparams.LoginRequest{
-			AuthTag: names.NewUserTag(user.Name).String(),
-			Token:   base64.StdEncoding.EncodeToString(jwt),
-		})
-		if err != nil {
-			return errorFnc(err)
-		}
-		m := *msg
-		m.Type = "Admin"
-		m.Request = "Login"
-		m.Version = 3
-		m.Params = data
-		return nil, &m, nil
-	}
-	switch msg.Request {
-	case "LoginDevice":
-		deviceResponse, err := p.loginService.LoginDevice(ctx)
-		if err != nil {
-			return errorFnc(err)
-		}
-		p.deviceOAuthResponse = deviceResponse
-
-		data, err := json.Marshal(apiparams.LoginDeviceResponse{
-			VerificationURI: deviceResponse.VerificationURI,
-			UserCode:        deviceResponse.UserCode,
-		})
-		if err != nil {
-			return errorFnc(err)
-		}
-		msg.Response = data
-		return msg, nil, nil
-	case "GetDeviceSessionToken":
-		sessionToken, err := p.loginService.GetDeviceSessionToken(ctx, p.deviceOAuthResponse)
-		if err != nil {
-			return errorFnc(err)
-		}
-		// #nosec G117 session token is sensitive but the data object is not logged.
-		data, err := json.Marshal(apiparams.GetDeviceSessionTokenResponse{
-			SessionToken: sessionToken,
-		})
-		if err != nil {
-			return errorFnc(err)
-		}
-		msg.Response = data
-		return msg, nil, nil
-	case "LoginWithSessionToken":
-		var request apiparams.LoginWithSessionTokenRequest
-		err := json.Unmarshal(msg.Params, &request)
-		if err != nil {
-			return errorFnc(err)
-		}
-
-		user, err := p.loginService.LoginWithSessionToken(ctx, request.SessionToken)
-		if err != nil {
-			return errorFnc(err)
-		}
-
-		return controllerLoginMessageFnc(user)
-	case "LoginWithClientCredentials":
-		var request apiparams.LoginWithClientCredentialsRequest
-		err := json.Unmarshal(msg.Params, &request)
-		if err != nil {
-			return errorFnc(err)
-		}
-		user, err := p.loginService.LoginClientCredentials(ctx, request.ClientID, request.ClientSecret)
-		if err != nil {
-			return errorFnc(err)
-		}
-
-		return controllerLoginMessageFnc(user)
-	case "LoginWithSessionCookie":
-		user, err := p.loginService.LoginWithSessionCookie(ctx, p.authenticatedIdentityID)
-		if err != nil {
-			return errorFnc(err)
-		}
-
-		return controllerLoginMessageFnc(user)
-	case "Login":
-		controllerMessage, err := p.handleLegacyLogin(ctx, msg)
-		return nil, controllerMessage, err
-	default:
-		return nil, nil, nil
-	}
-}
-
-// handleLegacyLogin handles old style username+password/macaroon login
-// requests and decides what to do based on the client's auth tag.
-//
-// If the request is an "anonymous login" request (i.e., the auth tag is
-// api.AnonymousUsername), it sets the anonymousLogin flag to true and returns
-// the message verbatim to the controller, allowing it to handle the login.
-// This supports login from a Juju controller during model migration.
-//
-// If the auth tag is a non-user entity e.g. a machine/unit then we return
-// a redirect to the backing Juju controller. This is also used for model migrations
-// but specifically for directing agents to speak to the backing Juju controller.
-//
-// Legacy login requests from users (i.e., those with a user tag) are not supported
-// in JIMM and will return an error.
-func (p *clientProxy) handleLegacyLogin(ctx context.Context, msg *message) (*message, error) {
-	var request jujuparams.LoginRequest
-	err := json.Unmarshal(msg.Params, &request)
-	if err != nil {
-		return nil, err
-	}
-	tag, err := names.ParseTag(request.AuthTag)
-	if err != nil {
-		return nil, fmt.Errorf("invalid user tag: %v", err)
-	}
-	switch tag := tag.(type) {
-	case names.UserTag:
-		if tag.Id() == api.AnonymousUsername {
-			p.anonymousLogin = true
-			// return the client's login message verbatim to the controller.
-			return msg, nil
-		}
-		return nil, errors.Codef(errors.CodeNotSupported, "JIMM does not support login from old clients")
-	case names.ModelTag, names.MachineTag, names.UnitTag:
-		zapctx.Debug(ctx, "Legacy login request from agent", zap.String("tag", tag.String()))
-
-		redirectInfo, err := p.redirectInfo.GetRedirectInfo(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get redirect info: %w", err)
-		}
-
-		// This is a legacy login request from an agent.
-		// We return a redirect to the backing Juju controller.
-		info := jujuparams.RedirectErrorInfo{
-			Servers: redirectInfo.Addresses,
-			CACert:  redirectInfo.CACert,
-		}.AsMap()
-		errRedirect := &errors.Error{
-			Code:    errors.CodeRedirect,
-			Message: "redirection to alternative server required",
-			Info:    info,
-		}
-
-		zapctx.Debug(ctx, "Redirecting agent to controller", zap.Any("servers", redirectInfo.Addresses))
-		return nil, errRedirect
-	default:
-		return nil, fmt.Errorf("unsupported login request for tag %s", tag)
-	}
 }


### PR DESCRIPTION
## Description
The internal/rpcproxy/rpcproxy.go file was becoming a bit lengthy, reaching over 800 lines, but more critically packing a lot of logic into one file. This PR splits things up into several files.
- controller_response.go handles logic for modifying the backing controller response and handles access required errors which require redoing login. We also add tests for two pieces of logic which were not tested before from what I could tell.
- inflight.go extracts the `inflightMsgs` struct into a new file and does some renaming.
- lifecycle.go extracts the logic that was validating params and creating the proxy.
- login_dispatch.go handles the login logic within the model proxy between the client -> JIMM.
- rpcproxy.go the original file, contains mostly removals.

The change is not particularly significant, in the sense that I didn't do any design/architectural changes. If we want to do a larger refactoring with a specific design goal then this change may be unnecessary so I have marked it as a draft and we can discuss. The additional test coverage is nice and the decreased concentration of logic in the single file is a minor positive imo.

I've also targetted the v3 branch but the change will be identical in the v4 branch.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests