### PR TITLE
refactor: model deletion tweaks

### DIFF
--- a/docs/howto/manage-models.md
+++ b/docs/howto/manage-models.md
@@ -321,3 +321,16 @@ During the migration phase, the model may be temporarily unavailable in the same
 To grant a (collection of) user(s) access to a model, add a `reader`, `writer`, or `administrator` permission between the user(s) and the model.
 
 > See more: {ref}`add-a-permission`
+
+(destroy-a-model)=
+## Destroy a model
+
+To destroy a model on a controller managed through JAAS, on your JAAS controller run:
+
+```
+juju destroy-model <model-name>
+```
+
+```{note}
+If you destroy a model on a controller managed by JAAS directly against the backing Juju controller, you may see a model marked as "unavailable" when listing models through JAAS. This happens because JIMM's database has become out-of-sync with the Juju controller. To reconcile the state, delete the model against JAAS too.
+```

--- a/docs/howto/manage-offers.md
+++ b/docs/howto/manage-offers.md
@@ -15,3 +15,15 @@ To grant a (collection of) user(s) access to an application offer, add a `reader
 
 > See more: {ref}`add-a-permission`
 
+(remove-an-offer)=
+## Remove an offer
+
+To remove an offer in a model on a controller managed through JAAS, on your JAAS controller run:
+
+```
+juju remove-offer <offer-url>
+```
+
+```{note}
+If you destroy an offer on a controller managed by JAAS directly against the backing Juju controller, you will still see it in JAAS. This happens because JIMM's database has become out-of-sync with the Juju controller. To reconcile the state, delete the offer against JAAS too.
+```

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/life"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/names/v5"
@@ -439,27 +440,56 @@ func (j *JujuManager) mergeModelInfo(ctx context.Context, user *openfga.User, mo
 // CodeNotFound, If the given user does not have admin access to the model
 // then the returned error will have the code CodeUnauthorized.
 func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt names.ModelTag) (base.ModelStatus, error) {
-	ms := base.ModelStatus{}
-	err := j.doModelAdmin(ctx, user, mt, func(m *dbmodel.Model, api API) error {
-		var err error
-		ms, err = api.ModelStatus(ctx, mt)
-		if err != nil {
-			// If the model is not found on the backing controller then
-			// we delete the model from JIMM.
-			if errors.ErrorCode(err) == errors.CodeNotFound {
-				errDelete := j.deleteModel(ctx, mt)
-				if errDelete != nil {
-					return errDelete
-				}
-			}
-			return err
-		}
-		return nil
-	})
+	var m dbmodel.Model
+	m.SetTag(mt)
+	if err := j.Database.GetModel(ctx, &m); err != nil {
+		return base.ModelStatus{}, err
+	}
+
+	hasAccess, err := user.HasModelRelation(ctx, mt, ofganames.AdministratorRelation)
 	if err != nil {
-		return ms, err
+		return base.ModelStatus{}, err
+	}
+	if !hasAccess {
+		return base.ModelStatus{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+	}
+
+	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
+	if err != nil {
+		return base.ModelStatus{}, err
+	}
+	defer api.Close()
+
+	ms, err := api.ModelStatus(ctx, mt)
+	if err != nil {
+		if errCleanup := j.maybeCleanupModel(ctx, err, &m); errCleanup != nil {
+			zapctx.Error(ctx, "error attempting model cleanup", zap.Error(errCleanup))
+		}
+		// Some clients like the Juju CLI inspect the model status fields to decide
+		// how to prompt users about volumes/filesystems and other model contents.
+		// When the backing controller returns a NotFound or Unauthorized error
+		// (also implying not found), there is no backing state left for those
+		// clients to inspect, so returning an empty fallback model is the most
+		// useful result we can provide.
+		if code := errors.ErrorCode(err); code == errors.CodeNotFound || code == errors.CodeUnauthorized {
+			return fallbackModelStatus(&m, nil), nil
+		}
+		return base.ModelStatus{}, err
 	}
 	return ms, nil
+}
+
+func fallbackModelStatus(m *dbmodel.Model, err error) base.ModelStatus {
+	modelLife := life.Value(m.Life)
+	if modelLife == "" {
+		modelLife = life.Alive
+	}
+	return base.ModelStatus{
+		UUID:  m.UUID.String,
+		Life:  modelLife,
+		Owner: m.OwnerIdentityName,
+		Error: err,
+	}
 }
 
 // deleteModel deletes the model with the given ModelTag from JIMM's database and
@@ -564,6 +594,12 @@ func (j *JujuManager) DestroyModel(ctx context.Context, user *openfga.User, mt n
 			return err
 		}
 		if err := api.DestroyModel(ctx, mt, destroyStorage, force, maxWait, timeout); err != nil {
+			// If the model is not found on the controller, it has already
+			// been deleted. In that case we can perform an immediate
+			// deletion from JIMM's database and OpenFGA.
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				return j.deleteModel(ctx, mt)
+			}
 			zapctx.Error(ctx, "failed to call DestroyModel juju api", zaputil.Error(err))
 			// this is a manual way of restoring the life state to alive if the JUJU api fails.
 			m.Life = state.Alive.String()

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -480,13 +480,9 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 }
 
 func fallbackModelStatus(m *dbmodel.Model, err error) base.ModelStatus {
-	modelLife := life.Value(m.Life)
-	if modelLife == "" {
-		modelLife = life.Alive
-	}
 	return base.ModelStatus{
 		UUID:  m.UUID.String,
-		Life:  modelLife,
+		Life:  life.Value(m.Life),
 		Owner: m.OwnerIdentityName,
 		Error: err,
 	}

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -129,6 +130,18 @@ func (j *JujuManager) maybeCleanupModel(ctx context.Context, errFromAPI error, m
 	// Some versions of juju return unauthorized for models that cannot be found.
 	modelDeleted := (errors.ErrorCode(errFromAPI) == errors.CodeNotFound || errors.ErrorCode(errFromAPI) == errors.CodeUnauthorized)
 	if modelDeleted {
+		if m.Life != state.Dying.String() {
+			zapctx.Warn(ctx, "model missing on controller but not marked dying; skipping cleanup",
+				zap.String("model", m.UUID.String),
+				zap.String("life", m.Life),
+			)
+			return nil
+		}
+		zapctx.Info(ctx, "model missing on controller and marked dying; cleaning up",
+			zap.String("model-uuid", m.UUID.String),
+			zap.String("model-name", m.Name),
+			zap.String("life", m.Life),
+		)
 		if err := j.deleteModel(ctx, m.ResourceTag()); err != nil {
 			return fmt.Errorf("failed to delete model: %w", err)
 		}

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -183,6 +183,11 @@ func TestModelCleanup(t *testing.T) {
 	s := setupModelPollerTest(c)
 	ctx := context.Background()
 
+	model := s.env.Models[1].DBObject(c, s.jujuManager.Database)
+	model.Life = state.Dying.String()
+	err := s.jujuManager.Database.UpdateModel(ctx, &model)
+	c.Assert(err, qt.IsNil)
+
 	s.jujuManager.Dialer = &jimmtest.Dialer{
 		API: &jimmtest.API{
 			ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
@@ -190,7 +195,7 @@ func TestModelCleanup(t *testing.T) {
 				case s.env.Models[0].UUID:
 					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "not found")
 				case s.env.Models[1].UUID:
-					return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeNotFound, "not found")
 				case s.env.Models[2].UUID:
 					return jujuclient.ModelInfo{}, fmt.Errorf("unexpected call to ModelInfo_ for model %s", model.Id())
 				default:
@@ -203,12 +208,21 @@ func TestModelCleanup(t *testing.T) {
 		},
 	}
 
-	err := s.jujuManager.PollModels(ctx)
+	err = s.jujuManager.PollModels(ctx)
 	c.Assert(err, qt.IsNil)
 
-	model := dbmodel.Model{
+	model = dbmodel.Model{
 		UUID: sql.NullString{
 			String: s.env.Models[0].UUID,
+			Valid:  true,
+		},
+	}
+	err = s.jujuManager.Database.GetModel(ctx, &model)
+	c.Assert(err, qt.IsNil)
+
+	model = dbmodel.Model{
+		UUID: sql.NullString{
+			String: s.env.Models[1].UUID,
 			Valid:  true,
 		},
 	}
@@ -217,7 +231,36 @@ func TestModelCleanup(t *testing.T) {
 
 	model = dbmodel.Model{
 		UUID: sql.NullString{
-			String: s.env.Models[1].UUID,
+			String: s.env.Models[2].UUID,
+			Valid:  true,
+		},
+	}
+	err = s.jujuManager.Database.GetModel(ctx, &model)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestModelCleanupUnauthorizedDoesNotDelete(t *testing.T) {
+	c := qt.New(t)
+	s := setupModelPollerTest(c)
+	ctx := context.Background()
+
+	s.jujuManager.Dialer = &jimmtest.Dialer{
+		API: &jimmtest.API{
+			ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
+				if model.Id() == s.env.Models[0].UUID {
+					return jujuclient.ModelInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+				}
+				return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
+			},
+		},
+	}
+
+	err := s.jujuManager.PollModels(ctx)
+	c.Assert(err, qt.IsNil)
+
+	model := dbmodel.Model{
+		UUID: sql.NullString{
+			String: s.env.Models[0].UUID,
 			Valid:  true,
 		},
 	}

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -2188,6 +2188,7 @@ controllers:
   region: test-cloud-region
 models:
 - name: model-1
+  life: alive
   uuid: 00000002-0000-0000-0000-000000000001
   controller: controller-1
   cloud: test-cloud

--- a/internal/jimm/juju/model_test.go
+++ b/internal/jimm/juju/model_test.go
@@ -1941,19 +1941,83 @@ func TestModelInfoNotFound(t *testing.T) {
 	_, err = j.ModelInfo(context.Background(), user, mt)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
-	// Check the model is deleted as a consequence of the error
+	// Check the model is retained because it is not marked for deletion.
 	model := env.Models[0].DBObject(c, j.Database)
 	err = j.Database.GetModel(context.Background(), &model)
-	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+	c.Assert(err, qt.IsNil)
 
-	// Check the openfga tuple is deleted as a consequence of the error
+	// Check the openfga tuple is retained as a consequence of the error.
 	ok, err = user.IsModelReader(c.Context(), mt)
 	c.Assert(err, qt.IsNil)
-	c.Assert(ok, qt.IsFalse)
+	c.Assert(ok, qt.IsTrue)
 
 	_, err = j.ModelInfo(context.Background(), user, mt)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
+}
+
+var modelInfoErrorTests = []struct {
+	name           string
+	modelInfoError error
+	expectDeleted  bool
+}{{
+	name:           "NotFoundErrorDeletes",
+	modelInfoError: errors.Codef(errors.CodeNotFound, "model not found"),
+	expectDeleted:  true,
+}, {
+	name:           "UnauthorizedErrorDeletes",
+	modelInfoError: errors.Codef(errors.CodeUnauthorized, "unauthorized"),
+	expectDeleted:  true,
+}, {
+	name:           "OtherErrorDoesNotDelete",
+	modelInfoError: errors.New("some other error"),
+	expectDeleted:  false,
+}}
+
+func TestModelInfoErrorDyingModel(t *testing.T) {
+	c := qt.New(t)
+
+	for _, test := range modelInfoErrorTests {
+		c.Run(test.name, func(c *qt.C) {
+			j := newTestJujuManager(c, &parameters{
+				Dialer: &jimmtest.Dialer{
+					API: &jimmtest.API{
+						ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
+							return jujuclient.ModelInfo{}, test.modelInfoError
+						},
+					},
+				},
+			})
+
+			env := jimmtest.ParseEnvironment(c, modelInfoTestEnv)
+			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+			dbUser, err := dbmodel.NewIdentity("alice@canonical.com")
+			c.Assert(err, qt.IsNil)
+
+			user := openfga.NewUser(dbUser, j.OpenFGAClient)
+			mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
+
+			model := env.Models[0].DBObject(c, j.Database)
+			model.Life = state.Dying.String()
+			err = j.Database.UpdateModel(context.Background(), &model)
+			c.Assert(err, qt.IsNil)
+
+			_, err = j.ModelInfo(context.Background(), user, mt)
+			c.Assert(err, qt.ErrorMatches, test.modelInfoError.Error())
+
+			model = env.Models[0].DBObject(c, j.Database)
+			err = j.Database.GetModel(context.Background(), &model)
+			if test.expectDeleted {
+				c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+			} else {
+				c.Assert(err, qt.IsNil)
+			}
+
+			ok, err := user.IsModelReader(c.Context(), mt)
+			c.Assert(err, qt.IsNil)
+			c.Assert(ok, qt.Equals, !test.expectDeleted)
+		})
+	}
 }
 
 func TestModelInfoRedirect(t *testing.T) {
@@ -2043,21 +2107,69 @@ func TestModelStatusNotFound(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsTrue)
 
-	_, err = j.ModelStatus(context.Background(), user, mt)
-	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+	status, err := j.ModelStatus(context.Background(), user, mt)
+	c.Assert(err, qt.IsNil)
+	c.Check(status, qt.CmpEquals(cmpopts.EquateEmpty(), cmpopts.IgnoreFields(base.ModelStatus{}, "Error")), base.ModelStatus{
+		UUID:  mt.Id(),
+		Life:  life.Value(state.Alive.String()),
+		Owner: "alice@canonical.com",
+	})
+	c.Check(status.Error, qt.IsNil)
 
-	// Check the model is deleted as a consequence of the error
+	// Check the model is retained because it is not marked for deletion.
 	model := env.Models[0].DBObject(c, j.Database)
+	err = j.Database.GetModel(context.Background(), &model)
+	c.Assert(err, qt.IsNil)
+
+	// Check the openfga tuple is retained as a consequence of the error.
+	ok, err = user.IsModelReader(c.Context(), mt)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+
+}
+
+func TestModelStatusNotFoundDyingModelDeletes(t *testing.T) {
+	c := qt.New(t)
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{
+			API: &jimmtest.API{
+				ModelStatus_: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
+					return base.ModelStatus{}, errors.Codef(errors.CodeNotFound, "model not found")
+				},
+			},
+		},
+	})
+
+	env := jimmtest.ParseEnvironment(c, modelInfoTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+	dbUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+
+	user := openfga.NewUser(dbUser, j.OpenFGAClient)
+	mt := names.NewModelTag("00000002-0000-0000-0000-000000000001")
+
+	model := env.Models[0].DBObject(c, j.Database)
+	model.Life = state.Dying.String()
+	err = j.Database.UpdateModel(context.Background(), &model)
+	c.Assert(err, qt.IsNil)
+
+	status, err := j.ModelStatus(context.Background(), user, mt)
+	c.Assert(err, qt.IsNil)
+	c.Check(status, qt.CmpEquals(cmpopts.EquateEmpty(), cmpopts.IgnoreFields(base.ModelStatus{}, "Error")), base.ModelStatus{
+		UUID:  mt.Id(),
+		Life:  life.Value(state.Dying.String()),
+		Owner: "alice@canonical.com",
+	})
+	c.Check(status.Error, qt.IsNil)
+
+	model = env.Models[0].DBObject(c, j.Database)
 	err = j.Database.GetModel(context.Background(), &model)
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 
-	// Check the openfga tuple is deleted as a consequence of the error
-	ok, err = user.IsModelReader(c.Context(), mt)
+	ok, err := user.IsModelReader(c.Context(), mt)
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsFalse)
-
-	_, err = j.ModelStatus(context.Background(), user, mt)
-	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 const modelStatusTestEnv = `clouds:
@@ -2098,6 +2210,8 @@ var modelStatusTests = []struct {
 	name              string
 	env               string
 	modelStatus       func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error)
+	dialError         error
+	mutateDB          func(c *qt.C, j *juju.JujuManager)
 	username          string
 	uuid              string
 	expectModelStatus base.ModelStatus
@@ -2150,6 +2264,55 @@ var modelStatusTests = []struct {
 	username:    "alice@canonical.com",
 	uuid:        "00000002-0000-0000-0000-000000000001",
 	expectError: "test error",
+}, {
+	name:        "ConnectionFailedReturnsError",
+	env:         modelStatusTestEnv,
+	username:    "alice@canonical.com",
+	uuid:        "00000002-0000-0000-0000-000000000001",
+	dialError:   errors.Codef(errors.CodeConnectionFailed, "controller offline"),
+	expectError: `controller offline`,
+}, {
+	name:     "APINotFoundReturnsEmptyFallback",
+	env:      modelStatusTestEnv,
+	username: "alice@canonical.com",
+	uuid:     "00000002-0000-0000-0000-000000000001",
+	modelStatus: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
+		return base.ModelStatus{}, errors.Codef(errors.CodeNotFound, "model not found")
+	},
+	expectModelStatus: base.ModelStatus{
+		UUID:  "00000002-0000-0000-0000-000000000001",
+		Life:  life.Value(state.Alive.String()),
+		Owner: "alice@canonical.com",
+	},
+}, {
+	name:     "APIUnauthorizedReturnsEmptyFallback",
+	env:      modelStatusTestEnv,
+	username: "alice@canonical.com",
+	uuid:     "00000002-0000-0000-0000-000000000001",
+	modelStatus: func(ctx context.Context, modelTag names.ModelTag) (base.ModelStatus, error) {
+		return base.ModelStatus{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
+	},
+	expectModelStatus: base.ModelStatus{
+		UUID:  "00000002-0000-0000-0000-000000000001",
+		Life:  life.Value(state.Alive.String()),
+		Owner: "alice@canonical.com",
+	},
+}, {
+	name:        "ConnectionFailedDyingModelReturnsError",
+	env:         modelStatusTestEnv,
+	username:    "alice@canonical.com",
+	uuid:        "00000002-0000-0000-0000-000000000001",
+	dialError:   errors.Codef(errors.CodeConnectionFailed, "controller offline"),
+	expectError: `controller offline`,
+	mutateDB: func(c *qt.C, j *juju.JujuManager) {
+		model := dbmodel.Model{}
+		model.SetTag(names.NewModelTag("00000002-0000-0000-0000-000000000001"))
+		err := j.Database.GetModel(context.Background(), &model)
+		c.Assert(err, qt.IsNil)
+		model.Life = state.Dying.String()
+		err = j.Database.UpdateModel(context.Background(), &model)
+		c.Assert(err, qt.IsNil)
+	},
 }}
 
 func TestModelStatus(t *testing.T) {
@@ -2161,6 +2324,7 @@ func TestModelStatus(t *testing.T) {
 				API: &jimmtest.API{
 					ModelStatus_: test.modelStatus,
 				},
+				Err: test.dialError,
 			}
 			j := newTestJujuManager(c, &parameters{
 				Dialer: dialer,
@@ -2168,6 +2332,9 @@ func TestModelStatus(t *testing.T) {
 
 			env := jimmtest.ParseEnvironment(c, test.env)
 			env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+			if test.mutateDB != nil {
+				test.mutateDB(c, j)
+			}
 
 			dbUser := env.User(test.username).DBObject(c, j.Database)
 			user := openfga.NewUser(&dbUser, j.OpenFGAClient)
@@ -2177,7 +2344,13 @@ func TestModelStatus(t *testing.T) {
 				c.Check(err, qt.ErrorMatches, test.expectError)
 			} else {
 				c.Assert(err, qt.IsNil)
-				c.Check(ms, qt.CmpEquals(cmpopts.EquateEmpty()), test.expectModelStatus)
+				c.Check(ms, qt.CmpEquals(cmpopts.EquateEmpty(), cmpopts.IgnoreFields(base.ModelStatus{}, "Error")), test.expectModelStatus)
+				if test.expectModelStatus.Error != nil {
+					c.Assert(ms.Error, qt.IsNotNil)
+					c.Check(ms.Error, qt.ErrorMatches, test.expectModelStatus.Error.Error())
+				} else {
+					c.Check(ms.Error, qt.IsNil)
+				}
 			}
 
 			c.Check(dialer.IsClosed(), qt.IsTrue)
@@ -2647,6 +2820,7 @@ var destroyModelTests = []struct {
 	expectError     string
 	expectErrorCode errors.Code
 	expectedLife    string
+	expectDeleted   bool
 }{{
 	name:            "NotFound",
 	env:             destroyModelTestEnv,
@@ -2716,6 +2890,15 @@ var destroyModelTests = []struct {
 	uuid:         "00000002-0000-0000-0000-000000000001",
 	expectError:  `api error`,
 	expectedLife: "alive",
+}, {
+	name: "APINotFoundDeletesModel",
+	env:  destroyModelTestEnv,
+	destroyModel: func(ctx context.Context, tag names.ModelTag, destroyStorage, force *bool, maxWait, timeout *time.Duration) error {
+		return errors.Codef(errors.CodeNotFound, "model not found")
+	},
+	username:      "charlie@canonical.com",
+	uuid:          "00000002-0000-0000-0000-000000000001",
+	expectDeleted: true,
 }}
 
 func TestDestroyModel(t *testing.T) {
@@ -2762,6 +2945,16 @@ func TestDestroyModel(t *testing.T) {
 				err = j.Database.GetModel(ctx, &m)
 				c.Assert(err, qt.IsNil)
 				c.Assert(m.Life, qt.Equals, test.expectedLife)
+			}
+			if test.expectDeleted {
+				m := dbmodel.Model{
+					UUID: sql.NullString{
+						String: test.uuid,
+						Valid:  true,
+					},
+				}
+				err = j.Database.GetModel(ctx, &m)
+				c.Assert(err, qt.ErrorMatches, `model not found`)
 			}
 		})
 	}

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -112,6 +112,27 @@ func TestModelStatus(t *testing.T) {
 	doTest(modelmanager.NewClient(conn))
 }
 
+func TestModelStatus_ModelDeletedOnBackingController(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	client, model := createAndDestroyBackingModel(c, s)
+
+	statuses, err := client.ModelStatus(model.ResourceTag())
+	c.Assert(err, qt.IsNil)
+	c.Assert(statuses, qt.HasLen, 1)
+	c.Check(statuses[0], qt.DeepEquals, base.ModelStatus{
+		UUID:         model.UUID.String,
+		Life:         life.Value(state.Alive.String()),
+		Owner:        "bob@canonical.com",
+		Applications: []base.Application{},
+		Machines:     []base.Machine{},
+		Volumes:      []base.Volume{},
+		Filesystems:  []base.Filesystem{},
+	})
+	c.Check(statuses[0].Error, qt.IsNil)
+}
+
 func TestIdentityProviderURL(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -10,6 +10,7 @@ import (
 	petname "github.com/dustinkirkland/golang-petname"
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/core/life"
@@ -20,6 +21,7 @@ import (
 	"github.com/juju/names/v5"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
@@ -226,6 +228,74 @@ func TestModelInfo(t *testing.T) {
 	c.Assert(models[3].Result, qt.IsNil)
 	c.Assert(models[3].Error, qt.Not(qt.IsNil))
 	c.Assert(models[3].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+}
+
+// createAndDestroyBackingModel creates a model and then destroys it on the backing controller.
+func createAndDestroyBackingModel(c *qt.C, s jimmtest.JimmWithControllers) (*modelmanager.Client, *dbmodel.Model) {
+	conn := s.Open(c, nil, "bob@canonical.com", nil)
+	c.Cleanup(func() { conn.Close() })
+	client := modelmanager.NewClient(conn)
+
+	model := s.CreateModelForBob(c)
+
+	controllerInfo := s.GetControllerConfig(c, model.Controller.Name)
+	directConn, err := api.Open(controllerInfo.ToAPIInfo(), api.DialOpts{})
+	c.Assert(err, qt.Equals, nil)
+	c.Cleanup(func() { directConn.Close() })
+	directClient := modelmanager.NewClient(directConn)
+
+	err = directClient.DestroyModel(model.ResourceTag(), nil, nil, nil, &zeroDuration)
+	c.Assert(err, qt.Equals, nil)
+
+	timeout := time.After(5 * time.Minute)
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			c.Fatalf("timeout waiting for model to disappear from backing controller")
+		case <-ticker.C:
+			results, err := directClient.ModelInfo([]names.ModelTag{model.ResourceTag()})
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(results, qt.HasLen, 1)
+			if results[0].Error != nil {
+				return client, model
+			}
+		}
+	}
+}
+
+func TestModelInfo_DeletesDyingModelMissingFromBackingController(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	client, model := createAndDestroyBackingModel(c, s)
+
+	// Initially the model should still be present after a ModelInfo call
+	// because it was not marked as dying.
+	results, err := client.ModelInfo([]names.ModelTag{model.ResourceTag()})
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Result, qt.IsNil)
+	c.Assert(results[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+
+	err = s.JIMM.Database.GetModel(c.Context(), model)
+	c.Assert(err, qt.IsNil)
+
+	// After being marked as dying, the model should dissapear in the next ModelInfo call.
+	model.Life = state.Dying.String()
+	err = s.JIMM.Database.UpdateModel(c.Context(), model)
+	c.Assert(err, qt.Equals, nil)
+
+	results, err = client.ModelInfo([]names.ModelTag{model.ResourceTag()})
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Result, qt.IsNil)
+	c.Assert(results[0].Error.Code, qt.Equals, jujuparams.CodeUnauthorized)
+
+	err = s.JIMM.Database.GetModel(c.Context(), model)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 func TestModelInfoDisableControllerUUIDMasking(t *testing.T) {
@@ -617,6 +687,21 @@ func TestDestroyModel(t *testing.T) {
 	// Make sure it's not an error if you destroy a model that's not there.
 	err = client.DestroyModel(tag, nil, nil, nil, &zeroDuration)
 	c.Assert(err, qt.Equals, nil)
+}
+
+func TestDestroyModel_DoesNotExist(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	client, model := createAndDestroyBackingModel(c, s)
+
+	// If the model does not exist on the backing controller
+	// we expect the DestroyModel call to remove the model from JIMM.
+	err := client.DestroyModel(model.ResourceTag(), nil, nil, nil, &zeroDuration)
+	c.Assert(err, qt.Equals, nil)
+
+	err = s.JIMM.Database.GetModel(c.Context(), model)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
 func TestDumpModel(t *testing.T) {

--- a/tests/modeldeletion/delete-from-backing-controller.sh
+++ b/tests/modeldeletion/delete-from-backing-controller.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# This script assumes that you have JIMM running with a controller
+# named "qa-lxd" attached (can be overriden via BACKING_CONTROLLER_NAME).
+#
+# This script creates a model via JAAS, deletes that model directly from
+# the backing controller, and then verifies the same model can be deleted
+# from JAAS via the Juju CLI.
+#
+# This test covers the case where JAAS still has a database record for a
+# model that no longer exists on its backing controller. In that case, a
+# Juju CLI destroy-model request through JAAS should clean up the JAAS model
+# record successfully.
+#
+# Usage: ./tests/modeldeletion/delete-from-backing-controller.sh
+
+set -euo pipefail
+
+# Notes:
+# - The script creates a model with a random suffix to avoid clashes with
+# previous runs.
+
+JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
+BACKING_CONTROLLER_NAME="${BACKING_CONTROLLER_NAME:-qa-lxd}"
+# Generate a random 4-character suffix for the model name.
+RAND_SUFFIX=$(tr -dc 'a-z0-9' </dev/urandom | head -c 4 || true)
+MODEL_NAME="deleted-from-backing-$RAND_SUFFIX"
+
+# Source the `JAAS` variable for executing jaas commands.
+source "local/jimm/detect-jaas.sh"
+
+# Ensure we start by using the JAAS controller.
+echo
+echo "Switching to JAAS controller $JIMM_CONTROLLER_NAME"
+juju switch "$JIMM_CONTROLLER_NAME"
+
+# Create a model through JAAS using the Juju CLI. The JAAS add-model plugin
+# lets us select the target controller so the model is created where this
+# test expects to delete it from.
+echo
+echo "Creating model $MODEL_NAME via JAAS on backing controller $BACKING_CONTROLLER_NAME"
+$JAAS add-model "$MODEL_NAME" localhost --target-controller "$BACKING_CONTROLLER_NAME"
+
+# Capture the model UUID so that we can verify the same model is later removed
+# from JAAS, even after the backing controller deletion makes normal model
+# status lookups fail.
+echo
+model_info=$(juju show-model "$MODEL_NAME" --format json)
+model_uuid=$(echo "$model_info" | jq -r ".[\"$MODEL_NAME\"].\"model-uuid\"")
+if [[ -z "$model_uuid" || "$model_uuid" == "null" ]]; then
+    echo "Unable to determine UUID for model $MODEL_NAME"
+    exit 1
+fi
+echo "Model UUID for $MODEL_NAME is $model_uuid"
+model_owner=$(echo "$model_info" | jq -r ".[\"$MODEL_NAME\"].owner")
+if [[ -z "$model_owner" || "$model_owner" == "null" ]]; then
+    echo "Unable to determine owner for model $MODEL_NAME"
+    exit 1
+fi
+QUALIFIED_MODEL_NAME="$model_owner/$MODEL_NAME"
+echo "Qualified model name is $QUALIFIED_MODEL_NAME"
+
+# Delete the model directly from the backing controller. This simulates JAAS
+# having a stale model record after the model has already gone from Juju.
+echo
+echo "Deleting model $MODEL_NAME directly from backing controller $BACKING_CONTROLLER_NAME"
+juju switch "$BACKING_CONTROLLER_NAME"
+juju destroy-model "$QUALIFIED_MODEL_NAME" --no-prompt
+
+# Wait until the backing controller no longer reports the model.
+echo
+echo "Waiting for $MODEL_NAME to disappear from backing controller $BACKING_CONTROLLER_NAME (timeout: 20 seconds)..."
+max_attempts=10
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+    sleep 2
+    backing_model_exists=$(juju models --format json 2>/dev/null | jq -r --arg model "$MODEL_NAME" '.models[]? | select(.name == $model or ."short-name" == $model)' | grep -c . || true)
+    if [[ "$backing_model_exists" -eq 0 ]]; then
+        echo "Model $MODEL_NAME no longer exists on backing controller $BACKING_CONTROLLER_NAME."
+        break
+    fi
+    echo "Model $MODEL_NAME still exists on backing controller (attempt $attempt/$max_attempts)"
+    attempt=$((attempt + 1))
+done
+if [ $attempt -gt $max_attempts ]; then
+    echo "Model $MODEL_NAME still exists on backing controller after 20 seconds."
+    exit 1
+fi
+
+# Switch back to JAAS and delete the stale model record through the Juju CLI.
+# This is the core behaviour under test: destroy-model should succeed through
+# JAAS even though the model has already been deleted from the backing
+# controller.
+echo
+echo "Deleting stale model $MODEL_NAME from JAAS via Juju CLI"
+juju switch "$JIMM_CONTROLLER_NAME"
+juju destroy-model "$QUALIFIED_MODEL_NAME" --no-prompt
+
+# Verify JAAS no longer lists the deleted model.
+echo
+echo "Waiting for $MODEL_NAME to disappear from JAAS (timeout: 20 seconds)..."
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+    sleep 2
+    jaas_model_exists=$(juju models --format json 2>/dev/null | jq -r --arg uuid "$model_uuid" '.models[]? | select(."model-uuid" == $uuid)' | grep -c . || true)
+    if [[ "$jaas_model_exists" -eq 0 ]]; then
+        echo "Model $MODEL_NAME with UUID $model_uuid no longer exists in JAAS."
+        break
+    fi
+    echo "Model $MODEL_NAME still exists in JAAS (attempt $attempt/$max_attempts)"
+    attempt=$((attempt + 1))
+done
+if [ $attempt -gt $max_attempts ]; then
+    echo "Model $MODEL_NAME still exists in JAAS after 20 seconds."
+    exit 1
+fi
+
+echo
+echo "Model deletion test completed successfully."
+exit 0

--- a/tests/modeldeletion/delete-from-backing-controller.sh
+++ b/tests/modeldeletion/delete-from-backing-controller.sh
@@ -46,12 +46,6 @@ $JAAS add-model "$MODEL_NAME" localhost --target-controller "$BACKING_CONTROLLER
 # status lookups fail.
 echo
 model_info=$(juju show-model "$MODEL_NAME" --format json)
-model_uuid=$(echo "$model_info" | jq -r ".[\"$MODEL_NAME\"].\"model-uuid\"")
-if [[ -z "$model_uuid" || "$model_uuid" == "null" ]]; then
-    echo "Unable to determine UUID for model $MODEL_NAME"
-    exit 1
-fi
-echo "Model UUID for $MODEL_NAME is $model_uuid"
 model_owner=$(echo "$model_info" | jq -r ".[\"$MODEL_NAME\"].owner")
 if [[ -z "$model_owner" || "$model_owner" == "null" ]]; then
     echo "Unable to determine owner for model $MODEL_NAME"
@@ -67,26 +61,6 @@ echo "Deleting model $MODEL_NAME directly from backing controller $BACKING_CONTR
 juju switch "$BACKING_CONTROLLER_NAME"
 juju destroy-model "$QUALIFIED_MODEL_NAME" --no-prompt
 
-# Wait until the backing controller no longer reports the model.
-echo
-echo "Waiting for $MODEL_NAME to disappear from backing controller $BACKING_CONTROLLER_NAME (timeout: 20 seconds)..."
-max_attempts=10
-attempt=1
-while [ $attempt -le $max_attempts ]; do
-    sleep 2
-    backing_model_exists=$(juju models --format json 2>/dev/null | jq -r --arg model "$MODEL_NAME" '.models[]? | select(.name == $model or ."short-name" == $model)' | grep -c . || true)
-    if [[ "$backing_model_exists" -eq 0 ]]; then
-        echo "Model $MODEL_NAME no longer exists on backing controller $BACKING_CONTROLLER_NAME."
-        break
-    fi
-    echo "Model $MODEL_NAME still exists on backing controller (attempt $attempt/$max_attempts)"
-    attempt=$((attempt + 1))
-done
-if [ $attempt -gt $max_attempts ]; then
-    echo "Model $MODEL_NAME still exists on backing controller after 20 seconds."
-    exit 1
-fi
-
 # Switch back to JAAS and delete the stale model record through the Juju CLI.
 # This is the core behaviour under test: destroy-model should succeed through
 # JAAS even though the model has already been deleted from the backing
@@ -95,25 +69,6 @@ echo
 echo "Deleting stale model $MODEL_NAME from JAAS via Juju CLI"
 juju switch "$JIMM_CONTROLLER_NAME"
 juju destroy-model "$QUALIFIED_MODEL_NAME" --no-prompt
-
-# Verify JAAS no longer lists the deleted model.
-echo
-echo "Waiting for $MODEL_NAME to disappear from JAAS (timeout: 20 seconds)..."
-attempt=1
-while [ $attempt -le $max_attempts ]; do
-    sleep 2
-    jaas_model_exists=$(juju models --format json 2>/dev/null | jq -r --arg uuid "$model_uuid" '.models[]? | select(."model-uuid" == $uuid)' | grep -c . || true)
-    if [[ "$jaas_model_exists" -eq 0 ]]; then
-        echo "Model $MODEL_NAME with UUID $model_uuid no longer exists in JAAS."
-        break
-    fi
-    echo "Model $MODEL_NAME still exists in JAAS (attempt $attempt/$max_attempts)"
-    attempt=$((attempt + 1))
-done
-if [ $attempt -gt $max_attempts ]; then
-    echo "Model $MODEL_NAME still exists in JAAS after 20 seconds."
-    exit 1
-fi
 
 echo
 echo "Model deletion test completed successfully."


### PR DESCRIPTION
## Description
This change slightly adjusts how we keep JIMM's database in sync with Juju, specifically with regards to models. Currently whenever certain calls like ModelInfo or ModelStatus return a NotFound or Unauthorized error, we would remove the model from JIMM's database assuming that this was because it was removed from the backing controller. That assumption is accurate, calls like `ModelInfo` return an Unauthorized error for a model that doesn't exist even when the user is a controller admin.

While this is usually works fine, there was one incident on the production JAAS where a model dissapeared from JIMM's database but was still present in the backing controller. It's hard to "re-sync" this model to JIMM because we lose all the authorization information when we delete resources.

This change makes the sync more conservative, ensuring we only remove models from JIMM that were marked as "dying", i.e. a user had previously run a `juju destroy-model` against JIMM. The only additional issue this revealed is that the Juju CLI does a `ModelStatus` call before doing a `DestroyModel` call, meaning that with JIMM's currently logic, if the model does not exist on a backing controller but does exist in JIMM, it is impossible, using the Juju CLI, to delete it from JIMM. So, we adjust `ModelStatus` to return a minimal status if the model does not exist on the backing controller.

This PR is mainly tests beyond the changes described above, unit tests, integration tests and an e2e test with the Juju CLI.

Fixes [JUJU-9182](https://warthogs.atlassian.net/browse/JUJU-9182)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests


[JUJU-9182]: https://warthogs.atlassian.net/browse/JUJU-9182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ