### PR TITLE
chore: update dashboard tests to v0.16.0

### DIFF
--- a/.github/workflows/dashboard-tests.yaml
+++ b/.github/workflows/dashboard-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run integration tests
-        uses: canonical/juju-dashboard/.github/actions/run-playwright@e7efd76723e74f7176ea1ccf001d3d04047a610e
+        uses: canonical/juju-dashboard/.github/actions/run-playwright@78ac6ca6ef44e399a704792bbc48d74426a1628e
         with:
           test-identifier: e2e-jimm-docker-keycloak
         env:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
         "golang.go",
-        "babakks.vscode-go-test-suite"
     ]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -152,7 +152,7 @@ services:
       retries: 30
 
   juju-dashboard:
-    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.16.0-beta.3}
+    image: ${JUJU_DASHBOARD_IMAGE:-ghcr.io/canonical/juju-dashboard:0.16.0}
     container_name: juju-dashboard
     profiles: ["dev"]
     environment:


### PR DESCRIPTION
## Description
Updates the version of the dashboard in our docker compose to the latest v0.16.0 release and updates the corresponding dashboard tests.

I've also removed the `vscode-go-test-suite` plugin from the recommended vs code extensions file as the plugin is crashing new versions of vs code and it was causing a popup on my machine. The extension is no longer needed since we removed the Juju conn suite.

## Engineering checklist
<!-- *Check only items that apply* -->

- [ ] Documentation updated
- [ ] Covered by unit tests
- [x] Covered by integration tests
