### PR TITLE
chore: update snaps to core24

### DIFF
--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -4,7 +4,7 @@ description: Juju plugin for providing JAAS functionality to the Juju CLI.
 version: git
 grade: stable
 base: bare
-build-base: core20
+build-base: core24
 confinement: strict
 
 slots:

--- a/snaps/jimm/snapcraft.yaml
+++ b/snaps/jimm/snapcraft.yaml
@@ -2,7 +2,7 @@ name: jimm
 summary: Juju Intelligent Model Manager
 description: Multi-cloud controller for managing JAAS models.
 grade: stable
-base: core20
+base: core24
 confinement: strict
 adopt-info: jimmsrv # Version our app via set-version within an override
 


### PR DESCRIPTION
## Description
A [recent attempt](https://github.com/canonical/jimm/actions/runs/28017844820/job/82930530310) to release JIMM failed to publish our snaps because,
> Base 'core20' is not supported by this version of Snapcraft

This is because we do not pin a specific version of the snapcraft tool and the most recent major has dropped support for core20. We could use an older snapcraft CLI, but it's better to just move forward the snap's base.
