### PR TITLE
fix: also clean up dangling offer on creation

### DIFF
--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -74,7 +74,26 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	offerCheck.URL = offerURL.String()
 	err = j.Database.GetApplicationOffer(ctx, &offerCheck)
 	if err == nil {
-		return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
+		// The offer exists in JIMM's database. Check whether it still
+		// exists on the controller — it may be dangling (e.g. the
+		// controller-side offer was destroyed but JIMM's cleanup did not
+		// complete). If the controller reports it as not found, remove
+		// the stale record and continue with the creation.
+		checkAPI, dialErr := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
+		if dialErr != nil {
+			return dialErr
+		}
+		_, controllerErr := checkAPI.GetApplicationOffer(ctx, offerURL.String())
+		checkAPI.Close()
+		if controllerErr != nil && errors.ErrorCode(controllerErr) == errors.CodeNotFound {
+			// Dangling offer: clean it up and proceed to (re-)create it.
+			if cleanupErr := j.deleteApplicationOffer(ctx, &offerCheck); cleanupErr != nil {
+				zapctx.Error(ctx, "error cleaning up dangling offer on create", zap.Error(cleanupErr))
+				return cleanupErr
+			}
+		} else {
+			return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
+		}
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.
 		return err

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -85,14 +85,19 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		}
 		_, controllerErr := checkAPI.GetApplicationOffer(ctx, offerURL.String())
 		checkAPI.Close()
-		if controllerErr != nil && errors.ErrorCode(controllerErr) == errors.CodeNotFound {
-			// Dangling offer: clean it up and proceed to (re-)create it.
-			if cleanupErr := j.deleteApplicationOffer(ctx, &offerCheck); cleanupErr != nil {
-				zapctx.Error(ctx, "error cleaning up dangling offer on create", zap.Error(cleanupErr))
-				return cleanupErr
-			}
-		} else {
+		if controllerErr == nil {
+			// Offer exists on both sides — genuine duplicate.
 			return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
+		}
+		if errors.ErrorCode(controllerErr) != errors.CodeNotFound {
+			// Unexpected error talking to the controller — propagate it.
+			return controllerErr
+		}
+		// Dangling offer: controller does not know about it. Clean it up
+		// and proceed to (re-)create it.
+		if cleanupErr := j.deleteApplicationOffer(ctx, &offerCheck); cleanupErr != nil {
+			zapctx.Error(ctx, "error cleaning up dangling offer on create", zap.Error(cleanupErr))
+			return cleanupErr
 		}
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
 		// Anything besides Not Found is a problem.

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -74,8 +74,8 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	offerCheck.URL = offerURL.String()
 	err = j.Database.GetApplicationOffer(ctx, &offerCheck)
 	if err == nil {
-		// The offer exists in JIMM's database, check against the Juju controller.
-		// It's possible for an offer record in JIMM to dangle.
+		// The offer exists in JIMM's database, check against the Juju controller
+		// It's possible for an offer record in JIMM to dangle
 		checkAPI, dialErr := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
 		if dialErr != nil {
 			return dialErr
@@ -83,7 +83,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		_, controllerErr := checkAPI.GetApplicationOffer(ctx, offerURL.String())
 		checkAPI.Close()
 		if controllerErr == nil {
-			// Actual duplicate offer
+			// Not dangling, legitimate collision
 			return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
 		}
 		if errors.ErrorCode(controllerErr) != errors.CodeNotFound {
@@ -96,7 +96,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 			return cleanupErr
 		}
 	} else if errors.ErrorCode(err) != errors.CodeNotFound {
-		// Anything besides Not Found is a problem.
+		// Any other error
 		return err
 	}
 

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -74,11 +74,8 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	offerCheck.URL = offerURL.String()
 	err = j.Database.GetApplicationOffer(ctx, &offerCheck)
 	if err == nil {
-		// The offer exists in JIMM's database. Check whether it still
-		// exists on the controller — it may be dangling (e.g. the
-		// controller-side offer was destroyed but JIMM's cleanup did not
-		// complete). If the controller reports it as not found, remove
-		// the stale record and continue with the creation.
+		// The offer exists in JIMM's database, check against the Juju controller.
+		// It's possible for an offer record in JIMM to dangle.
 		checkAPI, dialErr := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
 		if dialErr != nil {
 			return dialErr
@@ -86,15 +83,14 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		_, controllerErr := checkAPI.GetApplicationOffer(ctx, offerURL.String())
 		checkAPI.Close()
 		if controllerErr == nil {
-			// Offer exists on both sides — genuine duplicate.
+			// Actual duplicate offer
 			return errors.Codef(errors.CodeAlreadyExists, "offer %s already exists, please use a different name", offerURL.String())
 		}
 		if errors.ErrorCode(controllerErr) != errors.CodeNotFound {
-			// Unexpected error talking to the controller — propagate it.
+			// Any other error
 			return controllerErr
 		}
-		// Dangling offer: controller does not know about it. Clean it up
-		// and proceed to (re-)create it.
+		// Dangling offer, clean it up and continue
 		if cleanupErr := j.deleteApplicationOffer(ctx, &offerCheck); cleanupErr != nil {
 			zapctx.Error(ctx, "error cleaning up dangling offer on create", zap.Error(cleanupErr))
 			return cleanupErr

--- a/testing/applicationoffers_test.go
+++ b/testing/applicationoffers_test.go
@@ -655,7 +655,7 @@ func TestApplicationOffers(t *testing.T) {
 	})
 }
 
-func TestApplicationOfferDangling(t *testing.T) {
+func TestApplicationOfferDanglingOnRead(t *testing.T) {
 	c := qt.New(t)
 	s, model := SetupAppOfferTest(c)
 	ctx := context.Background()
@@ -699,4 +699,47 @@ func TestApplicationOfferDangling(t *testing.T) {
 	// Ensure offer doesn't show up in endpoint either
 	_, err = client.ApplicationOffer(url)
 	c.Assert(err, qt.ErrorMatches, "application offer not found")
+}
+
+func TestApplicationOfferDanglingOnCreate(t *testing.T) {
+	c := qt.New(t)
+	s, model := SetupAppOfferTest(c)
+	ctx := context.Background()
+
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
+	defer conn.Close()
+	client := applicationoffers.NewClient(conn)
+
+	url := "bob@canonical.com/" + model.Name + ".test-offer1"
+
+	// Simulate a dangling offer
+	offer := dbmodel.ApplicationOffer{
+		ID:      1,
+		UUID:    "00000001-0000-0000-0000-000000000001",
+		Name:    "test-offer1",
+		ModelID: model.ID,
+		URL:     url,
+	}
+	err := s.JIMM.Database.AddApplicationOffer(ctx, &offer)
+	c.Assert(err, qt.IsNil)
+
+	err = s.JIMM.OpenFGAClient.AddModelApplicationOffer(ctx, model.ResourceTag(), offer.ResourceTag())
+	c.Assert(err, qt.IsNil)
+
+	everyoneIdentity := &dbmodel.Identity{Name: ofganames.EveryoneUser}
+	everyoneUser := openfga.NewUser(everyoneIdentity, s.JIMM.OpenFGAClient)
+	err = everyoneUser.SetApplicationOfferAccess(ctx, offer.ResourceTag(), ofganames.ReaderRelation)
+	c.Assert(err, qt.IsNil)
+
+	// Creating an offer with the same URL should succeed: JIMM detects
+	// the dangling record, cleans it up, and creates the real offer.
+	results, err := client.Offer(model.UUID.String, "test-app", []string{"source"}, "bob@canonical.com", "test-offer1", "test offer description")
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Error, qt.Equals, (*jujuparams.Error)(nil))
+
+	// The offer should now be fetchable and reflect the real controller state.
+	details, err := client.ApplicationOffer(url)
+	c.Assert(err, qt.IsNil)
+	c.Assert(details.OfferName, qt.Equals, "test-offer1")
 }


### PR DESCRIPTION
## Description

Application offers in JIMM can dangle, where the record exists in JIMM's database and OpenFGA but the offer no longer exists on the Juju controller. The way this can happen is the destroying via JIMM where the request is made against the controller and succeeds, but JIMM never receives the response and times out.

Previously, dangling offer cleanup was only triggered on **read** (`GetApplicationOffer`). If a user tried to re-create an offer with the same URL without reading it first, JIMM would find the stale DB record and return `already exists`, leaving the dangling state in place indefinitely.

This PR adds the same cleanup on **create** (`Offer`). When the duplicate-URL check finds an existing record, JIMM now verifies whether the offer still exists on the controller.

Addresses https://github.com/canonical/jimm/issues/1942

## Engineering checklist

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests

## Test instructions

```bash
make qa-lxd

# create an offer through jimm
juju switch jimm-dev:jimm-test
juju deploy juju-qa-dummy-source dummy-source
juju offer dummy-source:sink myoffer
juju find-offers jimm-dev:            # myoffer listed

# simulate dangling
juju switch qa-lxd:jimm-test@canonical.com/test-lxd
juju remove-offer jimm-test@canonical.com/test-lxd.myoffer --force -y
juju find-offers jimm-dev:             # myoffer not seen

# reacreate same named offer
juju switch jimm-dev:test-lxd
juju offer dummy-source:sink myoffer
juju show-offer jimm-test@canonical.com/test-lxd.myoffer  # returns details, no error
```