### PR TITLE
perf: find-offers

### DIFF
--- a/internal/db/applicationoffer.go
+++ b/internal/db/applicationoffer.go
@@ -65,6 +65,36 @@ func (d *Database) GetApplicationOffer(ctx context.Context, offer *dbmodel.Appli
 	return nil
 }
 
+// GetControllersForApplicationOffers returns the distinct controllers
+// hosting the application offers whose UUIDs are in offerUUIDs. UUIDs that
+// do not exist in the database are ignored.
+func (d *Database) GetControllersForApplicationOffers(ctx context.Context, offerUUIDs []string) (_ []dbmodel.Controller, err error) {
+	const op = "db.GetControllersForApplicationOffers"
+
+	if len(offerUUIDs) == 0 {
+		return []dbmodel.Controller{}, nil
+	}
+	if err := d.ready(); err != nil {
+		return nil, err
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
+	var controllers []dbmodel.Controller
+	if err := d.DB.WithContext(ctx).
+		Model(&dbmodel.Controller{}).
+		Distinct().
+		Joins("JOIN models ON models.controller_id = controllers.id").
+		Joins("JOIN application_offers ON application_offers.model_id = models.id").
+		Where("application_offers.uuid IN ?", offerUUIDs).
+		Find(&controllers).Error; err != nil {
+		return nil, dbError(err)
+	}
+	return controllers, nil
+}
+
 // DeleteApplicationOffer deletes the application offer.
 func (d *Database) DeleteApplicationOffer(ctx context.Context, offer *dbmodel.ApplicationOffer) (err error) {
 	const op = "db.DeleteApplicationOffer"

--- a/internal/db/applicationoffer_test.go
+++ b/internal/db/applicationoffer_test.go
@@ -154,6 +154,81 @@ func (s *dbSuite) TestGetApplicationOffer(c *qt.C) {
 	c.Assert(errors.ErrorCode(err), qt.Equals, errors.CodeNotFound)
 }
 
+func (s *dbSuite) TestGetControllersForApplicationOffers(c *qt.C) {
+	env := initTestEnvironment(c, s.Database)
+
+	controller2 := dbmodel.Controller{
+		Name:        "test-controller-2",
+		UUID:        "00000000-0000-0000-0000-000000000002",
+		CloudName:   env.cloud.Name,
+		CloudRegion: env.cloud.Regions[0].Name,
+	}
+	c.Assert(s.Database.DB.Create(&controller2).Error, qt.IsNil)
+
+	model2 := dbmodel.Model{
+		Name: "test-model-3",
+		UUID: sql.NullString{
+			String: "00000001-0000-0000-0000-000000000003",
+			Valid:  true,
+		},
+		Owner:           env.u,
+		Controller:      controller2,
+		CloudRegion:     env.cloud.Regions[0],
+		CloudCredential: env.cred,
+		Life:            state.Alive.String(),
+	}
+	c.Assert(s.Database.DB.Create(&model2).Error, qt.IsNil)
+
+	offers := []dbmodel.ApplicationOffer{{
+		Name:    "offer-1",
+		UUID:    "00000000-0000-0000-0000-000000000001",
+		URL:     "offer-1-url",
+		ModelID: env.model.ID,
+	}, {
+		Name:    "offer-2",
+		UUID:    "00000000-0000-0000-0000-000000000002",
+		URL:     "offer-2-url",
+		ModelID: env.model1.ID,
+	}, {
+		Name:    "offer-3",
+		UUID:    "00000000-0000-0000-0000-000000000003",
+		URL:     "offer-3-url",
+		ModelID: model2.ID,
+	}}
+	for i := range offers {
+		c.Assert(s.Database.AddApplicationOffer(context.Background(), &offers[i]), qt.IsNil)
+	}
+
+	for _, test := range []struct {
+		about       string
+		offerUUIDs  []string
+		controllers []uint
+	}{
+		{
+			about:       "offers on one controller",
+			offerUUIDs:  []string{offers[0].UUID, offers[1].UUID},
+			controllers: []uint{env.controller.ID},
+		}, {
+			about:       "offers on different controllers",
+			offerUUIDs:  []string{offers[0].UUID, offers[2].UUID},
+			controllers: []uint{env.controller.ID, controller2.ID},
+		},
+	} {
+		c.Run(test.about, func(c *qt.C) {
+			controllers, err := s.Database.GetControllersForApplicationOffers(context.Background(), test.offerUUIDs)
+			c.Assert(err, qt.IsNil)
+			c.Assert(controllers, qt.HasLen, len(test.controllers))
+			controllerIDs := make(map[uint]bool)
+			for _, controller := range controllers {
+				controllerIDs[controller.ID] = true
+			}
+			for _, id := range test.controllers {
+				c.Check(controllerIDs[id], qt.IsTrue)
+			}
+		})
+	}
+}
+
 func (s *dbSuite) TestDeleteApplicationOffer(c *qt.C) {
 	env := initTestEnvironment(c, s.Database)
 

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -7,6 +7,8 @@ import (
 	"database/sql"
 	stderrors "errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 
@@ -489,27 +491,23 @@ func (o *offers) addOffer(offer *crossmodel.ApplicationOfferDetails) {
 
 // FindApplicationOffers returns details of offers matching the specified filter.
 func (j *JujuManager) FindApplicationOffers(ctx context.Context, user *openfga.User, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
-
 	if len(filters) == 0 {
 		return nil, errors.Codef(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
-	controllers := make(map[uint]*dbmodel.Controller)
-	err := j.Database.ForEachController(ctx, func(ctl *dbmodel.Controller) error {
-		controllers[ctl.ID] = ctl
-		return nil
-	})
+	// Only query the controllers that host at least one offer the user
+	// can read; the filters are passed to them unchanged.
+	offerUUIDs, err := user.ListApplicationOffers(ctx, ofganames.ReaderRelation)
+	if err != nil {
+		return nil, fmt.Errorf("list accessible application offers: %w", err)
+	}
+	controllers, err := j.Database.GetControllersForApplicationOffers(ctx, offerUUIDs)
 	if err != nil {
 		return nil, err
 	}
-
-	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
+	return j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
 		return api.FindApplicationOffers(ctx, filters)
 	})
-	if err != nil {
-		return nil, err
-	}
-	return offers, nil
 }
 
 // ListApplicationOffers returns details of offers matching the specified filter.
@@ -519,7 +517,7 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 		return nil, errors.Codef(errors.CodeBadRequest, "at least one filter must be specified")
 	}
 
-	controllers := make(map[uint]*dbmodel.Controller)
+	controllerSet := make(map[uint]dbmodel.Controller)
 	for _, f := range filters {
 		if f.ModelName == "" {
 			return nil, errors.New("application offer filter must specify a model name")
@@ -535,8 +533,9 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 		if err := j.Database.GetModel(ctx, &m); err != nil {
 			return nil, err
 		}
-		controllers[m.Controller.ID] = &m.Controller
+		controllerSet[m.Controller.ID] = m.Controller
 	}
+	controllers := slices.Collect(maps.Values(controllerSet))
 
 	offers, err := j.queryControllersForOffers(ctx, user, controllers, func(api API) ([]*crossmodel.ApplicationOfferDetails, error) {
 		return api.ListApplicationOffers(ctx, filters)
@@ -547,11 +546,12 @@ func (j *JujuManager) ListApplicationOffers(ctx context.Context, user *openfga.U
 	return offers, nil
 }
 
-func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openfga.User, controllers map[uint]*dbmodel.Controller, query func(API) ([]*crossmodel.ApplicationOfferDetails, error)) ([]*crossmodel.ApplicationOfferDetails, error) {
+func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openfga.User, controllers []dbmodel.Controller, query func(API) ([]*crossmodel.ApplicationOfferDetails, error)) ([]*crossmodel.ApplicationOfferDetails, error) {
 	var offerDetails offers
 	eg, ctx := errgroup.WithContext(ctx)
 
-	for _, ctl := range controllers {
+	for i := range controllers {
+		ctl := &controllers[i]
 		eg.Go(func() error {
 			// Return early if a single controller has an error
 			// to avoid misleading clients about what exists which

--- a/internal/jimm/juju/applicationoffer_test.go
+++ b/internal/jimm/juju/applicationoffer_test.go
@@ -2039,6 +2039,8 @@ func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
 	}
 
 	controller1Dialed := false
+	controller2Dialed := false
+	var controller2Filters []crossmodel.ApplicationOfferFilter
 	// Setup dialers for two controllers
 	dialers := jimmtest.DialerMap{
 		"controller-1": &jimmtest.Dialer{
@@ -2052,6 +2054,8 @@ func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
 		"controller-2": &jimmtest.Dialer{
 			API: &jimmtest.API{
 				FindApplicationOffers_: func(ctx context.Context, filters []crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error) {
+					controller2Dialed = true
+					controller2Filters = filters
 					return []*crossmodel.ApplicationOfferDetails{&expectedOffer}, nil
 				},
 			},
@@ -2080,5 +2084,7 @@ func TestFindApplicationOffers_MultipleControllers(t *testing.T) {
 	c.Assert(offers, qt.HasLen, 1)
 	c.Check(offers[0].OfferURL, qt.Equals, expectedOffer.OfferURL)
 	c.Check(offers[0].OfferUUID, qt.Equals, expectedOffer.OfferUUID)
-	c.Check(controller1Dialed, qt.IsTrue)
+	c.Check(controller1Dialed, qt.IsFalse)
+	c.Check(controller2Dialed, qt.IsTrue)
+	c.Check(controller2Filters, qt.DeepEquals, filters)
 }


### PR DESCRIPTION
# Description

This pr is a way to realize the way we are performing `find-offers`.
Before this pr we were always dialing every controller with the filter and then we were checking permission to avoid returning offer a user doesn't have access to.

Now it fetches the offer a user has at least reader access to, get the controllers where the offers live, and dial only the subset of controllers.

This should be a net improvement for whoever doesn't have a offer on a model on each controller.
It is slight slower for people having access to offers on each controller, because now it also list all offers from openfga.
But i think it's a good trade off.

Initially, i though i could improve this even more by:
- listing offers
- figuring model/controller pair for each
- build the filters to ask only the right offers from the controllers

But the code was harder to read, and this improvement is better in terms of not dialing unnecessary controllers without complicating the code too much.

