### PR TITLE
feat: improve juju jaas query-models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ docs/.sphinx/.wordlist.dic
 docs/.sphinx/.doctrees/
 docs/.sphinx/update/
 docs/.sphinx/node_modules/
+
+jaas

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"sync"
 
 	"github.com/itchyny/gojq"
 	jujucmd "github.com/juju/cmd/v3"
@@ -16,11 +17,14 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/pkg/api/params"
 )
+
+const maxConcurrentModelQueries = 10
 
 // QueryModels queries every specified model in modelUUIDs.
 //
@@ -39,71 +43,90 @@ func (j *JujuManager) QueryModelsJq(ctx context.Context, modelUUIDs []string, jq
 		return results, fmt.Errorf("failed to parse jq query: %w", err)
 	}
 
-	// Set up a formatterParamsRetriever to handle the heavy lifting
-	// of each facade call and type conversion.
-	retriever := newFormatterParamsRetriever(j)
-
 	models, err := j.Database.GetModelsByUUID(ctx, modelUUIDs)
 	if err != nil {
 		return results, errors.New("failed to get models for user")
 	}
 
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentModelQueries)
+	mux := sync.Mutex{}
+	addItem := func(modelUUID string, result any, err error) {
+		mux.Lock()
+		defer mux.Unlock()
+		if err != nil {
+			results.Errors[modelUUID] = append(results.Errors[modelUUID], err.Error())
+			return
+		}
+		results.Results[modelUUID] = append(results.Results[modelUUID], result)
+	}
+
 	for _, model := range models {
-		modelUUID := model.UUID.String
-		params, err := retriever.GetParams(ctx, model)
-		if err != nil {
-			zapctx.Error(ctx, "failed to get status formatter params", zap.String("model-uuid", modelUUID))
-			results.Errors[modelUUID] = append(results.Errors[modelUUID], err.Error())
-			continue
-		}
-
-		// We use very specific formatting parameters to ensure like-for-like output
-		// with the default juju client installation performing a "status --format json".
-		formatter := status.NewStatusFormatter(*params)
-
-		formattedStatus, err := formatter.Format()
-		if err != nil {
-			zapctx.Error(ctx, "failed to format status", zap.String("model-uuid", modelUUID))
-			results.Errors[modelUUID] = append(results.Errors[modelUUID], err.Error())
-			continue
-		}
-		// We could use output.NewFormatter() from 3.0+ juju/juju, but ultimately
-		// we just want some JSON output, regardless of user formatting. As such json.Marshal
-		// *should* be OK.
-		fb, err := json.Marshal(formattedStatus)
-		if err != nil {
-			zapctx.Error(ctx, "failed to marshal formatted status", zap.String("model-uuid", modelUUID))
-			results.Errors[modelUUID] = append(results.Errors[modelUUID], err.Error())
-			continue
-		}
-		tempMap := make(map[string]any)
-		if err := json.Unmarshal(fb, &tempMap); err != nil {
-			return results, err
-		}
-
-		queryCtx, cancel := context.WithTimeout(ctx, j.crossModelQueryTimeout)
-		defer cancel()
-		queryIter := query.RunWithContext(queryCtx, tempMap)
-
-		for {
-			v, ok := queryIter.Next()
-			if !ok {
-				break
+		g.Go(func() error {
+			var err error
+			modelUUID := model.UUID.String
+			// Set up a formatterParamsRetriever to handle the heavy lifting
+			// of each facade call and type conversion.
+			retriever := newFormatterParamsRetriever(j)
+			params, err := retriever.GetParams(ctx, model)
+			if err != nil {
+				zapctx.Error(ctx, "failed to get status formatter params", zap.String("model-uuid", modelUUID))
+				addItem(modelUUID, nil, err)
+				return nil
 			}
 
-			// Jq errors can range from one failure in an iterative query to an entirely broken
-			// query. As such, we simply append all to the errors field and continue to collect
-			// both erreoneous and valid query results.
-			if err, ok := v.(error); ok {
-				if stderrors.Is(err, context.DeadlineExceeded) {
-					return results, fmt.Errorf("jq query timed out after %.2f seconds: %w", j.crossModelQueryTimeout.Seconds(), err)
+			// We use very specific formatting parameters to ensure like-for-like output
+			// with the default juju client installation performing a "status --format json".
+			formatter := status.NewStatusFormatter(*params)
+
+			formattedStatus, err := formatter.Format()
+			if err != nil {
+				zapctx.Error(ctx, "failed to format status", zap.String("model-uuid", modelUUID))
+				addItem(modelUUID, nil, err)
+				return nil
+			}
+			// We could use output.NewFormatter() from 3.0+ juju/juju, but ultimately
+			// we just want some JSON output, regardless of user formatting. As such json.Marshal
+			// *should* be OK.
+			fb, err := json.Marshal(formattedStatus)
+			if err != nil {
+				zapctx.Error(ctx, "failed to marshal formatted status", zap.String("model-uuid", modelUUID))
+				addItem(modelUUID, nil, err)
+				return nil
+			}
+			tempMap := make(map[string]any)
+			if err := json.Unmarshal(fb, &tempMap); err != nil {
+				return err
+			}
+
+			queryCtx, cancel := context.WithTimeout(ctx, j.crossModelQueryTimeout)
+			defer cancel()
+			queryIter := query.RunWithContext(queryCtx, tempMap)
+
+			for {
+				v, ok := queryIter.Next()
+				if !ok {
+					break
 				}
-				results.Errors[modelUUID] = append(results.Errors[modelUUID], "jq error: "+err.Error())
-				continue
-			}
 
-			results.Results[modelUUID] = append(results.Results[modelUUID], v)
-		}
+				// Jq errors can range from one failure in an iterative query to an entirely broken
+				// query. As such, we simply append all to the errors field and continue to collect
+				// both erreoneous and valid query results.
+				if err, ok := v.(error); ok {
+					if stderrors.Is(err, context.DeadlineExceeded) {
+						return fmt.Errorf("jq query timed out after %.2f seconds: %w", j.crossModelQueryTimeout.Seconds(), err)
+					}
+					addItem(modelUUID, nil, fmt.Errorf("jq error: %w", err))
+					continue
+				}
+
+				addItem(modelUUID, v, nil)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return results, err
 	}
 	return results, nil
 }


### PR DESCRIPTION
## Description

Niko from IS complain `juju jaas query-models` was very slow for a query he was doing.

Indeed, we were querying sequentially each model, which in IS case is ~400.

This change is very simple and it just tries to parallellize the querying with an error group.

The behavior should be the exact same as before, just with a 10 parallelism.

We can go higher than 10 parallelism for sure, but i think it's a good start. I personally wouldn't expose it as a configurable option for now.

I'm aware this change means we have 10 jq queries potentially running at the same time, but i think it shouldn't be a problem. Or not less of a problem of 10 people running the same query, or 1 person running a very expensive query.

# QA

`make qa-lxd`

<create 100 models>

Before the patch:
```
[9:15:27] ➜  jimm-v3 git:(v3) ✗ time ./jaas query-models '.models'
<outpu>
./jaas query-models '.models'  0.02s user 0.01s system 1% cpu 2.010 total
```

After the patch:
```
[9:16:03] ➜  jimm-v3 git:(make-jaas-query-models-faster) time ./jaas query-models '.models'
<output>
./jaas query-models '.models'  0.02s user 0.02s system 7% cpu 0.464 total
```
