### PR TITLE
feat: show controller models

### DIFF
--- a/internal/dbmodel/model.go
+++ b/internal/dbmodel/model.go
@@ -55,6 +55,17 @@ type Model struct {
 	OwnerIdentityName string   `gorm:"uniqueIndex:unique_model_names;not null"`
 	Owner             Identity `gorm:"foreignkey:OwnerIdentityName;references:Name"`
 
+	// ControllerOwnerName is the model owner as known by the backing Juju
+	// controller. JAAS can alias a model's owner locally (imported models with a
+	// new owner, or backing controller models), so this preserves the owner the
+	// backing controller actually knows. When empty, OwnerIdentityName is also
+	// the controller-facing owner.
+	ControllerOwnerName string
+
+	// IsControllerModel records whether this model is a backing controller's
+	// model tracked by JAAS.
+	IsControllerModel bool `gorm:"not null;default:false"`
+
 	// Controller is the controller that is hosting the model.
 	ControllerID uint
 	Controller   Controller
@@ -77,9 +88,35 @@ type Model struct {
 	MigrationMode MigrationMode `gorm:"default:''"`
 }
 
+const (
+	// ControllerModelOwnerSuffix is the suffix of the synthetic identity that
+	// owns a backing controller's model within JAAS. The owner is
+	// "<controller-name>@controller", which lets us alias the (otherwise
+	// identically named) "controller" model of each backing controller to a
+	// unique "<controller-name>@controller/controller" address.
+	ControllerModelOwnerSuffix = "@controller"
+
+	// ControllerModelName is the name a controller model always has on its
+	// backing Juju controller.
+	ControllerModelName = "controller"
+)
+
 // Tag returns a names.Tag for the model.
 func (m Model) Tag() names.Tag {
 	return m.ResourceTag()
+}
+
+// ControllerFacingOwner returns the model owner as known by the backing Juju
+// controller. JAAS can alias a model's owner locally (imported models with a
+// new owner, or backing controller models), so operations that address the
+// model on the backing controller (e.g. building offer URLs) must use this
+// owner rather than OwnerIdentityName. When no aliased owner is recorded, the
+// JAAS owner is also the controller-facing owner.
+func (m Model) ControllerFacingOwner() string {
+	if m.ControllerOwnerName != "" {
+		return m.ControllerOwnerName
+	}
+	return m.OwnerIdentityName
 }
 
 // ResourceTag returns a tag for the model.  This method

--- a/internal/dbmodel/model_test.go
+++ b/internal/dbmodel/model_test.go
@@ -38,6 +38,25 @@ func TestModelTag(t *testing.T) {
 	c.Check(m2, qt.DeepEquals, m)
 }
 
+func TestModelControllerFacingOwner(t *testing.T) {
+	c := qt.New(t)
+
+	// When no aliased backing owner is recorded, the JAAS owner is used.
+	c.Check(dbmodel.Model{OwnerIdentityName: "alice@canonical.com"}.ControllerFacingOwner(), qt.Equals, "alice@canonical.com")
+
+	// When a backing owner is recorded (e.g. controller model or imported model
+	// with a new owner), it is preferred over the JAAS owner.
+	c.Check(dbmodel.Model{
+		OwnerIdentityName:   "my-controller@controller",
+		ControllerOwnerName: "admin",
+	}.ControllerFacingOwner(), qt.Equals, "admin")
+
+	c.Check(dbmodel.Model{
+		OwnerIdentityName:   "bob@canonical.com",
+		ControllerOwnerName: "original-owner@canonical.com",
+	}.ControllerFacingOwner(), qt.Equals, "original-owner@canonical.com")
+}
+
 func TestRecreateDeletedModel(t *testing.T) {
 	c := qt.New(t)
 	db := gormDB(c)

--- a/internal/dbmodel/sql/postgres/038_add_controller_owner_name.up.sql
+++ b/internal/dbmodel/sql/postgres/038_add_controller_owner_name.up.sql
@@ -1,0 +1,13 @@
+-- controller_owner_name records the model owner as known by the backing Juju
+-- controller. JAAS may alias a model's owner locally (e.g. imported models with
+-- a new owner, or backing controller models), so this column preserves the owner
+-- the backing controller actually knows, which is required when addressing the
+-- model on the controller (e.g. building offer URLs).
+--
+-- It is nullable: when NULL the model's JAAS owner (owner_identity_name) is also
+-- its controller-facing owner.
+ALTER TABLE models ADD COLUMN IF NOT EXISTS controller_owner_name TEXT;
+
+-- is_controller_model flags models that are a backing controller's own model,
+-- tracked by JAAS.
+ALTER TABLE models ADD COLUMN IF NOT EXISTS is_controller_model BOOLEAN NOT NULL DEFAULT FALSE;

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -28,6 +28,35 @@ import (
 	ofganames "github.com/canonical/jimm/v3/internal/openfga/names"
 )
 
+// controllerFacingOfferURL translates a JAAS offer URL into the URL the backing
+// controller knows. If the URL's owner matches a tracked model's JAAS owner but
+// differs from its controller-facing owner (imported or controller models), the
+// owner is rewritten. If the model cannot be resolved the URL is returned
+// unchanged so that offers stored under their original URL still work.
+func (j *JujuManager) controllerFacingOfferURL(ctx context.Context, offerURL string) (string, error) {
+	ourl, err := crossmodel.ParseOfferURL(offerURL)
+	if err != nil {
+		// Pass the URL through unchanged so the DB lookup can still
+		// match offers stored under a URL that ParseOfferURL can't
+		// parse (e.g. legacy data).
+		//nolint:nilerr // Intentional: we deliberately ignore the parse error
+		// to preserve backward compatibility.
+		return offerURL, nil
+	}
+	if ourl.User == "" || ourl.ModelName == "" {
+		return offerURL, nil
+	}
+	m := dbmodel.Model{Name: ourl.ModelName, OwnerIdentityName: ourl.User}
+	if err := j.Database.GetModel(ctx, &m); err != nil {
+		if errors.ErrorCode(err) == errors.CodeNotFound {
+			return offerURL, nil
+		}
+		return "", err
+	}
+	ourl.User = m.ControllerFacingOwner()
+	return ourl.String(), nil
+}
+
 // AddApplicationOfferParams holds parameters for the Offer method.
 type AddApplicationOfferParams struct {
 	ModelTag               names.ModelTag
@@ -62,7 +91,9 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	}
 
 	offerURL := crossmodel.OfferURL{
-		User:      model.OwnerIdentityName,
+		// The offer URL must use the owner the backing controller knows, which
+		// can differ from the JAAS owner (see Model.ControllerFacingOwner).
+		User:      model.ControllerFacingOwner(),
 		ModelName: model.Name,
 		// Confusingly the application name in the offer URL is
 		// actually the offer name.
@@ -201,8 +232,15 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 // the rest of the details.
 func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, user *openfga.User, details *jujuparams.ConsumeOfferDetails, v bakery.Version) error {
 
+	// Translate the JAAS offer URL to the controller-facing URL the offer is
+	// stored under and the backing controller expects.
+	controllerURL, err := j.controllerFacingOfferURL(ctx, details.Offer.OfferURL)
+	if err != nil {
+		return err
+	}
+
 	offer := dbmodel.ApplicationOffer{
-		URL: details.Offer.OfferURL,
+		URL: controllerURL,
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
@@ -233,7 +271,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 	}
 	defer api.Close()
 
-	consumeDetails, err := api.GetApplicationOfferConsumeDetails(ctx, details.Offer.OfferURL)
+	consumeDetails, err := api.GetApplicationOfferConsumeDetails(ctx, controllerURL)
 	if err != nil {
 		return err
 	}
@@ -359,10 +397,16 @@ func (j *JujuManager) enrichOfferDetails(ctx context.Context, user *openfga.User
 // GetApplicationOffer returns details of the offer with the specified URL.
 func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.User, offerURL string) (*crossmodel.ApplicationOfferDetails, error) {
 
-	offer := dbmodel.ApplicationOffer{
-		URL: offerURL,
+	// Translate the JAAS offer URL to the controller-facing URL.
+	controllerURL, err := j.controllerFacingOfferURL(ctx, offerURL)
+	if err != nil {
+		return nil, err
 	}
-	err := j.Database.GetApplicationOffer(ctx, &offer)
+
+	offer := dbmodel.ApplicationOffer{
+		URL: controllerURL,
+	}
+	err = j.Database.GetApplicationOffer(ctx, &offer)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return nil, errors.Codef(errors.CodeNotFound, "application offer not found")
@@ -391,7 +435,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	}
 	defer api.Close()
 
-	offerDetails, err := api.GetApplicationOffer(ctx, offerURL)
+	offerDetails, err := api.GetApplicationOffer(ctx, controllerURL)
 	if err != nil {
 		if errors.ErrorCode(err) != errors.CodeNotFound {
 			return nil, err
@@ -416,8 +460,8 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 
 // DestroyOffer removes the application offer.
 func (j *JujuManager) DestroyOffer(ctx context.Context, user *openfga.User, offerURL string, force bool) error {
-	err := j.doApplicationOfferAdmin(ctx, user, offerURL, func(offer *dbmodel.ApplicationOffer, api API) error {
-		if err := api.DestroyApplicationOffer(ctx, offerURL, force); err != nil {
+	err := j.doApplicationOfferAdmin(ctx, user, offerURL, func(offer *dbmodel.ApplicationOffer, api API, controllerURL string) error {
+		if err := api.DestroyApplicationOffer(ctx, controllerURL, force); err != nil {
 			return err
 		}
 		return j.deleteApplicationOffer(ctx, offer)
@@ -503,6 +547,24 @@ func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.U
 		return nil, err
 	}
 
+	// When a filter identifies a specific model by JAAS owner and name, rewrite
+	// the owner to the model's controller-facing owner (which can differ for
+	// imported and controller models) so the backing controller matches it.
+	for i := range filters {
+		f := &filters[i]
+		if f.OwnerName == "" || f.ModelName == "" {
+			continue
+		}
+		m := dbmodel.Model{Name: f.ModelName, OwnerIdentityName: f.OwnerName}
+		if err := j.Database.GetModel(ctx, &m); err != nil {
+			if errors.ErrorCode(err) == errors.CodeNotFound {
+				continue
+			}
+			return nil, err
+		}
+		f.OwnerName = m.ControllerFacingOwner()
+	}
+
 	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
 		return api.FindApplicationOffers(ctx, filters)
 	})
@@ -520,7 +582,8 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 	}
 
 	controllers := make(map[uint]*dbmodel.Controller)
-	for _, f := range filters {
+	for i := range filters {
+		f := &filters[i]
 		if f.ModelName == "" {
 			return nil, errors.New("application offer filter must specify a model name")
 		}
@@ -536,6 +599,12 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 			return nil, err
 		}
 		controllers[m.Controller.ID] = &m.Controller
+
+		// The model is resolved by its JAAS owner, but the backing controller
+		// knows it under its controller-facing owner (which can differ for
+		// imported and controller models). Rewrite the filter so it matches on
+		// the controller.
+		f.OwnerName = m.ControllerFacingOwner()
 	}
 
 	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
@@ -597,10 +666,16 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 // Note: The user does not need to have any access level on the offer itself.
 // As long as they are model admins or controller superusers they can also
 // manipulate the application offer as admins.
-func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga.User, offerURL string, f func(offer *dbmodel.ApplicationOffer, api API) error) error {
+func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga.User, offerURL string, f func(offer *dbmodel.ApplicationOffer, api API, controllerURL string) error) error {
+
+	// Translate the JAAS offer URL to the controller-facing URL.
+	controllerURL, err := j.controllerFacingOfferURL(ctx, offerURL)
+	if err != nil {
+		return err
+	}
 
 	offer := dbmodel.ApplicationOffer{
-		URL: offerURL,
+		URL: controllerURL,
 	}
 	if err := j.Database.GetApplicationOffer(ctx, &offer); err != nil {
 		return err
@@ -619,7 +694,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return err
 	}
 	defer api.Close()
-	if err := f(&offer, api); err != nil {
+	if err := f(&offer, api, controllerURL); err != nil {
 		return err
 	}
 	return nil

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -329,6 +329,108 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 		)
 	}
 
+	// Track the backing controller's model as a first-class JAAS model.
+	if err := j.ensureControllerModel(ctx, ctl); err != nil {
+		zapctx.Error(ctx, "failed to track controller model", zap.String("controller", ctl.Name), zap.Error(err))
+	}
+
+	return nil
+}
+
+// controllerModelOwner returns the synthetic identity that owns a backing
+// controller's model, i.e. "<controller-name>@controller".
+func controllerModelOwner(controllerName string) string {
+	return controllerName + dbmodel.ControllerModelOwnerSuffix
+}
+
+// ensureControllerModel tracks the backing controller's model as a first-class
+// JAAS model, persisting it in the database and relating it to the controller in
+// OpenFGA. It is idempotent and safe to call on every poll.
+//
+// The model is not granted to any specific user; it relies on the
+// "administrator from controller" inheritance so only controller admins can see
+// and operate it.
+func (j *JujuManager) ensureControllerModel(ctx context.Context, ctl *dbmodel.Controller) error {
+	api, err := j.dialController(ctx, ctl, nil)
+	if err != nil {
+		return fmt.Errorf("failed to dial controller: %w", err)
+	}
+	defer api.Close()
+	return j.ensureControllerModelWithAPI(ctx, ctl, api)
+}
+
+// ensureControllerModelWithAPI is the inner part of ensureControllerModel that
+// uses an existing API connection. It is used by the model poller to avoid
+// dialing a controller twice per cycle.
+func (j *JujuManager) ensureControllerModelWithAPI(ctx context.Context, ctl *dbmodel.Controller, api API) error {
+	modelUUID, err := api.ControllerModelUUID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get controller model UUID: %w", err)
+	}
+
+	existing := dbmodel.Model{UUID: sql.NullString{String: modelUUID, Valid: true}}
+	if err := j.Database.GetModel(ctx, &existing); err == nil {
+		return nil
+	} else if errors.ErrorCode(err) != errors.CodeNotFound {
+		return err
+	}
+
+	// Read the model's owner as the backing controller reports it rather than
+	// assuming a fixed value, so we stay correct if Juju changes it.
+	modelInfo, err := api.ModelInfo(ctx, names.NewModelTag(modelUUID))
+	if err != nil {
+		return fmt.Errorf("failed to get controller model info: %w", err)
+	}
+	backingOwner := modelInfo.Owner
+
+	owner, err := dbmodel.NewIdentity(controllerModelOwner(ctl.Name))
+	if err != nil {
+		return err
+	}
+	if err := j.Database.GetIdentity(ctx, owner); err != nil {
+		return err
+	}
+
+	cloud := dbmodel.Cloud{Name: ctl.CloudName}
+	if err := j.Database.GetCloud(ctx, &cloud); err != nil {
+		return fmt.Errorf("failed to get controller cloud: %w", err)
+	}
+	region := cloud.Region(ctl.CloudRegion)
+	if region.ID == 0 {
+		return fmt.Errorf("controller cloud region %q not found", ctl.CloudRegion)
+	}
+
+	// The controller model has no real cloud credential, so attach a placeholder
+	// "empty" credential to avoid a NULL foreign key.
+	credential := dbmodel.CloudCredential{
+		Name:              dbmodel.ControllerModelName,
+		CloudName:         ctl.CloudName,
+		OwnerIdentityName: owner.Name,
+		AuthType:          "empty",
+	}
+	if err := j.Database.SetCloudCredential(ctx, &credential); err != nil {
+		return fmt.Errorf("failed to set controller model credential: %w", err)
+	}
+
+	model := dbmodel.Model{
+		Name:                dbmodel.ControllerModelName,
+		UUID:                sql.NullString{String: modelUUID, Valid: true},
+		OwnerIdentityName:   owner.Name,
+		ControllerOwnerName: backingOwner,
+		IsControllerModel:   true,
+		ControllerID:        ctl.ID,
+		CloudRegionID:       region.ID,
+		CloudCredentialID:   credential.ID,
+		Life:                "alive",
+	}
+	if err := j.Database.AddModel(ctx, &model); err != nil {
+		return fmt.Errorf("failed to add controller model: %w", err)
+	}
+
+	if err := j.OpenFGAClient.AddControllerModel(ctx, ctl.ResourceTag(), model.ResourceTag()); err != nil {
+		return fmt.Errorf("failed to add controller->model relation: %w", err)
+	}
+
 	return nil
 }
 
@@ -370,9 +472,11 @@ func (j *JujuManager) EarliestControllerVersion(ctx context.Context) (version.Nu
 }
 
 type modelImporter struct {
-	jimm          *JujuManager
-	model         dbmodel.Model
-	modelInfo     base.ModelInfo
+	jimm      *JujuManager
+	model     dbmodel.Model
+	modelInfo base.ModelInfo
+	// newOwner may be nil if the user wants to keep the original owner.
+	newOwner      *names.UserTag
 	originalOwner names.UserTag
 	offersToAdd   []*crossmodel.ApplicationOfferDetails
 }
@@ -381,9 +485,14 @@ func newModelImporter(jimm *JujuManager, newOwner string) (modelImporter, error)
 	modelImporter := modelImporter{
 		jimm: jimm,
 	}
-	if newOwner != "" {
-		return modelImporter, errors.Codef(errors.CodeBadRequest, "switching the imported model owner is no longer supported")
+	if newOwner == "" {
+		return modelImporter, nil
 	}
+	if !names.IsValidUser(newOwner) {
+		return modelImporter, errors.Codef(errors.CodeBadRequest, "invalid new username for new model owner")
+	}
+	newOwnerTag := names.NewUserTag(newOwner)
+	modelImporter.newOwner = &newOwnerTag
 	return modelImporter, nil
 }
 
@@ -431,17 +540,29 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, 
 }
 
 func (m *modelImporter) setModelOwner(ctx context.Context) error {
-	if m.originalOwner.IsLocal() {
-		return errors.New("cannot import model from local user")
+	var ownerTag names.UserTag
+	if m.newOwner != nil {
+		ownerTag = *m.newOwner
+	} else {
+		ownerTag = m.originalOwner
+	}
+
+	if ownerTag.IsLocal() {
+		return errors.New("cannot import model from local user, try --owner to switch the model owner")
 	}
 	owner := dbmodel.Identity{}
-	owner.SetTag(m.originalOwner)
+	owner.SetTag(ownerTag)
 
 	err := m.jimm.Database.GetIdentity(ctx, &owner)
 	if err != nil {
 		return err
 	}
 	m.model.SetOwner(&owner)
+
+	// The backing controller still knows the model under its original owner.
+	if m.originalOwner.Id() != owner.Name {
+		m.model.ControllerOwnerName = m.originalOwner.Id()
+	}
 
 	return nil
 }
@@ -478,16 +599,20 @@ func (m *modelImporter) setCloudCredential(ctx context.Context) error {
 	}
 	sourceCredentialTag := names.NewCloudCredentialTag(m.modelInfo.CloudCredential)
 
+	// The credential in JIMM is owned by the JAAS model owner (which may
+	// differ from the backing controller's credential owner when importing
+	// with a new owner), but the credential name and cloud come from the
+	// source model's credential tag.
 	cloudCredential := dbmodel.CloudCredential{
 		CloudName:         sourceCredentialTag.Cloud().Id(),
-		OwnerIdentityName: sourceCredentialTag.Owner().Id(),
+		OwnerIdentityName: m.model.Owner.Name,
 		Name:              sourceCredentialTag.Name(),
 	}
 	err := m.jimm.Database.GetCloudCredential(ctx, &cloudCredential)
 	if err != nil {
 		if errors.ErrorCode(err) == errors.CodeNotFound {
 			return errors.Codef(errors.CodeNotFound, "Failed to find cloud credential %q for user %s on cloud %s",
-				sourceCredentialTag.Name(), sourceCredentialTag.Owner().Id(), sourceCredentialTag.Cloud().Id())
+				sourceCredentialTag.Name(), m.model.Owner.Name, sourceCredentialTag.Cloud().Id())
 		}
 		return err
 	}
@@ -555,7 +680,8 @@ func (m *modelImporter) save(ctx context.Context) error {
 	})
 }
 
-// ImportModel imports a model and existing offers into JIMM.
+// ImportModel imports a model and existing offers into JIMM.  A new owner  must be set to
+// represent the external user who will own this model (if the original owner is a local user).
 func (j *JujuManager) ImportModel(ctx context.Context, user *openfga.User, controllerName string, modelTag names.ModelTag, newOwner string) error {
 
 	if err := j.checkJimmAdmin(user); err != nil {

--- a/internal/jimm/juju/controller_test.go
+++ b/internal/jimm/juju/controller_test.go
@@ -651,12 +651,83 @@ func TestImportModel(t *testing.T) {
 			Life: state.Alive.String(),
 		},
 	}, {
-		about:          "owner switching not supported",
+		about:          "model from local user imported",
 		user:           "alice@canonical.com",
 		controllerName: "test-controller",
 		newOwner:       "alice@canonical.com",
 		modelUUID:      "00000002-0000-0000-0000-000000000001",
-		expectedError:  "switching the imported model owner is no longer supported",
+		jimmAdmin:      true,
+		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
+			info := jujuclient.ModelInfo{}
+			info.Name = "test-model"
+			info.Type = "test-type"
+			info.UUID = "00000002-0000-0000-0000-000000000001"
+			info.ControllerUUID = "00000001-0000-0000-0000-000000000001"
+			info.DefaultSeries = "test-series"
+			info.Cloud = "test-cloud"
+			info.CloudRegion = "test-region"
+			info.CloudCredential = "test-cloud/alice@canonical.com/test-credential"
+			info.Owner = "local-user"
+			info.Life = life.Alive
+			info.Status = base.Status{
+				Status: status.Status("available"),
+				Info:   "test-info",
+				Since:  &now,
+			}
+			info.Users = []base.UserInfo{{
+				UserName: "local-user",
+				Access:   string(jujuparams.ModelAdminAccess),
+			}, {
+				UserName: "another-user",
+				Access:   string(jujuparams.ModelReadAccess),
+			}}
+			info.Machines = []base.Machine{{
+				Id:          "test-machine",
+				DisplayName: "Test machine",
+				Status:      "test-status",
+				Message:     "test-message",
+			}}
+			info.AgentVersion = newVersion("2.1.0")
+			return info, nil
+		},
+		expectedModel: dbmodel.Model{
+			Name: "test-model",
+			UUID: sql.NullString{
+				String: "00000002-0000-0000-0000-000000000001",
+				Valid:  true,
+			},
+			Owner: dbmodel.Identity{
+				Name:        "alice@canonical.com",
+				DisplayName: "Alice",
+			},
+			Controller: dbmodel.Controller{
+				Name:         "test-controller",
+				UUID:         "00000001-0000-0000-0000-000000000001",
+				CloudName:    "test-cloud",
+				CloudRegion:  "test-region-1",
+				AgentVersion: "3.2.1",
+			},
+			CloudRegion: dbmodel.CloudRegion{
+				Cloud: dbmodel.Cloud{
+					Name: "test-cloud",
+					Type: "test",
+				},
+				Name: "test-region",
+			},
+			CloudCredential: dbmodel.CloudCredential{
+				Name:     "test-credential",
+				AuthType: "empty",
+			},
+			ControllerOwnerName: "local-user",
+			Life:                state.Alive.String(),
+		},
+	}, {
+		about:          "new model owner is local user",
+		user:           "alice@canonical.com",
+		controllerName: "test-controller",
+		newOwner:       "bob",
+		modelUUID:      "00000002-0000-0000-0000-000000000001",
+		expectedError:  "cannot import model from local user, try --owner to switch the model owner",
 		jimmAdmin:      true,
 		modelInfo: func(model names.ModelTag) (jujuclient.ModelInfo, error) {
 			info := jujuclient.ModelInfo{}
@@ -722,7 +793,7 @@ func TestImportModel(t *testing.T) {
 			info.Owner = "local-user"
 			return info, nil
 		},
-		expectedError: `cannot import model from local user`,
+		expectedError: `cannot import model from local user, try --owner to switch the model owner`,
 	}, {
 		about:          "cloud credentials not found",
 		user:           "alice@canonical.com",

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -76,13 +76,19 @@ func (j *JujuManager) ControllerInfo(ctx context.Context, user *openfga.User, na
 }
 
 // ControllerModelCount returns the number of models hosted on the given
-// controller.
+// controller, excluding backing controller models.
 func (j *JujuManager) ControllerModelCount(ctx context.Context, ctl dbmodel.Controller) (int, error) {
 	models, err := j.Database.GetModelsByController(ctx, ctl)
 	if err != nil {
 		return 0, err
 	}
-	return len(models), nil
+	count := 0
+	for _, m := range models {
+		if !m.IsControllerModel {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // GetControllerBootstrap returns the pending bootstrap reservation for a controller.
@@ -166,12 +172,20 @@ func (j *JujuManager) RemoveController(ctx context.Context, user *openfga.User, 
 		if err != nil {
 			return err
 		}
-		if len(models) > 0 && !force {
+		// Exclude controller models from the "still has models" check: they are
+		// always present on a tracked controller and are removed below.
+		userModels := make([]dbmodel.Model, 0, len(models))
+		for _, m := range models {
+			if !m.IsControllerModel {
+				userModels = append(userModels, m)
+			}
+		}
+		if len(userModels) > 0 && !force {
 			return errors.Codef(errors.CodeStillAlive, "controller still has models")
 		}
 
-		// Remove all models associated with the controller. If force is false,
-		// we can only reach here with an empty list of models.
+		// Remove all models associated with the controller (including the
+		// controller model). If force is false, only controller models remain.
 		for _, model := range models {
 			err := db.DeleteModel(ctx, &model)
 			if err != nil {

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -46,6 +46,11 @@ func (j *JujuManager) pollModels(ctx context.Context, models []*dbmodel.Model) e
 			zapctx.Error(ctx, "error getting model info", zap.Error(err))
 		}
 	}
+
+	// Ensure the controller model is tracked, reusing the open connection.
+	if err := j.ensureControllerModelWithAPI(ctx, &ctrl, api); err != nil {
+		zapctx.Error(ctx, "failed to ensure controller model", zap.String("controller", ctrl.Name), zap.Error(err))
+	}
 	return nil
 }
 
@@ -59,7 +64,7 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 	durationObserver := servermon.DurationObserver(servermon.JimmMethodsDurationHistogram, op)
 	defer durationObserver()
 
-	// Step 1: Group models by controller
+	// Group models by controller.
 	controllerModels := make(map[string][]*dbmodel.Model)
 	err = j.Database.ForEachModel(ctx, func(m *dbmodel.Model) error {
 		key := m.Controller.UUID
@@ -70,15 +75,21 @@ func (j *JujuManager) PollModels(ctx context.Context) (err error) {
 		return err
 	}
 
-	// Step 2: Loop over controllers and process their models
-	// This way we only dial each controller once.
-	for _, models := range controllerModels {
-		if len(models) == 0 {
-			continue
+	// Iterate every known controller once. Controllers with user models are
+	// polled (and their controller model ensured within the same dial).
+	// Controllers without user models are handled here to ensure their
+	// controller model is tracked too.
+	err = j.Database.ForEachController(ctx, func(c *dbmodel.Controller) error {
+		if models, ok := controllerModels[c.UUID]; ok && len(models) > 0 {
+			_ = j.pollModels(ctx, models)
+		} else {
+			if err := j.ensureControllerModel(ctx, c); err != nil {
+				zapctx.Error(ctx, "failed to ensure controller model", zap.String("controller", c.Name), zap.Error(err))
+			}
 		}
-		_ = j.pollModels(ctx, models)
-	}
-	return nil
+		return nil
+	})
+	return err
 }
 
 // checkModelMigratedInternal checks if the model has been migrated from

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -363,7 +363,10 @@ func TestPollModelsClosesControllerConnections(t *testing.T) {
 
 	dialer := newPerControllerDialer(&jimmtest.API{
 		ModelInfo_: func(ctx context.Context, model names.ModelTag) (jujuclient.ModelInfo, error) {
-			return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id()}}, nil
+			return jujuclient.ModelInfo{ModelInfo: base.ModelInfo{UUID: model.Id(), Owner: "admin"}}, nil
+		},
+		ControllerModelUUID_: func(ctx context.Context) (string, error) {
+			return "controller-model-uuid", nil
 		},
 	})
 	s.jujuManager.Dialer = dialer
@@ -372,9 +375,11 @@ func TestPollModelsClosesControllerConnections(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// controller-1 owns model-1, model-2, and model-3 so it must be dialed
-	// exactly once.  controller-2 has no models and must not be dialed at all.
+	// exactly once. controller-2 has no user models but PollModels now also
+	// backfills controller models, so it is dialed once too.
 	c.Assert(dialer.openedCounts(), qt.DeepEquals, map[string]int{
 		"controller-1": 1,
+		"controller-2": 1,
 	})
 	// Every opened connection must have been closed – no leaks.
 	c.Assert(dialer.closedCounts(), qt.DeepEquals, dialer.openedCounts())

--- a/pkg/api/params/params.go
+++ b/pkg/api/params/params.go
@@ -493,9 +493,6 @@ type ImportModelRequest struct {
 
 	// Owner specifies the new owner of the model after import.
 	// Can be empty to skip switching the owner.
-	//
-	// NOTICE: This field is deprecated and will return an error
-	// if set.
 	Owner string `json:"owner"`
 }
 

--- a/testing/backing_controller_model_test.go
+++ b/testing/backing_controller_model_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/client/applicationoffers"
+	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/names/v5"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// controllerModel returns the tracked backing controller model for the named
+// controller, failing the test if it is not present.
+func controllerModel(c *qt.C, s jimmtest.JimmWithControllers, controllerName string) *dbmodel.Model {
+	m := &dbmodel.Model{
+		OwnerIdentityName: controllerName + dbmodel.ControllerModelOwnerSuffix,
+		Name:              dbmodel.ControllerModelName,
+	}
+	err := s.JIMM.Database.GetModel(context.Background(), m)
+	c.Assert(err, qt.IsNil, qt.Commentf("controller model for %q not found", controllerName))
+	return m
+}
+
+// TestAddControllerTracksControllerModel checks that AddController (invoked by
+// the test setup) tracks the backing controller's model as a first-class JAAS
+// model under the "<controller-name>@controller" owner, without needing a poll,
+// and that it is only visible to controller admins.
+func TestAddControllerTracksControllerModel(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := context.Background()
+
+	// Note: no PollModels call here. AddController alone must have tracked the
+	// controller model.
+	controllerName, _ := s.GetOneControllerConfig(c)
+	m := controllerModel(c, s, controllerName)
+
+	c.Check(m.Name, qt.Equals, dbmodel.ControllerModelName)
+	c.Check(m.IsControllerModel, qt.IsTrue)
+	c.Check(m.OwnerIdentityName, qt.Equals, controllerName+dbmodel.ControllerModelOwnerSuffix)
+	// By default Juju owns the controller model as "admin"; JAAS reads this from
+	// the controller when tracking the model.
+	c.Check(m.ControllerFacingOwner(), qt.Equals, "admin")
+
+	// A JIMM/controller admin (alice) can see the controller model.
+	summaries, err := s.JIMM.JujuManager.ListModelSummaries(ctx, s.AdminUser, "")
+	c.Assert(err, qt.IsNil)
+	c.Check(containsModelUUID(summaries, m.UUID.String), qt.IsTrue)
+
+	// A non-admin user (bob) must NOT see the controller model.
+	bobIdentity, err := dbmodel.NewIdentity("bob@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.JIMM.Database.GetIdentity(ctx, bobIdentity), qt.IsNil)
+	bob := s.NewUser(bobIdentity)
+
+	bobSummaries, err := s.JIMM.JujuManager.ListModelSummaries(ctx, bob, "")
+	c.Assert(err, qt.IsNil)
+	c.Check(containsModelUUID(bobSummaries, m.UUID.String), qt.IsFalse)
+}
+
+// TestPollModelsBackfillsControllerModel checks that if the controller model is
+// missing (e.g. a controller added before tracking existed), PollModels
+// re-creates it. It is also idempotent.
+func TestPollModelsBackfillsControllerModel(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := context.Background()
+
+	controllerName, _ := s.GetOneControllerConfig(c)
+	m := controllerModel(c, s, controllerName)
+
+	// Delete the tracked controller model to simulate an untracked controller.
+	err := s.JIMM.OpenFGAClient.RemoveControllerModel(ctx, m.Controller.ResourceTag(), m.ResourceTag())
+	c.Assert(err, qt.IsNil)
+	err = s.JIMM.Database.DeleteModel(ctx, m)
+	c.Assert(err, qt.IsNil)
+
+	// Confirm it is gone.
+	gone := &dbmodel.Model{UUID: m.UUID}
+	err = s.JIMM.Database.GetModel(ctx, gone)
+	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
+
+	// PollModels must re-create it.
+	err = s.JIMM.JujuManager.PollModels(ctx)
+	c.Assert(err, qt.IsNil)
+	recreated := controllerModel(c, s, controllerName)
+	c.Check(recreated.UUID.String, qt.Equals, m.UUID.String)
+	c.Check(recreated.IsControllerModel, qt.IsTrue)
+
+	// Polling again is idempotent and does not fail or duplicate.
+	err = s.JIMM.JujuManager.PollModels(ctx)
+	c.Assert(err, qt.IsNil)
+	_ = controllerModel(c, s, controllerName)
+}
+
+func containsModelUUID(summaries []base.UserModelSummary, uuid string) bool {
+	for _, s := range summaries {
+		if s.UUID == uuid {
+			return true
+		}
+	}
+	return false
+}
+
+// TestImportModelWithOwnerCreateOffer imports a model into JAAS under a new
+// owner (so the JAAS owner differs from the backing controller owner) and then
+// creates an application offer for it.
+//
+// UX note: JAAS does not rewrite offer URLs into the JAAS namespace; offer URLs
+// are pass-through and always reflect the backing controller (the model's
+// original/controller-facing owner). So after importing under a new owner, the
+// model is listed under the new owner, but the offer URL keeps the ORIGINAL
+// owner. This test documents that behaviour: the offer is created successfully
+// (using the controller-facing owner) and its URL contains the original owner,
+// not the new JAAS owner.
+func TestImportModelWithOwnerCreateOffer(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := context.Background()
+
+	// Create a model owned by charlie and deploy an application to offer.
+	model := s.CreateModelForCharlie(c)
+	controllerName := model.Controller.Name
+	originalOwner := model.OwnerIdentityName
+
+	s.DeployApplication(c, s.AdminUser, model.Tag(), jimmtest.DeployApplicationParams{
+		App:   "test-app",
+		Charm: "juju-qa-dummy-sink",
+	})
+
+	// Remove the model from JIMM (but keep it on the backing controller) so we
+	// can re-import it under a different owner.
+	err := s.JIMM.OpenFGAClient.RemoveControllerModel(ctx, model.Controller.ResourceTag(), model.ResourceTag())
+	c.Assert(err, qt.IsNil)
+	err = s.JIMM.Database.DeleteModel(ctx, model)
+	c.Assert(err, qt.IsNil)
+
+	// Re-import the model assigning bob as the new owner.
+	newOwner := "bob@canonical.com"
+	err = s.JIMM.JujuManager.ImportModel(ctx, s.AdminUser, controllerName, model.ResourceTag(), newOwner)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		s.DestroyModelAndDeleteFromDatabase(c, model.ResourceTag())
+	})
+
+	imported := &dbmodel.Model{}
+	imported.SetTag(model.ResourceTag())
+	c.Assert(s.JIMM.Database.GetModel(ctx, imported), qt.IsNil)
+
+	// In JAAS the model is now owned by the new owner, but the backing
+	// controller still knows it under its original owner.
+	c.Check(imported.OwnerIdentityName, qt.Equals, newOwner)
+	c.Check(imported.ControllerFacingOwner(), qt.Equals, originalOwner)
+
+	// Creating an offer succeeds even though the owners differ, because the
+	// offer URL is built with the controller-facing (original) owner. Using the
+	// new JAAS owner would make the backing controller report "not found".
+	err = s.JIMM.JujuManager.Offer(ctx, s.AdminUser, juju.AddApplicationOfferParams{
+		ModelTag:        model.ResourceTag(),
+		OwnerTag:        names.NewUserTag(newOwner),
+		OfferName:       "test-offer",
+		ApplicationName: "test-app",
+		Endpoints:       map[string]string{"source": "source"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Listing offers works using the JAAS owner (the owner the user sees). JIMM
+	// resolves the model by its JAAS owner and translates to the controller-facing
+	// owner when querying the backing controller.
+	offers, err := s.JIMM.JujuManager.ListApplicationOffers(ctx, s.AdminUser, crossmodel.ApplicationOfferFilter{
+		OwnerName: newOwner,
+		ModelName: imported.Name,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(offers, qt.HasLen, 1)
+
+	// Pass-through UX: the returned offer URL keeps the model's ORIGINAL owner
+	// and does NOT use the new JAAS owner. This is what a user consuming the
+	// offer will use.
+	c.Check(strings.Contains(offers[0].OfferURL, originalOwner+"/"+imported.Name), qt.IsTrue,
+		qt.Commentf("offer URL should keep original owner %q; got %q", originalOwner, offers[0].OfferURL))
+	c.Check(strings.Contains(offers[0].OfferURL, newOwner), qt.IsFalse,
+		qt.Commentf("offer URL should NOT contain the new JAAS owner %q; got %q", newOwner, offers[0].OfferURL))
+
+	// Consuming the offer using the JAAS owner (the owner the user sees) must
+	// work. JIMM translates the JAAS URL to the controller-facing URL when
+	// looking up the offer and forwarding to the backing controller.
+	conn := s.Open(c, nil, "alice@canonical.com", nil)
+	defer conn.Close()
+	offerClient := applicationoffers.NewClient(conn)
+
+	jaasURL := crossmodel.OfferURL{
+		User:            newOwner,
+		ModelName:       imported.Name,
+		ApplicationName: "test-offer",
+	}
+	consumeDetails, err := offerClient.GetConsumeDetails(jaasURL.Path())
+	c.Assert(err, qt.IsNil)
+	c.Check(consumeDetails.Offer.OfferName, qt.Equals, "test-offer")
+	c.Check(consumeDetails.Offer.OfferURL, qt.Not(qt.Equals), "")
+}

--- a/testing/modelmanager_test.go
+++ b/testing/modelmanager_test.go
@@ -122,7 +122,10 @@ func TestListModelSummariesWithoutControllerUUIDMasking(t *testing.T) {
 	client := modelmanager.NewClient(conn)
 	models, err := client.ListModelSummaries("bob@canonical.com", false)
 	c.Assert(err, qt.Equals, nil)
-	c.Assert(len(models), qt.Equals, 1)
+	// Alice is a controller admin on every backing controller, so each
+	// controller model is visible in addition to bob's model.
+	expectedCount := len(s.GetControllersConfig(c).Controllers) + 1
+	c.Assert(len(models), qt.Equals, expectedCount)
 	for _, model := range models {
 		c.Assert(model.ControllerUUID, qt.Not(qt.Equals), jimmtest.ControllerUUID)
 	}


### PR DESCRIPTION
## Description

Show controller models in jaas.
The idea is to allow controller admin to switch to the controller model to run command (ex. juju debug-log), and also allow in the future to integrate COS with the controller application via terraform using JAAS.

The implementation is pretty straight forward:
- store the controller facing owner, which is the owner we will use when we talk to the backing controller
  - this will solve contextually the problem with import models with local users, or importing models with another external user
- the translation is done everytime we interact with offers in jaas, so during get, find, list, destroy. Since it's done just in JAAS, and the source of truth is kept in the backing controller i don't see potential issues we can't solve.

Potential problems for drifting terraform states(please think about scenarios, and we can qa/test it together)
- import model didnt' work before for local users, so there shouldn't be any offer created for those models that might drift with this change
- controller models were not shown so no drift there as well
- the only potential drift if somebody was listing all models to do something and now it will find an additional model, but i don't think that's a problem


# QA (controller model)

`make qa-lxd`

now `juju models` shows:
```
[4:21:31] ➜  jimm git:(backing-controller) juju models
Controller: jimm-dev

Model                          Cloud/Region         Type  Status     Machines  Units  Access  Last connection
qa-lxd@controller/controller*  localhost/localhost  lxd   available         1      1  admin   never connected
test-lxd                       localhost/localhost  lxd   available         1      1  admin   never connected
b                              localhost/localhost  lxd   available         1      1  admin   never connected
```

you should be able to switch to it, create an offer and consume it on another model.
For example:
```
juju switch qa-lxd@controller/controller
juju offer controller dashboard
juju add-model c
juju deploy juju-dashboard
juju consume <offer-url>
juju integration juju-dashboard controller
```


# QA (import model with local user)

```
juju switch qa-lxd
juju add-model c
```

```
juju switch jimm-dev
./jaas import-model qa-lxd 0893f41c-c129-48a2-812d-5c55a6471fce --owner jimm-test@canonical.com
juju deploy juju-qa-dummy-sink
juju offer dummy-sink:source 
juju switch b                               
juju consume jimm-test@canonical.com/c.dummy-sink                                       
```