### PR TITLE
ci: update juju dashboard tests

### DIFF
--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run integration tests
-        uses: canonical/juju-dashboard/.github/actions/run-playwright@d0c450599a13854d72cbfc4609d906d27800f38b
+        uses: canonical/juju-dashboard/.github/actions/run-playwright@e7efd76723e74f7176ea1ccf001d3d04047a610e
         with:
           test-identifier: e2e-jimm-docker-keycloak
         env:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,7 +152,7 @@ services:
       retries: 30
 
   juju-dashboard:
-    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.15.1-beta.3}
+    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.16.0-beta.3}
     container_name: juju-dashboard
     profiles: ["dev"]
     environment:


### PR DESCRIPTION
## Description
According to https://warthogs.atlassian.net/browse/JUJU-10046?focusedCommentId=1133724, I've updated the integration tests with the Juju dashboard to the latest release that adds,
> - Support for 4.0
> - Model management
> - New and updated E2E tests for destroy and add model flows

I've made the update on the v3 branch and we can merge it forward to the feature/juju-4 branch.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests
