### PR TITLE
feat(jujuapi): derive model placement cap from the reported client version

### DIFF
--- a/internal/jimmhttp/utils.go
+++ b/internal/jimmhttp/utils.go
@@ -38,6 +38,12 @@ func MigratingModelUUIDFromContext(ctx context.Context) string {
 	return s
 }
 
+// ContextWithClientVersion returns a context holding the client version
+// reported on the connection, as retrieved by ClientVersionFromContext.
+func ContextWithClientVersion(ctx context.Context, version string) context.Context {
+	return context.WithValue(ctx, clientVersionKey{}, version)
+}
+
 // ClientVersionFromContext returns the value of the client version sent in an
 // HTTP header if one was sent.
 func ClientVersionFromContext(ctx context.Context) string {

--- a/internal/jimmhttp/websocket.go
+++ b/internal/jimmhttp/websocket.go
@@ -55,7 +55,7 @@ func (h *WSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Set the migrating model UUID if it exists in the request header.
 	ctx = context.WithValue(ctx, migratingModelUUIDKey{}, req.Header.Get(jujuparams.MigrationModelHTTPHeader))
 	// Set the client version from the request header, expected by Juju controllers.
-	ctx = context.WithValue(ctx, clientVersionKey{}, req.Header.Get(jujuparams.JujuClientVersion))
+	ctx = ContextWithClientVersion(ctx, req.Header.Get(jujuparams.JujuClientVersion))
 
 	conn, err := h.Upgrader.Upgrade(w, req, nil)
 	if err != nil {

--- a/internal/jujuapi/controllerroot.go
+++ b/internal/jujuapi/controllerroot.go
@@ -7,14 +7,30 @@ import (
 	"sync"
 
 	"github.com/juju/names/v6"
+	"github.com/juju/version/v2"
 	"github.com/rogpeppe/fastuuid"
 	"golang.org/x/oauth2"
 
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jujuapi/rpc"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	jimmnames "github.com/canonical/jimm/v3/pkg/names"
 )
+
+// highestControllerVersionForClient returns the model-placement cap for the client on
+// this connection, per the JIMM/Juju interoperability spec: a client may only
+// host new models on controllers whose major version is <= the client's
+// reported major version (the X-Juju-ClientVersion websocket header), and a
+// client that reports no, or an unparseable, version is treated as a Juju 3.6
+// client (fail closed).
+func highestControllerVersionForClient(ctx context.Context) int {
+	v, err := version.Parse(jimmhttp.ClientVersionFromContext(ctx))
+	if err != nil {
+		return 3
+	}
+	return v.Major
+}
 
 // controllerRoot is the root for endpoints served on controller connections.
 type controllerRoot struct {

--- a/internal/jujuapi/jimm.go
+++ b/internal/jujuapi/jimm.go
@@ -205,6 +205,9 @@ func (r *controllerRoot) AddModelToController(ctx context.Context, req apiparams
 	}
 	// Add JIMM specific field.
 	mca.ControllerName = req.ControllerName
+	// The named controller must still be compatible with the client's
+	// reported version; an unversioned client is treated as Juju 3.6.
+	mca.MaxControllerMajorVersion = highestControllerVersionForClient(ctx)
 
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, mca)
 	if err != nil {

--- a/internal/jujuapi/jimm_test.go
+++ b/internal/jujuapi/jimm_test.go
@@ -860,6 +860,9 @@ func TestAddModelToController(t *testing.T) {
 						c.Check(args.CloudRegion, qt.Equals, "region-1")
 						c.Check(args.CloudCredential.String(), qt.Equals, "cloudcred-openstack_alice_mycred")
 						c.Check(args.ControllerName, qt.Equals, "controller-1")
+						// No client version is reported on this connection, so
+						// the client is treated as Juju 3.6.
+						c.Check(args.MaxControllerMajorVersion, qt.Equals, 3)
 						return base.ModelInfo{
 							Cloud:           "openstack",
 							Qualifier:       "alice@canonical.com",

--- a/internal/jujuapi/modelmanager.go
+++ b/internal/jujuapi/modelmanager.go
@@ -223,12 +223,14 @@ func (r *controllerRoot) CreateModel(ctx context.Context, args jujuparams.ModelC
 
 // createModel adds the model described by mca and converts the result to the
 // current (qualifier) wire format. It is shared by the v11 CreateModel handler
-// and the v10 CreateModelLegacy handler, which differ only in their wire format
-// and (for v10) the controller-version placement constraint set on mca.
+// and the v10 CreateModelLegacy handler, which differ only in their wire
+// format. The model is placed on a controller compatible with the client's
+// reported version; a client that reports no version is treated as Juju 3.6.
 func (r *controllerRoot) createModel(ctx context.Context, mca *juju.ModelCreateArgs) (jujuparams.ModelInfo, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	mca.MaxControllerMajorVersion = highestControllerVersionForClient(ctx)
 	info, err := r.jimm.JujuManager().AddModel(ctx, r.user, mca)
 	if err != nil {
 		servermon.ModelsCreatedFailCount.Inc()
@@ -467,10 +469,6 @@ func (r *controllerRoot) CreateModelLegacy(ctx context.Context, args jujuparams.
 	if err != nil {
 		return jujuparams.ModelInfoLegacy{}, err
 	}
-	// A 3.6 client reaches CreateModel only via this version 10 handler. A 3.6
-	// client cannot operate a 4.x controller, so its new model must be placed
-	// on a controller of major version <= 3.
-	mca.MaxControllerMajorVersion = 3
 	info, err := r.createModel(ctx, mca)
 	if err != nil {
 		return jujuparams.ModelInfoLegacy{}, err

--- a/internal/jujuapi/modelmanager_legacy_test.go
+++ b/internal/jujuapi/modelmanager_legacy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/names/v6"
 
 	"github.com/canonical/jimm/v3/internal/jimm/juju"
+	"github.com/canonical/jimm/v3/internal/jimmhttp"
 	"github.com/canonical/jimm/v3/internal/jujuapi"
 	"github.com/canonical/jimm/v3/internal/jujuclient"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -61,6 +62,89 @@ func TestCreateModelLegacy(t *testing.T) {
 	c.Check(got.OwnerTag, qt.Equals, "user-alice@external")
 	c.Check(got.Name, qt.Equals, "mymodel")
 	c.Check(got.UUID, qt.Equals, testModelUUID)
+}
+
+// TestCreateModelClientVersionPlacementCap verifies that both CreateModel
+// handlers derive the controller-version placement cap from the client version
+// reported on the connection, per the JIMM/Juju interoperability spec: the cap
+// is the reported major version, and a client that reports no (or an
+// unparseable) version is treated as a Juju 3.6 client, whichever facade
+// version it negotiated.
+func TestCreateModelClientVersionPlacementCap(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		about         string
+		clientVersion string
+		useLegacy     bool
+		expectedCap   int
+	}{{
+		about:       "no reported version, v11 handler",
+		expectedCap: 3,
+	}, {
+		about:       "no reported version, v10 handler",
+		useLegacy:   true,
+		expectedCap: 3,
+	}, {
+		about:         "4.x client, v11 handler",
+		clientVersion: "4.0.2",
+		expectedCap:   4,
+	}, {
+		about:         "4.x client, v10 handler",
+		clientVersion: "4.0.2",
+		useLegacy:     true,
+		expectedCap:   4,
+	}, {
+		about:         "3.6 client, v11 handler",
+		clientVersion: "3.6.8",
+		expectedCap:   3,
+	}, {
+		about:         "unparseable reported version, v11 handler",
+		clientVersion: "not-a-version",
+		expectedCap:   3,
+	}}
+
+	for _, test := range tests {
+		c.Run(test.about, func(c *qt.C) {
+			gotCap := -1
+			jujuManager := mocks.JujuManager{
+				ModelManager: mocks.ModelManager{
+					AddModel_: func(ctx context.Context, u *openfga.User, args *juju.ModelCreateArgs) (base.ModelInfo, error) {
+						gotCap = args.MaxControllerMajorVersion
+						return base.ModelInfo{
+							Name:            args.Name,
+							UUID:            testModelUUID,
+							Qualifier:       model.Qualifier("alice@external"),
+							Type:            model.IAAS,
+							Cloud:           "aws",
+							CloudRegion:     "eu-west-1",
+							CloudCredential: "aws/alice@external/cred",
+						}, nil
+					},
+				},
+			}
+			cr := newTestControllerRoot(jujuJIMM(&jujuManager), "alice@external", true)
+
+			ctx := context.Background()
+			if test.clientVersion != "" {
+				ctx = jimmhttp.ContextWithClientVersion(ctx, test.clientVersion)
+			}
+			var err error
+			if test.useLegacy {
+				_, err = cr.CreateModelLegacy(ctx, jujuparams.ModelCreateArgsLegacy{
+					Name:     "mymodel",
+					OwnerTag: "user-alice@external",
+				})
+			} else {
+				_, err = cr.CreateModel(ctx, jujuparams.ModelCreateArgs{
+					Name:      "mymodel",
+					Qualifier: "alice@external",
+				})
+			}
+			c.Assert(err, qt.IsNil)
+			c.Check(gotCap, qt.Equals, test.expectedCap)
+		})
+	}
 }
 
 // TestListModelsLegacy checks the v10 ListModels handler returns owner tags.

--- a/internal/testutils/jimmtest/dialwebsocket.go
+++ b/internal/testutils/jimmtest/dialwebsocket.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Canonical.
+
+package jimmtest
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/juju/errors"
+	"github.com/juju/juju/rpc/jsoncodec"
+	jujuparams "github.com/juju/juju/rpc/params"
+)
+
+// DialWebsocketWithClientVersion returns a websocket dialer for
+// api.DialOpts.DialWebsocket that reports the given client version via the
+// X-Juju-ClientVersion header on the main API dial, as the Juju 4.x client
+// does since juju/juju#22794. JIMM derives model placement and
+// model-connection compatibility from this header, so tests dial with the
+// current version by default (see OpenNoAssert); suites simulating a Juju 3.6
+// client dial with version "" — no header is sent at all, which stays
+// faithful even after jimm's juju dependency starts sending the header by
+// default.
+//
+// The dialer body is copied from the juju api client's gorillaDialWebsocket.
+func DialWebsocketWithClientVersion(version string) func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+	return func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+		parsedURL, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		netDialer := net.Dialer{}
+		dialer := &websocket.Dialer{
+			NetDial: func(netw, addr string) (net.Conn, error) {
+				if addr == parsedURL.Host {
+					addr = ipAddr
+				}
+				return netDialer.DialContext(ctx, netw, addr)
+			},
+			HandshakeTimeout: 45 * time.Second,
+			TLSClientConfig:  tlsConfig,
+		}
+
+		var requestHeader http.Header
+		if version != "" {
+			requestHeader = make(http.Header)
+			requestHeader.Set(jujuparams.JujuClientVersion, version)
+		}
+		c, resp, err := dialer.Dial(urlStr, requestHeader)
+		if err != nil {
+			if err == websocket.ErrBadHandshake {
+				defer resp.Body.Close()
+				body, readErr := io.ReadAll(resp.Body)
+				if readErr == nil {
+					err = errors.Errorf(
+						"%s (%s)",
+						strings.TrimSpace(string(body)),
+						http.StatusText(resp.StatusCode),
+					)
+				}
+			}
+			return nil, errors.Trace(err)
+		}
+		return jsoncodec.NewWebsocketConn(c), nil
+	}
+}

--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/core/constraints"
+	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/rpc/jsoncodec"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
@@ -150,6 +151,12 @@ type LoginDetails struct {
 	Username      string
 	Lp            api.LoginProvider
 	DialWebsocket func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error)
+	// NoClientVersion dials without the X-Juju-ClientVersion header,
+	// simulating a Juju 3.6 client. By default connections report the
+	// current juju version, as a released 4.x client does; JIMM treats an
+	// unversioned client as 3.6 (fail closed) for model placement and
+	// model-connection compatibility.
+	NoClientVersion bool
 }
 
 // SetupJimmWithControllers sets up a JIMM environment with externally bootstrapped controllers defined in the config file.
@@ -357,6 +364,13 @@ func (s *JimmWithControllers) OpenNoAssert(c *qt.C, d LoginDetails, modelTag *na
 
 	if d.DialWebsocket != nil {
 		dialOpts.DialWebsocket = d.DialWebsocket
+	} else if d.NoClientVersion {
+		// Dial with an explicitly headerless dialer rather than juju's
+		// default one, which reports the client version on the main API
+		// dial since juju/juju#22794.
+		dialOpts.DialWebsocket = DialWebsocketWithClientVersion("")
+	} else {
+		dialOpts.DialWebsocket = DialWebsocketWithClientVersion(jujuversion.Current.String())
 	}
 
 	return api.Open(context.Background(), &inf, dialOpts)
@@ -364,6 +378,16 @@ func (s *JimmWithControllers) OpenNoAssert(c *qt.C, d LoginDetails, modelTag *na
 
 func (s *JimmWithControllers) Open(c *qt.C, info *api.Info, username string, modelTag *names.ModelTag) api.Connection {
 	ld := LoginDetails{Info: info, Username: username}
+	conn, err := s.OpenNoAssert(c, ld, modelTag)
+	c.Assert(err, qt.Equals, nil)
+	return conn
+}
+
+// OpenNoClientVersion is like Open but dials without the
+// X-Juju-ClientVersion header, simulating a Juju 3.6 client (which does not
+// report its version on the main API dial).
+func (s *JimmWithControllers) OpenNoClientVersion(c *qt.C, info *api.Info, username string, modelTag *names.ModelTag) api.Connection {
+	ld := LoginDetails{Info: info, Username: username, NoClientVersion: true}
 	conn, err := s.OpenNoAssert(c, ld, modelTag)
 	c.Assert(err, qt.Equals, nil)
 	return conn

--- a/internal/testutils/jimmtest/setup_e2e.go
+++ b/internal/testutils/jimmtest/setup_e2e.go
@@ -362,14 +362,15 @@ func (s *JimmWithControllers) OpenNoAssert(c *qt.C, d LoginDetails, modelTag *na
 		LoginProvider:      d.Lp,
 	}
 
-	if d.DialWebsocket != nil {
+	switch {
+	case d.DialWebsocket != nil:
 		dialOpts.DialWebsocket = d.DialWebsocket
-	} else if d.NoClientVersion {
+	case d.NoClientVersion:
 		// Dial with an explicitly headerless dialer rather than juju's
 		// default one, which reports the client version on the main API
 		// dial since juju/juju#22794.
 		dialOpts.DialWebsocket = DialWebsocketWithClientVersion("")
-	} else {
+	default:
 		dialOpts.DialWebsocket = DialWebsocketWithClientVersion(jujuversion.Current.String())
 	}
 

--- a/testing/applicationoffers_legacy_test.go
+++ b/testing/applicationoffers_legacy_test.go
@@ -22,7 +22,7 @@ func TestApplicationOffersV5ListAndFind(t *testing.T) {
 	c := qt.New(t)
 	s, model := SetupAppOfferTest(c)
 
-	conn := s.Open(c, nil, "bob@canonical.com", nil)
+	conn := s.OpenNoClientVersion(c, nil, "bob@canonical.com", nil)
 	defer conn.Close()
 
 	client := applicationoffers.NewClient(conn)

--- a/testing/controller_legacy_test.go
+++ b/testing/controller_legacy_test.go
@@ -29,7 +29,7 @@ func TestControllerV12AllModels(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	var list jujuparams.UserModelListLegacy
@@ -57,7 +57,7 @@ func TestControllerV12ModelStatus(t *testing.T) {
 	s := jimmtest.SetupJimmWithControllers(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	args := jujuparams.Entities{Entities: []jujuparams.Entity{

--- a/testing/modelconfig_legacy_test.go
+++ b/testing/modelconfig_legacy_test.go
@@ -21,7 +21,7 @@ func TestModelConfigV3ModelGet(t *testing.T) {
 	c := qt.New(t)
 	s := jimmtest.SetupJimmWithControllers(c)
 
-	conn := s.Open(c, nil, "alice@canonical.com", nil)
+	conn := s.OpenNoClientVersion(c, nil, "alice@canonical.com", nil)
 	defer conn.Close()
 
 	var res jujuparams.ModelConfigResults

--- a/testing/modelmanager_legacy_test.go
+++ b/testing/modelmanager_legacy_test.go
@@ -45,7 +45,7 @@ func TestModelManagerV10CreateModel(t *testing.T) {
 	s := setupLegacyModelManagerTest(c)
 	existing := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	cred := names.NewCloudCredentialTag(jimmtest.TestE2ECloudName + "/" + bobOwnerTag.Id() + "/cred")
@@ -127,7 +127,7 @@ func TestModelManagerV10ModelInfo(t *testing.T) {
 	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	args := jujuparams.Entities{Entities: []jujuparams.Entity{
@@ -162,7 +162,7 @@ func TestModelManagerV10ListModels(t *testing.T) {
 	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	var list jujuparams.UserModelListLegacy
@@ -190,7 +190,7 @@ func TestModelManagerV10ModelStatus(t *testing.T) {
 	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	args := jujuparams.Entities{Entities: []jujuparams.Entity{
@@ -217,7 +217,7 @@ func TestModelManagerV10ListModelSummaries(t *testing.T) {
 	s := setupLegacyModelManagerTest(c)
 	model := s.CreateModelForBob(c)
 
-	conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+	conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
 	defer conn.Close()
 
 	var res jujuparams.ModelSummaryResultsLegacy

--- a/testing/modelplacement_test.go
+++ b/testing/modelplacement_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"database/sql"
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+	"github.com/juju/version/v2"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// TestModelPlacementByClientVersion exercises client-version-driven model
+// placement end to end: a real websocket dial to JIMM carrying a chosen
+// X-Juju-ClientVersion header, JIMM's header extraction, and placement
+// against the real backing fleet. Per the JIMM/Juju interoperability spec, a
+// new model may only be placed on a controller whose major version is <= the
+// client's reported major version, and a client that reports no version is
+// treated as a Juju 3.6 client (fail closed).
+//
+// Expectations branch on the composition of the backing fleet, so the test is
+// meaningful whether the environment provides 3.x controllers, 4.x
+// controllers, or a mix.
+func TestModelPlacementByClientVersion(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	has3x := s.HasControllerWithMajorVersionAtMost(c, 3)
+
+	// createModel creates a model over the given connection using the
+	// current (v11) wire format and returns the response and error.
+	createModel := func(c *qt.C, conn api.Connection) (jujuparams.ModelInfo, error) {
+		args := jujuparams.ModelCreateArgs{
+			Name:               petname.Generate(2, "-"),
+			Qualifier:          bobOwnerTag.Id(),
+			CloudTag:           names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+			CloudCredentialTag: s.BobCredential.ResourceTag().String(),
+		}
+		var info jujuparams.ModelInfo
+		err := conn.APICall(c.Context(), "ModelManager", 11, "", "CreateModel", args, &info)
+		return info, err
+	}
+
+	// hostingControllerMajor returns the agent major version of the
+	// controller hosting the model, straight from JIMM's database.
+	hostingControllerMajor := func(c *qt.C, uuid string) int {
+		m := dbmodel.Model{
+			UUID: sql.NullString{String: uuid, Valid: true},
+		}
+		err := s.JIMM.Database.GetModel(c.Context(), &m)
+		c.Assert(err, qt.IsNil)
+		v, err := version.Parse(m.Controller.AgentVersion)
+		c.Assert(err, qt.IsNil)
+		return v.Major
+	}
+
+	// assertConstrainedPlacement asserts the spec's behavior for a client
+	// treated as Juju 3.6: the model lands on a <=3.x controller when one is
+	// available, and the create fails with a clear error otherwise.
+	assertConstrainedPlacement := func(c *qt.C, conn api.Connection) {
+		info, err := createModel(c, conn)
+		if !has3x {
+			c.Assert(err, qt.ErrorMatches,
+				"no controller compatible with your Juju client is available; please upgrade your client to use the available controllers.*")
+			return
+		}
+		c.Assert(err, qt.IsNil)
+		c.Cleanup(func() { s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(info.UUID)) })
+		c.Check(hostingControllerMajor(c, info.UUID) <= 3, qt.IsTrue,
+			qt.Commentf("model for a 3.6-treated client landed on a controller of major > 3"))
+	}
+
+	c.Run("unversioned client is treated as Juju 3.6", func(c *qt.C) {
+		conn := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
+		defer conn.Close()
+		assertConstrainedPlacement(c, conn)
+	})
+
+	c.Run("client reporting 3.6 is placed on a 3.x controller", func(c *qt.C) {
+		conn := s.OpenWithDialWebsocket(c, nil, bobOwnerTag.Id(),
+			jimmtest.DialWebsocketWithClientVersion("3.6.8"))
+		defer conn.Close()
+		assertConstrainedPlacement(c, conn)
+	})
+
+	c.Run("client reporting 4.x may be placed on any controller", func(c *qt.C) {
+		conn := s.OpenWithDialWebsocket(c, nil, bobOwnerTag.Id(),
+			jimmtest.DialWebsocketWithClientVersion("4.0.2"))
+		defer conn.Close()
+
+		info, err := createModel(c, conn)
+		c.Assert(err, qt.IsNil)
+		c.Cleanup(func() { s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(info.UUID)) })
+		c.Check(hostingControllerMajor(c, info.UUID) <= 4, qt.IsTrue)
+	})
+}


### PR DESCRIPTION
## Description

Per the approved JIMM/Juju interoperability spec, model placement is constrained by the client version reported in the X-Juju-ClientVersion websocket header, not by the negotiated facade version: a new model may only be placed on a controller whose major version is <= the client's reported major, and a client that reports no (or an unparseable) version is treated as a Juju 3.6 client (fail closed).

Previously the ModelManager v10 (legacy) CreateModel handler hardcoded a <=3 cap and the v11 handler was unconstrained. Both handlers, and the JIMM facade's AddModelToController, now derive the same cap from the connection's reported client version. The builder machinery is unchanged; only the cap derivation moves.

Note this changes v11 behavior: until a Juju client that reports its version on the main API websocket dial is released, all clients look unversioned and new models are placed only on <=3.x controllers. This is the spec's intended fail-closed default; API-driven model-creation tests therefore require a 3.6 backing controller (as CI already uses).

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests

