### PR TITLE
feat(jujuapi): serve Controller v12 for Juju 3.6 clients

### DIFF
--- a/internal/jujuapi/controller.go
+++ b/internal/jujuapi/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jujuapi/params36"
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	jimmversion "github.com/canonical/jimm/v3/version"
@@ -33,6 +34,23 @@ func init() {
 		watchAllModelSummariesMethod := rpc.Method(r.WatchAllModelSummaries)
 		initiateMigrationMethod := rpc.Method(r.InitiateMigration)
 
+		allModelsLegacyMethod := rpc.Method(r.AllModelsLegacy)
+		modelStatusLegacyMethod := rpc.Method(r.ModelStatusLegacy)
+
+		// Controller facade version 12 (Juju 3.6 clients).
+		r.AddMethod("Controller", 12, "AllModels", allModelsLegacyMethod)
+		r.AddMethod("Controller", 12, "ConfigSet", configSetMethod)
+		r.AddMethod("Controller", 12, "ControllerConfig", controllerConfigMethod)
+		r.AddMethod("Controller", 12, "ControllerVersion", controllerVersionMethod)
+		r.AddMethod("Controller", 12, "GetControllerAccess", getControllerAccessMethod)
+		r.AddMethod("Controller", 12, "IdentityProviderURL", identityProviderURLMethod)
+		r.AddMethod("Controller", 12, "ModelStatus", modelStatusLegacyMethod)
+		r.AddMethod("Controller", 12, "MongoVersion", mongoVersionMethod)
+		r.AddMethod("Controller", 12, "WatchModelSummaries", watchModelSummariesMethod)
+		r.AddMethod("Controller", 12, "WatchAllModelSummaries", watchAllModelSummariesMethod)
+		r.AddMethod("Controller", 12, "InitiateMigration", initiateMigrationMethod)
+
+		// Controller facade version 14 (Juju 4.x clients).
 		r.AddMethod("Controller", 14, "AllModels", allModelsMethod)
 		r.AddMethod("Controller", 14, "ConfigSet", configSetMethod)
 		r.AddMethod("Controller", 14, "ControllerConfig", controllerConfigMethod)
@@ -45,7 +63,7 @@ func init() {
 		r.AddMethod("Controller", 14, "WatchAllModelSummaries", watchAllModelSummariesMethod)
 		r.AddMethod("Controller", 14, "InitiateMigration", initiateMigrationMethod)
 
-		return []int{14}
+		return []int{12, 14}
 	}
 }
 
@@ -169,6 +187,16 @@ func (r *controllerRoot) WatchAllModelSummaries(ctx context.Context) (jujuparams
 // AllModels implments the AllModels command on the Controller facade.
 func (r *controllerRoot) AllModels(ctx context.Context) (jujuparams.UserModelList, error) {
 	return r.allModels(ctx)
+}
+
+// AllModelsLegacy implements the Controller facade version 12 AllModels method,
+// which returns model owner tags instead of qualifiers.
+func (r *controllerRoot) AllModelsLegacy(ctx context.Context) (jujuparams.UserModelListLegacy, error) {
+	list, err := r.AllModels(ctx)
+	if err != nil {
+		return jujuparams.UserModelListLegacy{}, err
+	}
+	return params36.LegacyUserModelList(list)
 }
 
 // allModels returns all the models the logged in user has access to.

--- a/internal/jujuapi/controller_legacy_test.go
+++ b/internal/jujuapi/controller_legacy_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+// TestControllerAdvertisesLegacyAndCurrent asserts the Controller facade
+// advertises both the 3.6 (v12) and 4.x (v14) versions.
+func TestControllerAdvertisesLegacyAndCurrent(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(jujuapi.SupportedFacades()["Controller"], qt.DeepEquals, []int{12, 14})
+}
+
+// TestAllModelsLegacy checks the Controller v12 AllModels handler reports
+// models in owner-tag form.
+func TestAllModelsLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	jujuManager := mocks.JujuManager{
+		ModelManager: mocks.ModelManager{
+			ForEachUserModel_: func(ctx context.Context, u *openfga.User, f func(*dbmodel.Model, string) error) error {
+				m := &dbmodel.Model{
+					Name:              "mymodel",
+					OwnerIdentityName: "alice@external",
+				}
+				m.UUID = sql.NullString{String: testModelUUID, Valid: true}
+				return f(m, "admin")
+			},
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	got, err := cr.AllModelsLegacy(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.UserModels, qt.HasLen, 1)
+	c.Check(got.UserModels[0].OwnerTag, qt.Equals, "user-alice@external")
+	c.Check(got.UserModels[0].Name, qt.Equals, "mymodel")
+	c.Check(got.UserModels[0].UUID, qt.Equals, testModelUUID)
+}

--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -10,7 +10,7 @@ package jujuapi
 var SupportedFacadeVersions = map[string][]int{
 	"ApplicationOffers":   []int{6},
 	"Cloud":               []int{7},
-	"Controller":          []int{14},
+	"Controller":          []int{12, 14},
 	"JIMM":                []int{4},
 	"MigrationTarget":     []int{6},
 	"ModelConfig":         []int{4},

--- a/testing/controller_legacy_test.go
+++ b/testing/controller_legacy_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// These tests exercise the Controller facade version 12 (Juju 3.6) handlers end
+// to end against a real backing controller, using hand-crafted version-pinned
+// calls with conn.APICall and the juju 4.x "*Legacy" param structs (the 3.6
+// owner-tag wire shapes).
+//
+// Unlike the ModelManager v10 CreateModel tests, the Controller v12 handlers
+// covered here (AllModels, ModelStatus) are read operations: JIMM brokers them
+// to the hosting controller and translates the result, so they work against a
+// backing controller of any version and do not require a Juju 3.x controller.
+
+// TestControllerV12AllModels checks the Controller v12 AllModels handler reports
+// models in owner-tag form.
+func TestControllerV12AllModels(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	var list jujuparams.UserModelListLegacy
+	err := conn.APICall(t.Context(), "Controller", 12, "", "AllModels", nil, &list)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(list.UserModels) > 0, qt.IsTrue)
+
+	var found bool
+	for _, um := range list.UserModels {
+		// Every model must be reported in owner-tag form, never qualifier form.
+		c.Check(strings.HasPrefix(um.OwnerTag, "user-"), qt.IsTrue, qt.Commentf("owner tag %q", um.OwnerTag))
+		if um.UUID == model.UUID.String {
+			found = true
+			c.Check(um.OwnerTag, qt.Equals, bobOwnerTag.String())
+			c.Check(um.Name, qt.Equals, model.Name)
+		}
+	}
+	c.Assert(found, qt.IsTrue)
+}
+
+// TestControllerV12ModelStatus checks the Controller v12 ModelStatus handler
+// reports owner tags, with a per-result error for a malformed tag.
+func TestControllerV12ModelStatus(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+
+	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	defer conn.Close()
+
+	args := jujuparams.Entities{Entities: []jujuparams.Entity{
+		{Tag: model.ResourceTag().String()},
+		{Tag: "invalid-model-tag"},
+	}}
+
+	var res jujuparams.ModelStatusResultsLegacy
+	err := conn.APICall(t.Context(), "Controller", 12, "", "ModelStatus", args, &res)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Results, qt.HasLen, 2)
+
+	c.Check(res.Results[0].OwnerTag, qt.Equals, bobOwnerTag.String())
+	c.Check(res.Results[0].Error == nil, qt.IsTrue)
+
+	c.Check(res.Results[1].OwnerTag, qt.Equals, "")
+	c.Check(res.Results[1].Error != nil, qt.IsTrue)
+}


### PR DESCRIPTION
## Description

Register the Controller facade at version 12 (Juju 3.6) alongside the existing version 14 (Juju 4.x), so a 3.6 client negotiates v12 and talks to JIMM in the owner-tag wire format.

Verified that the 12->14 jump is clean: all 11 methods JIMM serves exist at v12, and only AllModels and ModelStatus changed wire format (the owner-tag -> qualifier rename). AllModels gets a dedicated AllModelsLegacy handler that delegates to v14 and converts via params36.LegacyUserModelList; ModelStatus reuses the version-agnostic ModelStatusLegacy handler already added for ModelManager v10. The other nine methods are wire-identical and register the existing v14 handlers at v12. facadeInit now returns {12, 14}.

Tests cover the advertised version set and the AllModelsLegacy owner-tag round-trip.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
