### PR TITLE
feat: jaas upgrade-controller

### DIFF
--- a/cmd/jaas/cmd/interface.go
+++ b/cmd/jaas/cmd/interface.go
@@ -80,5 +80,6 @@ type JIMMAPI interface {
 	CrossModelQuery(req *params.CrossModelQueryRequest) (*params.CrossModelQueryResponse, error)
 
 	// Other operations
+	UpgradeController(req *params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error)
 	UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error)
 }

--- a/cmd/jaas/cmd/mocks/client_mock.go
+++ b/cmd/jaas/cmd/mocks/client_mock.go
@@ -1822,6 +1822,45 @@ func (c *MockJIMMAPIUpdateMigratedModelCall) DoAndReturn(f func(*params.UpdateMi
 	return c
 }
 
+// UpgradeController mocks base method.
+func (m *MockJIMMAPI) UpgradeController(req *params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeController", req)
+	ret0, _ := ret[0].(params.UpgradeControllerResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeController indicates an expected call of UpgradeController.
+func (mr *MockJIMMAPIMockRecorder) UpgradeController(req any) *MockJIMMAPIUpgradeControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeController", reflect.TypeOf((*MockJIMMAPI)(nil).UpgradeController), req)
+	return &MockJIMMAPIUpgradeControllerCall{Call: call}
+}
+
+// MockJIMMAPIUpgradeControllerCall wrap *gomock.Call
+type MockJIMMAPIUpgradeControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockJIMMAPIUpgradeControllerCall) Return(arg0 params.UpgradeControllerResponse, arg1 error) *MockJIMMAPIUpgradeControllerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockJIMMAPIUpgradeControllerCall) Do(f func(*params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error)) *MockJIMMAPIUpgradeControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockJIMMAPIUpgradeControllerCall) DoAndReturn(f func(*params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error)) *MockJIMMAPIUpgradeControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpgradeTo mocks base method.
 func (m *MockJIMMAPI) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
 	m.ctrl.T.Helper()

--- a/cmd/jaas/cmd/upgradecontroller.go
+++ b/cmd/jaas/cmd/upgradecontroller.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Canonical.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/version/v2"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+const (
+	upgradeControllerDoc = `
+Upgrades the Juju agent running on the named backing controller to the next
+available patch release. If --target-version is specified, upgrades to that
+exact version instead.
+
+The command requires the caller to be a JIMM admin.
+`
+	upgradeControllerExamples = `
+    jaas upgrade-controller mycontroller
+    jaas upgrade-controller mycontroller --target-version 3.6.8
+    jaas upgrade-controller mycontroller --dry-run
+`
+)
+
+// NewUpgradeControllerCommand returns a command to upgrade a backing controller's agent.
+func NewUpgradeControllerCommand() cmd.Command {
+	cmd := &upgradeControllerCommand{}
+	cmd.SetClientStore(jujuclient.NewFileClientStore())
+	return modelcmd.WrapBase(cmd)
+}
+
+type upgradeControllerCommand struct {
+	jaasCommandBase
+
+	controllerName      string
+	targetVersionStr    string
+	targetVersion       version.Number
+	agentStream         string
+	ignoreAgentVersions bool
+	dryRun              bool
+}
+
+func (c *upgradeControllerCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "upgrade-controller",
+		Args:     "<controller-name>",
+		Purpose:  "Upgrades the agent of a backing Juju controller",
+		Doc:      upgradeControllerDoc,
+		Examples: upgradeControllerExamples,
+	})
+}
+
+func (c *upgradeControllerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.targetVersionStr, "target-version", "", "Upgrade to this specific version")
+	f.StringVar(&c.agentStream, "agent-stream", "", "Check this agent stream for upgrades")
+	f.BoolVar(&c.ignoreAgentVersions, "ignore-agent-versions", false, "Don't check if all agents have already reached the current version")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Don't change anything, just report what version would be chosen")
+}
+
+func (c *upgradeControllerCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("controller name is required")
+	}
+	c.controllerName = args[0]
+
+	if c.targetVersionStr != "" {
+		v, err := version.Parse(c.targetVersionStr)
+		if err != nil {
+			return fmt.Errorf("invalid --target-version %q: %w", c.targetVersionStr, err)
+		}
+		c.targetVersion = v
+	}
+
+	return cmd.CheckEmpty(args[1:])
+}
+
+func (c *upgradeControllerCommand) Run(ctxt *cmd.Context) error {
+	client, err := c.getJIMMAPI()
+	if err != nil {
+		return fmt.Errorf("failed to create JIMM client: %w", err)
+	}
+	defer client.Close()
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName:      c.controllerName,
+		TargetVersion:       c.targetVersion,
+		AgentStream:         c.agentStream,
+		IgnoreAgentVersions: c.ignoreAgentVersions,
+		DryRun:              c.dryRun,
+	}
+
+	resp, err := client.UpgradeController(req)
+	if err != nil {
+		return fmt.Errorf("upgrade-controller failed: %w", err)
+	}
+
+	if c.dryRun {
+		fmt.Fprintf(ctxt.Stderr, "best version:\n    %v\n", resp.ChosenVersion)
+		fmt.Fprintf(ctxt.Stderr, "upgrade-controller --dry-run: no changes applied\n")
+	} else {
+		fmt.Fprintf(ctxt.Stdout, "started upgrade to %s\n", resp.ChosenVersion)
+	}
+	return nil
+}

--- a/cmd/jaas/cmd/upgradecontroller.go
+++ b/cmd/jaas/cmd/upgradecontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Canonical.
+// Copyright 2025 Canonical.
 
 package cmd
 
@@ -104,8 +104,8 @@ func (c *upgradeControllerCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	if c.dryRun {
-		fmt.Fprintf(ctxt.Stderr, "best version:\n    %v\n", resp.ChosenVersion)
-		fmt.Fprintf(ctxt.Stderr, "upgrade-controller --dry-run: no changes applied\n")
+		ctxt.Infof("best version:\n    %v", resp.ChosenVersion)
+		ctxt.Infof("upgrade-controller --dry-run: no changes applied")
 	} else {
 		fmt.Fprintf(ctxt.Stdout, "started upgrade to %s\n", resp.ChosenVersion)
 	}

--- a/cmd/jaas/cmd/upgradecontroller.go
+++ b/cmd/jaas/cmd/upgradecontroller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/cmd/upgradecontroller_test.go
+++ b/cmd/jaas/cmd/upgradecontroller_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Canonical.
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/version/v2"
+
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+func TestUpgradeController_Success(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	chosenVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName: "my-controller",
+	}
+	s.client.EXPECT().UpgradeController(req).Return(apiparams.UpgradeControllerResponse{
+		ChosenVersion: chosenVersion,
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	upgradeCmd.setJIMMAPI(s.client)
+	upgradeCmd.SetClientStore(s.store)
+	initCommand(c, upgradeCmd, "my-controller")
+
+	ctx := newTestContext(c)
+	err = upgradeCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Equals, "started upgrade to 3.6.12\n")
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), qt.Equals, "")
+}
+
+func TestUpgradeController_WithTargetVersion(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	targetVersion, err := version.Parse("3.6.8")
+	c.Assert(err, qt.IsNil)
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName: "my-controller",
+		TargetVersion:  targetVersion,
+	}
+	s.client.EXPECT().UpgradeController(req).Return(apiparams.UpgradeControllerResponse{
+		ChosenVersion: targetVersion,
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	upgradeCmd.setJIMMAPI(s.client)
+	upgradeCmd.SetClientStore(s.store)
+	initCommand(c, upgradeCmd, "my-controller", "--target-version", "3.6.8")
+
+	ctx := newTestContext(c)
+	err = upgradeCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Equals, "started upgrade to 3.6.8\n")
+}
+
+func TestUpgradeController_DryRun(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	chosenVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName: "my-controller",
+		DryRun:         true,
+	}
+	s.client.EXPECT().UpgradeController(req).Return(apiparams.UpgradeControllerResponse{
+		ChosenVersion: chosenVersion,
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	upgradeCmd.setJIMMAPI(s.client)
+	upgradeCmd.SetClientStore(s.store)
+	initCommand(c, upgradeCmd, "my-controller", "--dry-run")
+
+	ctx := newTestContext(c)
+	err = upgradeCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Equals, "")
+	// dry-run output goes to Stderr via ctxt.Infof
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), qt.Contains, "3.6.12")
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), qt.Contains, "no changes applied")
+}
+
+func TestUpgradeController_AllFlags(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	targetVersion, err := version.Parse("3.6.5")
+	c.Assert(err, qt.IsNil)
+	chosenVersion, err := version.Parse("3.6.5")
+	c.Assert(err, qt.IsNil)
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName:      "my-controller",
+		TargetVersion:       targetVersion,
+		AgentStream:         "proposed",
+		IgnoreAgentVersions: true,
+		DryRun:              true,
+	}
+	s.client.EXPECT().UpgradeController(req).Return(apiparams.UpgradeControllerResponse{
+		ChosenVersion: chosenVersion,
+	}, nil)
+	s.client.EXPECT().Close().Return(nil)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	upgradeCmd.setJIMMAPI(s.client)
+	upgradeCmd.SetClientStore(s.store)
+	initCommand(c, upgradeCmd,
+		"my-controller",
+		"--target-version", "3.6.5",
+		"--agent-stream", "proposed",
+		"--ignore-agent-versions",
+		"--dry-run",
+	)
+
+	ctx := newTestContext(c)
+	err = upgradeCmd.Run(ctx)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestUpgradeController_APIError(t *testing.T) {
+	c := qt.New(t)
+	s := setupCmdMocks(c)
+
+	req := &apiparams.UpgradeControllerRequest{
+		ControllerName: "my-controller",
+	}
+	s.client.EXPECT().UpgradeController(req).Return(apiparams.UpgradeControllerResponse{}, errors.New("controller not found"))
+	s.client.EXPECT().Close().Return(nil)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	upgradeCmd.setJIMMAPI(s.client)
+	upgradeCmd.SetClientStore(s.store)
+	initCommand(c, upgradeCmd, "my-controller")
+
+	ctx := newTestContext(c)
+	err := upgradeCmd.Run(ctx)
+	c.Assert(err, qt.ErrorMatches, "upgrade-controller failed: controller not found")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), qt.Equals, "")
+}
+
+func TestUpgradeController_MissingControllerName(t *testing.T) {
+	c := qt.New(t)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	err := initCommandWithError(upgradeCmd)
+	c.Assert(err, qt.ErrorMatches, "controller name is required")
+}
+
+func TestUpgradeController_InvalidTargetVersion(t *testing.T) {
+	c := qt.New(t)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	err := initCommandWithError(upgradeCmd, "my-controller", "--target-version", "not-a-version")
+	c.Assert(err, qt.ErrorMatches, `invalid --target-version "not-a-version":.*`)
+}
+
+func TestUpgradeController_TooManyArgs(t *testing.T) {
+	c := qt.New(t)
+
+	upgradeCmd := &upgradeControllerCommand{}
+	err := initCommandWithError(upgradeCmd, "my-controller", "extra-arg")
+	c.Assert(err, qt.ErrorMatches, `unrecognized args:.*extra-arg.*`)
+}

--- a/cmd/jaas/cmd/upgradecontroller_test.go
+++ b/cmd/jaas/cmd/upgradecontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package cmd
 

--- a/cmd/jaas/main.go
+++ b/cmd/jaas/main.go
@@ -66,6 +66,7 @@ func NewSuperCommand() *jujucmd.SuperCommand {
 	jaasCmd.Register(cmd.NewUnregisterControllerCommand())
 	jaasCmd.Register(cmd.NewUpdateControllerProfileCommand())
 	jaasCmd.Register(cmd.NewUpdateMigratedModelCommand())
+	jaasCmd.Register(cmd.NewUpgradeControllerCommand())
 	jaasCmd.Register(cmd.NewUpgradeToCommand())
 	jaasCmd.Register(cmd.NewBootstrapStatusCommand())
 	jaasCmd.Register(cmd.NewBootstrapStopCommand())

--- a/docs/howto/manage-juju-controllers.md
+++ b/docs/howto/manage-juju-controllers.md
@@ -218,6 +218,18 @@ To grant a (collection of) user(s) access to a Juju controller, add a `can_addmo
 > See more: {ref}`add-a-permission`
 
 
+## Upgrade a Juju controller
+
+To upgrade the Juju agent running on a controller registered with JIMM, use the `jaas upgrade-controller` command followed by the controller name:
+
+```text
+juju switch jimm
+juju jaas upgrade-controller mycontroller
+```
+
+> See more: {ref}`command-jaas-upgrade-controller`
+
+
 ## Remove a Juju controller
 
 As with bootstrap there are 2 ways to remove a Juju controller attached to JIMM.

--- a/docs/reference/list-of-jaas-plugin-commands/index.md
+++ b/docs/reference/list-of-jaas-plugin-commands/index.md
@@ -1672,6 +1672,40 @@ Updates a model known to JIMM that has been migrated
 externally to a different JAAS controller.
 
 
+(command-jaas-upgrade-controller)=
+# jaas upgrade-controller
+
+## Summary
+Upgrades the agent of a backing Juju controller
+
+## Usage
+```juju jaas upgrade-controller [options] <controller-name>```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--agent-stream` |  | Check this agent stream for upgrades |
+| `--dry-run` | false | Don't change anything, just report what version would be chosen |
+| `--ignore-agent-versions` | false | Don't check if all agents have already reached the current version |
+| `--target-version` |  | Upgrade to this specific version |
+
+## Examples
+
+    jaas upgrade-controller mycontroller
+    jaas upgrade-controller mycontroller --target-version 3.6.8
+    jaas upgrade-controller mycontroller --dry-run
+
+
+## Details
+
+Upgrades the Juju agent running on the named backing controller to the next
+available patch release. If --target-version is specified, upgrades to that
+exact version instead.
+
+The command requires the caller to be a JIMM admin.
+
+
 (command-jaas-upgrade-to)=
 # jaas upgrade-to
 

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -196,6 +196,12 @@ type API interface {
 		ignoreAgentVersions bool,
 		dryRun bool,
 	) (version.Number, error)
+
+	// ControllerModelUUID returns the UUID of the controller model on the
+	// connected controller. It reads the model configuration of the model
+	// the connection is scoped to (the controller model) and returns its
+	// UUID.
+	ControllerModelUUID(context.Context) (string, error)
 }
 
 // PermissionManager provides a way to manage permissions within JIMM.

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -630,10 +630,9 @@ func (j *JujuManager) AbortModelUpgrade(ctx context.Context, user *openfga.User,
 }
 
 // UpgradeController upgrades the agent of the named backing Juju controller.
-// It resolves the controller model UUID by dialling the controller and calling
-// ListModels as admin, selecting the model named "controller". The caller must
-// be a JIMM admin; this is enforced in the facade layer before this method is
-// called.
+// It resolves the controller model UUID by dialling the controller and reading
+// the controller model's configuration. The caller must be a JIMM admin; this
+// is enforced in the facade layer before this method is called.
 func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User, controllerName string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
 	controller, err := j.getControllerByName(ctx, controllerName)
 	if err != nil {
@@ -646,20 +645,9 @@ func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User,
 	}
 	defer api.Close()
 
-	models, err := api.ListModels(ctx)
+	controllerModelUUID, err := api.ControllerModelUUID(ctx)
 	if err != nil {
-		return version.Number{}, errors.Codef(errors.CodeServerError, "failed to list models on controller %q: %w", controllerName, err)
-	}
-
-	var controllerModelUUID string
-	for _, m := range models {
-		if m.Name == "controller" {
-			controllerModelUUID = m.UUID
-			break
-		}
-	}
-	if controllerModelUUID == "" {
-		return version.Number{}, errors.Codef(errors.CodeNotFound, "controller model not found on controller %q", controllerName)
+		return version.Number{}, errors.Codef(errors.CodeServerError, "failed to get controller model UUID on controller %q: %w", controllerName, err)
 	}
 
 	chosenVersion, err := api.UpgradeModel(controllerModelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -634,6 +634,46 @@ func (j *JujuManager) AbortModelUpgrade(ctx context.Context, user *openfga.User,
 // error with the code CodeUnauthorized is returned. The targetVersion can be
 // version.Zero, in which case the best version is selected by the controller.
 // Writer access is equivalent to Juju's WriteAccess permission.
+// UpgradeController upgrades the agent of the named backing Juju controller.
+// It resolves the controller model UUID by dialling the controller and calling
+// ListModels as admin, selecting the model named "controller". The caller must
+// be a JIMM admin; this is enforced in the facade layer before this method is
+// called.
+func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User, controllerName string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+	controller, err := j.getControllerByName(ctx, controllerName)
+	if err != nil {
+		return version.Number{}, err
+	}
+
+	api, err := j.dialController(ctx, controller, user)
+	if err != nil {
+		return version.Number{}, err
+	}
+	defer api.Close()
+
+	models, err := api.ListModels(ctx)
+	if err != nil {
+		return version.Number{}, errors.Codef(errors.CodeNotFound, "failed to list models on controller %q: %w", controllerName, err)
+	}
+
+	var controllerModelUUID string
+	for _, m := range models {
+		if m.Name == "controller" {
+			controllerModelUUID = m.UUID
+			break
+		}
+	}
+	if controllerModelUUID == "" {
+		return version.Number{}, errors.Codef(errors.CodeNotFound, "controller model not found on controller %q", controllerName)
+	}
+
+	chosenVersion, err := api.UpgradeModel(controllerModelUUID, targetVersion, stream, ignoreAgentVersions, dryRun)
+	if err != nil {
+		return version.Number{}, err
+	}
+	return chosenVersion, nil
+}
+
 func (j *JujuManager) UpgradeModel(ctx context.Context, user *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
 	var chosenVersion version.Number
 	err := j.doModel(ctx, user, mt, ofganames.WriterRelation, func(_ *dbmodel.Model, api API) error {

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -629,11 +629,6 @@ func (j *JujuManager) AbortModelUpgrade(ctx context.Context, user *openfga.User,
 	})
 }
 
-// UpgradeModel upgrades the model with the given model tag to the provided agent
-// version. If the given user does not have writer access to the model then an
-// error with the code CodeUnauthorized is returned. The targetVersion can be
-// version.Zero, in which case the best version is selected by the controller.
-// Writer access is equivalent to Juju's WriteAccess permission.
 // UpgradeController upgrades the agent of the named backing Juju controller.
 // It resolves the controller model UUID by dialling the controller and calling
 // ListModels as admin, selecting the model named "controller". The caller must
@@ -653,7 +648,7 @@ func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User,
 
 	models, err := api.ListModels(ctx)
 	if err != nil {
-		return version.Number{}, errors.Codef(errors.CodeNotFound, "failed to list models on controller %q: %w", controllerName, err)
+		return version.Number{}, errors.Codef(errors.CodeServerError, "failed to list models on controller %q: %w", controllerName, err)
 	}
 
 	var controllerModelUUID string
@@ -674,6 +669,11 @@ func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User,
 	return chosenVersion, nil
 }
 
+// UpgradeModel upgrades the model with the given model tag to the provided agent
+// version. If the given user does not have writer access to the model then an
+// error with the code CodeUnauthorized is returned. The targetVersion can be
+// version.Zero, in which case the best version is selected by the controller.
+// Writer access is equivalent to Juju's WriteAccess permission.
 func (j *JujuManager) UpgradeModel(ctx context.Context, user *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
 	var chosenVersion version.Number
 	err := j.doModel(ctx, user, mt, ofganames.WriterRelation, func(_ *dbmodel.Model, api API) error {

--- a/internal/jimm/upgrade/mocks/api.go
+++ b/internal/jimm/upgrade/mocks/api.go
@@ -746,6 +746,45 @@ func (c *MockAPIControllerConfigCall) DoAndReturn(f func(context.Context) (contr
 	return c
 }
 
+// ControllerModelUUID mocks base method.
+func (m *MockAPI) ControllerModelUUID(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerModelUUID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerModelUUID indicates an expected call of ControllerModelUUID.
+func (mr *MockAPIMockRecorder) ControllerModelUUID(arg0 any) *MockAPIControllerModelUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerModelUUID", reflect.TypeOf((*MockAPI)(nil).ControllerModelUUID), arg0)
+	return &MockAPIControllerModelUUIDCall{Call: call}
+}
+
+// MockAPIControllerModelUUIDCall wrap *gomock.Call
+type MockAPIControllerModelUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAPIControllerModelUUIDCall) Return(arg0 string, arg1 error) *MockAPIControllerModelUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAPIControllerModelUUIDCall) Do(f func(context.Context) (string, error)) *MockAPIControllerModelUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAPIControllerModelUUIDCall) DoAndReturn(f func(context.Context) (string, error)) *MockAPIControllerModelUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateModel mocks base method.
 func (m *MockAPI) CreateModel(arg0 context.Context, arg1 *jujuclient.CreateModelArgs) (base.ModelInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -259,6 +259,7 @@ type JujuManager interface {
 	UpdateMigratedModel(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
 	AbortModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag) error
 	UpgradeModel(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
+	UpgradeController(ctx context.Context, u *openfga.User, controllerName string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	ValidateModelUpgrade(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 	SupportedVersions(ctx context.Context, contextualVersion *string) (params.SupportedJujuVersionsResponse, error)
 	// Migration related methods

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -74,6 +74,7 @@ func init() {
 		getControllerProfile := rpc.Method(r.GetControllerProfile)
 		listControllerProfiles := rpc.Method(r.ListControllerProfiles)
 		removeControllerProfile := rpc.Method(r.RemoveControllerProfile)
+		upgradeControllerMethod := rpc.Method(r.UpgradeController)
 		upgradeToMethod := rpc.Method(r.UpgradeTo)
 		listUserCloudsMethod := rpc.Method(r.ListUserClouds)
 		listModelsMethod := rpc.Method(r.ListModelControllerInfo)
@@ -133,6 +134,7 @@ func init() {
 		r.AddMethod("JIMM", 4, "StartDestroyController", startDestroyController)
 		r.AddMethod("JIMM", 4, "StopBootstrap", stopBootstrap)
 		// JIMM Upgrades
+		r.AddMethod("JIMM", 4, "UpgradeController", upgradeControllerMethod)
 		r.AddMethod("JIMM", 4, "UpgradeTo", upgradeToMethod)
 		// Job management
 		r.AddMethod("JIMM", 4, "JobInfo", jobInfoMethod)
@@ -780,6 +782,28 @@ func (r *controllerRoot) StartDestroyController(ctx context.Context, req apipara
 	return apiparams.StartBootstrapResponse{
 		JobID: strconv.FormatInt(jobID, 10),
 	}, nil
+}
+
+// UpgradeController upgrades the agent of the named backing Juju controller
+// to the next available patch release (or the specified target version).
+// The caller must be a JIMM admin.
+func (r *controllerRoot) UpgradeController(ctx context.Context, req apiparams.UpgradeControllerRequest) (apiparams.UpgradeControllerResponse, error) {
+	if !r.user.JimmAdmin {
+		return apiparams.UpgradeControllerResponse{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+	}
+	chosenVersion, err := r.jimm.JujuManager().UpgradeController(
+		ctx,
+		r.user,
+		req.ControllerName,
+		req.TargetVersion,
+		req.AgentStream,
+		req.IgnoreAgentVersions,
+		req.DryRun,
+	)
+	if err != nil {
+		return apiparams.UpgradeControllerResponse{}, err
+	}
+	return apiparams.UpgradeControllerResponse{ChosenVersion: chosenVersion}, nil
 }
 
 // UpgradeTo upgrades the controller hosting the given model by cloning a new controller

--- a/internal/jujuapi/upgradecontroller_test.go
+++ b/internal/jujuapi/upgradecontroller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Canonical.
+// Copyright 2026 Canonical.
 
 package jujuapi_test
 

--- a/internal/jujuapi/upgradecontroller_test.go
+++ b/internal/jujuapi/upgradecontroller_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Canonical.
+
+package jujuapi_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jujuapi"
+	"github.com/canonical/jimm/v3/internal/openfga"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest/mocks"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+func TestUpgradeController_Unauthorized(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", false)
+
+	_, err := root.UpgradeController(ctx, apiparams.UpgradeControllerRequest{
+		ControllerName: "test-controller",
+	})
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeUnauthorized)
+	c.Assert(err, qt.ErrorMatches, "unauthorized")
+}
+
+func TestUpgradeController_Success(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	targetVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+	chosenVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	called := false
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeController_: func(_ context.Context, _ *openfga.User, controllerName string, tv version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+						called = true
+						c.Check(controllerName, qt.Equals, "test-controller")
+						c.Check(tv, qt.DeepEquals, targetVersion)
+						c.Check(stream, qt.Equals, "")
+						c.Check(ignoreAgentVersions, qt.IsFalse)
+						c.Check(dryRun, qt.IsFalse)
+						return chosenVersion, nil
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	resp, err := root.UpgradeController(ctx, apiparams.UpgradeControllerRequest{
+		ControllerName: "test-controller",
+		TargetVersion:  targetVersion,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(called, qt.IsTrue)
+	c.Assert(resp.ChosenVersion, qt.DeepEquals, chosenVersion)
+}
+
+func TestUpgradeController_DryRun(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	chosenVersion, err := version.Parse("3.6.12")
+	c.Assert(err, qt.IsNil)
+
+	called := false
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeController_: func(_ context.Context, _ *openfga.User, _ string, _ version.Number, _ string, _ bool, dryRun bool) (version.Number, error) {
+						called = true
+						c.Check(dryRun, qt.IsTrue)
+						return chosenVersion, nil
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	resp, err := root.UpgradeController(ctx, apiparams.UpgradeControllerRequest{
+		ControllerName: "test-controller",
+		DryRun:         true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(called, qt.IsTrue)
+	c.Assert(resp.ChosenVersion, qt.DeepEquals, chosenVersion)
+}
+
+func TestUpgradeController_ControllerNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeController_: func(_ context.Context, _ *openfga.User, _ string, _ version.Number, _ string, _ bool, _ bool) (version.Number, error) {
+						return version.Zero, errors.Codef(errors.CodeNotFound, "controller not found")
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	_, err := root.UpgradeController(ctx, apiparams.UpgradeControllerRequest{
+		ControllerName: "nonexistent",
+	})
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+}
+
+func TestUpgradeController_AllOptions(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := c.Context()
+	chosenVersion, err := version.Parse("3.6.9")
+	c.Assert(err, qt.IsNil)
+
+	called := false
+	jimm := &jimmtest.JIMM{
+		JujuManager_: func() jujuapi.JujuManager {
+			return &mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					UpgradeController_: func(_ context.Context, _ *openfga.User, controllerName string, _ version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+						called = true
+						c.Check(controllerName, qt.Equals, "test-controller")
+						c.Check(stream, qt.Equals, "proposed")
+						c.Check(ignoreAgentVersions, qt.IsTrue)
+						c.Check(dryRun, qt.IsTrue)
+						return chosenVersion, nil
+					},
+				},
+			}
+		},
+	}
+	root := newTestControllerRoot(jimm, "alice@canonical.com", true)
+
+	resp, err := root.UpgradeController(ctx, apiparams.UpgradeControllerRequest{
+		ControllerName:      "test-controller",
+		AgentStream:         "proposed",
+		IgnoreAgentVersions: true,
+		DryRun:              true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(called, qt.IsTrue)
+	c.Assert(resp.ChosenVersion, qt.DeepEquals, chosenVersion)
+}

--- a/internal/jujuclient/controller.go
+++ b/internal/jujuclient/controller.go
@@ -18,6 +18,24 @@ func (c Connection) ControllerConfig(ctx context.Context) (jujucontroller.Config
 	return controller.NewClient(&c).ControllerConfig()
 }
 
+// ControllerModelUUID returns the UUID of the controller model on the
+// connected controller. The connection must be scoped to the controller
+// (not a specific model), in which case ModelGet returns the controller
+// model's configuration.
+func (c Connection) ControllerModelUUID(ctx context.Context) (string, error) {
+	attrs, err := modelconfig.NewClient(&c).ModelGet()
+	if err != nil {
+		return "", err
+	}
+
+	cfg, err := config.New(config.NoDefaults, attrs)
+	if err != nil {
+		return "", err
+	}
+
+	return cfg.UUID(), nil
+}
+
 // CloudSpec retrieves the cloud spec of the model connected to.
 func (c Connection) CloudSpec(ctx context.Context) (cloudspec.CloudSpec, error) {
 	modelCfgClient := modelconfig.NewClient(&c)

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -173,6 +173,7 @@ type API struct {
 	CredentialContents_                func(cloud string, credential string, withSecrets bool) ([]jujuparams.CredentialContentResult, error)
 	UpgradeModel_                      func(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	AbortModelUpgrade_                 func(modelUUID string) error
+	ControllerModelUUID_               func(ctx context.Context) (string, error)
 }
 
 func (a *API) Activate(modelUUID string, sourceInfo coremigration.SourceControllerInfo, relatedModels []string) error {
@@ -490,6 +491,13 @@ func (a *API) AbortModelUpgrade(modelUUID string) error {
 		return errors.New("not implemented")
 	}
 	return a.AbortModelUpgrade_(modelUUID)
+}
+
+func (a *API) ControllerModelUUID(ctx context.Context) (string, error) {
+	if a.ControllerModelUUID_ == nil {
+		return "", errors.New("not implemented")
+	}
+	return a.ControllerModelUUID_(ctx)
 }
 
 var _ juju.API = &API{}

--- a/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_juju_model_mock.go
@@ -41,6 +41,7 @@ type ModelManager struct {
 	UnsetModelDefaults_     func(ctx context.Context, user *dbmodel.Identity, cloudTag names.CloudTag, region string, keys []string) error
 	AbortModelUpgrade_      func(ctx context.Context, u *openfga.User, mt names.ModelTag) error
 	UpdateMigratedModel_    func(ctx context.Context, user *openfga.User, modelTag names.ModelTag, targetControllerName string) error
+	UpgradeController_      func(ctx context.Context, u *openfga.User, controllerName string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	UpgradeModel_           func(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error)
 	ValidateModelUpgrade_   func(ctx context.Context, u *openfga.User, mt names.ModelTag, force bool) error
 	WatchAllModelSummaries_ func(ctx context.Context, controller *dbmodel.Controller) (_ func() error, err error)
@@ -176,6 +177,13 @@ func (j *ModelManager) UpdateMigratedModel(ctx context.Context, user *openfga.Us
 	}
 	return j.UpdateMigratedModel_(ctx, user, modelTag, targetControllerName)
 }
+func (j *ModelManager) UpgradeController(ctx context.Context, u *openfga.User, controllerName string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
+	if j.UpgradeController_ == nil {
+		return version.Zero, errors.New("not implemented")
+	}
+	return j.UpgradeController_(ctx, u, controllerName, targetVersion, stream, ignoreAgentVersions, dryRun)
+}
+
 func (j *ModelManager) UpgradeModel(ctx context.Context, u *openfga.User, mt names.ModelTag, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {
 	if j.UpgradeModel_ == nil {
 		return version.Zero, errors.New("not implemented")

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -138,6 +138,13 @@ func (c *Client) RemoveControllerProfile(req *params.RemoveControllerProfileRequ
 }
 
 // UpgradeTo initiates a controller upgrade to the specified version.
+// UpgradeController upgrades the agent of the named backing Juju controller.
+func (c *Client) UpgradeController(req *params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error) {
+	var resp params.UpgradeControllerResponse
+	err := c.caller.APICall("JIMM", 4, "", "UpgradeController", req, &resp)
+	return resp, err
+}
+
 func (c *Client) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
 	var resp params.UpgradeToResponse
 	err := c.caller.APICall("JIMM", 4, "", "UpgradeTo", req, &resp)

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -137,7 +137,6 @@ func (c *Client) RemoveControllerProfile(req *params.RemoveControllerProfileRequ
 	return c.caller.APICall("JIMM", 4, "", "RemoveControllerProfile", req, nil)
 }
 
-// UpgradeTo initiates a controller upgrade to the specified version.
 // UpgradeController upgrades the agent of the named backing Juju controller.
 func (c *Client) UpgradeController(req *params.UpgradeControllerRequest) (params.UpgradeControllerResponse, error) {
 	var resp params.UpgradeControllerResponse
@@ -145,6 +144,7 @@ func (c *Client) UpgradeController(req *params.UpgradeControllerRequest) (params
 	return resp, err
 }
 
+// UpgradeTo initiates a controller upgrade to the specified version.
 func (c *Client) UpgradeTo(req *params.UpgradeToRequest) (params.UpgradeToResponse, error) {
 	var resp params.UpgradeToResponse
 	err := c.caller.APICall("JIMM", 4, "", "UpgradeTo", req, &resp)

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -428,22 +428,22 @@ type RemoveControllerProfileRequest struct {
 // UpgradeControllerRequest holds the parameters for upgrading a controller's agent.
 type UpgradeControllerRequest struct {
 	// ControllerName is the name of the controller to upgrade.
-	ControllerName string `json:"controller-name"`
+	ControllerName string `json:"controller-name" yaml:"controller-name"`
 	// TargetVersion is the version to upgrade to. The zero value means
 	// "let the controller pick the best available patch release".
-	TargetVersion version.Number `json:"target-version"`
+	TargetVersion version.Number `json:"target-version" yaml:"target-version"`
 	// AgentStream is the agent stream to use. Empty means the default stream.
-	AgentStream string `json:"agent-stream,omitempty"`
+	AgentStream string `json:"agent-stream,omitempty" yaml:"agent-stream,omitempty"`
 	// IgnoreAgentVersions skips the agent version sanity check.
-	IgnoreAgentVersions bool `json:"ignore-agent-versions,omitempty"`
+	IgnoreAgentVersions bool `json:"ignore-agent-versions,omitempty" yaml:"ignore-agent-versions,omitempty"`
 	// DryRun reports the chosen version without applying the upgrade.
-	DryRun bool `json:"dry-run,omitempty"`
+	DryRun bool `json:"dry-run,omitempty" yaml:"dry-run,omitempty"`
 }
 
 // UpgradeControllerResponse holds the result of upgrading a controller's agent.
 type UpgradeControllerResponse struct {
 	// ChosenVersion is the version the controller will upgrade to.
-	ChosenVersion version.Number `json:"chosen-version"`
+	ChosenVersion version.Number `json:"chosen-version" yaml:"chosen-version"`
 }
 
 // UpgradeToRequest holds the parameters for phase 1 for automated upgrades.

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/version/v2"
 )
 
 // An AddCloudToControllerRequest is the request sent when adding a new cloud
@@ -422,6 +423,27 @@ type ListControllerProfilesResponse struct {
 // RemoveControllerProfileRequest removes a controller profile by name.
 type RemoveControllerProfileRequest struct {
 	Name string `json:"name" yaml:"name"`
+}
+
+// UpgradeControllerRequest holds the parameters for upgrading a controller's agent.
+type UpgradeControllerRequest struct {
+	// ControllerName is the name of the controller to upgrade.
+	ControllerName string `json:"controller-name"`
+	// TargetVersion is the version to upgrade to. The zero value means
+	// "let the controller pick the best available patch release".
+	TargetVersion version.Number `json:"target-version"`
+	// AgentStream is the agent stream to use. Empty means the default stream.
+	AgentStream string `json:"agent-stream,omitempty"`
+	// IgnoreAgentVersions skips the agent version sanity check.
+	IgnoreAgentVersions bool `json:"ignore-agent-versions,omitempty"`
+	// DryRun reports the chosen version without applying the upgrade.
+	DryRun bool `json:"dry-run,omitempty"`
+}
+
+// UpgradeControllerResponse holds the result of upgrading a controller's agent.
+type UpgradeControllerResponse struct {
+	// ChosenVersion is the version the controller will upgrade to.
+	ChosenVersion version.Number `json:"chosen-version"`
 }
 
 // UpgradeToRequest holds the parameters for phase 1 for automated upgrades.

--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -89,4 +89,5 @@ parts:
       ln -sf jaas bin/juju-update-controller-profile
       ln -sf jaas bin/juju-list-models
       ln -sf jaas bin/juju-models
-      ln -sf jaas bin/juju-show-controller      
+      ln -sf jaas bin/juju-show-controller
+      ln -sf jaas bin/juju-upgrade-controller


### PR DESCRIPTION
## Description

Add a `jaas upgrade-controller <controller-name>` command that upgrades the Juju agent running on a named backing controller registered with JIMM.

Uses a new `UpgradeController` RPC methods. The controller model UUID can't be directly exposed by JIMM since there is one for each backing controller, hence the need for a `jaas` command.

JIMM also doesn't have any (other) need to store the UUID of this model, so JIMM calls `ListModels` and picks the model named `"controller"`. It then calls the existing `API.UpgradeModel` with that UUID, keeping the upgrade logic entirely on the backing controller.

The command is restricted to JIMM admins, consistent with `AddController`, `RemoveController`, and other controller-level operations.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions

```bash
make dev-env
juju login jimm.localhost -c jimm-dev

# bootstrap a controller making sure newer patch is available
AGENT_VERSION=3.6.21 ./local/jimm/setup-controller.sh

./local/jimm/add-controller.sh

jaas upgrade-controller qa-lxd --dry-run
jaas upgrade-controller qa-lxd
juju show-controller qa-lxd # will soon see the new version
jaas show-controller qa-lxd # will eventually see the new version
```