### PR TITLE
feat(jujuapi): serve ModelConfig v3 for Juju 3.6 clients

### DIFF
--- a/internal/jujuapi/facadeversions.go
+++ b/internal/jujuapi/facadeversions.go
@@ -13,7 +13,7 @@ var SupportedFacadeVersions = map[string][]int{
 	"Controller":          []int{12, 14},
 	"JIMM":                []int{4},
 	"MigrationTarget":     []int{6},
-	"ModelConfig":         []int{4},
+	"ModelConfig":         []int{3, 4},
 	"ModelManager":        []int{10, 11},
 	"ModelSummaryWatcher": []int{1},
 	"ModelUpgrader":       []int{1},

--- a/internal/jujuapi/modelconfig.go
+++ b/internal/jujuapi/modelconfig.go
@@ -15,8 +15,12 @@ func init() {
 	facadeInit["ModelConfig"] = func(r *controllerRoot) []int {
 		modelGetMethod := rpc.Method(r.ModelGet)
 
+		// ModelGet returns a generic config map (no model owner), so its wire
+		// format is identical at v3 (Juju 3.6) and v4 (Juju 4.x); the same
+		// handler is registered at both versions.
+		r.AddMethod("ModelConfig", 3, "ModelGet", modelGetMethod)
 		r.AddMethod("ModelConfig", 4, "ModelGet", modelGetMethod)
-		return []int{4}
+		return []int{3, 4}
 	}
 }
 

--- a/internal/jujuapi/modelconfig_test.go
+++ b/internal/jujuapi/modelconfig_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+)
+
+// TestModelConfigAdvertisesLegacyAndCurrent asserts the ModelConfig facade
+// advertises both the 3.6 (v3) and 4.x (v4) versions.
+func TestModelConfigAdvertisesLegacyAndCurrent(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(jujuapi.SupportedFacades()["ModelConfig"], qt.DeepEquals, []int{3, 4})
+}
+
+// TestModelConfigModelGet checks ModelGet returns the simulated agent-version
+// config; the same handler serves v3 and v4 (its wire format is unchanged).
+func TestModelConfigModelGet(t *testing.T) {
+	c := qt.New(t)
+
+	cr := newTestControllerRoot(jujuJIMM(nil), "alice@external", true)
+
+	res, err := cr.ModelGet(context.Background())
+	c.Assert(err, qt.IsNil)
+	_, ok := res.Config["agent-version"]
+	c.Check(ok, qt.IsTrue)
+}

--- a/testing/modelconfig_legacy_test.go
+++ b/testing/modelconfig_legacy_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	jimmversion "github.com/canonical/jimm/v3/version"
+)
+
+// TestModelConfigV3ModelGet checks the ModelConfig facade version 3 (Juju 3.6)
+// ModelGet handler returns the simulated controller agent-version config,
+// via a hand-crafted version-pinned call. ModelGet returns a hardcoded config
+// (JIMM does not dial a controller for it), so it works against a backing
+// controller of any version. This mirrors TestModelGet, which covers v4.
+func TestModelConfigV3ModelGet(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
+	defer conn.Close()
+
+	var res jujuparams.ModelConfigResults
+	err := conn.APICall(t.Context(), "ModelConfig", 3, "", "ModelGet", nil, &res)
+	c.Assert(err, qt.IsNil)
+
+	v, ok := res.Config["agent-version"]
+	c.Assert(ok, qt.IsTrue)
+	vers, ok := v.Value.(string)
+	c.Assert(ok, qt.IsTrue)
+	c.Check(vers, qt.Equals, jimmversion.ControllerVersion)
+}


### PR DESCRIPTION
## Description

Register the ModelConfig facade at version 3 (Juju 3.6) alongside the existing version 4 (Juju 4.x). JIMM implements only ModelGet, which returns a generic config map with no model owner, so its wire format is identical at v3 and v4; the same handler is registered at both versions. A 3.6 CLI needs ModelConfig.ModelGet during show-controller (to read the agent version), and previously could not negotiate the facade. facadeInit now returns {3, 4}.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
