### PR TITLE
feat(jujuapi): place Juju 3.6 client models on compatible controllers

### DIFF
--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -55,6 +55,11 @@ type ModelCreateArgs struct {
 	// ControllerName is optional and specifies the controller
 	// name which should host the new model.
 	ControllerName string
+	// MaxControllerMajorVersion, when non-zero, restricts model placement to
+	// controllers whose agent major version is <= this value. It is set for
+	// Juju 3.6 clients, which cannot operate 4.x controllers, and left zero
+	// (unconstrained) for 4.x clients.
+	MaxControllerMajorVersion int
 }
 
 // AddModel adds the specified model to JIMM.
@@ -82,6 +87,7 @@ func (j *JujuManager) AddModel(ctx context.Context, user *openfga.User, args *Mo
 		return base.ModelInfo{}, err
 	}
 
+	builder = builder.WithMaxControllerMajorVersion(args.MaxControllerMajorVersion)
 	if args.ControllerName != "" {
 		builder = builder.WithController(args.ControllerName)
 	} else {

--- a/internal/jimm/juju/model_placement_test.go
+++ b/internal/jimm/juju/model_placement_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Canonical.
+
+package juju_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// TestAddModelControllerVersionPlacement verifies that AddModel honours the
+// MaxControllerMajorVersion constraint (set for Juju 3.6 clients): the new
+// model is placed only on a controller whose agent major version is within the
+// constraint, and a request that cannot be satisfied fails with a clear error.
+//
+// The controllers' agent versions are set directly in the test environment, so
+// the placement decision is exercised deterministically without bootstrapping
+// real controllers of specific versions.
+func TestAddModelControllerVersionPlacement(t *testing.T) {
+	c := qt.New(t)
+
+	// A two-controller fleet serving the same cloud/region. controller-40 (a
+	// 4.x controller) has the higher placement priority, so it is preferred
+	// when no version constraint applies; controller-36 is a 3.6 controller.
+	mixedFleetEnv := `
+clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region-1
+  users:
+  - user: alice@canonical.com
+    access: add-model
+cloud-credentials:
+- name: test-credential-1
+  owner: alice@canonical.com
+  cloud: test-cloud
+  auth-type: empty
+controllers:
+- name: controller-40
+  uuid: 00000000-0000-0000-0000-000000000040
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: "4.0.2"
+  cloud-regions:
+  - cloud: test-cloud
+    region: test-region-1
+    priority: 10
+  users:
+  - user: alice@canonical.com
+    access: add-model
+- name: controller-36
+  uuid: 00000000-0000-0000-0000-000000000036
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: "3.6.1"
+  cloud-regions:
+  - cloud: test-cloud
+    region: test-region-1
+    priority: 1
+  users:
+  - user: alice@canonical.com
+    access: add-model
+`[1:]
+
+	// A fleet with only a 4.x controller.
+	only40Env := `
+clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-region-1
+  users:
+  - user: alice@canonical.com
+    access: add-model
+cloud-credentials:
+- name: test-credential-1
+  owner: alice@canonical.com
+  cloud: test-cloud
+  auth-type: empty
+controllers:
+- name: controller-40
+  uuid: 00000000-0000-0000-0000-000000000040
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: "4.0.2"
+  cloud-regions:
+  - cloud: test-cloud
+    region: test-region-1
+    priority: 10
+  users:
+  - user: alice@canonical.com
+    access: add-model
+`[1:]
+
+	const modelUUID = "00000001-0000-0000-0000-000000000001"
+	createModelMock := createModel(`uuid: 00000001-0000-0000-0000-000000000001
+status:
+  status: started
+  info: running a test
+life: alive
+users:
+- user: alice@canonical.com
+  access: admin
+`)
+
+	cloudCredTag := names.NewCloudCredentialTag("test-cloud/alice@canonical.com/test-credential-1")
+
+	tests := []struct {
+		name             string
+		env              string
+		maxMajor         int
+		controllerName   string
+		expectController string
+		expectError      string
+	}{{
+		name:             "constrained client skips the higher-priority incompatible controller",
+		env:              mixedFleetEnv,
+		maxMajor:         3,
+		expectController: "controller-36",
+	}, {
+		name:             "unconstrained client uses the higher-priority controller",
+		env:              mixedFleetEnv,
+		maxMajor:         0,
+		expectController: "controller-40",
+	}, {
+		name:        "constrained client with no compatible controller fails",
+		env:         only40Env,
+		maxMajor:    3,
+		expectError: "no controller compatible with your Juju client is available; please upgrade your client to use the available controllers",
+	}, {
+		name:           "constrained client naming a too-new controller fails",
+		env:            mixedFleetEnv,
+		maxMajor:       3,
+		controllerName: "controller-40",
+		expectError:    `controller "controller-40" \(version "4.0.2"\) is not compatible with your Juju client; please upgrade your client to use this controller`,
+	}}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			ctx := context.Background()
+			j := newTestJujuManager(c, &parameters{
+				Dialer: &jimmtest.Dialer{
+					API: &jimmtest.API{
+						UpdateCloudsCredentialForce_: func(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
+							return []jujuparams.UpdateCredentialResult{{}}, nil
+						},
+						GrantJIMMModelAdmin_: func(context.Context, names.ModelTag) error {
+							return nil
+						},
+						CreateModel_: createModelMock,
+					},
+				},
+			})
+
+			env := jimmtest.ParseEnvironment(c, test.env)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+			err := j.CredentialStore.Put(ctx, cloudCredTag, map[string]string{"key": "value"})
+			c.Assert(err, qt.IsNil)
+
+			dbUser := env.User("alice@canonical.com").DBObject(c, j.Database)
+			user := openfga.NewUser(&dbUser, j.OpenFGAClient)
+			user.JimmAdmin = true
+
+			args := juju.ModelCreateArgs{
+				Name:                      "test-model",
+				Owner:                     names.NewUserTag("alice@canonical.com"),
+				Cloud:                     names.NewCloudTag("test-cloud"),
+				CloudRegion:               "test-region-1",
+				CloudCredential:           cloudCredTag,
+				ControllerName:            test.controllerName,
+				MaxControllerMajorVersion: test.maxMajor,
+			}
+
+			_, err = j.AddModel(ctx, user, &args)
+			if test.expectError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+
+			m := dbmodel.Model{UUID: sql.NullString{String: modelUUID, Valid: true}}
+			err = j.Database.GetModel(ctx, &m)
+			c.Assert(err, qt.IsNil)
+			c.Check(m.Controller.Name, qt.Equals, test.expectController)
+		})
+	}
+}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
+	"github.com/juju/version/v2"
 	"github.com/juju/zaputil"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
@@ -55,18 +56,19 @@ type modelBuilder struct {
 	jujuManager *JujuManager
 	ofgaUser    *openfga.User
 
-	name               string
-	candidates         []candidateController
-	config             map[string]any
-	owner              *dbmodel.Identity
-	credential         *dbmodel.CloudCredential
-	controller         *dbmodel.Controller
-	cloud              *dbmodel.Cloud
-	cloudRegion        string
-	cloudRegionID      uint
-	cloudRegionVirtual bool
-	model              *dbmodel.Model
-	modelInfo          base.ModelInfo
+	name                      string
+	candidates                []candidateController
+	maxControllerMajorVersion int
+	config                    map[string]any
+	owner                     *dbmodel.Identity
+	credential                *dbmodel.CloudCredential
+	controller                *dbmodel.Controller
+	cloud                     *dbmodel.Cloud
+	cloudRegion               string
+	cloudRegionID             uint
+	cloudRegionVirtual        bool
+	model                     *dbmodel.Model
+	modelInfo                 base.ModelInfo
 }
 
 // Error returns the error that occurred in the process
@@ -146,6 +148,36 @@ func (b *modelBuilder) WithConfig(cfg map[string]any) *modelBuilder {
 	return b
 }
 
+// WithMaxControllerMajorVersion restricts model placement to controllers whose
+// agent major version is <= major. A value of 0 (the default) means no
+// restriction. It must be set before WithController/WithAnyController.
+func (b *modelBuilder) WithMaxControllerMajorVersion(major int) *modelBuilder {
+	b.maxControllerMajorVersion = major
+	return b
+}
+
+// controllerCompatible reports whether the controller may host a model for the
+// requesting client, given the max-major-version constraint (if any). When
+// constrained, a controller with an empty or unparseable agent version is
+// treated as ineligible, since its compatibility cannot be established.
+func (b *modelBuilder) controllerCompatible(c *dbmodel.Controller) bool {
+	if b.maxControllerMajorVersion == 0 {
+		return true
+	}
+	if c.AgentVersion == "" {
+		zapctx.Warn(b.ctx, "excluding controller with unknown agent version from version-constrained placement",
+			zap.String("controller", c.Name))
+		return false
+	}
+	v, err := version.Parse(c.AgentVersion)
+	if err != nil {
+		zapctx.Warn(b.ctx, "excluding controller with unparseable agent version from version-constrained placement",
+			zap.String("controller", c.Name), zap.String("version", c.AgentVersion))
+		return false
+	}
+	return v.Major <= b.maxControllerMajorVersion
+}
+
 // WithController returns a builder with the specified target controller
 // if it exists and the user has access to it.
 func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
@@ -173,6 +205,12 @@ func (b *modelBuilder) WithController(controllerName string) *modelBuilder {
 		b.err = errors.Codef(errors.CodeUnauthorized, "not authorized to add model to controller %q", controllerName)
 		return b
 	}
+	if !b.controllerCompatible(&targetController) {
+		b.err = errors.Codef(errors.CodeBadRequest,
+			"controller %q (version %q) is not compatible with your Juju client; please upgrade your client to use this controller",
+			controllerName, targetController.AgentVersion)
+		return b
+	}
 	b.candidates = append(b.candidates, candidateController{
 		controller: targetController,
 		priority:   0, // priority is unknown until we select the cloud-region
@@ -191,6 +229,7 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 		return b
 	}
 	var candidateControllers []candidateController
+	versionExcluded := false
 	err := b.jujuManager.Database.ForEachController(b.ctx, func(c *dbmodel.Controller) error {
 		if c.Deprecated {
 			return nil
@@ -199,12 +238,17 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 		if err != nil {
 			return fmt.Errorf("failed to verify permissions for adding model to controller: %v", err)
 		}
-		if ok {
-			candidateControllers = append(candidateControllers, candidateController{
-				controller: *c,
-				priority:   0, // priority is unknown until we select the cloud-region
-			})
+		if !ok {
+			return nil
 		}
+		if !b.controllerCompatible(c) {
+			versionExcluded = true
+			return nil
+		}
+		candidateControllers = append(candidateControllers, candidateController{
+			controller: *c,
+			priority:   0, // priority is unknown until we select the cloud-region
+		})
 		return nil
 	})
 	if err != nil {
@@ -215,7 +259,12 @@ func (b *modelBuilder) WithAnyController() *modelBuilder {
 	// Error early with a helpful message if no
 	// candidate controllers are available.
 	if len(b.candidates) == 0 {
-		b.err = errors.New("no available controllers - check permissions to controllers and list of available controllers")
+		if versionExcluded {
+			b.err = errors.Codef(errors.CodeBadRequest,
+				"no controller compatible with your Juju client is available; please upgrade your client to use the available controllers")
+		} else {
+			b.err = errors.New("no available controllers - check permissions to controllers and list of available controllers")
+		}
 	}
 	return b
 }

--- a/internal/jimm/juju/modelbuilder_internal_test.go
+++ b/internal/jimm/juju/modelbuilder_internal_test.go
@@ -3,6 +3,7 @@
 package juju
 
 import (
+	"context"
 	"math/rand/v2"
 	"testing"
 
@@ -10,6 +11,63 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 )
+
+func TestControllerCompatible(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name         string
+		maxMajor     int
+		agentVersion string
+		expect       bool
+	}{{
+		name:         "unconstrained allows a newer controller",
+		maxMajor:     0,
+		agentVersion: "4.0.2",
+		expect:       true,
+	}, {
+		name:         "unconstrained allows an unknown version",
+		maxMajor:     0,
+		agentVersion: "",
+		expect:       true,
+	}, {
+		name:         "constrained allows an equal major",
+		maxMajor:     3,
+		agentVersion: "3.6.1",
+		expect:       true,
+	}, {
+		name:         "constrained allows a lower major",
+		maxMajor:     3,
+		agentVersion: "2.9.5",
+		expect:       true,
+	}, {
+		name:         "constrained excludes a higher major",
+		maxMajor:     3,
+		agentVersion: "4.0.2",
+		expect:       false,
+	}, {
+		name:         "constrained excludes an unknown version",
+		maxMajor:     3,
+		agentVersion: "",
+		expect:       false,
+	}, {
+		name:         "constrained excludes an unparseable version",
+		maxMajor:     3,
+		agentVersion: "not-a-version",
+		expect:       false,
+	}}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			b := &modelBuilder{
+				ctx:                       context.Background(),
+				maxControllerMajorVersion: test.maxMajor,
+			}
+			ctrl := &dbmodel.Controller{Name: "test-controller", AgentVersion: test.agentVersion}
+			c.Check(b.controllerCompatible(ctrl), qt.Equals, test.expect)
+		})
+	}
+}
 
 func TestShuffleCandidateControllers(t *testing.T) {
 	c := qt.New(t)

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -214,14 +214,21 @@ func (r *controllerRoot) ModelInfo(ctx context.Context, args jujuparams.Entities
 
 // CreateModel implements the ModelManager facade's CreateModel method.
 func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelCreateArgs) (jujuparams.ModelInfo, error) {
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	mca, err := toAddModelArgs(args, r.user.ResourceTag())
 	if err != nil {
 		return jujuparams.ModelInfo{}, err
 	}
+	return r.createModel(ctx, mca)
+}
+
+// createModel adds the model described by mca and converts the result to the
+// current (qualifier) wire format. It is shared by the v11 CreateModel handler
+// and the v10 CreateModelLegacy handler, which differ only in their wire format
+// and (for v10) the controller-version placement constraint set on mca.
+func (r *controllerRoot) createModel(ctx context.Context, mca *juju.ModelCreateArgs) (jujuparams.ModelInfo, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, mca)
 	if err != nil {
 		servermon.ModelsCreatedFailCount.Inc()
@@ -452,14 +459,19 @@ func (r *controllerRoot) ModelDefaultsForClouds(ctx context.Context, args jujupa
 // CreateModelLegacy implements the ModelManager facade version 10 CreateModel
 // method, which uses an owner tag instead of a model qualifier.
 func (r *controllerRoot) CreateModelLegacy(ctx context.Context, args jujuparams.ModelCreateArgsLegacy) (jujuparams.ModelInfoLegacy, error) {
-	// TODO(JAAS-6): a 3.6 client reaches CreateModel only via this version 10
-	// handler, so this is where the "place on a <=3 controller" constraint is
-	// set once version-aware placement lands.
 	currentArgs, err := params36.ModelCreateArgs(args)
 	if err != nil {
 		return jujuparams.ModelInfoLegacy{}, err
 	}
-	info, err := r.CreateModel(ctx, currentArgs)
+	mca, err := toAddModelArgs(currentArgs, r.user.ResourceTag())
+	if err != nil {
+		return jujuparams.ModelInfoLegacy{}, err
+	}
+	// A 3.6 client reaches CreateModel only via this version 10 handler. A 3.6
+	// client cannot operate a 4.x controller, so its new model must be placed
+	// on a controller of major version <= 3.
+	mca.MaxControllerMajorVersion = 3
+	info, err := r.createModel(ctx, mca)
 	if err != nil {
 		return jujuparams.ModelInfoLegacy{}, err
 	}

--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/rpc/jsoncodec"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
+	"github.com/juju/version/v2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -208,6 +209,31 @@ func SetupJimmWithControllers(c *qt.C, opts ...SetupOption) JimmWithControllers 
 	c.Assert(err, qt.Equals, nil)
 
 	return s
+}
+
+// HasControllerWithMajorVersionAtMost reports whether at least one backing
+// controller known to JIMM has an agent major version <= maxMajor. Controllers
+// with an unset or unparseable agent version are ignored. It is used to gate
+// the 3.6-client tests: the version 10 ModelManager handlers place models on a
+// controller of major version <= 3, so those tests need such a controller in
+// the backing fleet.
+func (s *JimmWithControllers) HasControllerWithMajorVersionAtMost(c *qt.C, maxMajor int) bool {
+	found := false
+	err := s.JIMM.Database.ForEachController(c.Context(), func(ctl *dbmodel.Controller) error {
+		if ctl.AgentVersion == "" {
+			return nil
+		}
+		v, err := version.Parse(ctl.AgentVersion)
+		if err != nil {
+			return err
+		}
+		if v.Major <= maxMajor {
+			found = true
+		}
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	return found
 }
 
 // CreateModelForBob creates a model with bob@canonical.com as the owner.

--- a/testing/modelmanager_legacy_test.go
+++ b/testing/modelmanager_legacy_test.go
@@ -24,12 +24,25 @@ import (
 
 var bobOwnerTag = names.NewUserTag("bob@canonical.com")
 
+// setupLegacyModelManagerTest sets up the JIMM e2e environment and skips the
+// test unless a Juju 3.x backing controller is available. The 3.6-client
+// (ModelManager version 10) handlers place new models on a controller of major
+// version <= 3 (see JAAS-6), so these tests are only meaningful when the
+// backing fleet includes such a controller.
+func setupLegacyModelManagerTest(c *qt.C) jimmtest.JimmWithControllers {
+	s := jimmtest.SetupJimmWithControllers(c)
+	if !s.HasControllerWithMajorVersionAtMost(c, 3) {
+		c.Skip("no Juju <=3.x backing controller available; 3.6-client ModelManager tests require one")
+	}
+	return s
+}
+
 // TestModelManagerV10CreateModel covers the v10 CreateModel handler: the
 // owner-tag happy path, owner defaulting, authorization, duplicate names, and
 // owner tags that cannot be converted to a qualifier.
 func TestModelManagerV10CreateModel(t *testing.T) {
 	c := qt.New(t)
-	s := jimmtest.SetupJimmWithControllers(c)
+	s := setupLegacyModelManagerTest(c)
 	existing := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
@@ -111,7 +124,7 @@ func TestModelManagerV10CreateModel(t *testing.T) {
 // inaccessible or malformed tag becomes a result-level error.
 func TestModelManagerV10ModelInfo(t *testing.T) {
 	c := qt.New(t)
-	s := jimmtest.SetupJimmWithControllers(c)
+	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
@@ -146,7 +159,7 @@ func TestModelManagerV10ModelInfo(t *testing.T) {
 // accessible model in owner-tag form.
 func TestModelManagerV10ListModels(t *testing.T) {
 	c := qt.New(t)
-	s := jimmtest.SetupJimmWithControllers(c)
+	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
@@ -174,7 +187,7 @@ func TestModelManagerV10ListModels(t *testing.T) {
 // reports per-result errors inline on each ModelStatus entry.
 func TestModelManagerV10ModelStatus(t *testing.T) {
 	c := qt.New(t)
-	s := jimmtest.SetupJimmWithControllers(c)
+	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
@@ -201,7 +214,7 @@ func TestModelManagerV10ModelStatus(t *testing.T) {
 // handler reports summaries in owner-tag form.
 func TestModelManagerV10ListModelSummaries(t *testing.T) {
 	c := qt.New(t)
-	s := jimmtest.SetupJimmWithControllers(c)
+	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
 	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)


### PR DESCRIPTION
## Description

A Juju 3.6 client cannot operate a 4.x controller: JIMM brokers the controller-level facades, but model-level facades are proxied raw, so a 3.6 client talking to a 4.x-hosted model breaks. When a 3.6 client creates a model (the ModelManager v10 handler), its model must therefore be placed on a controller of major version <= 3.

- Add MaxControllerMajorVersion to the internal ModelCreateArgs (0 means unconstrained); the v10 CreateModelLegacy handler sets it to 3, the v11 handler leaves it unset.
- Add modelBuilder.WithMaxControllerMajorVersion and a controllerCompatible helper; apply it in WithAnyController (excludes incompatible controllers and, when that empties the candidate set, returns a version-specific error) and in the explicit WithController path (errors if the named controller is too new). Controllers with an empty or unparseable agent version are treated as ineligible under a constraint, and logged.
- Refactor CreateModel into a shared createModel core so v10 and v11 reuse the same logic, differing only in wire format and the constraint.

Unit-tests the version-decision helper (controllerCompatible) across equal/lower/higher majors and empty/unparseable versions.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

