### PR TITLE
feat: add simple security events for ssh connections

### DIFF
--- a/internal/logger/securityevent_logger.go
+++ b/internal/logger/securityevent_logger.go
@@ -60,6 +60,24 @@ func LogSuccessfulLogin(ctx context.Context, identityId string) {
 	})
 }
 
+// LogFailedSSHConnection logs a failed SSH connection attempt for the given identityId.
+func LogFailedSSHConnection(ctx context.Context, identityId string, description string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "ssh_connection_fail:" + identityId,
+		Description: description,
+		Severity:    warning,
+	})
+}
+
+// LogSuccessfulSSHConnection logs a successful SSH connection for the given identityId.
+func LogSuccessfulSSHConnection(ctx context.Context, identityId string, description string) {
+	logSecurityEvent(ctx, securityEvent{
+		Event:       "ssh_connection_success:" + identityId,
+		Description: description,
+		Severity:    warning,
+	})
+}
+
 // LogUnauthorizedAccess logs an unauthorized access attempt for the given identityId.
 func LogUnauthorizedAccess(ctx context.Context, identityId string, description string) {
 	logSecurityEvent(ctx, securityEvent{

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -18,6 +18,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	jimmssh "github.com/canonical/jimm/v3/internal/jimm/ssh"
+	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
@@ -82,7 +83,7 @@ func NewJumpServer(ctx context.Context, config Config, sshManager SSHManager) (S
 			PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
 				user, err := sshManager.PublicKeyHandler(ctx, ctx.User(), key.Marshal())
 				if err != nil {
-					zapctx.Debug(ctx, fmt.Sprintf("cannot verify key for user %s", ctx.User()), zap.Error(err))
+					logger.LogFailedSSHConnection(ctx, ctx.User(), "SSH public key authentication failed")
 					return false
 				}
 				ctx.SetValue(publicKeySSHUserKey{}, user)
@@ -171,12 +172,12 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			rejectConnectionAndLogError(ctx, newChan, "failed to create tunnel to controller", err)
 			return
 		}
-
 		clientConn, reqs, err := newChan.Accept()
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to accept channel creation request", err)
 			return
 		}
+		logger.LogSuccessfulSSHConnection(ctx, user.Name, fmt.Sprintf("SSH connection to %s succeeded", d.DestAddr))
 		// gossh.Request are requests sent outside of the normal stream of data (ex. pty-req for an interactive session).
 		// Since we only need the raw data to redirect, we can discard them.
 		go gossh.DiscardRequests(reqs)


### PR DESCRIPTION
# Description

Initially i though of adding it to our audit events, but those are facade scoped, and it wouldn't make sense to add a fake facade just to add these events.
So i've just added some security events, like we do for authentication in the other http paths. 

An example: 
```
09:14:25.422	WARN	ssh_connection_success:jimm-test@canonical.com	{"event": "ssh_connection_success:jimm-test@canonical.com", "description": "SSH connection to 0.7906914c-9558-44e4-8069-e2b1bd2a645a.juju.local succeeded", "severity": "WARN"}
09:16:02.293	WARN	ssh_connection_fail:jimm-test@canonical.com	{"event": "ssh_connection_fail:jimm-test@canonical.com", "description": "SSH public key authentication failed", "severity": "WARN"}
```
