### PR TITLE
feat(jujuapi): serve ModelManager v10 for Juju 3.6 clients

### DIFF
--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -14,7 +14,7 @@ var SupportedFacadeVersions = map[string][]int{
 	"JIMM":                []int{4},
 	"MigrationTarget":     []int{6},
 	"ModelConfig":         []int{4},
-	"ModelManager":        []int{11},
+	"ModelManager":        []int{10, 11},
 	"ModelSummaryWatcher": []int{1},
 	"ModelUpgrader":       []int{1},
 	"Pinger":              []int{1},

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jujuapi/params36"
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/servermon"
@@ -37,6 +38,32 @@ func init() {
 		unsetModelDefaultsMethod := rpc.Method(r.UnsetModelDefaults)
 		modelDefaultsForCloudsMethod := rpc.Method(r.ModelDefaultsForClouds)
 
+		// v10 (Juju 3.6) legacy handlers for the methods whose wire format
+		// changed (owner-tag -> qualifier). The remaining methods are
+		// wire-identical and reuse the v11 handlers above.
+		createModelLegacyMethod := rpc.Method(r.CreateModelLegacy)
+		listModelSummariesLegacyMethod := rpc.Method(r.ListModelSummariesLegacy)
+		listModelsLegacyMethod := rpc.Method(r.ListModelsLegacy)
+		modelInfoLegacyMethod := rpc.Method(r.ModelInfoLegacy)
+		modelStatusLegacyMethod := rpc.Method(r.ModelStatusLegacy)
+
+		// ModelManager facade version 10 (Juju 3.6 clients).
+		r.AddMethod("ModelManager", 10, "ChangeModelCredential", changeModelCredentialMethod)
+		r.AddMethod("ModelManager", 10, "CreateModel", createModelLegacyMethod)
+		r.AddMethod("ModelManager", 10, "DestroyModels", destroyModelsMethod)
+		r.AddMethod("ModelManager", 10, "DumpModels", dumpModelsMethod)
+		r.AddMethod("ModelManager", 10, "DumpModelsDB", dumpModelsDBMethod)
+		r.AddMethod("ModelManager", 10, "ListModelSummaries", listModelSummariesLegacyMethod)
+		r.AddMethod("ModelManager", 10, "ListModels", listModelsLegacyMethod)
+		r.AddMethod("ModelManager", 10, "ModelInfo", modelInfoLegacyMethod)
+		r.AddMethod("ModelManager", 10, "ModelStatus", modelStatusLegacyMethod)
+		r.AddMethod("ModelManager", 10, "ModifyModelAccess", modifyModelAccessMethod)
+		r.AddMethod("ModelManager", 10, "ValidateModelUpgrades", validateModelUpgradesMethod)
+		r.AddMethod("ModelManager", 10, "SetModelDefaults", setModelDefaultsMethod)
+		r.AddMethod("ModelManager", 10, "UnsetModelDefaults", unsetModelDefaultsMethod)
+		r.AddMethod("ModelManager", 10, "ModelDefaultsForClouds", modelDefaultsForCloudsMethod)
+
+		// ModelManager facade version 11 (Juju 4.x clients).
 		r.AddMethod("ModelManager", 11, "ChangeModelCredential", changeModelCredentialMethod)
 		r.AddMethod("ModelManager", 11, "CreateModel", createModelMethod)
 		r.AddMethod("ModelManager", 11, "DestroyModels", destroyModelsMethod)
@@ -52,7 +79,7 @@ func init() {
 		r.AddMethod("ModelManager", 11, "UnsetModelDefaults", unsetModelDefaultsMethod)
 		r.AddMethod("ModelManager", 11, "ModelDefaultsForClouds", modelDefaultsForCloudsMethod)
 
-		return []int{11}
+		return []int{10, 11}
 	}
 }
 
@@ -413,3 +440,69 @@ func (r *controllerRoot) ModelDefaultsForClouds(ctx context.Context, args jujupa
 }
 
 // TODO (ashipika) Implement ModelDefaults - need to determine which cloud this would refer to.
+
+// The methods below are the ModelManager facade version 10 (Juju 3.6) handlers
+// for the methods whose wire format changed at version 11 (the model
+// owner-tag -> qualifier rename). Each adapts the 3.6 owner-tag wire format to
+// the version 11 handler, reusing the same business logic, via the params36
+// conversion package. The "Legacy" suffix is version-agnostic so the same
+// handlers can be shared with other facades that pin to a 3.6 version (e.g. the
+// Controller facade's ModelStatus at version 12).
+
+// CreateModelLegacy implements the ModelManager facade version 10 CreateModel
+// method, which uses an owner tag instead of a model qualifier.
+func (r *controllerRoot) CreateModelLegacy(ctx context.Context, args jujuparams.ModelCreateArgsLegacy) (jujuparams.ModelInfoLegacy, error) {
+	// TODO(JAAS-6): a 3.6 client reaches CreateModel only via this version 10
+	// handler, so this is where the "place on a <=3 controller" constraint is
+	// set once version-aware placement lands.
+	currentArgs, err := params36.ModelCreateArgs(args)
+	if err != nil {
+		return jujuparams.ModelInfoLegacy{}, err
+	}
+	info, err := r.CreateModel(ctx, currentArgs)
+	if err != nil {
+		return jujuparams.ModelInfoLegacy{}, err
+	}
+	return params36.LegacyModelInfo(info)
+}
+
+// ModelInfoLegacy implements the ModelManager facade version 10 ModelInfo
+// method, which returns model owner tags instead of qualifiers.
+func (r *controllerRoot) ModelInfoLegacy(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelInfoResultsLegacy, error) {
+	results, err := r.ModelInfo(ctx, args)
+	if err != nil {
+		return jujuparams.ModelInfoResultsLegacy{}, err
+	}
+	return params36.LegacyModelInfoResults(results), nil
+}
+
+// ListModelsLegacy implements the ModelManager facade version 10 ListModels
+// method, which returns model owner tags instead of qualifiers.
+func (r *controllerRoot) ListModelsLegacy(ctx context.Context, arg jujuparams.Entity) (jujuparams.UserModelListLegacy, error) {
+	list, err := r.ListModels(ctx, arg)
+	if err != nil {
+		return jujuparams.UserModelListLegacy{}, err
+	}
+	return params36.LegacyUserModelList(list)
+}
+
+// ModelStatusLegacy implements the ModelManager facade version 10 ModelStatus
+// method, which returns model owner tags instead of qualifiers.
+func (r *controllerRoot) ModelStatusLegacy(ctx context.Context, args jujuparams.Entities) (jujuparams.ModelStatusResultsLegacy, error) {
+	results, err := r.ModelStatus(ctx, args)
+	if err != nil {
+		return jujuparams.ModelStatusResultsLegacy{}, err
+	}
+	return params36.LegacyModelStatusResults(results), nil
+}
+
+// ListModelSummariesLegacy implements the ModelManager facade version 10
+// ListModelSummaries method, which returns model owner tags instead of
+// qualifiers.
+func (r *controllerRoot) ListModelSummariesLegacy(ctx context.Context, req jujuparams.ModelSummariesRequest) (jujuparams.ModelSummaryResultsLegacy, error) {
+	results, err := r.ListModelSummaries(ctx, req)
+	if err != nil {
+		return jujuparams.ModelSummaryResultsLegacy{}, err
+	}
+	return params36.LegacyModelSummaryResults(results), nil
+}

--- a/internal/jujuapi/modelmanager_legacy_test.go
+++ b/internal/jujuapi/modelmanager_legacy_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/model"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/jujuclient"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+const testModelUUID = "00000000-0000-0000-0000-000000000001"
+
+// TestModelManagerAdvertisesLegacyAndCurrent asserts the ModelManager facade
+// advertises both the 3.6 (v10) and 4.x (v11) versions.
+func TestModelManagerAdvertisesLegacyAndCurrent(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(jujuapi.SupportedFacades()["ModelManager"], qt.DeepEquals, []int{10, 11})
+}
+
+// TestCreateModelLegacy checks that the v10 CreateModel handler accepts an
+// owner-tag request and returns an owner-tag response, reusing the v11 logic.
+func TestCreateModelLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	jujuManager := mocks.JujuManager{
+		ModelManager: mocks.ModelManager{
+			AddModel_: func(ctx context.Context, u *openfga.User, args *juju.ModelCreateArgs) (base.ModelInfo, error) {
+				// The owner tag must have been converted to a qualifier.
+				c.Check(args.Owner.Id(), qt.Equals, "alice@external")
+				return base.ModelInfo{
+					Name:            args.Name,
+					UUID:            testModelUUID,
+					Qualifier:       model.Qualifier("alice@external"),
+					Type:            model.IAAS,
+					Cloud:           "aws",
+					CloudRegion:     "eu-west-1",
+					CloudCredential: "aws/alice@external/cred",
+				}, nil
+			},
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	got, err := cr.CreateModelLegacy(context.Background(), jujuparams.ModelCreateArgsLegacy{
+		Name:     "mymodel",
+		OwnerTag: "user-alice@external",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Check(got.OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.Name, qt.Equals, "mymodel")
+	c.Check(got.UUID, qt.Equals, testModelUUID)
+}
+
+// TestListModelsLegacy checks the v10 ListModels handler returns owner tags.
+func TestListModelsLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	jujuManager := mocks.JujuManager{
+		ListModels_: func(ctx context.Context, user *openfga.User) ([]base.UserModel, error) {
+			return []base.UserModel{{
+				Name:      "mymodel",
+				UUID:      testModelUUID,
+				Qualifier: model.Qualifier("alice@external"),
+				Type:      model.IAAS,
+			}}, nil
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	got, err := cr.ListModelsLegacy(context.Background(), jujuparams.Entity{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.UserModels, qt.HasLen, 1)
+	c.Check(got.UserModels[0].OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.UserModels[0].Name, qt.Equals, "mymodel")
+	c.Check(got.UserModels[0].UUID, qt.Equals, testModelUUID)
+}
+
+// TestModelInfoLegacy checks the v10 ModelInfo handler returns owner tags.
+func TestModelInfoLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	mt := names.NewModelTag(testModelUUID)
+	jujuManager := mocks.JujuManager{
+		ModelManager: mocks.ModelManager{
+			ModelInfo_: func(ctx context.Context, u *openfga.User, gotTag names.ModelTag) (jujuclient.ModelInfo, error) {
+				c.Check(gotTag.String(), qt.Equals, mt.String())
+				return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{
+					Name:            "mymodel",
+					UUID:            testModelUUID,
+					Qualifier:       model.Qualifier("alice@external"),
+					Type:            model.IAAS,
+					Cloud:           "aws",
+					CloudRegion:     "eu-west-1",
+					CloudCredential: "aws/alice@external/cred",
+				}}, nil
+			},
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	got, err := cr.ModelInfoLegacy(context.Background(), jujuparams.Entities{
+		Entities: []jujuparams.Entity{{Tag: mt.String()}},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Results, qt.HasLen, 1)
+	c.Assert(got.Results[0].Result, qt.IsNotNil)
+	c.Check(got.Results[0].Result.OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.Results[0].Result.Name, qt.Equals, "mymodel")
+}
+
+// jujuJIMM wraps a JujuManager mock in a jimmtest.JIMM.
+func jujuJIMM(jm *mocks.JujuManager) *jimmtest.JIMM {
+	return &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return jm
+		},
+	}
+}

--- a/testing/modelmanager_legacy_test.go
+++ b/testing/modelmanager_legacy_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"strings"
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// These tests exercise the ModelManager facade version 10 (Juju 3.6) handlers
+// end to end against a real backing controller. A single Go module pins one
+// Juju version (4.x), so we cannot import a 3.6 API client; instead we make
+// hand-crafted version-pinned calls with conn.APICall and the juju 4.x
+// "*Legacy" param structs, which are the 3.6 owner-tag wire shapes. This
+// confirms a real JIMM advertises and dispatches v10 and that the owner-tag
+// conversion holds on real controller data.
+
+var bobOwnerTag = names.NewUserTag("bob@canonical.com")
+
+// TestModelManagerV10CreateModel covers the v10 CreateModel handler: the
+// owner-tag happy path, owner defaulting, authorization, duplicate names, and
+// owner tags that cannot be converted to a qualifier.
+func TestModelManagerV10CreateModel(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	existing := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	cred := names.NewCloudCredentialTag(jimmtest.TestE2ECloudName + "/" + bobOwnerTag.Id() + "/cred")
+
+	tests := []struct {
+		about          string
+		name           string
+		ownerTag       string
+		credentialTag  names.CloudCredentialTag
+		expectError    string
+		expectOwnerTag string // expected response owner tag for the success cases
+	}{{
+		about:          "success with explicit owner tag",
+		name:           petname.Generate(2, "-"),
+		ownerTag:       bobOwnerTag.String(),
+		credentialTag:  cred,
+		expectOwnerTag: bobOwnerTag.String(),
+	}, {
+		about:          "empty owner tag defaults to the authenticated user",
+		name:           petname.Generate(2, "-"),
+		ownerTag:       "",
+		credentialTag:  cred,
+		expectOwnerTag: bobOwnerTag.String(),
+	}, {
+		about:         "unauthorized for another user",
+		name:          petname.Generate(2, "-"),
+		ownerTag:      "user-noauthuser@canonical.com",
+		credentialTag: cred,
+		expectError:   `unauthorized \(unauthorized access\)`,
+	}, {
+		about:         "duplicate model name",
+		name:          existing.Name,
+		ownerTag:      bobOwnerTag.String(),
+		credentialTag: cred,
+		expectError:   "model " + bobOwnerTag.Id() + "/" + existing.Name + " already exists \\(already exists\\)",
+	}, {
+		about:       "owner tag is not a tag",
+		name:        petname.Generate(2, "-"),
+		ownerTag:    "not-a-tag",
+		expectError: `.*is not a valid.*tag.*`,
+	}, {
+		about:       "owner tag is not a user",
+		name:        petname.Generate(2, "-"),
+		ownerTag:    "machine-0",
+		expectError: `.*is not a valid.*tag.*`,
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d. %s", i, test.about)
+
+		args := jujuparams.ModelCreateArgsLegacy{
+			Name:     test.name,
+			OwnerTag: test.ownerTag,
+			CloudTag: names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+		}
+		emptyCred := names.CloudCredentialTag{}
+		if test.credentialTag != emptyCred {
+			args.CloudCredentialTag = test.credentialTag.String()
+		}
+
+		var info jujuparams.ModelInfoLegacy
+		err := conn.APICall(t.Context(), "ModelManager", 10, "", "CreateModel", args, &info)
+		if test.expectError != "" {
+			c.Check(err, qt.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, qt.IsNil)
+		c.Check(info.OwnerTag, qt.Equals, test.expectOwnerTag)
+		c.Check(info.Name, qt.Equals, test.name)
+		c.Check(info.UUID, qt.Not(qt.Equals), "")
+	}
+}
+
+// TestModelManagerV10ModelInfo covers the v10 ModelInfo handler, which reports
+// per-result errors: a valid model returns an owner tag, while an
+// inaccessible or malformed tag becomes a result-level error.
+func TestModelManagerV10ModelInfo(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	args := jujuparams.Entities{Entities: []jujuparams.Entity{
+		{Tag: model.ResourceTag().String()},
+		// A well-formed but inaccessible model -> mapped to unauthorized.
+		{Tag: names.NewModelTag("00000000-0000-0000-0000-0000000000ff").String()},
+		// A malformed tag -> bad request.
+		{Tag: "invalid-model-tag"},
+	}}
+
+	var res jujuparams.ModelInfoResultsLegacy
+	err := conn.APICall(t.Context(), "ModelManager", 10, "", "ModelInfo", args, &res)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Results, qt.HasLen, 3)
+
+	c.Assert(res.Results[0].Result, qt.IsNotNil)
+	c.Check(res.Results[0].Result.OwnerTag, qt.Equals, bobOwnerTag.String())
+	c.Check(res.Results[0].Result.UUID, qt.Equals, model.UUID.String)
+	c.Check(res.Results[0].Error == nil, qt.IsTrue)
+
+	c.Check(res.Results[1].Result, qt.IsNil)
+	c.Check(res.Results[1].Error != nil, qt.IsTrue)
+
+	c.Check(res.Results[2].Result, qt.IsNil)
+	c.Check(res.Results[2].Error != nil, qt.IsTrue)
+}
+
+// TestModelManagerV10ListModels checks the v10 ListModels handler reports every
+// accessible model in owner-tag form.
+func TestModelManagerV10ListModels(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	var list jujuparams.UserModelListLegacy
+	err := conn.APICall(t.Context(), "ModelManager", 10, "", "ListModels", jujuparams.Entity{}, &list)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(list.UserModels) > 0, qt.IsTrue)
+
+	var found bool
+	for _, um := range list.UserModels {
+		// Every model must be reported in owner-tag form, never qualifier form.
+		c.Check(strings.HasPrefix(um.OwnerTag, "user-"), qt.IsTrue, qt.Commentf("owner tag %q", um.OwnerTag))
+		if um.UUID == model.UUID.String {
+			found = true
+			c.Check(um.OwnerTag, qt.Equals, bobOwnerTag.String())
+			c.Check(um.Name, qt.Equals, model.Name)
+		}
+	}
+	c.Assert(found, qt.IsTrue)
+}
+
+// TestModelManagerV10ModelStatus covers the v10 ModelStatus handler, which
+// reports per-result errors inline on each ModelStatus entry.
+func TestModelManagerV10ModelStatus(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	args := jujuparams.Entities{Entities: []jujuparams.Entity{
+		{Tag: model.ResourceTag().String()},
+		{Tag: "invalid-model-tag"},
+	}}
+
+	var res jujuparams.ModelStatusResultsLegacy
+	err := conn.APICall(t.Context(), "ModelManager", 10, "", "ModelStatus", args, &res)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Results, qt.HasLen, 2)
+
+	c.Check(res.Results[0].OwnerTag, qt.Equals, bobOwnerTag.String())
+	c.Check(res.Results[0].Error == nil, qt.IsTrue)
+
+	c.Check(res.Results[1].OwnerTag, qt.Equals, "")
+	c.Check(res.Results[1].Error != nil, qt.IsTrue)
+}
+
+// TestModelManagerV10ListModelSummaries checks the v10 ListModelSummaries
+// handler reports summaries in owner-tag form.
+func TestModelManagerV10ListModelSummaries(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	var res jujuparams.ModelSummaryResultsLegacy
+	err := conn.APICall(t.Context(), "ModelManager", 10, "", "ListModelSummaries", jujuparams.ModelSummariesRequest{}, &res)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(res.Results) > 0, qt.IsTrue)
+
+	var found bool
+	for _, r := range res.Results {
+		if r.Result == nil {
+			continue
+		}
+		c.Check(strings.HasPrefix(r.Result.OwnerTag, "user-"), qt.IsTrue, qt.Commentf("owner tag %q", r.Result.OwnerTag))
+		if r.Result.UUID == model.UUID.String {
+			found = true
+			c.Check(r.Result.OwnerTag, qt.Equals, bobOwnerTag.String())
+		}
+	}
+	c.Assert(found, qt.IsTrue)
+}


### PR DESCRIPTION
## Description

Register the ModelManager facade at version 10 (Juju 3.6) alongside the existing version 11 (Juju 4.x), so a 3.6 client negotiates v10 and talks to JIMM in the owner-tag wire format.

The five methods whose wire format changed at v11 (the model owner-tag -> qualifier rename) get dedicated v10 handlers (CreateModelLegacy, ModelInfoLegacy, ListModelsLegacy, ModelStatusLegacy, ListModelSummariesLegacy). Each adapts the 3.6 owner-tag format to the v11 handler via the params36 conversion package, reusing the same business logic. The other nine methods are wire-identical and register the existing v11 handlers at v10. facadeInit now returns {10, 11}.

Placement of a 3.6 client's new model onto a compatible controller is left for future work; CreateModelLegacy is the natural seam for that constraint and carries a TODO marking it.

Tests cover the advertised version set and owner-tag round-tripping for CreateModel, ListModels and ModelInfo via mocked JujuManager results.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests


