### PR TITLE
fix: fix UpdateCredentials to check against the args.Credentials

### DIFF
--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -176,7 +176,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 
 	if !args.SkipCheck {
 		err := j.forEachController(ctx, controllers, func(ctl *dbmodel.Controller, api API) error {
-			models, err := j.updateControllerCloudCredential(ctx, &credential, api.CheckCredentialModels)
+			models, err := j.checkControllerCloudCredential(ctx, &credential, args.Credential.Attributes, api)
 			resultMu.Lock()
 			defer resultMu.Unlock()
 			result = append(result, models...)
@@ -204,7 +204,7 @@ func (j *JujuManager) UpdateCloudCredential(ctx context.Context, user *openfga.U
 	}
 
 	err = j.forEachController(ctx, controllers, func(ctl *dbmodel.Controller, api API) error {
-		models, err := j.updateControllerCloudCredential(ctx, &credential, api.UpdateCloudsCredentialForce)
+		models, err := j.forceUpdateControllerCloudCredential(ctx, &credential, args.Credential.Attributes, api)
 		if err != nil {
 			return err
 		}
@@ -234,29 +234,25 @@ func (j *JujuManager) updateCredential(ctx context.Context, credential *dbmodel.
 	return nil
 }
 
-func (j *JujuManager) updateControllerCloudCredential(
+// checkControllerCloudCredential validates that the given credential would be
+// accepted by all models currently using it on the controller reachable via
+// api. The attributes passed are the NEW ones being validated.
+func (j *JujuManager) checkControllerCloudCredential(
 	ctx context.Context,
 	cred *dbmodel.CloudCredential,
-	f func(context.Context, jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error),
+	attrs map[string]string,
+	api API,
 ) ([]jujuparams.UpdateCredentialModelResult, error) {
-
-	attr, err := j.getCloudCredentialAttributes(ctx, cred)
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := f(ctx, jujuparams.TaggedCredential{
+	out, err := api.CheckCredentialModels(ctx, jujuparams.TaggedCredential{
 		Tag: cred.Tag().String(),
 		Credential: jujuparams.CloudCredential{
 			AuthType:   cred.AuthType,
-			Attributes: attr,
+			Attributes: attrs,
 		},
 	})
-
 	if err != nil {
 		return nil, err
 	}
-
 	// Shouldn't happen, the Juju client presumes that
 	// the returned slice will always contain a result
 	// for each credential passed in, but handle it just
@@ -264,11 +260,48 @@ func (j *JujuManager) updateControllerCloudCredential(
 	if len(out) == 0 {
 		return nil, nil
 	}
-
 	if out[0].Error != nil {
 		return out[0].Models, out[0].Error
 	}
+	return out[0].Models, nil
+}
 
+// forceUpdateControllerCloudCredential force-updates the credential on the
+// controller reachable via api. If attrs is nil the attributes are fetched
+// from the credential store; otherwise the supplied attrs are applied.
+func (j *JujuManager) forceUpdateControllerCloudCredential(
+	ctx context.Context,
+	cred *dbmodel.CloudCredential,
+	attrs map[string]string,
+	api API,
+) ([]jujuparams.UpdateCredentialModelResult, error) {
+	if attrs == nil {
+		fetched, err := j.getCloudCredentialAttributes(ctx, cred)
+		if err != nil {
+			return nil, err
+		}
+		attrs = fetched
+	}
+	out, err := api.UpdateCloudsCredentialForce(ctx, jujuparams.TaggedCredential{
+		Tag: cred.Tag().String(),
+		Credential: jujuparams.CloudCredential{
+			AuthType:   cred.AuthType,
+			Attributes: attrs,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Shouldn't happen, the Juju client presumes that
+	// the returned slice will always contain a result
+	// for each credential passed in, but handle it just
+	// in case.
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if out[0].Error != nil {
+		return out[0].Models, out[0].Error
+	}
 	return out[0].Models, nil
 }
 

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -234,9 +234,9 @@ func (j *JujuManager) updateCredential(ctx context.Context, credential *dbmodel.
 	return nil
 }
 
-// checkControllerCloudCredential validates that the given credential would be
-// accepted by all models currently using it on the controller reachable via
-// api. The attributes passed are the NEW ones being validated.
+// checkControllerCloudCredential checks that a given credential is safe to
+// update across all of the models it is currently used. This is useful for
+// doing a cross-controller check credential update safety.
 func (j *JujuManager) checkControllerCloudCredential(
 	ctx context.Context,
 	cred *dbmodel.CloudCredential,
@@ -253,10 +253,6 @@ func (j *JujuManager) checkControllerCloudCredential(
 	if err != nil {
 		return nil, err
 	}
-	// Shouldn't happen, the Juju client presumes that
-	// the returned slice will always contain a result
-	// for each credential passed in, but handle it just
-	// in case.
 	if len(out) == 0 {
 		return nil, nil
 	}
@@ -266,22 +262,15 @@ func (j *JujuManager) checkControllerCloudCredential(
 	return out[0].Models, nil
 }
 
-// forceUpdateControllerCloudCredential force-updates the credential on the
-// controller reachable via api. If attrs is nil the attributes are fetched
-// from the credential store; otherwise the supplied attrs are applied.
+// forceUpdateControllerCloudCredential updates a cloud credential for a
+// given controller. It presumes the caller has run checkControllerCloudCredential
+// prior.
 func (j *JujuManager) forceUpdateControllerCloudCredential(
 	ctx context.Context,
 	cred *dbmodel.CloudCredential,
 	attrs map[string]string,
 	api API,
 ) ([]jujuparams.UpdateCredentialModelResult, error) {
-	if attrs == nil {
-		fetched, err := j.getCloudCredentialAttributes(ctx, cred)
-		if err != nil {
-			return nil, err
-		}
-		attrs = fetched
-	}
 	out, err := api.UpdateCloudsCredentialForce(ctx, jujuparams.TaggedCredential{
 		Tag: cred.Tag().String(),
 		Credential: jujuparams.CloudCredential{
@@ -292,10 +281,6 @@ func (j *JujuManager) forceUpdateControllerCloudCredential(
 	if err != nil {
 		return nil, err
 	}
-	// Shouldn't happen, the Juju client presumes that
-	// the returned slice will always contain a result
-	// for each credential passed in, but handle it just
-	// in case.
 	if len(out) == 0 {
 		return nil, nil
 	}

--- a/internal/jimm/juju/cloudcredential_test.go
+++ b/internal/jimm/juju/cloudcredential_test.go
@@ -1866,3 +1866,91 @@ func TestCopyCredentialWithMissingCredential(t *testing.T) {
 	_, _, err = j.CopyCredential(ctx, user, svcAcc, cred.ResourceTag())
 	c.Assert(err, qt.ErrorMatches, "cloudcredential .* not found")
 }
+
+// #nosec G101 fixed test signing keys
+const updateCloudCredentialChecksNewAttributesTestEnv = `clouds:
+- name: test-cloud
+  type: test-provider
+  regions:
+  - name: test-cloud-region
+cloud-credentials:
+- owner: alice@canonical.com
+  name: cred-1
+  cloud: test-cloud
+  auth-type: empty
+users:
+- username: alice@canonical.com
+  controller-access: superuser
+controllers:
+- name: controller-1
+  uuid: 00000001-0000-0000-0000-000000000001
+  cloud: test-cloud
+  region: test-cloud-region
+models:
+- name: model-1
+  uuid: 00000002-0000-0000-0000-000000000001
+  controller: controller-1
+  cloud: test-cloud
+  region: test-cloud-region
+  cloud-credential: cred-1
+  owner: alice@canonical.com
+  life: alive
+  users:
+  - user: alice@canonical.com
+    access: admin
+`
+
+// TestUpdateCloudCredentialChecksNewAttributes verifies that the
+// CheckCredentialModels call (the pre-update validation step) is passed
+// the NEW credential attributes supplied in the update request, not the
+// OLD attributes currently stored for the credential. This is a regression
+// test for a bug where the check phase validated the existing credential
+// instead of the one about to be applied.
+func TestUpdateCloudCredentialChecksNewAttributes(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	oldAttributes := map[string]string{"secret-key": "OLD-VALUE"}
+	newAttributes := map[string]string{"secret-key": "NEW-VALUE"}
+
+	// Capture the credential that CheckCredentialModels receives.
+	var checkedCredential jujuparams.TaggedCredential
+	api := &jimmtest.API{
+		CheckCredentialModels_: func(_ context.Context, cred jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
+			checkedCredential = cred
+			return []jujuparams.UpdateCredentialResult{{}}, nil
+		},
+		UpdateCloudsCredentialForce_: func(_ context.Context, _ jujuparams.TaggedCredential) ([]jujuparams.UpdateCredentialResult, error) {
+			return []jujuparams.UpdateCredentialResult{{}}, nil
+		},
+	}
+
+	j := newTestJujuManager(c, &parameters{
+		Dialer: &jimmtest.Dialer{API: api},
+	})
+
+	env := jimmtest.ParseEnvironment(c, updateCloudCredentialChecksNewAttributesTestEnv)
+	env.PopulateDBAndPermissions(c, j.ResourceTag(), j.Database, j.OpenFGAClient)
+
+	// Seed the credential store with the OLD attributes.
+	credTag := names.NewCloudCredentialTag("test-cloud/alice@canonical.com/cred-1")
+	c.Assert(j.CredentialStore.Put(ctx, credTag, oldAttributes), qt.IsNil)
+
+	u := env.User("alice@canonical.com").DBObject(c, j.Database)
+	user := openfga.NewUser(&u, j.OpenFGAClient)
+	user.JimmAdmin = true
+
+	_, err := j.UpdateCloudCredential(ctx, user, juju.UpdateCloudCredentialArgs{
+		CredentialTag: credTag,
+		Credential: jujuparams.CloudCredential{
+			AuthType:   "test-auth-type",
+			Attributes: newAttributes,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// The check must have validated the NEW auth-type and attributes,
+	// not the OLD ones from the store.
+	c.Assert(checkedCredential.Credential.AuthType, qt.Equals, "test-auth-type")
+	c.Assert(checkedCredential.Credential.Attributes, qt.DeepEquals, newAttributes)
+}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -820,7 +820,7 @@ func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.U
 
 	var m *dbmodel.Model
 	err = j.doModelAdmin(ctx, user, modelTag, func(model *dbmodel.Model, api API) error {
-		_, err = j.updateControllerCloudCredential(ctx, &credential, api.UpdateCloudsCredentialForce)
+		_, err = j.forceUpdateControllerCloudCredential(ctx, &credential, nil, api)
 		if err != nil {
 			return err
 		}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -819,8 +819,12 @@ func (j *JujuManager) ChangeModelCredential(ctx context.Context, user *openfga.U
 	}
 
 	var m *dbmodel.Model
+	attrs, err := j.getCloudCredentialAttributes(ctx, &credential)
+	if err != nil {
+		return err
+	}
 	err = j.doModelAdmin(ctx, user, modelTag, func(model *dbmodel.Model, api API) error {
-		_, err = j.forceUpdateControllerCloudCredential(ctx, &credential, nil, api)
+		_, err = j.forceUpdateControllerCloudCredential(ctx, &credential, attrs, api)
 		if err != nil {
 			return err
 		}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -603,7 +603,11 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 }
 
 func (b *modelBuilder) updateCredential(ctx context.Context, api API, cred *dbmodel.CloudCredential) error {
-	_, err := b.jujuManager.forceUpdateControllerCloudCredential(ctx, cred, nil, api)
+	attrs, err := b.jujuManager.getCloudCredentialAttributes(ctx, cred)
+	if err != nil {
+		return err
+	}
+	_, err = b.jujuManager.forceUpdateControllerCloudCredential(ctx, cred, attrs, api)
 	return err
 }
 

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -603,9 +603,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 }
 
 func (b *modelBuilder) updateCredential(ctx context.Context, api API, cred *dbmodel.CloudCredential) error {
-	var err error
-
-	_, err = b.jujuManager.updateControllerCloudCredential(ctx, cred, api.UpdateCloudsCredentialForce)
+	_, err := b.jujuManager.forceUpdateControllerCloudCredential(ctx, cred, nil, api)
 	return err
 }
 


### PR DESCRIPTION
## Description

In this pr I've addressed a bug where we were checking credentials using the current attributes and not the new attributes.
While doing this i've noticed we were using this method with a closure, and it is just unclear to read.
I've created a specialized method, which fetch the attrs if they are not provided.

All calls site now have:
- the correct credential + attr in jimm's state, so we don't need to provide them from the args
- the attrs arg specified