### PR TITLE
feat(jujuapi): serve ApplicationOffers v5 for Juju 3.6 clients

### DIFF
--- a/internal/jujuapi/applicationoffers.go
+++ b/internal/jujuapi/applicationoffers.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jujuapi/params36"
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
@@ -28,6 +29,24 @@ func init() {
 		findOffersMethod := rpc.Method(r.FindApplicationOffers)
 		applicationOffersMethod := rpc.Method(r.ApplicationOffers)
 
+		// v5 (Juju 3.6) legacy handlers for the methods whose wire format
+		// changed (the model owner-name -> qualifier rename in offer filters and
+		// offer URLs). The remaining methods are wire-identical and reuse the v6
+		// handlers.
+		listOffersLegacyMethod := rpc.Method(r.ListApplicationOffersLegacy)
+		findOffersLegacyMethod := rpc.Method(r.FindApplicationOffersLegacy)
+		applicationOffersLegacyMethod := rpc.Method(r.ApplicationOffersLegacy)
+
+		// ApplicationOffers facade version 5 (Juju 3.6 clients).
+		r.AddMethod("ApplicationOffers", 5, "Offer", offerMethod)
+		r.AddMethod("ApplicationOffers", 5, "GetConsumeDetails", getConsumeDetailsMethod)
+		r.AddMethod("ApplicationOffers", 5, "ListApplicationOffers", listOffersLegacyMethod)
+		r.AddMethod("ApplicationOffers", 5, "ModifyOfferAccess", modifyOfferAccessMethod)
+		r.AddMethod("ApplicationOffers", 5, "DestroyOffers", destroyOffersMethod)
+		r.AddMethod("ApplicationOffers", 5, "FindApplicationOffers", findOffersLegacyMethod)
+		r.AddMethod("ApplicationOffers", 5, "ApplicationOffers", applicationOffersLegacyMethod)
+
+		// ApplicationOffers facade version 6 (Juju 4.x clients).
 		r.AddMethod("ApplicationOffers", 6, "Offer", offerMethod)
 		r.AddMethod("ApplicationOffers", 6, "GetConsumeDetails", getConsumeDetailsMethod)
 		r.AddMethod("ApplicationOffers", 6, "ListApplicationOffers", listOffersMethod)
@@ -36,7 +55,7 @@ func init() {
 		r.AddMethod("ApplicationOffers", 6, "FindApplicationOffers", findOffersMethod)
 		r.AddMethod("ApplicationOffers", 6, "ApplicationOffers", applicationOffersMethod)
 
-		return []int{6}
+		return []int{5, 6}
 	}
 }
 
@@ -153,6 +172,28 @@ func (r *controllerRoot) FindApplicationOffers(ctx context.Context, args jujupar
 	results.Results = offersToParams(offers)
 
 	return results, nil
+}
+
+// ListApplicationOffersLegacy implements the ApplicationOffers facade version 5
+// ListApplicationOffers method, whose filters identify a model by owner name
+// rather than qualifier.
+func (r *controllerRoot) ListApplicationOffersLegacy(ctx context.Context, args jujuparams.OfferFiltersLegacy) (jujuparams.QueryApplicationOffersResultsV5, error) {
+	return r.ListApplicationOffers(ctx, params36.OfferFilters(args))
+}
+
+// FindApplicationOffersLegacy implements the ApplicationOffers facade version 5
+// FindApplicationOffers method, whose filters identify a model by owner name
+// rather than qualifier.
+func (r *controllerRoot) FindApplicationOffersLegacy(ctx context.Context, args jujuparams.OfferFiltersLegacy) (jujuparams.QueryApplicationOffersResultsV5, error) {
+	return r.FindApplicationOffers(ctx, params36.OfferFilters(args))
+}
+
+// ApplicationOffersLegacy implements the ApplicationOffers facade version 5
+// ApplicationOffers method, whose offer URLs use a model owner name rather than
+// a qualifier.
+func (r *controllerRoot) ApplicationOffersLegacy(ctx context.Context, args jujuparams.OfferURLs) (jujuparams.ApplicationOffersResults, error) {
+	args.OfferURLs = params36.TransformOfferURLs(args.OfferURLs)
+	return r.ApplicationOffers(ctx, args)
 }
 
 // ModifyOfferAccess modifies application offer access.

--- a/internal/jujuapi/applicationoffers_legacy_test.go
+++ b/internal/jujuapi/applicationoffers_legacy_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/core/crossmodel"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+)
+
+// TestApplicationOffersAdvertisesLegacyAndCurrent asserts the ApplicationOffers
+// facade advertises both the 3.6 (v5) and 4.x (v6) versions.
+func TestApplicationOffersAdvertisesLegacyAndCurrent(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(jujuapi.SupportedFacades()["ApplicationOffers"], qt.DeepEquals, []int{5, 6})
+}
+
+// TestListApplicationOffersLegacy checks the v5 ListApplicationOffers handler
+// converts the model owner name in the filter to a qualifier and delegates to
+// the v6 handler.
+func TestListApplicationOffersLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	var gotFilters []crossmodel.ApplicationOfferFilter
+	jujuManager := mocks.JujuManager{
+		ListApplicationOffers_: func(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
+			gotFilters = filters
+			return nil, nil
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	_, err := cr.ListApplicationOffersLegacy(context.Background(), jujuparams.OfferFiltersLegacy{
+		Filters: []jujuparams.OfferFilterLegacy{{
+			OwnerName: "alice@external",
+			ModelName: "mymodel",
+			OfferName: "myoffer",
+		}},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotFilters, qt.HasLen, 1)
+	c.Check(string(gotFilters[0].ModelQualifier), qt.Equals, "alice@external")
+	c.Check(gotFilters[0].ModelName, qt.Equals, "mymodel")
+	c.Check(gotFilters[0].OfferName, qt.Equals, "myoffer")
+}
+
+// TestFindApplicationOffersLegacy checks the v5 FindApplicationOffers handler
+// performs the same owner-name -> qualifier filter conversion.
+func TestFindApplicationOffersLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	var gotFilters []crossmodel.ApplicationOfferFilter
+	jujuManager := mocks.JujuManager{
+		FindApplicationOffers_: func(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
+			gotFilters = filters
+			return nil, nil
+		},
+	}
+	cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+	_, err := cr.FindApplicationOffersLegacy(context.Background(), jujuparams.OfferFiltersLegacy{
+		Filters: []jujuparams.OfferFilterLegacy{{
+			OwnerName: "alice@external",
+			ModelName: "mymodel",
+		}},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotFilters, qt.HasLen, 1)
+	c.Check(string(gotFilters[0].ModelQualifier), qt.Equals, "alice@external")
+	c.Check(gotFilters[0].ModelName, qt.Equals, "mymodel")
+}

--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -8,7 +8,7 @@ package jujuapi
 //
 // It is generated from runtime registration (see SupportedFacades).
 var SupportedFacadeVersions = map[string][]int{
-	"ApplicationOffers":   []int{6},
+	"ApplicationOffers":   []int{5, 6},
 	"Cloud":               []int{7},
 	"Controller":          []int{12, 14},
 	"JIMM":                []int{4},

--- a/testing/applicationoffers_legacy_test.go
+++ b/testing/applicationoffers_legacy_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api/client/applicationoffers"
+	jujuparams "github.com/juju/juju/rpc/params"
+)
+
+// TestApplicationOffersV5ListAndFind checks the ApplicationOffers facade
+// version 5 (Juju 3.6) ListApplicationOffers and FindApplicationOffers handlers
+// accept a filter that identifies the model by owner name (the 3.6 wire form),
+// which JIMM converts to a qualifier before delegating to the v6 handler.
+//
+// These are read operations, so JIMM brokers and translates them against a
+// backing controller of any version and they do not require a Juju 3.x
+// controller. The offer itself is created with the v6 client.
+func TestApplicationOffersV5ListAndFind(t *testing.T) {
+	c := qt.New(t)
+	s, model := SetupAppOfferTest(c)
+
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
+	defer conn.Close()
+
+	client := applicationoffers.NewClient(conn)
+	results, err := client.Offer(t.Context(),
+		model.UUID.String, "test-app", []string{"source"}, "bob@canonical.com", "test-offer", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Error, qt.Equals, (*jujuparams.Error)(nil))
+
+	// The 3.6 filter identifies the model by owner name rather than qualifier.
+	filters := jujuparams.OfferFiltersLegacy{
+		Filters: []jujuparams.OfferFilterLegacy{{
+			OwnerName: model.Owner.Name,
+			ModelName: model.Name,
+			OfferName: "test-offer",
+		}},
+	}
+
+	var listResult jujuparams.QueryApplicationOffersResultsV5
+	err = conn.APICall(t.Context(), "ApplicationOffers", 5, "", "ListApplicationOffers", filters, &listResult)
+	c.Assert(err, qt.IsNil)
+	c.Assert(listResult.Results, qt.HasLen, 1)
+	c.Check(listResult.Results[0].OfferName, qt.Equals, "test-offer")
+
+	var findResult jujuparams.QueryApplicationOffersResultsV5
+	err = conn.APICall(t.Context(), "ApplicationOffers", 5, "", "FindApplicationOffers", filters, &findResult)
+	c.Assert(err, qt.IsNil)
+	c.Assert(findResult.Results, qt.HasLen, 1)
+	c.Check(findResult.Results[0].OfferName, qt.Equals, "test-offer")
+}


### PR DESCRIPTION
## Description

Register the ApplicationOffers facade at version 5 (Juju 3.6) alongside the existing version 6 (Juju 4.x), so a 3.6 client negotiates v5 and talks to JIMM in the owner-name wire format.

Verified that only the request side diverged (the offer detail response structs are already the V5 variants at both versions). Three methods get dedicated v5 handlers that convert the request and delegate to the v6 handler:
- ListApplicationOffers / FindApplicationOffers: filter model owner name -> qualifier via params36.OfferFilters;
- ApplicationOffers: offer-URL owner name -> qualifier via params36.TransformOfferURLs. The other four methods (Offer, GetConsumeDetails, ModifyOfferAccess, DestroyOffers) are wire-identical and register the v6 handlers at v5. facadeInit now returns {5, 6}.

Tests cover the advertised version set and the owner-name -> qualifier filter conversion for the list/find handlers.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests

