### PR TITLE
refactor: adjust model import

### DIFF
--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -370,11 +370,9 @@ func (j *JujuManager) EarliestControllerVersion(ctx context.Context) (version.Nu
 }
 
 type modelImporter struct {
-	jimm      *JujuManager
-	model     dbmodel.Model
-	modelInfo base.ModelInfo
-	// newOwner may be nil if the user wants to keep the original owner.
-	newOwner      *names.UserTag
+	jimm          *JujuManager
+	model         dbmodel.Model
+	modelInfo     base.ModelInfo
 	originalOwner names.UserTag
 	offersToAdd   []*crossmodel.ApplicationOfferDetails
 }
@@ -383,14 +381,9 @@ func newModelImporter(jimm *JujuManager, newOwner string) (modelImporter, error)
 	modelImporter := modelImporter{
 		jimm: jimm,
 	}
-	if newOwner == "" {
-		return modelImporter, nil
+	if newOwner != "" {
+		return modelImporter, errors.Codef(errors.CodeBadRequest, "switching the imported model owner is no longer supported")
 	}
-	if !names.IsValidUser(newOwner) {
-		return modelImporter, errors.Codef(errors.CodeBadRequest, "invalid new username for new model owner")
-	}
-	newOwnerTag := names.NewUserTag(newOwner)
-	modelImporter.newOwner = &newOwnerTag
 	return modelImporter, nil
 }
 
@@ -438,18 +431,11 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, 
 }
 
 func (m *modelImporter) setModelOwner(ctx context.Context) error {
-	var ownerTag names.UserTag
-	if m.newOwner != nil {
-		ownerTag = *m.newOwner
-	} else {
-		ownerTag = m.originalOwner
-	}
-
-	if ownerTag.IsLocal() {
-		return errors.New("cannot import model from local user, try --owner to switch the model owner")
+	if m.originalOwner.IsLocal() {
+		return errors.New("cannot import model from local user")
 	}
 	owner := dbmodel.Identity{}
-	owner.SetTag(ownerTag)
+	owner.SetTag(m.originalOwner)
 
 	err := m.jimm.Database.GetIdentity(ctx, &owner)
 	if err != nil {
@@ -483,21 +469,28 @@ func (m *modelImporter) addPermissions(ctx context.Context) error {
 }
 
 func (m *modelImporter) setCloudCredential(ctx context.Context) error {
-	// fetch cloud credential used by the model
+	if m.modelInfo.CloudCredential == "" {
+		return errors.Codef(errors.CodeNotFound, "model has no cloud credential configured")
+	}
 
-	// Note that the model already has a cloud credential configured which it will use when deploying new
-	// applications. JIMM needs some cloud credential reference to be able to import the model so use any
-	// credential against the cloud the model is deployed against. Even using the correct cloud for the
-	// credential is not strictly necessary, but will help prevent the user thinking they can create new
-	// models on the incoming cloud.
-	allCredentials, err := m.jimm.Database.GetIdentityCloudCredentials(ctx, &m.model.Owner, m.modelInfo.Cloud)
+	if !names.IsValidCloudCredential(m.modelInfo.CloudCredential) {
+		return errors.Codef(errors.CodeBadRequest, "invalid model cloud credential %q", m.modelInfo.CloudCredential)
+	}
+	sourceCredentialTag := names.NewCloudCredentialTag(m.modelInfo.CloudCredential)
+
+	cloudCredential := dbmodel.CloudCredential{
+		CloudName:         sourceCredentialTag.Cloud().Id(),
+		OwnerIdentityName: sourceCredentialTag.Owner().Id(),
+		Name:              sourceCredentialTag.Name(),
+	}
+	err := m.jimm.Database.GetCloudCredential(ctx, &cloudCredential)
 	if err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return errors.Codef(errors.CodeNotFound, "Failed to find cloud credential %q for user %s on cloud %s",
+				sourceCredentialTag.Name(), sourceCredentialTag.Owner().Id(), sourceCredentialTag.Cloud().Id())
+		}
 		return err
 	}
-	if len(allCredentials) == 0 {
-		return errors.Codef(errors.CodeNotFound, "Failed to find cloud credential for user %s on cloud %s", m.model.Owner.Name, m.modelInfo.Cloud)
-	}
-	cloudCredential := allCredentials[0]
 
 	m.model.CloudCredentialID = cloudCredential.ID
 	m.model.CloudCredential = cloudCredential
@@ -562,8 +555,7 @@ func (m *modelImporter) save(ctx context.Context) error {
 	})
 }
 
-// ImportModel imports a model and existing offers into JIMM.  A new owner  must be set to
-// represent the external user who will own this model (if the original owner is a local user).
+// ImportModel imports a model and existing offers into JIMM.
 func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
 
 	if err := j.checkJimmAdmin(user); err != nil {

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -462,7 +462,7 @@ cloud-credentials:
 - name: test-credential
   cloud: test-cloud
   owner: alice@canonical.com
-  type: empty
+  auth-type: empty
 controllers:
 - name: test-controller
   uuid: 00000001-0000-0000-0000-000000000001
@@ -575,7 +575,8 @@ func TestImportModel(t *testing.T) {
 				Name: "test-region",
 			},
 			CloudCredential: dbmodel.CloudCredential{
-				Name: "test-credential",
+				Name:     "test-credential",
+				AuthType: "empty",
 			},
 			Life: state.Alive.String(),
 		},
@@ -644,86 +645,18 @@ func TestImportModel(t *testing.T) {
 				Name: "test-region",
 			},
 			CloudCredential: dbmodel.CloudCredential{
-				Name: "test-credential",
+				Name:     "test-credential",
+				AuthType: "empty",
 			},
 			Life: state.Alive.String(),
 		},
 	}, {
-		about:          "model from local user imported",
+		about:          "owner switching not supported",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
 		newOwner:       "alice@canonical.com",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
-		jimmAdmin:      true,
-		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
-			info := jujuclient.ModelInfo{}
-			info.Name = "test-model"
-			info.Type = "test-type"
-			info.UUID = "00000002-0000-0000-0000-000000000001"
-			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
-			info.DefaultSeries = "test-series"
-			info.Cloud = "test-cloud"
-			info.CloudRegion = "test-region"
-			info.CloudCredential = "test-cloud/local-user/test-credential"
-			info.Owner = "local-user"
-			info.Life = life.Alive
-			info.Status = base.Status{
-				Status: status.Status("available"),
-				Info:   "test-info",
-				Since:  &now,
-			}
-			info.Users = []base.UserInfo{{
-				UserName: "local-user",
-				Access:   string(jujuparams.ModelAdminAccess),
-			}, {
-				UserName: "another-user",
-				Access:   string(jujuparams.ModelReadAccess),
-			}}
-			info.Machines = []base.Machine{{
-				Id:          "test-machine",
-				DisplayName: "Test machine",
-				Status:      "test-status",
-				Message:     "test-message",
-			}}
-			info.AgentVersion = newVersion("2.1.0")
-			return info, nil
-		},
-		expectedModel: dbmodel.Model{
-			Name: "test-model",
-			UUID: sql.NullString{
-				String: "00000002-0000-0000-0000-000000000001",
-				Valid:  true,
-			},
-			Owner: dbmodel.Identity{
-				Name:        "alice@canonical.com",
-				DisplayName: "Alice",
-			},
-			Controller: dbmodel.Controller{
-				Name:         "test-controller",
-				UUID:         "00000001-0000-0000-0000-000000000001",
-				CloudName:    "test-cloud",
-				CloudRegion:  "test-region-1",
-				AgentVersion: "3.2.1",
-			},
-			CloudRegion: dbmodel.CloudRegion{
-				Cloud: dbmodel.Cloud{
-					Name: "test-cloud",
-					Type: "test",
-				},
-				Name: "test-region",
-			},
-			CloudCredential: dbmodel.CloudCredential{
-				Name: "test-credential",
-			},
-			Life: state.Alive.String(),
-		},
-	}, {
-		about:          "new model owner is local user",
-		user:           "alice@canonical.com",
-		controllerName: "test-controller",
-		newOwner:       "bob",
-		modelUUID:      "00000002-0000-0000-0000-000000000001",
-		expectedError:  "cannot import model from local user, try --owner to switch the model owner",
+		expectedError:  "switching the imported model owner is no longer supported",
 		jimmAdmin:      true,
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
 			info := jujuclient.ModelInfo{}
@@ -770,7 +703,7 @@ func TestImportModel(t *testing.T) {
 		},
 		expectedError: "model not found",
 	}, {
-		about:          "fail import from local user without newOwner flag",
+		about:          "fail import from local user",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
 		newOwner:       "",
@@ -789,7 +722,7 @@ func TestImportModel(t *testing.T) {
 			info.Owner = "local-user"
 			return info, nil
 		},
-		expectedError: `cannot import model from local user, try --owner to switch the model owner`,
+		expectedError: `cannot import model from local user`,
 	}, {
 		about:          "cloud credentials not found",
 		user:           "alice@canonical.com",
@@ -810,7 +743,28 @@ func TestImportModel(t *testing.T) {
 			info.Owner = "alice@canonical.com"
 			return info, nil
 		},
-		expectedError: `Failed to find cloud credential for user alice@canonical.com on cloud invalid-cloud`,
+		expectedError: `Failed to find cloud credential "unknown-credential" for user alice@canonical.com on cloud invalid-cloud`,
+	}, {
+		about:          "matching cloud credential name not found",
+		user:           "alice@canonical.com",
+		controllerName: "test-controller",
+		newOwner:       "",
+		modelUUID:      "00000002-0000-0000-0000-000000000001",
+		jimmAdmin:      true,
+		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
+			info := jujuclient.ModelInfo{}
+			info.Name = "test-model"
+			info.Type = "test-type"
+			info.UUID = "00000002-0000-0000-0000-000000000001"
+			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
+			info.DefaultSeries = "test-series"
+			info.Cloud = "test-cloud"
+			info.CloudRegion = "test-region"
+			info.CloudCredential = "test-cloud/alice@canonical.com/source-credential"
+			info.Owner = "alice@canonical.com"
+			return info, nil
+		},
+		expectedError: `Failed to find cloud credential "source-credential" for user alice@canonical.com on cloud test-cloud`,
 	}, {
 		about:          "cloud region not found",
 		user:           "alice@canonical.com",
@@ -926,7 +880,8 @@ func TestImportModel(t *testing.T) {
 				Name: "test-region",
 			},
 			CloudCredential: dbmodel.CloudCredential{
-				Name: "test-credential",
+				Name:     "test-credential",
+				AuthType: "empty",
 			},
 			Life: state.Alive.String(),
 			Offers: []dbmodel.ApplicationOffer{

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -476,7 +476,7 @@ func (a *API) CredentialContents(cloud string, credential string, withSecrets bo
 	if a.CredentialContents_ == nil {
 		return nil, errors.New("not implemented")
 	}
-	return a.CredentialContents(cloud, credential, withSecrets)
+	return a.CredentialContents_(cloud, credential, withSecrets)
 }
 
 func (a *API) UpgradeModel(modelUUID string, targetVersion version.Number, stream string, ignoreAgentVersions bool, dryRun bool) (version.Number, error) {

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -493,6 +493,9 @@ type ImportModelRequest struct {
 
 	// Owner specifies the new owner of the model after import.
 	// Can be empty to skip switching the owner.
+	//
+	// NOTICE: This field is deprecated and will return an error
+	// if set.
 	Owner string `json:"owner"`
 }
 


### PR DESCRIPTION
## Description
This PR fixes an issue in JIMM's model import logic. Originally this logic was written to be able to take a set of models created outside of JAAS and import them. That was never used and actually has issues where e.g. creating an offer for a model where the owner in JIMM != owner in Juju fails. Where this logic is useful is rebuilding JIMM's state if a model is present in the backing controller but not in JIMM.

One issue in the import logic was that JIMM associated a cloud-credential with a model, during import it picked any credential in JIMM that was A) Appropriate for the model's cloud and B) had the same owner. This breaks down when using a reconciliation tool like Terraform which may try to reconcile a model's credential. Specifically in a scenario with IS, they had a model in Juju that was not present in JIMM, imported the model back into JIMM and then Terraform notices that the cloud-credential that JIMM reports for the model is not the same as the one it expects.

To resolve this, we:
1. Require the same credential in JIMM as the importing model.
2. Drop support for changing model owner, this causes issues when creating offers and doesn't align with 1. when importing a model using a credential owned by a local user.

Fixes [JUJU-10117](https://warthogs.atlassian.net/browse/JUJU-10117)

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

[JUJU-10117]: https://warthogs.atlassian.net/browse/JUJU-10117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ