### PR TITLE
docs: Juju client interoperability

### DIFF
--- a/doc/juju-interoperability.md
+++ b/doc/juju-interoperability.md
@@ -1,0 +1,183 @@
+# Juju client interoperability
+
+JIMM sits in front of a fleet of Juju controllers that may span major
+versions (3.6 and 4.x). This document describes how JIMM decides which
+controllers and models a given Juju client may interact with, where that
+decision is enforced, and what is deliberately left unrestricted. It
+reflects the approved "JIMM and Juju Interoperability" spec (approved
+2026-06-25) and the implementation as shipped.
+
+Juju 2.9 clients are out of scope: they are not supported against JIMM.
+
+## The compatibility rule
+
+A client may interact with controllers — and the models hosted on them —
+whose **major version is less than or equal to the client's reported major
+version**.
+
+This is Juju's own [cross-version compatibility
+contract](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju/juju-cross-version-compatibility/)
+applied across a fleet: components of the same major series are compatible
+with each other (Juju's per-facade version negotiation absorbs the
+finer-grained differences), while across major series a newer client can
+operate older controllers but an older client cannot operate newer ones.
+Concretely:
+
+|                          | 3.6-hosted model | 4.x-hosted model        |
+|--------------------------|------------------|-------------------------|
+| **Juju 3.6 client**      | compatible       | rejected                |
+| **Juju 4.x client**      | compatible       | compatible              |
+| **non-reporting client** | compatible       | rejected (treated as 3.6) |
+
+- The client reports its version via the `X-Juju-ClientVersion` header on
+  the main API websocket dial.
+- A client that reports no version, or an unparseable one, is treated as a
+  **Juju 3.6** client. Juju 3.6 clients predate the header, so this is the
+  correct resolution for them, and it fails closed for anything else.
+- The header is client-asserted. It gates UX and routing only — it is
+  **not** an authorization input; all authorization happens at login as
+  usual.
+
+### How the version reaches JIMM
+
+Juju clients have always sent `X-Juju-ClientVersion` on stream and
+plain-HTTP connections, but the main API websocket dial carried no headers
+until juju/juju#22794 (commit `cf559c20`, first tagged in v4.0.13). JIMM is
+the first consumer of the header on that connection.
+
+JIMM extracts the header at the websocket upgrade for every websocket
+endpoint (`internal/jimmhttp/websocket.go`) and carries it in the request
+context (`jimmhttp.ClientVersionFromContext`), so both enforcement points
+below read the same value.
+
+## Enforcement point 1: model placement
+
+When a client creates a model, JIMM only places it on a controller whose
+major version is ≤ the client's reported major version.
+
+- The cap is derived once per connection by
+  `highestControllerVersionForClient` (`internal/jujuapi/controllerroot.go`):
+  the major component of the reported version, or 3 when the version is
+  absent or unparseable.
+- It is applied in the shared `createModel` path, covering both the
+  ModelManager v10 (3.6 client) and v11 (4.x client) facades, and in the
+  JIMM facade's `AddModelToController` (used by the jaas plugin), where an
+  explicitly named controller must also satisfy the cap.
+- Controller eligibility filtering, the explicit-controller check and the
+  client-facing error messages live in the model-creation builder
+  (`MaxControllerMajorVersion`).
+
+A controller whose agent version is unknown is not eligible for a capped
+placement (fail closed).
+
+## Enforcement point 2: the model proxy
+
+JIMM proxies model API connections (`/model/{uuid}/api`, `/commands`) to
+the hosting controller without translating the wire format, so a 3.6 client
+talking to a 4.x-hosted model would otherwise fail deep inside operations
+with obscure errors. Instead, the compatibility rule is applied up front,
+at **user login** on the proxied connection
+(`internal/rpcproxy/compatibility.go`):
+
+- The connection is rejected when the major version of the model's hosting
+  controller (which serves the model's API, and therefore determines
+  compatibility — not the model's own agent version) exceeds the client's
+  reported major version:
+
+  > your Juju client is not compatible with model "prod" (4.0.2); please
+  > upgrade your Juju client to interact with this model
+
+- A hosting controller whose agent version is unknown is rejected fail
+  closed, consistent with placement:
+
+  > cannot establish that your Juju client is compatible with model
+  > "prod": the hosting controller's version is unknown
+
+- Connections to 3.6-hosted models are unrestricted; a 4.x-reporting client
+  reaches everything.
+
+The check applies to user logins only. Agent and anonymous logins are
+redirected to, or handled by, the backing controller and never reach it.
+Enforcement is always on; there is no configuration flag.
+
+## What is deliberately not gated
+
+- **Model listings.** `juju models` (and every other listing) shows all of
+  a user's models regardless of compatibility. Discovery is unaffected;
+  incompatibility surfaces only on interaction. This is a spec UX decision —
+  do not "helpfully" filter listings by client version.
+- **Stream endpoints** (`/log` and friends). Juju versions the log stream
+  itself via a `version` query parameter that defaults to the legacy (3.6)
+  format, so gating the stream would break something juju already made
+  work. JIMM forwards the client's `X-Juju-ClientVersion` header when
+  dialing the controller-side stream
+  (`internal/jujuapi/streamcontrollerproxy.go`).
+
+## Facade multi-versioning (background)
+
+Independently of the version-driven gating above, JIMM's own controller
+endpoint serves both the 3.6-era and 4.x-era versions of the facades it
+implements, dispatching on the version each client negotiates — e.g.
+ModelManager 10 and 11, ModelConfig 3 and 4, Controller 12 and 14,
+ApplicationOffers 5 and 6, Admin 1–4. Where the request or response wire
+shapes differ between eras, the older facade version translates. See
+[add-new-facade.md](add-new-facade.md) for how facades are added.
+
+The complete per-facade wire-format analysis — including why the 4.x API
+client JIMM uses to talk to backing controllers remains compatible with 3.6
+controllers — is in
+[juju4-client-36-compat-analysis.md](juju4-client-36-compat-analysis.md).
+
+The gating in this document is about *model* interaction: JIMM's own
+controller-level facades work for both client generations, while
+model-level traffic is proxied raw, which is exactly why the proxy check
+exists.
+
+## Deployment notes
+
+- **Ingress must forward the header.** Any L7 proxy or ingress in front of
+  JIMM must pass `X-Juju-ClientVersion` through on the websocket upgrade
+  request. An ingress that strips it makes every client look unversioned
+  (i.e. 3.6), locking 4.x clients out of 4.x-hosted models.
+- **Client release requirement.** Enforcement is always on, so JIMM
+  versions containing it should not serve production traffic until a
+  *released* 4.x client sending the header (v4.0.13 or later) is available
+  to users — an older 4.x CLI sends no header on the main dial and is
+  treated as 3.6.
+
+## Release verification checklist
+
+The automated e2e suite (`testing/`, run by the E2E workflow against 3-only,
+4-only and mixed fleets) covers the spec scenarios as follows:
+
+- Native header path of the released 4.x client library (the same dialer a
+  released CLI uses): `TestNativeClientVersionHeader`.
+- Placement capping for unversioned/3.6/4.x clients:
+  `TestModelPlacementByClientVersion`.
+- Proxy gating, unfiltered discovery and ungated agent logins:
+  `TestModelProxyClientCompatibilityJuju3Controller` / `...Juju4Controller`.
+
+What the suite cannot exercise is the released **snap CLI binary** itself.
+When validating a release, verify manually against a JIMM with a mixed
+3.6/4.x fleet:
+
+1. `juju add-model` from a released 4.x CLI (≥ 4.0.14) can land a model on
+   a 4.x controller.
+2. `juju add-model` from a 3.6 CLI lands only on 3.6 controllers.
+3. A 3.6 CLI switched to a 4.x-hosted model gets the upgrade error on
+   interaction (e.g. `juju status`), while `juju models` still lists the
+   model.
+4. A 4.x CLI can interact with models hosted on both controller
+   generations.
+
+## References
+
+- "JIMM and Juju Interoperability" spec (approved 2026-06-25).
+- [Juju component cross-version
+  compatibility](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju/juju-cross-version-compatibility/)
+  — the upstream compatibility rules this document applies fleet-wide.
+- juju/juju#22794 — client sends `X-Juju-ClientVersion` on the main API
+  websocket dial (first tagged in v4.0.13).
+- canonical/jimm#2058 — placement cap from the reported client version.
+- canonical/jimm#2065 — client/model compatibility enforced in the model
+  proxy.

--- a/doc/juju4-client-36-compat-analysis.md
+++ b/doc/juju4-client-36-compat-analysis.md
@@ -1,0 +1,147 @@
+# Using the juju 4.x API client against 3.6 controllers: compatibility analysis
+
+Date: 2026-06-12
+Scope: what happens if JIMM upgrades its `github.com/juju/juju` dependency to 4.x,
+keeps using the juju 4 typed API client in `internal/jujuclient` to talk to 3.6
+controllers, and translates results back to the 3.6 wire format for 3.6 CLI clients.
+
+Verified against: JIMM's pinned juju (`v0.0.0-20260325121537-78832a31ad6b`, tip of 3.6)
+and the juju `4.0` branch as of 2026-06-12.
+
+## 1. Why two juju versions can't be imported at once
+
+A Go build can contain only one version of a module path. Both juju `main` and
+`4.0` still declare `module github.com/juju/juju` (no `/v4` suffix), so JIMM can
+link exactly one juju version. The realistic strategy is therefore: import juju
+4.x, use its typed client everywhere, and rely on the 4.x client's built-in
+3.6 compatibility (which exists because the juju 4 CLI itself must manage and
+migrate 3.6 controllers).
+
+## 2. Facade version negotiation: 3.6 server vs 4.0 client
+
+Every facade `internal/jujuclient` uses has a non-empty version intersection:
+
+| Facade (JIMM's usage) | 3.6 server offers | 4.0 client supports | Negotiated |
+|---|---|---|---|
+| Admin (Login — hand-rolled by JIMM) | 3 | n/a | 3 |
+| Pinger | 1 | 1 | 1 |
+| ApplicationOffers | 4, 5 | 5, 6 | 5 |
+| Client (Status) | 6–8 | 8 | 8 |
+| Cloud | 7 | 7, 8 | 7 |
+| Controller | 11, 12 | 12, 13, 14 | 12 |
+| ModelConfig | 3 | 3, 4 | 3 |
+| ModelManager | 9, 10 | 9, 10, 11 | 10 |
+| ModelUpgrader | 1 | 1, 2 | 1 |
+| Storage | 6, 7 | 6, 7 | 7 |
+| MigrationTarget | 1–6 | 4–7 | 6 |
+| ModelSummaryWatcher | 1 | 1 | 1 |
+
+The 4.0 typed clients carry working legacy code at those versions:
+
+- `api/client/modelmanager`: `createModelCompat`, `modelInfoCompat`,
+  `listModelsCompat`, `listModelSummariesCompat` keyed on `BestAPIVersion() < 11`,
+  using `params.*Legacy` structs that still speak `owner-tag`.
+- `api/controller/migrationtarget`: `< 7` branch using `MigrationModelInfoLegacy`,
+  `< 2` branch for `Activate`.
+- `api/client/applicationoffers`: legacy filter conversion for `< 6`; `Offer`
+  still sends `OwnerTag`.
+- `Controller.CloudSpec` is served by 3.6 (embedded `CloudSpecer` at v11/12).
+- `UpgradeModelParams`, `ModelAbstract`, all Storage and Cloud v7 structs:
+  wire-identical between 3.6 and 4.0.
+
+Conclusion: **no `jujuclient` method needs raw reimplementation today.** JIMM's
+hand-rolled calls (`Admin.Login` v3, `Pinger.Ping` v1, raw
+`MigrationTarget.Prechecks`/`AdoptResources` pinned to v6) are unaffected.
+
+## 3. Serving 3.6 CLIs from JIMM built on juju 4
+
+Only the facades JIMM itself implements need translation; model connections go
+through `internal/rpcproxy` as raw frames (3.6 CLI ↔ 3.6 controller directly).
+
+JIMM-implemented facades (versions advertised by `setupFacades`): Admin,
+Pinger 1, ModelManager 9/10, Cloud 7, Controller 11/12, ApplicationOffers 5,
+ModelConfig 3, ModelUpgrader 1, UserManager 3, MigrationTarget 6,
+ModelSummaryWatcher 1, JIMM 4 (custom).
+
+JIMM owns its RPC layer (`internal/rpc`), so handlers can declare any structs.
+For 3.6-format requests/responses, switch the affected handler signatures from
+`jujuparams.X` to `jujuparams.XLegacy` (or JIMM-owned copies of the 3.6 structs).
+
+### ModelInfo round trip (owner `alice@external`), verified hop by hop
+
+1. 4.0 client → 3.6 controller: `modelInfoCompat` decodes the response into
+   `params.ModelInfoLegacy` (`owner-tag` intact).
+2. Compat conversion: every field copied 1:1; `ParseUserTag("user-alice@external")`
+   → `QualifierFromUserTag` → `Qualifier = "alice@external"`. Lossless:
+   `QualifierFromUserTag(u)` is literally `Qualifier(u.Id())`.
+3. JIMM → 3.6 CLI: `OwnerTag = names.NewUserTag(qualifier).String()` →
+   `"user-alice@external"`, byte-identical to the original.
+
+## 4. Complete wire-format diff (every jujuparams type used by internal/jujuapi)
+
+All ~140 `jujuparams` types referenced by `internal/jujuapi` were diffed by JSON
+tag signature between 3.6 and 4.0, including transitive sub-structs of
+`FullStatus`, offer details, and summaries. Full list of differences:
+
+### Owner→qualifier renames (lossless single-field transforms; Legacy twins exist)
+
+| Struct | Change |
+|---|---|
+| `ModelInfo` | `owner-tag` → `qualifier` |
+| `ModelCreateArgs` | `owner-tag` → `qualifier` (request direction) |
+| `Model` (in `UserModelList`) | `owner-tag` → `qualifier` |
+| `ModelStatus` | `owner-tag` → `qualifier` |
+| `ModelSummary` | `owner-tag` → `qualifier` |
+| `MigrationModelInfo` | `owner-tag` → `qualifier` |
+| `OfferFilter` | `owner-name` → `model-qualifier` (request direction) |
+
+### Dropped deprecated fields (accepted as irrelevant for JAAS)
+
+- `ModelInfo`: `default-series`, `default-base`, `sla`
+- `ModelSummary`: `default-series`, `sla`
+- `ModelSLAInfo`: type removed
+- `ModelMachineInfo`: `has-vote`, `wants-vote`, `ha-primary` (controller models
+  only — JIMM hides controller models from users)
+- `FullStatus` tree: `ModelStatusInfo.meter-status`/`sla`,
+  `ApplicationStatus.meter-statuses`; `MeterStatus` type removed
+
+### Additive-only fields (omitempty; leave unset for 3.6 output)
+
+- `ModelInfo`/`ModelCreateArgs`: `target-controller` (JAAS-specific, added by juju)
+- `MachineStatus`: `cluster-role`
+
+### Everything else: byte-identical
+
+All Cloud facade structs (v7), all credential structs, ApplicationOffers
+response types (`ApplicationOfferDetailsV5`, `ApplicationOfferAdminDetailsV5`,
+`ConsumeOfferDetails`, `OfferConnection`, `RemoteEndpoint`, `OfferUserDetails`),
+UserManager `UserInfo`, `LoginRequest`/`LoginResult`, `ModelUserInfo`,
+model defaults, access-modification requests, `InitiateMigrationArgs`/
+`MigrationSpec`, controller config, summary-watcher types, destroy/upgrade/
+credential-change args, generic envelopes (`Entities`, `ErrorResults`, ...).
+
+**Conclusion: no conversion is hard or impossible.**
+
+## 5. Caveats / follow-ups
+
+1. **Legacy structs are temporary in juju.** The `*Legacy` params and the
+   `< 11`/`< 7` client branches exist only while juju 4.x supports managing 3.6
+   controllers and will be deleted later. They are plain data structs — copy
+   them into a JIMM-owned package (e.g. `internal/jujuapi/params36`) to decouple
+   from juju's deletion schedule. The same seam supports serving both wire
+   formats later (advertise e.g. ModelManager 10 legacy + 11 qualifier).
+2. **Qualifier == user id is an implementation detail of 4.0.** Juju 4 allows
+   non-user qualifiers (`staging`, ...). Data from 3.6 controllers always
+   round-trips (those models have real owners), but prefer JIMM's DB as the
+   source of truth for owner-tag rather than parsing qualifiers. A 4.x model
+   with a non-user qualifier has no faithful `owner-tag` representation for a
+   3.6 CLI — inherent to the data, not the translation layer.
+3. **Same-version struct drift can recur in future 4.x releases.** All findings
+   verified against the 4.0 branch on 2026-06-12. Recommended: commit a golden
+   file of the wire signatures of the types in §4 and diff it in CI on every
+   juju dependency bump, so silent field drops fail loudly.
+4. **Mechanical migration cost** (separate from wire compat): every 4.0 typed
+   client method takes a `ctx`, `CreateModel`'s signature changed
+   (`names.UserTag` instead of owner string), and `internal/jimm`/`dbmodel`
+   code referencing `OwnerTag` on params structs must move to the Legacy
+   structs or qualifier fields.

--- a/testing/clientversion_native_test.go
+++ b/testing/clientversion_native_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	qt "github.com/frankban/quicktest"
+	jujuversion "github.com/juju/juju/core/version"
+	jujuparams "github.com/juju/juju/rpc/params"
+	"github.com/juju/names/v6"
+
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+	apiparams "github.com/canonical/jimm/v3/pkg/api/params"
+)
+
+// TestNativeClientVersionHeader verifies the full released-client header
+// path end to end: the juju api client jimm embeds (a released 4.x
+// dependency) dials JIMM with its own websocket dialer — no test override —
+// so the X-Juju-ClientVersion header on the main API dial is produced by
+// the same code path a released 4.x CLI uses, and JIMM's placement and
+// proxy decisions act on it.
+//
+// The remaining spec scenarios are covered elsewhere with an explicitly
+// headerless dialer (faithful to a 3.6 CLI, which sends no header):
+// placement capping in TestModelPlacementByClientVersion and proxy
+// gating/unfiltered discovery in TestModelProxyClientCompatibility*.
+func TestNativeClientVersionHeader(t *testing.T) {
+	c := qt.New(t)
+
+	// The premise of the native path: the embedded dependency is a
+	// released 4.x client library.
+	c.Assert(jujuversion.Current.Major >= 4, qt.IsTrue,
+		qt.Commentf("embedded juju client version %s is not 4.x", jujuversion.Current))
+
+	s := jimmtest.SetupJimmWithControllers(c)
+
+	c.Run("native dial pins a model to a 4.x controller", func(c *qt.C) {
+		fleet4 := backingControllersMatching(c, s, func(major int) bool { return major >= 4 })
+		if len(fleet4) == 0 {
+			c.Skip("no Juju 4.x backing controller in the environment")
+		}
+		target := fleet4[0]
+
+		args := apiparams.AddModelToControllerRequest{
+			ModelCreateArgs: jujuparams.ModelCreateArgs{
+				Name:               petname.Generate(2, "-"),
+				Qualifier:          bobOwnerTag.Id(),
+				CloudTag:           names.NewCloudTag(jimmtest.TestE2ECloudName).String(),
+				CloudCredentialTag: s.BobCredential.ResourceTag().String(),
+			},
+			ControllerName: target.name,
+		}
+
+		// A headerless (3.6) client may not use the 4.x controller: proves
+		// the placement gate is active for this exact request.
+		headerless := s.OpenNoClientVersion(c, nil, bobOwnerTag.Id(), nil)
+		defer headerless.Close()
+		var mi jujuparams.ModelInfo
+		err := headerless.APICall(c.Context(), "JIMM", 4, "", "AddModelToController", args, &mi)
+		c.Assert(err, qt.ErrorMatches,
+			fmt.Sprintf(`.*controller %q \(version %q\) is not compatible with your Juju client; please upgrade your client to use this controller.*`,
+				target.name, target.agent))
+
+		// The same request over a native dial succeeds — possible only if
+		// juju's own dialer delivered the version header to JIMM.
+		conn := s.Open(c, nil, bobOwnerTag.Id(), nil)
+		defer conn.Close()
+		err = conn.APICall(c.Context(), "JIMM", 4, "", "AddModelToController", args, &mi)
+		c.Assert(err, qt.IsNil)
+		c.Cleanup(func() { s.DestroyModelAndDeleteFromDatabase(c, names.NewModelTag(mi.UUID)) })
+
+		model := dbmodel.Model{
+			UUID: sql.NullString{String: mi.UUID, Valid: true},
+		}
+		err = s.JIMM.Database.GetModel(c.Context(), &model)
+		c.Assert(err, qt.IsNil)
+		c.Check(model.Controller.Name, qt.Equals, target.name)
+	})
+
+	c.Run("native client reaches models hosted on every controller", func(c *qt.C) {
+		fleet := backingControllersMatching(c, s, func(int) bool { return true })
+		c.Assert(fleet, qt.Not(qt.HasLen), 0)
+		for _, ctl := range fleet {
+			c.Run(fmt.Sprintf("model hosted on %s (%s)", ctl.name, ctl.agent), func(c *qt.C) {
+				model := createModelOn(c, s, ctl.name)
+				mt := model.ResourceTag()
+
+				conn, err := s.OpenNoAssert(c, jimmtest.LoginDetails{Username: bobOwnerTag.Id()}, &mt)
+				c.Assert(err, qt.IsNil)
+				defer conn.Close()
+				err = conn.APICall(c.Context(), "Pinger", 1, "", "Ping", nil, nil)
+				c.Check(err, qt.IsNil)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Description

Delivers the documentation story of the 3.6-client-compatibility epic (JAAS-10), plus the one e2e test the doc's verification checklist references that had not been committed yet.

- **doc/juju-interoperability.md** — describes the client/model compatibility design as shipped on `feature/juju-4`: the `X-Juju-ClientVersion` header as the client-version signal (fail closed to 3.6), the two enforcement points (model placement, #2058; the model proxy, #2065), what is deliberately not gated (model listings, stream endpoints), deployment notes (ingress must forward the header; ≥ 4.0.13 client requirement), and a release verification checklist mapping the spec scenarios to the e2e suite. The compatibility rule is framed against [Juju's own cross-version compatibility reference](https://canonical.com/juju/docs/juju-cli/3.6/reference/juju/juju-cross-version-compatibility/).
- **doc/juju4-client-36-compat-analysis.md** — the per-facade wire-format analysis (point-in-time record, cross-linked from the doc above).
- **testing/clientversion_native_test.go** — `TestNativeClientVersionHeader`: exercises the header path using the embedded juju 4.x client library's own websocket dialer (no test override), proving placement and proxy gating act on the header a released 4.x CLI actually sends.

## Engineering checklist

- [x] Documentation updated
- [x] Covered by unit/integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)