### PR TITLE
chore(ssh): change dialing user for ssh

### DIFF
--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -198,7 +198,7 @@ func (s *SSHManager) DialController(ctx context.Context, dialInfo DialInfo, user
 	for _, addr := range dialInfo.Addresses {
 		dest := net.JoinHostPort(addr, fmt.Sprint(dialInfo.Port))
 		client, err = s.dialer.Dial("tcp", dest, &gossh.ClientConfig{
-			User: "jimm",
+			User: "external-auth",
 			//nolint:gosec // this will be removed once we handle hostkeys
 			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 			Auth: []gossh.AuthMethod{


### PR DESCRIPTION
## Description
A minor change to accomodate a tweak in Juju. In https://github.com/juju/juju/pull/22943 we diverged slightly from the SSH spec - when we want Juju to authenticate via a JWT we previously special cased the dialer's username to "JIMM". Now we instead use "external-auth" as the special case username.
