### PR TITLE
chore: fix snap builds for snapcraft v9

### DIFF
--- a/snaps/jaas/snapcraft.yaml
+++ b/snaps/jaas/snapcraft.yaml
@@ -24,13 +24,15 @@ parts:
     plugin: go
     source: ./
     source-type: git
+    build-snaps:
+      - go/1.26/stable
     prime:
       - bin/jaas
     override-build: |
       set -e
       CGO_ENABLED=0 go install github.com/canonical/jimm/v3/cmd/jaas
     override-prime: |
-      snapcraftctl prime
+      craftctl default
       # Add all CLI commands below as symlinks to make them appear top-level to Juju.
       ln -sf jaas bin/juju-jaas
       ln -sf jaas bin/juju-add-cloud

--- a/snaps/jimm/snapcraft.yaml
+++ b/snaps/jimm/snapcraft.yaml
@@ -4,7 +4,7 @@ description: Multi-cloud controller for managing JAAS models.
 grade: stable
 base: core24
 confinement: strict
-adopt-info: jimmsrv # Version our app via set-version within an override
+version: git
 
 apps:
   jimm:
@@ -20,13 +20,14 @@ parts:
     build-packages:
       - git
       - gcc
+    build-snaps:
+      - go/1.26/stable
     override-pull: |-
       set -e
-      snapcraftctl pull
+      craftctl default
       mkdir -p $SNAPCRAFT_PART_SRC/version
       git -C $SNAPCRAFT_PART_SRC rev-parse --verify HEAD | tee $SNAPCRAFT_PART_SRC/version/commit.txt
       git -C $SNAPCRAFT_PART_SRC describe --dirty --abbrev=0 | tee $SNAPCRAFT_PART_SRC/version/version.txt
-      snapcraftctl set-version `cat $SNAPCRAFT_PART_SRC/version/version.txt`
     override-build: |-
       set -e
       go install -mod readonly -ldflags '-linkmode=external' -tags version github.com/canonical/jimm/v3/cmd/jimmsrv


### PR DESCRIPTION
## Description
Building our `jaas` snap was failing with the recent release of Snapcraft v9. See the changelog [here](https://documentation.ubuntu.com/snapcraft/9.0/release-notes/snapcraft-9-0/#release-9-0). We need to,
1. Use `craftctl` instead of `snapcraftctl` in override scripts.
2. Specify the Go snap explicitly as a dependency.

The other snap in our repo `jimmsrv` is not published or used but I made similar changes to get it building. For that snap there was an additional change. `snapcraftctl set-version` does not have a `craftctl` equivalent, see https://github.com/canonical/snapcraft/issues/5102 so I made a slight tweak so that its version comes from git just like the `jaas` snap.

Run `make jaas-snap` and `make jimm-snap` to verify.

Fixes [JUJU-10140](https://warthogs.atlassian.net/browse/JUJU-10140)

[JUJU-10140]: https://warthogs.atlassian.net/browse/JUJU-10140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ