### PR TITLE
feat: controller reader relation

### DIFF
--- a/docs/explanation/jaas-authorization.md
+++ b/docs/explanation/jaas-authorization.md
@@ -60,6 +60,7 @@ type controller
   relations
     define controller: [controller]
     define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
+    define reader: [user, user:*, group#member, role#assignee] or administrator
     define audit_log_viewer: [user, user:*, group#member, role#assignee] or administrator
     define can_addmodel: [user, user:*, group#member, role#assignee] or administrator
 
@@ -67,7 +68,7 @@ type model
   relations
     define controller: [controller]
     define administrator: [user, user:*, group#member, role#assignee] or administrator from controller
-    define reader: [user, user:*, group#member, role#assignee] or writer
+    define reader: [user, user:*, group#member, role#assignee] or writer or reader from controller
     define writer: [user, user:*, group#member, role#assignee] or administrator
 
 type applicationoffer

--- a/docs/howto/manage-permissions.md
+++ b/docs/howto/manage-permissions.md
@@ -57,6 +57,14 @@ juju add-permission group-mygroup#member can-addmodel cloud-mycloud
 
 For any given resource, permissions are currently hierarchical and some permissions are implicit -- e.g., given a cloud associated with a controller and a model associated with the cloud, a controller `administrator` entails cloud `administrator` entails cloud `can_addmodel`.
 
+Granting the `reader` permission on a controller cascades read access to every model on that controller. For example, to give a user, all assignees of a role, or all members of an IdP group read access to all models on controller `mycontroller`:
+
+```text
+juju add-permission user-alice@canonical.com reader controller-mycontroller
+juju add-permission role-myrole#assignee reader controller-mycontroller
+juju add-permission idpgroup-myidpgroup#member reader controller-mycontroller
+```
+
 > See more: {doc}`juju add-permission <../reference/jaas-plugin>`
 
 

--- a/internal/openfga/openfga_test.go
+++ b/internal/openfga/openfga_test.go
@@ -601,6 +601,7 @@ func TestListObjectsWithContextualTuples(t *testing.T) {
 		"10000000-0000-0000-0000-000000000000",
 		"20000000-0000-0000-0000-000000000000",
 		"30000000-0000-0000-0000-000000000000",
+		"40000000-0000-0000-0000-000000000000",
 	}
 
 	expected := make([]openfga.Tag, len(modelUUIDs))
@@ -640,6 +641,17 @@ func TestListObjectsWithContextualTuples(t *testing.T) {
 			Object:   ofganames.ConvertTag(names.NewControllerTag("00000000-0000-0000-0000-000000000000")),
 			Relation: ofganames.ControllerRelation,
 			Target:   ofganames.ConvertTag(names.NewModelTag(modelUUIDs[2])),
+		},
+		// Reader to model via reader of controller
+		{
+			Object:   ofganames.ConvertTag(names.NewUserTag("alice")),
+			Relation: ofganames.ReaderRelation,
+			Target:   ofganames.ConvertTag(names.NewControllerTag("11111111-0000-0000-0000-000000000000")),
+		},
+		{
+			Object:   ofganames.ConvertTag(names.NewControllerTag("11111111-0000-0000-0000-000000000000")),
+			Relation: ofganames.ControllerRelation,
+			Target:   ofganames.ConvertTag(names.NewModelTag(modelUUIDs[3])),
 		},
 	})
 	c.Assert(err, qt.Equals, nil)
@@ -696,6 +708,7 @@ func TestListObjectsWithPeristedTuples(t *testing.T) {
 		"10000000-0000-0000-0000-000000000000",
 		"20000000-0000-0000-0000-000000000000",
 		"30000000-0000-0000-0000-000000000000",
+		"40000000-0000-0000-0000-000000000000",
 	}
 
 	expected := make([]openfga.Tag, len(modelUUIDs))
@@ -736,6 +749,17 @@ func TestListObjectsWithPeristedTuples(t *testing.T) {
 				Object:   ofganames.ConvertTag(names.NewControllerTag("00000000-0000-0000-0000-000000000000")),
 				Relation: ofganames.ControllerRelation,
 				Target:   ofganames.ConvertTag(names.NewModelTag(modelUUIDs[2])),
+			},
+			// Reader to model via reader of controller
+			{
+				Object:   ofganames.ConvertTag(names.NewUserTag("alice")),
+				Relation: ofganames.ReaderRelation,
+				Target:   ofganames.ConvertTag(names.NewControllerTag("11111111-0000-0000-0000-000000000000")),
+			},
+			{
+				Object:   ofganames.ConvertTag(names.NewControllerTag("11111111-0000-0000-0000-000000000000")),
+				Relation: ofganames.ControllerRelation,
+				Target:   ofganames.ConvertTag(names.NewModelTag(modelUUIDs[3])),
 			},
 		}...,
 	), qt.Equals, nil)

--- a/openfga/authorisation_model.fga
+++ b/openfga/authorisation_model.fga
@@ -19,6 +19,7 @@ type controller
   relations
     define controller: [controller]
     define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from controller
+    define reader: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
     define audit_log_viewer: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
     define can_addmodel: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
 
@@ -26,7 +27,7 @@ type model
   relations
     define controller: [controller]
     define administrator: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator from controller
-    define reader: [user, user:*, group#member, idpgroup#member, role#assignee] or writer
+    define reader: [user, user:*, group#member, idpgroup#member, role#assignee] or writer or reader from controller
     define writer: [user, user:*, group#member, idpgroup#member, role#assignee] or administrator
 
 type applicationoffer

--- a/openfga/tests.fga.yaml
+++ b/openfga/tests.fga.yaml
@@ -111,6 +111,28 @@ tuples:
     - user: group:co-group-3#member
       relation: can_addmodel
       object: controller:co-controller-2
+    - user: user:co-user-7
+      relation: reader
+      object: controller:co-controller-1
+    - user: user:co-user-8
+      relation: member
+      object: group:co-group-4
+    - user: group:co-group-4#member
+      relation: reader
+      object: controller:co-controller-2
+    - user: group:co-group-4#member
+      relation: reader
+      object: controller:co-controller-1
+    # Models inheriting reader from a controller (co-controller-3).
+    - user: user:co-user-9
+      relation: reader
+      object: controller:co-controller-3
+    - user: controller:co-controller-3
+      relation: controller
+      object: model:co-model-1
+    - user: controller:co-controller-3
+      relation: controller
+      object: model:co-model-2
 
     # Model (mo)
     - user: user:mo-user-1
@@ -307,9 +329,9 @@ tests:
               - role:ro-role-6
             
     # Checks whether:
-    # - all or invididual users, or group members can become administators and audit_log_viewers of a controller
+    # - all or invididual users, or group members can become administators, audit_log_viewers and readers of a controller
     # - controllers can be related to each other with correct inheritance of administrators
-    # - proper hierarchy of relations is upheld: administrator > audit_log_viewer, administrator > can_addmodel
+    # - proper hierarchy of relations is upheld: administrator > audit_log_viewer, administrator > can_addmodel, administrator > reader
     - name: Controller
       list_objects:
          - user: user:co-user-1
@@ -322,6 +344,9 @@ tests:
                - controller:co-controller-1
                - controller:co-controller-2
              can_addmodel:
+               - controller:co-controller-1
+               - controller:co-controller-2
+             reader:
                - controller:co-controller-1
                - controller:co-controller-2
          - user: group:co-group-1#member
@@ -359,6 +384,20 @@ tests:
            assertions:
              can_addmodel:
                - controller:co-controller-2
+         - user: user:co-user-7
+           type: controller
+           assertions:
+             # co-controller-2 is included because user:* is an administrator
+             # of it (and administrators are readers).
+             reader:
+               - controller:co-controller-1
+               - controller:co-controller-2
+         - user: group:co-group-4#member
+           type: controller
+           assertions:
+             reader:
+               - controller:co-controller-1
+               - controller:co-controller-2
 
       check:
         - user: user:co-user-2
@@ -367,6 +406,19 @@ tests:
             audit_log_viewer: true
             administrator: false
             can_addmodel: false
+            reader: false
+        - user: user:co-user-7
+          object: controller:co-controller-1
+          assertions:
+            reader: true
+            administrator: false
+            audit_log_viewer: false
+            can_addmodel: false
+        - user: user:co-user-8
+          object: controller:co-controller-1
+          assertions:
+            reader: true
+            administrator: false
 
     # Ensures:
     # - all or individual users, as well as group members can take part in appropriate relations
@@ -429,6 +481,15 @@ tests:
             reader:
               - model:mo-model-1
               - model:mo-model-2
+        # A controller reader inherits reader on every model of that controller.
+        # mo-model-2 is also included because user:* is an administrator of it.
+        - user: user:co-user-9
+          type: model
+          assertions:
+            reader:
+              - model:co-model-1
+              - model:co-model-2
+              - model:mo-model-2
       check:
         - user: group:mo-group-2#member
           object: model:mo-model-1
@@ -441,6 +502,13 @@ tests:
           assertions:
             writer: false
             reader: true
+            administrator: false
+        # Controller reader gets read-only access to models, not write/admin.
+        - user: user:co-user-9
+          object: model:co-model-1
+          assertions:
+            reader: true
+            writer: false
             administrator: false
     
     # Makes sure that: 

--- a/testing/accesscontrol_test.go
+++ b/testing/accesscontrol_test.go
@@ -1491,6 +1491,77 @@ func TestCheckRelationControllerAdministratorFlow(t *testing.T) {
 	c.Assert(results, qt.DeepEquals, expected)
 }
 
+// TestCheckRelationControllerReaderCascadesToModel verifies that granting a
+// user the reader relation on a controller cascades to read access on that
+// controller's models, via the "reader from controller" clause in the
+// authorisation model.
+func TestCheckRelationControllerReaderCascadesToModel(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	ctx := context.Background()
+	ofgaClient := s.JIMM.OpenFGAClient
+
+	user, _, controller, model, _, _, _, client, closeClient := createTestControllerEnvironment(c, s)
+	defer closeClient()
+
+	userTag := ofganames.ConvertTag(user.ResourceTag())
+	controllerTag := ofganames.ConvertTag(controller.ResourceTag())
+	modelTag := ofganames.ConvertTag(model.ResourceTag())
+
+	// JAAS style keys, to be translated and checked against UUIDs/users.
+	userJAASKey := "user-" + user.Name
+	modelJAASKey := "model-" + user.Name + "/" + model.Name
+
+	// Make the user a reader of the controller and relate the model to its
+	// controller so controller-level access cascades down to the model.
+	userToControllerReader := openfga.Tuple{
+		Object:   userTag,
+		Relation: "reader",
+		Target:   controllerTag,
+	}
+	controllerToModel := openfga.Tuple{
+		Object:   controllerTag,
+		Relation: "controller",
+		Target:   modelTag,
+	}
+
+	err := ofgaClient.AddRelation(ctx, userToControllerReader, controllerToModel)
+	c.Assert(err, qt.IsNil)
+
+	type test struct {
+		input apiparams.RelationshipTuple
+		want  bool
+	}
+
+	tests := []test{
+		// Test user -> reader -> model (due to reader from controller).
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "reader",
+				TargetObject: modelJAASKey,
+			},
+			want: true,
+		},
+		// Test user -> writer -> model (FAILS as reader does not imply writer).
+		{
+			input: apiparams.RelationshipTuple{
+				Object:       userJAASKey,
+				Relation:     "writer",
+				TargetObject: modelJAASKey,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		req := apiparams.CheckRelationRequest{Tuple: tc.input}
+		res, err := client.CheckRelation(&req)
+		c.Assert(err, qt.IsNil)
+		c.Assert(res.Allowed, qt.Equals, tc.want)
+	}
+}
+
 /*
  None-facade related tests
 */


### PR DESCRIPTION
## Description
In #2055 it was expressed adding reader permission to each model individually is excessive and an operator burden, and the only laternative they have is setting superuser to the user which may not be ideal in the case of simply wishing to read all models on a controller. 

I liked the suggestion proposed in the issue and just did the suggestion.

As I explained in my response on the issue, we often mirror the Juju RBAC model so that it is possible to add the permissions either via our AddRelation API or Juju's built in grants (which we internally convert to ofga calls). Obviously in this case Juju only models `superuser` and `login` and does not have a concept of `reader` for controllers.

This may be a point of contention (as explained in my response to the issue), but as it is a reading permission, it should have no side effects and is simply additive to our auth model, which I believe is grounds to stray away from the Juju RBAC in [this] reading cases.

As it stands, I haven't added anything extra to enable operators to set this permission. I did think about adding an explicit JIMM command, but I don't believe it is necessary given we have our AddRelation API.

Now the following is possible:
`juju add-permission group-<uuid>#member reader controller-<uuid>` 


## Engineering checklist
<!-- *Check only items that apply* -->

- [x] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

## Test instructions
<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->
