### PR TITLE
fix: fix authcode state cookie verification path

### DIFF
--- a/cmd/jimmsrv/service/service.go
+++ b/cmd/jimmsrv/service/service.go
@@ -512,9 +512,20 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 	}
 	deps.cleanupFuncs = append(deps.cleanupFuncs, cleanupFuncs...)
 
-	redirectUrl := p.PublicDNSName + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint
-	if !strings.HasPrefix(redirectUrl, "https://") && !strings.HasPrefix(redirectUrl, "http://") {
-		redirectUrl = "https://" + redirectUrl
+	publicDNSURL := p.PublicDNSName
+	if !strings.HasPrefix(publicDNSURL, "https://") && !strings.HasPrefix(publicDNSURL, "http://") {
+		publicDNSURL = "https://" + publicDNSURL
+	}
+	redirectUrl := publicDNSURL + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint
+
+	// authBasePath is the external sub-path under which JIMM is hosted (e.g.
+	// "/jimm-jimm" when behind an ingress). It is derived from the public DNS
+	// name so that the OAuth state cookie is scoped to the same path the
+	// identity provider redirects back to. It is empty when JIMM is hosted at
+	// the root.
+	var authBasePath string
+	if parsedDNS, err := url.Parse(publicDNSURL); err == nil {
+		authBasePath = strings.TrimSuffix(parsedDNS.Path, "/")
 	}
 
 	authSvc, err := auth.NewAuthenticationService(
@@ -547,6 +558,7 @@ func NewServiceDependencies(ctx context.Context, p Params) (*ServiceDependencies
 		deps.OAuthHandler, err = jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
 			Authenticator:             authSvc,
 			DashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
+			BasePath:                  authBasePath,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup authentication handler: %w", err)

--- a/internal/jimmhttp/auth_handler.go
+++ b/internal/jimmhttp/auth_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/juju/zaputil/zapctx"
@@ -34,6 +35,11 @@ type OAuthHandler struct {
 	Router                    *chi.Mux
 	authenticator             BrowserOAuthAuthenticator
 	dashboardFinalRedirectURL string
+	// cookieCallbackPath is the path used to scope the OAuth state cookie so
+	// that the browser sends it back on the callback request. It includes any
+	// external base path under which JIMM is hosted (e.g. when behind an
+	// ingress that prefixes requests with a sub-path).
+	cookieCallbackPath string
 }
 
 // OAuthHandlerParams holds the parameters to configure the OAuthHandler.
@@ -44,6 +50,13 @@ type OAuthHandlerParams struct {
 	// DashboardFinalRedirectURL is the final redirection URL to send users to
 	// upon completing the authorisation code flow.
 	DashboardFinalRedirectURL string
+
+	// BasePath is the external base path under which JIMM is hosted, derived
+	// from JIMM's public DNS name (e.g. "/jimm-jimm" when served behind an
+	// ingress that prefixes requests with a sub-path). It is prepended to the
+	// OAuth state cookie path so the browser sends the cookie back on the
+	// callback request. It may be empty when JIMM is hosted at the root.
+	BasePath string
 }
 
 // BrowserOAuthAuthenticator handles authorisation code authentication within JIMM
@@ -77,7 +90,18 @@ func NewOAuthHandler(p OAuthHandlerParams) (*OAuthHandler, error) {
 		Router:                    chi.NewRouter(),
 		authenticator:             p.Authenticator,
 		dashboardFinalRedirectURL: p.DashboardFinalRedirectURL,
+		cookieCallbackPath:        callbackCookiePath(p.BasePath),
 	}, nil
+}
+
+// callbackCookiePath builds the path used to scope the OAuth state cookie. It
+// prepends the supplied external base path (if any) to the callback endpoint
+// so the browser sends the cookie back when the identity provider redirects to
+// JIMM, even when JIMM is hosted under a sub-path. A trailing slash on the base
+// path is trimmed to avoid producing a double slash.
+func callbackCookiePath(basePath string) string {
+	basePath = strings.TrimSuffix(basePath, "/")
+	return basePath + AuthResourceBasePath + CallbackEndpoint
 }
 
 // Routes returns the grouped routers routes with group specific middlewares.
@@ -105,10 +129,10 @@ func (oah *OAuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.StateKey,
 		Value:    state,
-		MaxAge:   900,                                     // 15 min.
-		Path:     AuthResourceBasePath + CallbackEndpoint, // Only send the cookie back on /auth paths.
-		HttpOnly: true,                                    // Restrict access from JS.
-		SameSite: http.SameSiteLaxMode,                    // Allow the cookie to be sent on a redirect from the IdP to JIMM.
+		MaxAge:   900,                    // 15 min.
+		Path:     oah.cookieCallbackPath, // Only send the cookie back on the callback path.
+		HttpOnly: true,                   // Restrict access from JS.
+		SameSite: http.SameSiteLaxMode,   // Allow the cookie to be sent on a redirect from the IdP to JIMM.
 	})
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }

--- a/internal/jimmhttp/auth_handler_test.go
+++ b/internal/jimmhttp/auth_handler_test.go
@@ -203,3 +203,68 @@ func TestCallbackFailsExchange(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(b), qt.Equals, http.StatusText(http.StatusForbidden)+` - authorisation code exchange failed: oauth2: "invalid_grant" "Code not valid"`+"\n")
 }
+
+// stubLoginAuthenticator is a minimal BrowserOAuthAuthenticator that only
+// supports the Login flow, allowing the state cookie path to be exercised
+// without a real identity provider.
+type stubLoginAuthenticator struct {
+	jimmhttp.BrowserOAuthAuthenticator
+}
+
+func (stubLoginAuthenticator) AuthCodeURL() (string, string, error) {
+	return "http://localhost/idp/auth?state=teststate", "teststate", nil
+}
+
+// TestLoginStateCookiePath verifies that the OAuth state cookie is scoped to a
+// path that includes the external base path under which JIMM is hosted, so the
+// browser sends the cookie back when the identity provider redirects to the
+// callback endpoint.
+func TestLoginStateCookiePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name         string
+		basePath     string
+		expectedPath string
+	}{{
+		name:         "no base path",
+		basePath:     "",
+		expectedPath: jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint,
+	}, {
+		name:         "with base path",
+		basePath:     "/jimm-jimm",
+		expectedPath: "/jimm-jimm" + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint,
+	}, {
+		name:         "base path with trailing slash",
+		basePath:     "/jimm-jimm/",
+		expectedPath: "/jimm-jimm" + jimmhttp.AuthResourceBasePath + jimmhttp.CallbackEndpoint,
+	}}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			h, err := jimmhttp.NewOAuthHandler(jimmhttp.OAuthHandlerParams{
+				Authenticator:             stubLoginAuthenticator{},
+				DashboardFinalRedirectURL: "http://localhost/dashboard",
+				BasePath:                  test.basePath,
+			})
+			c.Assert(err, qt.IsNil)
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", jimmhttp.AuthResourceBasePath+jimmhttp.LoginEndpoint, nil)
+			h.Login(rr, req)
+
+			res := rr.Result()
+			defer res.Body.Close()
+
+			var stateCookie *http.Cookie
+			for _, cookie := range res.Cookies() {
+				if cookie.Name == auth.StateKey {
+					stateCookie = cookie
+					break
+				}
+			}
+			c.Assert(stateCookie, qt.Not(qt.IsNil))
+			c.Check(stateCookie.Path, qt.Equals, test.expectedPath)
+		})
+	}
+}


### PR DESCRIPTION
## Description

### Why
The browser OAuth2 login flow stores a CSRF `state` value in a short-lived cookie (`jimm-oauth-state`) and compares it against the `state` query parameter on the `/auth/callback` request. The cookie's `Path` was hardcoded to `/auth/callback`.

However, the redirect URI sent to the identity provider is built from `PublicDNSName` (`JIMM_DNS_NAME`), which may include a sub-path. With `JIMM_DNS_NAME = https://jimm.workshop/jimm-jimm`, the IdP redirects the browser to `https://jimm.workshop/jimm-jimm/auth/callback`. Per [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4), a cookie is only sent when the request path matches (or is a subpath of) the cookie's `Path`. `/jimm-jimm/auth/callback` is not under `/auth/callback`, so the browser withheld the cookie and the callback failed with `no state cookie present`.

This only affected deployments where JIMM is not hosted at the root (e.g., charmed deployments behind Traefik with a path prefix, domain would be unaffected).

## Options considered

1. Derive the base path from our preexisting `PublicDnssName`
2. Set cookie to just `/`
3. Add an explicit config option for this path 

I decided to go with option 1 because it is the most correct (from an operational POV) and keeps the cookie tightly scoped, while reusing the existing `PublicDNSName` as the single source of truth — exactly how the redirect URI is already derived. Option 2 was a viable quick fix but needlessly widens the cookie scope, right now it doesn't matter but it may in the future. Option 3 adds redundant configuration and user drift risk.

Behaviour is unchanged for root hosted/doman deployments (cookie path remains `/auth/callback`).

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

`TestLoginStateCookiePath` covers the cookie-path derivation for: no base path, a base path, and a base path with a trailing slash. So I think we're all good here.

I didn't verify manually, as we can deploy to staging but... To verify manually, deploy JIMM behind an ingress with a path prefix (e.g. `JIMM_DNS_NAME=https://<host>/jimm-jimm`), perform a browser logi, and confirm the flow completes through `/jimm-jimm/auth/callback` without a `no state cookie present` error. And then in the browser we could inspect the `jimm-oauth-state` cookie and confirm its `Path` is `/jimm-jimm/auth/callback` (which if you successfully logged in, it obviously will be.





