### PR TITLE
feat: run dry run on migrate

### DIFF
--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -28,22 +28,6 @@ import (
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
-// ControllerClient defines an interface of the juju controller api client
-// used by JIMM to interact with the Controller facade of Juju controllers.
-type ControllerClient interface {
-	// InitiateMigration attempts to begin the migration of one or
-	// more models to other controllers.
-	InitiateMigration(controller.MigrationSpec, bool) (string, error)
-	// Close closes the connection to the API server.
-	Close() error
-}
-
-var (
-	newControllerClient = func(api base.APICallCloser) ControllerClient {
-		return controller.NewClient(api)
-	}
-)
-
 // convertJujuCloudsToDbClouds converts all of the incoming Juju clouds (from a map) into
 // a slice of dbmodel Clouds.
 func convertJujuCloudsToDbClouds(clouds map[names.CloudTag]jujucloud.Cloud) []dbmodel.Cloud {
@@ -716,10 +700,9 @@ func (j *JujuManager) DryRunInternalMigration(ctx context.Context, user *openfga
 	if err != nil {
 		return fmt.Errorf("failed to dial source controller: %w", err)
 	}
-	client := newControllerClient(api)
-	defer client.Close()
+	defer api.Close()
 
-	if _, err = client.InitiateMigration(spec, true); err != nil {
+	if _, err = api.InitiateMigration(spec, true); err != nil {
 		return fmt.Errorf("migration precheck failed: %w", err)
 	}
 	return nil
@@ -809,11 +792,9 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		rollbackMigrationMode()
 		return result, fmt.Errorf("failed to dial the controller: %w", err)
 	}
+	defer api.Close()
 
-	client := newControllerClient(api)
-	defer client.Close()
-
-	result.MigrationId, err = client.InitiateMigration(controller.MigrationSpec{
+	result.MigrationId, err = api.InitiateMigration(controller.MigrationSpec{
 		ModelUUID:             mt.Id(),
 		TargetControllerUUID:  targetControllerTag.Id(),
 		TargetControllerAlias: spec.TargetInfo.ControllerAlias,

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -660,6 +660,71 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	return nil
 }
 
+// minDryRunMigrateVersion is the minimum Juju controller version that supports
+// the dry-run flag on InitiateMigration (introduced in Juju 3.6.13).
+var minDryRunMigrateVersion = version.Number{Major: 3, Minor: 6, Patch: 13}
+
+// DryRunInternalMigration runs a migration precheck (dry run) against the
+// source controller without actually initiating the migration.
+//
+// If the source controller is older than [minDryRunMigrateVersion], the call
+// returns an error asking the user to upgrade the controller first. Otherwise
+// it calls InitiateMigration with dryRun=true; any precheck failure is
+// returned as an error.
+func (j *JujuManager) DryRunInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetControllerName string) error {
+	migrationTarget, _, err := fillMigrationTarget(j.Database, j.CredentialStore, targetControllerName)
+	if err != nil {
+		return err
+	}
+
+	model, err := j.resolveModel(ctx, modelNameOrUUID)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the source controller supports dry-run migrations.
+	sourceVersion, err := version.Parse(model.Controller.AgentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse source controller version %q: %w", model.Controller.AgentVersion, err)
+	}
+	if sourceVersion.Compare(minDryRunMigrateVersion) < 0 {
+		return fmt.Errorf(
+			"controller %q (version %s) does not support migration dry runs; upgrade to %s or later before running upgrade-to",
+			model.Controller.Name, sourceVersion, minDryRunMigrateVersion,
+		)
+	}
+
+	targetControllerTag, err := names.ParseControllerTag(migrationTarget.ControllerTag)
+	if err != nil {
+		return fmt.Errorf("failed to parse target controller tag: %w", err)
+	}
+	targetUserTag, err := names.ParseUserTag(migrationTarget.AuthTag)
+	if err != nil {
+		return fmt.Errorf("failed to parse target auth tag: %w", err)
+	}
+
+	spec := controller.MigrationSpec{
+		ModelUUID:            model.ResourceTag().Id(),
+		TargetControllerUUID: targetControllerTag.Id(),
+		TargetAddrs:          migrationTarget.Addrs,
+		TargetCACert:         migrationTarget.CACert,
+		TargetUser:           targetUserTag.Id(),
+		TargetPassword:       migrationTarget.Password,
+	}
+
+	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to dial source controller: %w", err)
+	}
+	client := newControllerClient(api)
+	defer client.Close()
+
+	if _, err = client.InitiateMigration(spec, true); err != nil {
+		return fmt.Errorf("migration precheck failed: %w", err)
+	}
+	return nil
+}
+
 // InitiateMigration triggers the migration of the specified model to a controller
 // that is not managed by JIMM.
 func (j *JujuManager) InitiateMigration(ctx context.Context, user *openfga.User, spec jujuparams.MigrationSpec) (jujuparams.InitiateMigrationResult, error) {

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -1514,11 +1514,17 @@ type result struct {
 type testControllerClient struct {
 	mu                       sync.Mutex
 	initiateMigrationResults []result
+	// onInitiateMigration is an optional callback invoked with the dryRun flag
+	// on each InitiateMigration call, allowing tests to observe how it was called.
+	onInitiateMigration func(dryRun bool)
 }
 
 func (c *testControllerClient) InitiateMigration(spec controller.MigrationSpec, dryRun bool) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.onInitiateMigration != nil {
+		c.onInitiateMigration(dryRun)
+	}
 	if len(c.initiateMigrationResults) == 0 {
 		return "", errors.Codef(errors.CodeNotImplemented, "not implemented")
 	}
@@ -1583,4 +1589,149 @@ func TestControllerDetailsForModel(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(controllerDetails.ControllerUUID, qt.Equals, env.Controllers[0].UUID)
 	c.Assert(controllerDetails.PublicAddress, qt.Equals, "test-address.com")
+}
+
+// testDryRunMigrationEnv has two source controllers:
+//   - source-new  (agent-version 3.6.13) – supports dry-run
+//   - source-old  (agent-version 3.6.5)  – too old for dry-run
+//
+// controller-target is the migration destination; its credentials are
+// populated in the in-memory credential store during each test.
+const testDryRunMigrationEnv = `clouds:
+- name: test-cloud
+  type: test
+  regions:
+  - name: test-region-1
+cloud-credentials:
+- name: test-cred
+  cloud: test-cloud
+  owner: alice@canonical.com
+  type: empty
+controllers:
+- name: source-new
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: 3.6.13
+- name: source-old
+  uuid: 00000001-0000-0000-0000-000000000002
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: 3.6.5
+- name: controller-target
+  uuid: 00000001-0000-0000-0000-000000000003
+  cloud: test-cloud
+  region: test-region-1
+  agent-version: 4.0.0
+models:
+- name: model-on-new
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: source-new
+  cloud: test-cloud
+  region: test-region-1
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+  users:
+  - user: alice@canonical.com
+    access: admin
+- name: model-on-old
+  uuid: 00000002-0000-0000-0000-000000000002
+  controller: source-old
+  cloud: test-cloud
+  region: test-region-1
+  cloud-credential: test-cred
+  owner: alice@canonical.com
+  users:
+  - user: alice@canonical.com
+    access: admin
+`
+
+func TestDryRunInternalMigration(t *testing.T) {
+	c := qt.New(t)
+
+	modelOnNew := "00000002-0000-0000-0000-000000000001"
+	modelOnOld := "00000002-0000-0000-0000-000000000002"
+	targetController := "controller-target"
+
+	tests := []struct {
+		about                    string
+		modelUUID                string
+		initiateMigrationResults []result
+		expectedError            string
+		// dryRunReceived is set to true by the mock when InitiateMigration is called.
+		expectDryRun bool
+	}{{
+		about:        "dry run succeeds",
+		modelUUID:    modelOnNew,
+		expectDryRun: true,
+		initiateMigrationResults: []result{{
+			result: "", // dry-run returns an empty migration ID
+		}},
+	}, {
+		about:        "dry run precheck fails",
+		modelUUID:    modelOnNew,
+		expectDryRun: true,
+		initiateMigrationResults: []result{{
+			err: errors.New("charm not compatible with target"),
+		}},
+		expectedError: "migration precheck failed: charm not compatible with target",
+	}, {
+		about:         "source controller version too old",
+		modelUUID:     modelOnOld,
+		expectDryRun:  false,
+		expectedError: `controller "source-old" \(version 3\.6\.5\) does not support migration dry runs; upgrade to 3\.6\.13 or later before running upgrade-to`,
+	}, {
+		about:         "model not found",
+		modelUUID:     "00000002-0000-0000-0000-000000000099",
+		expectDryRun:  false,
+		expectedError: "model not found",
+	}, {
+		about:         "target controller not found",
+		modelUUID:     modelOnNew,
+		expectDryRun:  false,
+		expectedError: `not found`,
+	}}
+
+	for _, test := range tests {
+		c.Run(test.about, func(c *qt.C) {
+			store := jimmtest.NewInMemoryCredentialStore()
+			// Only put target credentials when they should be found.
+			if test.about != "target controller not found" {
+				err := store.PutControllerCredentials(context.Background(), targetController, "admin", "test-secret")
+				c.Assert(err, qt.IsNil)
+			}
+
+			j := newTestJujuManager(c, &parameters{
+				CredentialStore: store,
+			})
+
+			env := jimmtest.ParseEnvironment(c, testDryRunMigrationEnv)
+			env.PopulateDB(c, j.Database)
+
+			var dryRunCalled bool
+			c.Patch(juju.NewControllerClient, func(api base.APICallCloser) juju.ControllerClient {
+				return &testControllerClient{
+					initiateMigrationResults: test.initiateMigrationResults,
+					onInitiateMigration: func(dryRun bool) {
+						if dryRun {
+							dryRunCalled = true
+						}
+					},
+				}
+			})
+
+			u, err := dbmodel.NewIdentity("alice@canonical.com")
+			c.Assert(err, qt.IsNil)
+			user := openfga.NewUser(u, nil)
+
+			err = j.DryRunInternalMigration(context.Background(), user, test.modelUUID, targetController)
+
+			if test.expectedError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectedError)
+			} else {
+				c.Assert(err, qt.IsNil)
+			}
+			c.Assert(dryRunCalled, qt.Equals, test.expectDryRun)
+		})
+	}
 }

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"sync"
 	"testing"
 
 	"github.com/canonical/ofga"
@@ -14,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/controller/controller"
+	controllerapi "github.com/juju/juju/api/controller/controller"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
@@ -1265,12 +1264,12 @@ func TestInitiateMigration(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	tests := []struct {
-		about                    string
-		initiateMigrationResults []result
-		user                     func(*openfga.OFGAClient) *openfga.User
-		spec                     jujuparams.MigrationSpec
-		expectedError            string
-		expectedResult           jujuparams.InitiateMigrationResult
+		about          string
+		migrateFn      func(controllerapi.MigrationSpec, bool) (string, error)
+		user           func(*openfga.OFGAClient) *openfga.User
+		spec           jujuparams.MigrationSpec
+		expectedError  string
+		expectedResult jujuparams.InitiateMigrationResult
 	}{{
 		about: "model migration initiated successfully",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1289,9 +1288,9 @@ func TestInitiateMigration(t *testing.T) {
 				Macaroons:     string(macaroonData),
 			},
 		},
-		initiateMigrationResults: []result{{
-			result: migrationId1,
-		}},
+		migrateFn: func(_ controllerapi.MigrationSpec, _ bool) (string, error) {
+			return migrationId1, nil
+		},
 		expectedResult: jujuparams.InitiateMigrationResult{
 			ModelTag:    mt1.String(),
 			MigrationId: migrationId1,
@@ -1314,8 +1313,7 @@ func TestInitiateMigration(t *testing.T) {
 				Macaroons:     string(macaroonData),
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            "unauthorized",
+		expectedError: "unauthorized",
 	}, {
 		about: "InitiateMigration call fails",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1333,9 +1331,9 @@ func TestInitiateMigration(t *testing.T) {
 				AuthTag:       names.NewUserTag("target-user@canonical.com").String(),
 			},
 		},
-		initiateMigrationResults: []result{{
-			err: errors.New("mocked error"),
-		}},
+		migrateFn: func(_ controllerapi.MigrationSpec, _ bool) (string, error) {
+			return "", errors.New("mocked error")
+		},
 		expectedError: "mocked error",
 	}, {
 		about: "non-admin-user gets unauthorized error",
@@ -1354,8 +1352,7 @@ func TestInitiateMigration(t *testing.T) {
 				AuthTag:       names.NewUserTag("target-user@canonical.com").String(),
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            "unauthorized",
+		expectedError: "unauthorized",
 	}, {
 		about: "invalid model tag",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1373,8 +1370,7 @@ func TestInitiateMigration(t *testing.T) {
 				AuthTag:       names.NewUserTag("target-user@canonical.com").String(),
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            `"invalid-model-tag" is not a valid tag`,
+		expectedError: `"invalid-model-tag" is not a valid tag`,
 	}, {
 		about: "invalid target controller tag",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1392,8 +1388,7 @@ func TestInitiateMigration(t *testing.T) {
 				AuthTag:       names.NewUserTag("target-user@canonical.com").String(),
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            `"invalid-controller-tag" is not a valid tag`,
+		expectedError: `"invalid-controller-tag" is not a valid tag`,
 	}, {
 		about: "invalid target user tag",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1411,8 +1406,7 @@ func TestInitiateMigration(t *testing.T) {
 				AuthTag:       "invalid-user-tag",
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            `"invalid-user-tag" is not a valid tag`,
+		expectedError: `"invalid-user-tag" is not a valid tag`,
 	}, {
 		about: "invalid macaroon data",
 		user: func(client *openfga.OFGAClient) *openfga.User {
@@ -1431,22 +1425,20 @@ func TestInitiateMigration(t *testing.T) {
 				Macaroons:     "invalid-macaroon-data",
 			},
 		},
-		initiateMigrationResults: []result{{}},
-		expectedError:            "failed to unmarshal macaroons",
+		expectedError: "failed to unmarshal macaroons",
 	}}
 
 	for _, test := range tests {
 		c.Run(test.about, func(c *qt.C) {
-			j := newTestJujuManager(c, nil)
+			api := &jimmtest.API{
+				InitiateMigration_: test.migrateFn,
+			}
+			j := newTestJujuManager(c, &parameters{
+				Dialer: &jimmtest.Dialer{API: api},
+			})
 
 			env := jimmtest.ParseEnvironment(c, testInitiateMigrationEnv)
 			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-			c.Patch(juju.NewControllerClient, func(api base.APICallCloser) juju.ControllerClient {
-				return &testControllerClient{
-					initiateMigrationResults: test.initiateMigrationResults,
-				}
-			})
 
 			user := test.user(j.OpenFGAClient)
 
@@ -1474,18 +1466,18 @@ func TestInitiateMigration(t *testing.T) {
 func TestInitiateMigration_InProgress(t *testing.T) {
 	c := qt.New(t)
 
-	j := newTestJujuManager(c, nil)
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				InitiateMigration_: func(spec controllerapi.MigrationSpec, dryRun bool) (string, error) {
+					return "migration-result-id", nil
+				},
+			},
+		},
+	})
 
 	env := jimmtest.ParseEnvironment(c, testInitiateMigrationEnv)
 	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
-
-	c.Patch(juju.NewControllerClient, func(api base.APICallCloser) juju.ControllerClient {
-		return &testControllerClient{
-			initiateMigrationResults: []result{{
-				result: "migration-result-id",
-			}},
-		}
-	})
 
 	u, err := dbmodel.NewIdentity("alice@canonical.com")
 	c.Assert(err, qt.IsNil)
@@ -1504,40 +1496,6 @@ func TestInitiateMigration_InProgress(t *testing.T) {
 
 	_, err = j.InitiateMigration(context.Background(), user, migrationSpec)
 	c.Assert(err, qt.ErrorMatches, `failed to update the model's migration mode: model is already in migration mode "exporting"`)
-}
-
-type result struct {
-	err    error
-	result any
-}
-
-type testControllerClient struct {
-	mu                       sync.Mutex
-	initiateMigrationResults []result
-	// onInitiateMigration is an optional callback invoked with the dryRun flag
-	// on each InitiateMigration call, allowing tests to observe how it was called.
-	onInitiateMigration func(dryRun bool)
-}
-
-func (c *testControllerClient) InitiateMigration(spec controller.MigrationSpec, dryRun bool) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.onInitiateMigration != nil {
-		c.onInitiateMigration(dryRun)
-	}
-	if len(c.initiateMigrationResults) == 0 {
-		return "", errors.Codef(errors.CodeNotImplemented, "not implemented")
-	}
-	var result result
-	result, c.initiateMigrationResults = c.initiateMigrationResults[0], c.initiateMigrationResults[1:]
-	if result.err != nil {
-		return "", result.err
-	}
-	return result.result.(string), nil
-}
-
-func (c *testControllerClient) Close() error {
-	return nil
 }
 
 const testControllerDetailsForModelEnv = `clouds:
@@ -1654,26 +1612,26 @@ func TestDryRunInternalMigration(t *testing.T) {
 	targetController := "controller-target"
 
 	tests := []struct {
-		about                    string
-		modelUUID                string
-		initiateMigrationResults []result
-		expectedError            string
-		// dryRunReceived is set to true by the mock when InitiateMigration is called.
+		about         string
+		modelUUID     string
+		migrateFn     func(controllerapi.MigrationSpec, bool) (string, error)
+		expectedError string
+		// expectDryRun is set to true when InitiateMigration should be called with dryRun=true.
 		expectDryRun bool
 	}{{
 		about:        "dry run succeeds",
 		modelUUID:    modelOnNew,
 		expectDryRun: true,
-		initiateMigrationResults: []result{{
-			result: "", // dry-run returns an empty migration ID
-		}},
+		migrateFn: func(_ controllerapi.MigrationSpec, _ bool) (string, error) {
+			return "", nil
+		},
 	}, {
 		about:        "dry run precheck fails",
 		modelUUID:    modelOnNew,
 		expectDryRun: true,
-		initiateMigrationResults: []result{{
-			err: errors.New("charm not compatible with target"),
-		}},
+		migrateFn: func(_ controllerapi.MigrationSpec, _ bool) (string, error) {
+			return "", errors.New("charm not compatible with target")
+		},
 		expectedError: "migration precheck failed: charm not compatible with target",
 	}, {
 		about:         "source controller version too old",
@@ -1701,24 +1659,22 @@ func TestDryRunInternalMigration(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 			}
 
+			var dryRunCalled bool
+			api := &jimmtest.API{
+				InitiateMigration_: func(spec controllerapi.MigrationSpec, dryRun bool) (string, error) {
+					if dryRun {
+						dryRunCalled = true
+					}
+					return test.migrateFn(spec, dryRun)
+				},
+			}
 			j := newTestJujuManager(c, &parameters{
 				CredentialStore: store,
+				Dialer:          &jimmtest.Dialer{API: api},
 			})
 
 			env := jimmtest.ParseEnvironment(c, testDryRunMigrationEnv)
 			env.PopulateDB(c, j.Database)
-
-			var dryRunCalled bool
-			c.Patch(juju.NewControllerClient, func(api base.APICallCloser) juju.ControllerClient {
-				return &testControllerClient{
-					initiateMigrationResults: test.initiateMigrationResults,
-					onInitiateMigration: func(dryRun bool) {
-						if dryRun {
-							dryRunCalled = true
-						}
-					},
-				}
-			})
 
 			u, err := dbmodel.NewIdentity("alice@canonical.com")
 			c.Assert(err, qt.IsNil)

--- a/internal/jimm/juju/export_test.go
+++ b/internal/jimm/juju/export_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 var (
-	NewControllerClient       = &newControllerClient
 	FillMigrationTarget       = fillMigrationTarget
 	InitiateInternalMigration = &initiateInternalMigration
 	ReleasesCacheTTL          = releasesCacheTTL

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/api/base"
+	controllerapi "github.com/juju/juju/api/controller/controller"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
@@ -196,6 +197,11 @@ type API interface {
 		ignoreAgentVersions bool,
 		dryRun bool,
 	) (version.Number, error)
+
+	// InitiateMigration begins a model migration to another controller.
+	// When dryRun is true the call runs the migration prechecks only and
+	// does not start an actual migration.
+	InitiateMigration(spec controllerapi.MigrationSpec, dryRun bool) (string, error)
 }
 
 // PermissionManager provides a way to manage permissions within JIMM.

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -255,6 +255,34 @@ func fillMigrationTarget(db *db.Database, credStore credentials.CredentialStore,
 	return targetInfo, dbController.ID, nil
 }
 
+// resolveModel looks up a model by UUID or "owner/name" string and returns
+// the fully-populated dbmodel.Model (including its Controller association).
+func (j *JujuManager) resolveModel(ctx context.Context, modelNameOrUUID string) (dbmodel.Model, error) {
+	model := dbmodel.Model{}
+	_, err := uuid.Parse(modelNameOrUUID)
+	if err != nil {
+		s := strings.Split(modelNameOrUUID, "/")
+		if len(s) != 2 {
+			return model, errors.New("invalid model target")
+		}
+		owner, name := s[0], s[1]
+		if !names.IsValidUser(owner) {
+			return model, errors.New("invalid user name")
+		}
+		if !names.IsValidModelName(name) {
+			return model, errors.New("invalid model name")
+		}
+		model.Name = name
+		model.OwnerIdentityName = owner
+	} else {
+		model.UUID = sql.NullString{String: modelNameOrUUID, Valid: true}
+	}
+	if err := j.Database.GetModel(ctx, &model); err != nil {
+		return model, err
+	}
+	return model, nil
+}
+
 // InitiateInternalMigration initiates a model migration between two controllers within JIMM.
 func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error) {
 
@@ -263,36 +291,11 @@ func (j *JujuManager) InitiateInternalMigration(ctx context.Context, user *openf
 		return jujuparams.InitiateMigrationResult{}, err
 	}
 
-	model := dbmodel.Model{}
-	// Check if the user is providing a model UUID or name
-	_, err = uuid.Parse(modelNameOrUUID)
-	if err != nil {
-		s := strings.Split(modelNameOrUUID, "/")
-		if len(s) != 2 {
-			return jujuparams.InitiateMigrationResult{}, errors.New("invalid model target")
-		}
-
-		owner, name := s[0], s[1]
-		if !names.IsValidUser(owner) {
-			return jujuparams.InitiateMigrationResult{}, errors.New("invalid user name")
-		}
-		if !names.IsValidModelName(name) {
-			return jujuparams.InitiateMigrationResult{}, errors.New("invalid model name")
-		}
-
-		model.Name = name
-		model.OwnerIdentityName = owner
-	} else {
-		model.UUID = sql.NullString{
-			String: modelNameOrUUID,
-			Valid:  true,
-		}
-	}
-
-	err = j.Database.GetModel(ctx, &model)
+	model, err := j.resolveModel(ctx, modelNameOrUUID)
 	if err != nil {
 		return jujuparams.InitiateMigrationResult{}, err
 	}
+
 	spec := jujuparams.MigrationSpec{ModelTag: model.ResourceTag().String(), TargetInfo: migrationTarget}
 	result, err := initiateInternalMigration(ctx, j, user, spec)
 	if err != nil {

--- a/internal/jimm/upgrade/mocks/api.go
+++ b/internal/jimm/upgrade/mocks/api.go
@@ -18,8 +18,9 @@ import (
 
 	jujuclient "github.com/canonical/jimm/v3/internal/jujuclient"
 	base "github.com/juju/juju/api/base"
+	controller "github.com/juju/juju/api/controller/controller"
 	cloud "github.com/juju/juju/cloud"
-	controller "github.com/juju/juju/controller"
+	controller0 "github.com/juju/juju/controller"
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	migration "github.com/juju/juju/core/migration"
 	cloudspec "github.com/juju/juju/environs/cloudspec"
@@ -708,10 +709,10 @@ func (c *MockAPIConnectStreamCall) DoAndReturn(f func(string, url.Values) (base.
 }
 
 // ControllerConfig mocks base method.
-func (m *MockAPI) ControllerConfig(arg0 context.Context) (controller.Config, error) {
+func (m *MockAPI) ControllerConfig(arg0 context.Context) (controller0.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig", arg0)
-	ret0, _ := ret[0].(controller.Config)
+	ret0, _ := ret[0].(controller0.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -729,19 +730,19 @@ type MockAPIControllerConfigCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPIControllerConfigCall) Return(arg0 controller.Config, arg1 error) *MockAPIControllerConfigCall {
+func (c *MockAPIControllerConfigCall) Return(arg0 controller0.Config, arg1 error) *MockAPIControllerConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIControllerConfigCall) Do(f func(context.Context) (controller.Config, error)) *MockAPIControllerConfigCall {
+func (c *MockAPIControllerConfigCall) Do(f func(context.Context) (controller0.Config, error)) *MockAPIControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockAPIControllerConfigCall {
+func (c *MockAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller0.Config, error)) *MockAPIControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1206,6 +1207,45 @@ func (c *MockAPIImportCall) Do(f func([]byte) error) *MockAPIImportCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAPIImportCall) DoAndReturn(f func([]byte) error) *MockAPIImportCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// InitiateMigration mocks base method.
+func (m *MockAPI) InitiateMigration(spec controller.MigrationSpec, dryRun bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitiateMigration", spec, dryRun)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InitiateMigration indicates an expected call of InitiateMigration.
+func (mr *MockAPIMockRecorder) InitiateMigration(spec, dryRun any) *MockAPIInitiateMigrationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateMigration", reflect.TypeOf((*MockAPI)(nil).InitiateMigration), spec, dryRun)
+	return &MockAPIInitiateMigrationCall{Call: call}
+}
+
+// MockAPIInitiateMigrationCall wrap *gomock.Call
+type MockAPIInitiateMigrationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAPIInitiateMigrationCall) Return(arg0 string, arg1 error) *MockAPIInitiateMigrationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAPIInitiateMigrationCall) Do(f func(controller.MigrationSpec, bool) (string, error)) *MockAPIInitiateMigrationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAPIInitiateMigrationCall) DoAndReturn(f func(controller.MigrationSpec, bool) (string, error)) *MockAPIInitiateMigrationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/mocks/jujumanager.go
+++ b/internal/jimm/upgrade/mocks/jujumanager.go
@@ -45,6 +45,44 @@ func (m *MockJujuManager) EXPECT() *MockJujuManagerMockRecorder {
 	return m.recorder
 }
 
+// DryRunInternalMigration mocks base method.
+func (m *MockJujuManager) DryRunInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID, targetController string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DryRunInternalMigration", ctx, user, modelNameOrUUID, targetController)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DryRunInternalMigration indicates an expected call of DryRunInternalMigration.
+func (mr *MockJujuManagerMockRecorder) DryRunInternalMigration(ctx, user, modelNameOrUUID, targetController any) *MockJujuManagerDryRunInternalMigrationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRunInternalMigration", reflect.TypeOf((*MockJujuManager)(nil).DryRunInternalMigration), ctx, user, modelNameOrUUID, targetController)
+	return &MockJujuManagerDryRunInternalMigrationCall{Call: call}
+}
+
+// MockJujuManagerDryRunInternalMigrationCall wrap *gomock.Call
+type MockJujuManagerDryRunInternalMigrationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJujuManagerDryRunInternalMigrationCall) Return(arg0 error) *MockJujuManagerDryRunInternalMigrationCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJujuManagerDryRunInternalMigrationCall) Do(f func(context.Context, *openfga.User, string, string) error) *MockJujuManagerDryRunInternalMigrationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJujuManagerDryRunInternalMigrationCall) DoAndReturn(f func(context.Context, *openfga.User, string, string) error) *MockJujuManagerDryRunInternalMigrationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetModel mocks base method.
 func (m *MockJujuManager) GetModel(ctx context.Context, uuid string) (dbmodel.Model, error) {
 	m.ctrl.T.Helper()

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -38,6 +38,10 @@ type JujuManager interface {
 	ListMigrationTargets(ctx context.Context, user *openfga.User, modelTag names.ModelTag) ([]dbmodel.Controller, error)
 	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
 	InitiateInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) (jujuparams.InitiateMigrationResult, error)
+	// DryRunInternalMigration runs a migration precheck (dry run) without actually
+	// initiating the migration. It returns an error if the source controller does not
+	// support dry-run migrations (i.e. version < 3.6.13), or if the precheck fails.
+	DryRunInternalMigration(ctx context.Context, user *openfga.User, modelNameOrUUID string, targetController string) error
 	ModelInfo(ctx context.Context, user *openfga.User, mt names.ModelTag) (jujuclient.ModelInfo, error)
 }
 
@@ -183,6 +187,13 @@ func (u *UpgradeManager) UpgradeTo(ctx context.Context, user *openfga.User, mode
 	targetVersion, err := version.Parse(targetController.AgentVersion)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse target controller version: %w", err)
+	}
+
+	// Run a migration dry run to verify the model can be migrated to the target
+	// controller before committing to the job. This catches precheck failures
+	// (e.g. cross-version constraints, credential issues) early.
+	if err := u.jujuManager.DryRunInternalMigration(ctx, user, modelUUID, targetControllerName); err != nil {
+		return 0, fmt.Errorf("migration precheck failed: %w", err)
 	}
 
 	job, err := u.enqueuer.EnqueueUpgradeTo(ctx, rivertypes.UpgradeToArgs{

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -94,6 +94,11 @@ func TestUpgradeTo_Success(t *testing.T) {
 			},
 		}, nil)
 
+	// Dry-run precheck expectation.
+	s.jujuManager.EXPECT().
+		DryRunInternalMigration(gomock.Any(), gomock.Any(), modelUUID, targetController).
+		Return(nil)
+
 	// Migration expectations.
 	s.enqueuer.EXPECT().EnqueueUpgradeTo(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, uta rivertypes.UpgradeToArgs, metadata rivertypes.JobModelUUIDMetadata) (*rivertype.JobInsertResult, error) {
 		c.Check(uta.ModelUUID, qt.Equals, modelUUID)
@@ -110,6 +115,72 @@ func TestUpgradeTo_Success(t *testing.T) {
 	jobID, err := upgradeMgr.UpgradeTo(ctx, user, modelUUID, targetController)
 	c.Assert(err, qt.IsNil)
 	c.Assert(jobID, qt.Equals, int64(1))
+}
+
+func TestUpgradeTo_DryRunFails(t *testing.T) {
+	s := setupTest(t)
+	c := qt.New(t)
+
+	ctx := c.Context()
+	user := &openfga.User{
+		Identity: &dbmodel.Identity{
+			Name: "alice@canonical.com",
+		},
+	}
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	targetController := "controller-foo"
+
+	upgradeMgr, err := upgrade.NewUpgradeManager(s.jujuManager, s.store, s.dialer, s.enqueuer)
+	c.Assert(err, qt.IsNil)
+
+	s.jujuManager.EXPECT().
+		ListMigrationTargets(gomock.Any(), gomock.Any(), names.NewModelTag(modelUUID)).
+		Return([]dbmodel.Controller{
+			{
+				Name:         targetController,
+				AgentVersion: "4.1.0",
+			},
+		}, nil)
+
+	s.jujuManager.EXPECT().
+		DryRunInternalMigration(gomock.Any(), gomock.Any(), modelUUID, targetController).
+		Return(errors.New("charm not compatible with target version"))
+
+	_, err = upgradeMgr.UpgradeTo(ctx, user, modelUUID, targetController)
+	c.Assert(err, qt.ErrorMatches, ".*migration precheck failed.*charm not compatible with target version.*")
+}
+
+func TestUpgradeTo_DryRunControllerTooOld(t *testing.T) {
+	s := setupTest(t)
+	c := qt.New(t)
+
+	ctx := c.Context()
+	user := &openfga.User{
+		Identity: &dbmodel.Identity{
+			Name: "alice@canonical.com",
+		},
+	}
+	modelUUID := "93608db4-f1cb-4da5-9926-8233981aef0a"
+	targetController := "controller-foo"
+
+	upgradeMgr, err := upgrade.NewUpgradeManager(s.jujuManager, s.store, s.dialer, s.enqueuer)
+	c.Assert(err, qt.IsNil)
+
+	s.jujuManager.EXPECT().
+		ListMigrationTargets(gomock.Any(), gomock.Any(), names.NewModelTag(modelUUID)).
+		Return([]dbmodel.Controller{
+			{
+				Name:         targetController,
+				AgentVersion: "4.1.0",
+			},
+		}, nil)
+
+	s.jujuManager.EXPECT().
+		DryRunInternalMigration(gomock.Any(), gomock.Any(), modelUUID, targetController).
+		Return(errors.New(`controller "source-ctrl" (version 3.6.5) does not support migration dry runs; upgrade to 3.6.13 or later before running upgrade-to`))
+
+	_, err = upgradeMgr.UpgradeTo(ctx, user, modelUUID, targetController)
+	c.Assert(err, qt.ErrorMatches, ".*migration precheck failed.*does not support migration dry runs.*")
 }
 
 func TestUpgradeTo_InvalidTargetController(t *testing.T) {

--- a/internal/jujuclient/controller.go
+++ b/internal/jujuclient/controller.go
@@ -18,6 +18,11 @@ func (c Connection) ControllerConfig(ctx context.Context) (jujucontroller.Config
 	return controller.NewClient(&c).ControllerConfig()
 }
 
+// InitiateMigration begins a model migration to another controller.
+func (c Connection) InitiateMigration(spec controller.MigrationSpec, dryRun bool) (string, error) {
+	return controller.NewClient(&c).InitiateMigration(spec, dryRun)
+}
+
 // CloudSpec retrieves the cloud spec of the model connected to.
 func (c Connection) CloudSpec(ctx context.Context) (cloudspec.CloudSpec, error) {
 	modelCfgClient := modelconfig.NewClient(&c)

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/api/base"
+	controllerapi "github.com/juju/juju/api/controller/controller"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
@@ -173,6 +174,7 @@ type API struct {
 	CredentialContents_                func(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
 	UpgradeModel_                      func(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	AbortModelUpgrade_                 func(modelUUID string) error
+	InitiateMigration_                 func(spec controllerapi.MigrationSpec, dryRun bool) (string, error)
 }
 
 func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
@@ -490,6 +492,13 @@ func (a *API) AbortModelUpgrade(modelUUID string) error {
 		return errors.New("not implemented")
 	}
 	return a.AbortModelUpgrade_(modelUUID)
+}
+
+func (a *API) InitiateMigration(spec controllerapi.MigrationSpec, dryRun bool) (string, error) {
+	if a.InitiateMigration_ == nil {
+		return "", errors.New("not implemented")
+	}
+	return a.InitiateMigration_(spec, dryRun)
 }
 
 var _ juju.API = &API{}


### PR DESCRIPTION
## Description
This PR runs dry-run logic before we perform a `upgrade-to` operation. Because this feature landed in 3.6.13 without a bump in facade version, we return an error if the target controller version is <3.6.13. 

Fixes [JUJU-9061](https://warthogs.atlassian.net/browse/JUJU-9061)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


[JUJU-9061]: https://warthogs.atlassian.net/browse/JUJU-9061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ