### PR TITLE
perf: improve ListModelSummaries by querying openfga a single time

### DIFF
--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -315,11 +315,52 @@ func (m *modelSummariesMap) addModelSummary(summary base.UserModelSummary) {
 	m.modelSummaries[summary.UUID] = summary
 }
 
+// listUserModelAccess returns a map from model UUID to the user's highest
+// access level ("admin", "write" or "read") for every model the user can
+// read.
+func (j *JujuManager) listUserModelAccess(ctx context.Context, user *openfga.User) (map[string]string, error) {
+	access := make(map[string]string)
+	for _, relation := range []openfga.Relation{
+		ofganames.ReaderRelation,
+		ofganames.WriterRelation,
+		ofganames.AdministratorRelation,
+	} {
+		uuids, err := user.ListModels(ctx, relation)
+		if err != nil {
+			return nil, err
+		}
+		accessStr := permissions.ToModelAccessString(relation)
+		for _, uuid := range uuids {
+			access[uuid] = accessStr
+		}
+	}
+	return access, nil
+}
+
 // ListModelSummaries returns the list of modelsummary the user has access to.
 // It queries the controllers and then merge the info from the JIMM db.
 func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User, maskingControllerUUID string) ([]base.UserModelSummary, error) {
 	modelSummariesSafeMap := modelSummariesMap{}
 	modelSummaryResults := []base.UserModelSummary{}
+
+	modelAccess, err := j.listUserModelAccess(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(modelAccess) == 0 {
+		return modelSummaryResults, nil
+	}
+
+	uuids := make([]string, 0, len(modelAccess))
+	for uuid := range modelAccess {
+		uuids = append(uuids, uuid)
+	}
+
+	dbModels, err := j.Database.GetModelsByUUID(ctx, uuids)
+	if err != nil {
+		return nil, err
+	}
 
 	var models []struct {
 		model      *dbmodel.Model
@@ -328,21 +369,17 @@ func (j *JujuManager) ListModelSummaries(ctx context.Context, user *openfga.User
 	// we collect models belonging to the user and we extract the unique controllers.
 	var uniqueControllers []dbmodel.Controller
 	uniqueControllerMap := make(map[string]struct{}, 0)
-	err := j.ForEachUserModel(ctx, user, func(m *dbmodel.Model, uap string) error {
+	for i := range dbModels {
+		m := &dbModels[i]
 		models = append(models, struct {
 			model      *dbmodel.Model
 			userAccess string
-		}{model: m, userAccess: uap})
+		}{model: m, userAccess: modelAccess[m.UUID.String]})
 
 		if _, ok := uniqueControllerMap[m.Controller.UUID]; !ok {
 			uniqueControllers = append(uniqueControllers, m.Controller)
 			uniqueControllerMap[m.Controller.UUID] = struct{}{}
 		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	// we query the model summaries for each controller


### PR DESCRIPTION
## Description

Making ListModelSummaries a little bit faster.
Before: using ForEachModel that was iterating over each model and making a call to openfga to check access O(n)

Now: 3 calls to fetch the access level for a user, this is closer to the implementation for `ListModels`.

It is slightly faster (30-40ms in a local setup), so i would expect something to be gained on ps7, not the 20seconds IS was complaining about.

The real performance problem is that:
- we get the model uuids a user has access too
- we call `AllModels` on the backing controllers with an admin user
- so even if a user has a single model on a controller we are still fetching the whole list

For that we would need to work out a `ListSummaries` with filters on passing the model-uuids in the jwt, i don't know.

I guess there is where the 20seconds are spent, but this is better than nothing.
 
With 100 models.

Traces before:
<img width="1042" height="817" alt="image" src="https://github.com/user-attachments/assets/86b296bc-1bdf-44b6-9b46-c4b5579c664e" />


Traces now:
<img width="952" height="424" alt="image" src="https://github.com/user-attachments/assets/3431ec5d-be84-45af-bf12-9dbd179be929" />


# QA

`make qa-lxd`

...create 100 models...


`juju models` should feel faster between the 2 implementation.