### PR TITLE
feat: intercept key manager to populate jimm's db

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -20,9 +20,9 @@ jobs:
           - name: "Juju 3"
             versions: '["3/stable", "3/stable"]'
           - name: "Juju 4"
-            versions: '["4.0/edge", "4.0/edge"]'
+            versions: '["4.1/edge", "4.1/edge"]'
           - name: "Mix"
-            versions: '["3/stable", "4.0/edge"]'
+            versions: '["3/stable", "4.1/edge"]'
     steps:
       - name: Checkout JIMM repo
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -79,7 +79,7 @@ jobs:
         id: jaas
         with:
           jimm-version: dev
-          juju-channel: "4.0/edge"
+          juju-channel: "4.1/edge"
           ghcr-pat: ${{ secrets.GITHUB_TOKEN }}
 
       # Build the JAAS plugin to test any changes made 

--- a/internal/db/sshkeys.go
+++ b/internal/db/sshkeys.go
@@ -32,6 +32,32 @@ func (d *Database) AddSSHKey(ctx context.Context, sshKey *dbmodel.SSHKey) (err e
 	return nil
 }
 
+// RemoveSSHKeys removes a user's keys matching any provided fingerprint or
+// comment. Missing targets are ignored.
+func (d *Database) RemoveSSHKeys(ctx context.Context, identityName string, model SSHKeyModelFilter, targets ...string) (err error) {
+	const op = "db.RemoveSSHKeys"
+	if err := d.ready(); err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	durationObserver := servermon.DurationObserver(servermon.DBQueryDurationHistogram, op)
+	defer durationObserver()
+	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
+
+	query := d.DB.WithContext(ctx).
+		Where("identity_name = ?", identityName).
+		Where("model_uuid = ?", model.ModelUUID).
+		Where("md5_fingerprint IN ? OR key_comment IN ?", targets, targets).
+		Delete(&dbmodel.SSHKey{})
+	if query.Error != nil {
+		return dbError(query.Error)
+	}
+	return nil
+}
+
 // RemoveSSHKeyByFingerprint removes a user's ssh key identified by its fingerprint.
 func (d *Database) RemoveSSHKeyByFingerprint(ctx context.Context, identityName string, model SSHKeyModelFilter, fingerprint string) (err error) {
 	const op = "db.RemoveSSHKeyByFingerprint"
@@ -72,7 +98,8 @@ func (d *Database) RemoveSSHKeyByComment(ctx context.Context, identityName strin
 	defer durationObserver()
 	defer servermon.ErrorCounter(servermon.DBQueryErrorCount, &err, op)
 
-	query := d.DB.Where("key_comment = ?", comment).
+	query := d.DB.Where("identity_name = ?", identityName).
+		Where("key_comment = ?", comment).
 		Where("model_uuid = ?", model.ModelUUID).
 		Delete(&dbmodel.SSHKey{})
 	if err := query.Error; err != nil {

--- a/internal/db/sshkeys_test.go
+++ b/internal/db/sshkeys_test.go
@@ -130,6 +130,41 @@ func (s *sshKeysSuite) TestRemoveSSHKeyByFingerprint(c *qt.C) {
 	c.Assert(keys, qt.HasLen, 1)
 }
 
+func (s *sshKeysSuite) TestRemoveSSHKeyByComment(c *qt.C) {
+	ctx := context.Background()
+
+	otherUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(otherUser).Error, qt.IsNil)
+
+	key := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      []byte("first-key"),
+		KeyComment:     "shared-comment",
+		MD5Fingerprint: "first-fingerprint",
+		Model:          s.Model,
+	}
+	otherUserKey := dbmodel.SSHKey{
+		Identity:       *otherUser,
+		PublicKey:      []byte("second-key"),
+		KeyComment:     "shared-comment",
+		MD5Fingerprint: "second-fingerprint",
+		Model:          s.Model,
+	}
+	c.Assert(s.Database.AddSSHKey(ctx, &key), qt.IsNil)
+	c.Assert(s.Database.AddSSHKey(ctx, &otherUserKey), qt.IsNil)
+
+	err = s.Database.RemoveSSHKeyByComment(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String}, "shared-comment")
+	c.Assert(err, qt.IsNil)
+
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Check(keys, qt.HasLen, 0)
+	keys, err = s.Database.ListSSHKeysForUser(ctx, otherUser.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Check(keys, qt.HasLen, 1)
+}
+
 func (s *sshKeysSuite) TestListSSHKeysForUser(c *qt.C) {
 	ctx := context.Background()
 

--- a/internal/db/sshkeys_test.go
+++ b/internal/db/sshkeys_test.go
@@ -87,6 +87,41 @@ func (s *sshKeysSuite) TestCreateSSHKey(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 }
 
+func (s *sshKeysSuite) TestRemoveSSHKeysIsScopedToIdentity(c *qt.C) {
+	ctx := context.Background()
+	otherUser, err := dbmodel.NewIdentity("alice@canonical.com")
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.Database.DB.Create(otherUser).Error, qt.IsNil)
+
+	key := dbmodel.SSHKey{
+		Identity:       s.User,
+		PublicKey:      []byte("first-key"),
+		KeyComment:     "shared-comment",
+		MD5Fingerprint: "shared-fingerprint",
+		Model:          s.Model,
+	}
+	otherUserKey := dbmodel.SSHKey{
+		Identity:       *otherUser,
+		PublicKey:      []byte("second-key"),
+		KeyComment:     "shared-comment",
+		MD5Fingerprint: "shared-fingerprint",
+		Model:          s.Model,
+	}
+	c.Assert(s.Database.AddSSHKey(ctx, &key), qt.IsNil)
+	c.Assert(s.Database.AddSSHKey(ctx, &otherUserKey), qt.IsNil)
+
+	err = s.Database.RemoveSSHKeys(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String}, "shared-fingerprint")
+	c.Assert(err, qt.IsNil)
+
+	keys, err := s.Database.ListSSHKeysForUser(ctx, s.User.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Check(keys, qt.HasLen, 0)
+
+	keys, err = s.Database.ListSSHKeysForUser(ctx, otherUser.Name, db.SSHKeyModelFilter{ModelUUID: s.Model.UUID.String})
+	c.Assert(err, qt.IsNil)
+	c.Check(keys, qt.HasLen, 1)
+}
+
 func (s *sshKeysSuite) TestRemoveSSHKeyByFingerprint(c *qt.C) {
 	ctx := context.Background()
 

--- a/internal/jimm/sshkeys/sshkeys.go
+++ b/internal/jimm/sshkeys/sshkeys.go
@@ -89,22 +89,24 @@ func (sm *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.U
 	return pubKeys, nil
 }
 
-// RemoveUserKeyByComment removes a user's public key(s) by the key comment.
-func (sm *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
-
-	err := sm.store.RemoveSSHKeyByComment(ctx, user.Name, model, comment)
-	if err != nil {
-		return err
+// RemoveUserKeys removes a user's keys matching fingerprints, comments, or
+// full authorized-key values. Missing keys are ignored.
+func (sm *SSHKeyManager) RemoveUserKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error {
+	for i, target := range targets {
+		publicKey, _, _, _, err := gossh.ParseAuthorizedKey([]byte(target))
+		if err == nil {
+			targets[i] = gossh.FingerprintLegacyMD5(publicKey)
+		}
 	}
-	return nil
+	return sm.store.RemoveSSHKeys(ctx, user.Name, model, targets...)
 }
 
-// RemoveUserKeyByFingerprint removes a user's public key by the key fingerprint.
-func (sm *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
+// RemoveUserKeyByComment removes a user's public key(s) by comment.
+func (sm *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
+	return sm.RemoveUserKeys(ctx, user, model, comment)
+}
 
-	err := sm.store.RemoveSSHKeyByFingerprint(ctx, user.Name, model, fingerprint)
-	if err != nil {
-		return err
-	}
-	return nil
+// RemoveUserKeyByFingerprint removes a user's public key by fingerprint.
+func (sm *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
+	return sm.RemoveUserKeys(ctx, user, model, fingerprint)
 }

--- a/internal/jimm/sshkeys/sshkeys_test.go
+++ b/internal/jimm/sshkeys/sshkeys_test.go
@@ -206,6 +206,19 @@ func (s *sshKeysManagerSuite) TestRemoveUserKeyByFingerprint(c *qt.C) {
 	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).Error, qt.Equals, gorm.ErrRecordNotFound)
 }
 
+func (s *sshKeysManagerSuite) TestRemoveUserKeys(c *qt.C) {
+	c.Parallel()
+	ctx := context.Background()
+
+	err := s.manager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, s.pubKey)
+	c.Assert(err, qt.IsNil)
+
+	authorizedKey := string(gossh.MarshalAuthorizedKey(s.pubKey)) + s.pubKey.Comment
+	err = s.manager.RemoveUserKeys(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, authorizedKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(s.db.DB.First(&dbmodel.SSHKey{}).Error, qt.Equals, gorm.ErrRecordNotFound)
+}
+
 func TestSSHKeyManager(t *testing.T) {
 	qtsuite.Run(qt.New(t), &sshKeysManagerSuite{})
 }

--- a/internal/jujuapi/interface.go
+++ b/internal/jujuapi/interface.go
@@ -166,10 +166,8 @@ type SSHKeyManager interface {
 	AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
 	// ListUserPublicKeys lists a user's public keys.
 	ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
-	// RemoveUserKeyByComment removes a user's public key(s) by the key comment.
-	RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error
-	// RemoveUserKeyByFingerprint removes a user's public key(s) by the key fingerprint.
-	RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error
+	// RemoveUserKeys removes a user's public keys by fingerprint, comment, or full key value.
+	RemoveUserKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error
 	// VerifyPublicKey lists the key for a user and compares the key to find a match.
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }

--- a/internal/jujuapi/websocket.go
+++ b/internal/jujuapi/websocket.go
@@ -209,6 +209,7 @@ func (s apiModelProxier) ServeWS(ctx context.Context, clientConn *websocket.Conn
 	zapctx.Debug(ctx, "Starting proxier")
 	proxyHelpers := rpcproxy.ProxyHelpers{
 		ConnClient:              clientConn,
+		SSHKeyManager:           s.jimm.SSHKeyManager,
 		TokenGen:                &jwtGenerator,
 		ConnectController:       connectionFunc,
 		AuditLog:                auditLogger,
@@ -261,11 +262,12 @@ func controllerConnectionFunc(jwtGenerator *jujuauth.LoginTokenGenerator, m *dbm
 		}
 		fullModelName := m.Controller.Name + "/" + m.Name
 		return rpcproxy.WebsocketConnectionWithMetadata{
-			Conn:           controllerConn,
-			ControllerUUID: m.Controller.UUID,
-			ModelName:      fullModelName,
-			ModelUUID:      m.UUID.String,
-			MigrationMode:  m.MigrationMode,
+			Conn:              controllerConn,
+			ControllerUUID:    m.Controller.UUID,
+			ControllerVersion: m.Controller.AgentVersion,
+			ModelName:         fullModelName,
+			ModelUUID:         m.UUID.String,
+			MigrationMode:     m.MigrationMode,
 		}, nil
 	}
 }

--- a/internal/jujuclient/migrationtarget.go
+++ b/internal/jujuclient/migrationtarget.go
@@ -84,7 +84,17 @@ func (c Connection) LatestLogTime(ctx context.Context, modelUUID string) (time.T
 
 // Import imports a model migration from the given bytes of the
 // serialized model description.
+//
+// This method uses a raw facade call because Juju 4.1+ registers
+// MigrationTarget v8, whose Import method takes a SerializedModelV2
+// envelope rather than the legacy SerializedModel. The legacy import
+// path is still served by facade versions 6 and 7, so we call those
+// explicitly to avoid the client negotiating v8 against newer
+// controllers.
 func (c Connection) Import(ctx context.Context, bytes []byte) error {
-	migrationTarget := migrationtarget.NewClient(&c)
-	return migrationTarget.Import(ctx, bytes)
+	args := jujuparams.SerializedModel{Bytes: bytes}
+	if err := c.CallHighestFacadeVersion(ctx, "MigrationTarget", []int{7, 6}, "", "Import", &args, nil); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/rpcproxy/keymanager.go
+++ b/internal/rpcproxy/keymanager.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Canonical.
+
+package rpcproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	jujuparams "github.com/juju/juju/rpc/params"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+// keyManagerFacade implements the model-scoped KeyManager facade using JIMM's
+// SSH key store.
+type keyManagerFacade struct {
+	keyManager SSHKeyManager
+	user       *openfga.User
+	modelUUID  string
+}
+
+// ListKeys lists the authenticated user's SSH keys in the requested format.
+func (s *keyManagerFacade) ListKeys(ctx context.Context, args jujuparams.ListSSHKeys) (jujuparams.StringsResults, error) {
+	keys, err := s.keyManager.ListUserPublicKeys(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID})
+	if err != nil {
+		return jujuparams.StringsResults{}, err
+	}
+
+	var formatter func(sshkeys.PublicKey) string
+	switch args.Mode {
+	case jujuparams.SSHListModeFull:
+		formatter = marshalAuthorizedKeyWithComment
+	case jujuparams.SSHListModeFingerprint:
+		formatter = fingerprintWithComment
+	default:
+		return jujuparams.StringsResults{}, fmt.Errorf("unknown mode (%v)", args.Mode)
+	}
+
+	result := jujuparams.StringsResult{}
+	for _, key := range keys {
+		result.Result = append(result.Result, formatter(key))
+	}
+	return jujuparams.StringsResults{Results: []jujuparams.StringsResult{result}}, nil
+}
+
+// AddKeys saves each key and associates it with the authenticated user and model.
+func (s *keyManagerFacade) AddKeys(ctx context.Context, args jujuparams.ModifyUserSSHKeys) (jujuparams.ErrorResults, error) {
+	var results []jujuparams.ErrorResult
+	errorResult := func(err error, message string) jujuparams.ErrorResult {
+		return jujuparams.ErrorResult{Error: &jujuparams.Error{
+			Code:    string(errors.ErrorCode(err)),
+			Message: fmt.Sprintf("%s: %s", message, err),
+		}}
+	}
+
+	for i, key := range args.Keys {
+		publicKey, comment, _, _, err := gossh.ParseAuthorizedKey([]byte(key))
+		if err != nil {
+			results = append(results, errorResult(err, fmt.Sprintf("failed to parse key (entry %d)", i)))
+			continue
+		}
+		if err := s.keyManager.AddUserPublicKey(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, sshkeys.PublicKey{
+			PublicKey: publicKey,
+			Comment:   comment,
+		}); err != nil {
+			results = append(results, errorResult(err, fmt.Sprintf("failed to add key (comment %s)", comment)))
+		}
+	}
+
+	return jujuparams.ErrorResults{Results: results}, nil
+}
+
+// DeleteKeys removes keys by fingerprint, comment, or full key value.
+func (s *keyManagerFacade) DeleteKeys(ctx context.Context, args jujuparams.ModifyUserSSHKeys) (jujuparams.ErrorResults, error) {
+	if err := s.keyManager.RemoveUserKeys(ctx, s.user, db.SSHKeyModelFilter{ModelUUID: s.modelUUID}, args.Keys...); err != nil {
+		return jujuparams.ErrorResults{}, err
+	}
+	return jujuparams.ErrorResults{}, nil
+}
+
+// marshalAuthorizedKeyWithComment marshals an OpenSSH key including its comment.
+func marshalAuthorizedKeyWithComment(key sshkeys.PublicKey) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(key.Type())
+	buffer.WriteByte(' ')
+	encoder := base64.NewEncoder(base64.StdEncoding, &buffer)
+	_, _ = encoder.Write(key.Marshal())
+	_ = encoder.Close()
+	if key.Comment != "" {
+		buffer.WriteByte(' ')
+		buffer.WriteString(key.Comment)
+	}
+	return buffer.String()
+}
+
+// fingerprintWithComment renders the short form used by the Juju CLI.
+func fingerprintWithComment(key sshkeys.PublicKey) string {
+	return fmt.Sprintf("%s (%s)", gossh.FingerprintLegacyMD5(key), key.Comment)
+}

--- a/internal/rpcproxy/keymanager_test.go
+++ b/internal/rpcproxy/keymanager_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Canonical.
+
+package rpcproxy
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	jujuparams "github.com/juju/juju/rpc/params"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/dbmodel"
+	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
+	"github.com/canonical/jimm/v3/internal/openfga"
+)
+
+const testModelUUID = "00000000-0000-0000-0000-000000000001"
+
+type testSSHKeyManager struct {
+	add    func(context.Context, *openfga.User, db.SSHKeyModelFilter, sshkeys.PublicKey) error
+	list   func(context.Context, *openfga.User, db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
+	remove func(context.Context, *openfga.User, db.SSHKeyModelFilter, ...string) error
+}
+
+func (m testSSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, key sshkeys.PublicKey) error {
+	return m.add(ctx, user, model, key)
+}
+
+func (m testSSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
+	return m.list(ctx, user, model)
+}
+
+func (m testSSHKeyManager) RemoveUserKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error {
+	return m.remove(ctx, user, model, targets...)
+}
+
+func newTestPublicKey(c *qt.C, comment string) sshkeys.PublicKey {
+	c.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	c.Assert(err, qt.IsNil)
+	publicKey, err := gossh.NewPublicKey(privateKey.Public())
+	c.Assert(err, qt.IsNil)
+	return sshkeys.PublicKey{PublicKey: publicKey, Comment: comment}
+}
+
+func testFacade(keyManager SSHKeyManager) keyManagerFacade {
+	return keyManagerFacade{
+		keyManager: keyManager,
+		user:       &openfga.User{Identity: &dbmodel.Identity{Name: "alice@canonical.com"}},
+		modelUUID:  testModelUUID,
+	}
+}
+
+func TestKeyManagerFacadeListKeysIsModelScoped(t *testing.T) {
+	c := qt.New(t)
+	first := newTestPublicKey(c, "first")
+	second := newTestPublicKey(c, "second")
+	manager := testSSHKeyManager{
+		list: func(_ context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error) {
+			c.Check(user.Name, qt.Equals, "alice@canonical.com")
+			c.Check(model, qt.DeepEquals, db.SSHKeyModelFilter{ModelUUID: testModelUUID})
+			return []sshkeys.PublicKey{first, second}, nil
+		},
+	}
+
+	facade := testFacade(manager)
+	result, err := facade.ListKeys(c.Context(), jujuparams.ListSSHKeys{Mode: jujuparams.SSHListModeFingerprint})
+	c.Assert(err, qt.IsNil)
+	c.Check(result.Results, qt.DeepEquals, []jujuparams.StringsResult{{
+		Result: []string{
+			fmt.Sprintf("%s (first)", gossh.FingerprintLegacyMD5(first)),
+			fmt.Sprintf("%s (second)", gossh.FingerprintLegacyMD5(second)),
+		},
+	}})
+}
+
+func TestKeyManagerFacadeAddKeysPersistsValidKeysOnly(t *testing.T) {
+	c := qt.New(t)
+	key := newTestPublicKey(c, "test-key")
+	var added []sshkeys.PublicKey
+	manager := testSSHKeyManager{
+		add: func(_ context.Context, user *openfga.User, model db.SSHKeyModelFilter, key sshkeys.PublicKey) error {
+			c.Check(user.Name, qt.Equals, "alice@canonical.com")
+			c.Check(model, qt.DeepEquals, db.SSHKeyModelFilter{ModelUUID: testModelUUID})
+			added = append(added, key)
+			return nil
+		},
+	}
+
+	facade := testFacade(manager)
+	result, err := facade.AddKeys(c.Context(), jujuparams.ModifyUserSSHKeys{Keys: []string{
+		"not a public key",
+		marshalAuthorizedKeyWithComment(key),
+	}})
+	c.Assert(err, qt.IsNil)
+	c.Check(added, qt.HasLen, 1)
+	c.Check(added[0].Marshal(), qt.DeepEquals, key.Marshal())
+	c.Check(added[0].Comment, qt.Equals, key.Comment)
+	c.Check(result.Results, qt.HasLen, 1)
+	c.Check(result.Results[0].Error.Message, qt.Matches, "failed to parse key.*")
+}
+
+func TestKeyManagerFacadeDeleteKeysPassesRawTargets(t *testing.T) {
+	c := qt.New(t)
+	key := newTestPublicKey(c, "test-key")
+	fingerprint := gossh.FingerprintLegacyMD5(key)
+	fullKey := marshalAuthorizedKeyWithComment(key)
+	var removedTargets []string
+	manager := testSSHKeyManager{
+		remove: func(_ context.Context, _ *openfga.User, model db.SSHKeyModelFilter, targets ...string) error {
+			c.Check(model, qt.DeepEquals, db.SSHKeyModelFilter{ModelUUID: testModelUUID})
+			removedTargets = targets
+			return nil
+		},
+	}
+
+	facade := testFacade(manager)
+	result, err := facade.DeleteKeys(c.Context(), jujuparams.ModifyUserSSHKeys{Keys: []string{"test-key", fingerprint, fullKey}})
+	c.Assert(err, qt.IsNil)
+	c.Check(result.Results, qt.HasLen, 0)
+	c.Check(removedTargets, qt.DeepEquals, []string{"test-key", fingerprint, fullKey})
+}
+
+func TestShouldInterceptKeyManager(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range []struct {
+		version   string
+		intercept bool
+		err       string
+	}{
+		{version: "3.6.12", intercept: false},
+		{version: "4.0.0", intercept: true},
+		{version: "4.1.3", intercept: true},
+		{version: "", err: `cannot determine KeyManager routing: controller version "" is invalid`},
+		{version: "2.9.0", err: `cannot determine KeyManager routing for Juju 2.9.0`},
+	} {
+		c.Run(test.version, func(c *qt.C) {
+			intercept, err := shouldInterceptKeyManager(test.version)
+			if test.err != "" {
+				c.Check(err, qt.ErrorMatches, test.err)
+				return
+			}
+			c.Check(err, qt.IsNil)
+			c.Check(intercept, qt.Equals, test.intercept)
+		})
+	}
+}
+
+func TestKeyManagerFacadeRoutesByControllerVersion(t *testing.T) {
+	c := qt.New(t)
+	key := newTestPublicKey(c, "test-key")
+	request, err := json.Marshal(jujuparams.ModifyUserSSHKeys{Keys: []string{marshalAuthorizedKeyWithComment(key)}})
+	c.Assert(err, qt.IsNil)
+
+	for _, test := range []struct {
+		version   string
+		intercept bool
+	}{
+		{version: "4.0.0", intercept: true},
+	} {
+		c.Run(test.version, func(c *qt.C) {
+			added := false
+			modelProxy := modelProxy{modelUUID: testModelUUID, controllerVersion: test.version}
+			if test.intercept {
+				modelProxy.sshKeyManager = testSSHKeyManager{
+					add: func(_ context.Context, _ *openfga.User, model db.SSHKeyModelFilter, addedKey sshkeys.PublicKey) error {
+						c.Check(model, qt.DeepEquals, db.SSHKeyModelFilter{ModelUUID: testModelUUID})
+						c.Check(addedKey.Marshal(), qt.DeepEquals, key.Marshal())
+						added = true
+						return nil
+					},
+				}
+			}
+			proxy := clientProxy{
+				modelProxy: modelProxy,
+				user:       &openfga.User{Identity: &dbmodel.Identity{Name: "alice@canonical.com"}},
+			}
+			message := &message{Type: "KeyManager", Request: "AddKeys", Params: request}
+			clientResponse, err := proxy.handleKeyManagerFacade(c.Context(), message)
+			c.Assert(err, qt.IsNil)
+			c.Check(added, qt.IsTrue)
+			c.Check(clientResponse, qt.Equals, message)
+		})
+	}
+}

--- a/internal/rpcproxy/message.go
+++ b/internal/rpcproxy/message.go
@@ -28,7 +28,6 @@ type message struct {
 	ErrorCode string          `json:"error-code,omitempty"`
 	ErrorInfo map[string]any  `json:"error-info,omitempty"`
 	Response  json.RawMessage `json:"response,omitempty"`
-
 	// --- tracing fields ---
 	span       *telemetry.TrackedSpan `json:"-"`
 	TraceID    string                 `json:"trace-id,omitempty"`

--- a/internal/rpcproxy/rpcproxy.go
+++ b/internal/rpcproxy/rpcproxy.go
@@ -17,12 +17,15 @@ import (
 	"github.com/juju/juju/api"
 	jujuparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/names/v6"
+	"github.com/juju/version/v2"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"github.com/canonical/jimm/v3/internal/db"
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
+	"github.com/canonical/jimm/v3/internal/jimm/sshkeys"
 	"github.com/canonical/jimm/v3/internal/logger"
 	"github.com/canonical/jimm/v3/internal/openfga"
 	"github.com/canonical/jimm/v3/internal/servermon"
@@ -51,6 +54,13 @@ type RedirectInfoGetter interface {
 	GetRedirectInfo(ctx context.Context) (ControllerDetails, error)
 }
 
+// SSHKeyManager manages model-scoped SSH keys stored by JIMM.
+type SSHKeyManager interface {
+	AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
+	ListUserPublicKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
+	RemoveUserKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error
+}
+
 // TokenGenerator authenticates a user and generates a JWT token.
 type TokenGenerator interface {
 	// MakeLoginToken returns a JWT containing claims about user's access
@@ -77,11 +87,12 @@ type WebsocketConnection interface {
 // WebsocketConnectionWithMetadata holds the websocket connection and metadata about the
 // established connection.
 type WebsocketConnectionWithMetadata struct {
-	Conn           WebsocketConnection
-	ControllerUUID string
-	ModelName      string
-	ModelUUID      string
-	MigrationMode  dbmodel.MigrationMode
+	Conn              WebsocketConnection
+	ControllerUUID    string
+	ControllerVersion string
+	ModelName         string
+	ModelUUID         string
+	MigrationMode     dbmodel.MigrationMode
 }
 
 // LoginService represents the LoginService interface used by the proxy.
@@ -98,6 +109,7 @@ type LoginService interface {
 // connection to a model.
 type ProxyHelpers struct {
 	ConnClient              WebsocketConnection
+	SSHKeyManager           SSHKeyManager
 	TokenGen                TokenGenerator
 	ConnectController       func(context.Context) (WebsocketConnectionWithMetadata, error)
 	AuditLog                func(*dbmodel.AuditLogEntry)
@@ -135,6 +147,7 @@ func ProxySockets(ctx context.Context, helpers ProxyHelpers) error {
 			tokenGen:                helpers.TokenGen,
 			auditLog:                helpers.AuditLog,
 			conversationId:          utils.NewConversationID(),
+			sshKeyManager:           helpers.SSHKeyManager,
 			loginService:            helpers.LoginService,
 			authenticatedIdentityID: helpers.AuthenticatedIdentityID,
 			redirectInfo:            helpers.RedirectInfo,
@@ -271,9 +284,11 @@ type modelProxy struct {
 	anonymousLogin          bool // anonymousLogin is true if the client is not authenticated.
 	auditLog                func(*dbmodel.AuditLogEntry)
 	tokenGen                TokenGenerator
+	sshKeyManager           SSHKeyManager
 	loginService            LoginService
 	modelName               string
 	modelUUID               string
+	controllerVersion       string
 	modelMigrationMode      dbmodel.MigrationMode
 	conversationId          string
 	authenticatedIdentityID string
@@ -364,6 +379,7 @@ func unexpectedReadError(err error) bool {
 // clientProxy proxies messages from client->controller.
 type clientProxy struct {
 	modelProxy
+	user                 *openfga.User
 	wg                   sync.WaitGroup
 	errChan              chan error
 	createControllerConn func(context.Context) (WebsocketConnectionWithMetadata, error)
@@ -371,6 +387,8 @@ type clientProxy struct {
 }
 
 // start begins the client->controller proxier.
+//
+//nolint:gocognit
 func (p *clientProxy) start(ctx context.Context) error {
 	defer func() {
 		if p.dst != nil {
@@ -420,6 +438,25 @@ func (p *clientProxy) start(ctx context.Context) error {
 				p.msgs.addLoginMessage(toController)
 			}
 		}
+		if msg.Type == "KeyManager" {
+			intercept, err := shouldInterceptKeyManager(p.controllerVersion)
+			if err != nil {
+				p.sendError(ctx, p.src, msg, err)
+				continue
+			}
+			if intercept {
+				toClient, err := p.handleKeyManagerFacade(ctx, msg)
+				if err != nil {
+					p.sendError(ctx, p.src, msg, err)
+					continue
+				}
+				p.src.sendMessage(nil, toClient)
+				if err := p.auditLogMessage(toClient, true); err != nil {
+					zapctx.Error(ctx, "failed to audit local KeyManager response", zap.Error(err))
+				}
+				continue
+			}
+		}
 		p.msgs.addMessage(ctx, msg)
 		if err := p.dst.writeJson(msg); err != nil {
 			zapctx.Error(ctx, "clientProxy error writing to dst", zap.Error(err))
@@ -447,6 +484,7 @@ func (p *clientProxy) makeControllerConnection(ctx context.Context) error {
 		p.msgs.controllerUUID = connWithMetadata.ControllerUUID
 		p.modelName = connWithMetadata.ModelName
 		p.modelUUID = connWithMetadata.ModelUUID
+		p.controllerVersion = connWithMetadata.ControllerVersion
 		p.modelMigrationMode = connWithMetadata.MigrationMode
 		p.dst = &writeLockConn{conn: connWithMetadata.Conn}
 		controllerToClient := controllerProxy{
@@ -695,6 +733,7 @@ func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clie
 		return nil, nil, err
 	}
 	controllerLoginMessageFnc := func(user *openfga.User) (*message, *message, error) {
+		p.user = user
 		// User logins funnel through here, so this is
 		// where client/model compatibility is enforced.
 		if err := checkClientModelCompatibility(ctx); err != nil {
@@ -786,6 +825,80 @@ func (p *clientProxy) handleAdminFacade(ctx context.Context, msg *message) (clie
 		return nil, controllerMessage, err
 	default:
 		return nil, nil, nil
+	}
+}
+
+// handleKeyManagerFacade processes a model-scoped Juju 4 KeyManager facade
+// call using JIMM's key store.
+func (p *clientProxy) handleKeyManagerFacade(ctx context.Context, msg *message) (*message, error) {
+	if p.user == nil {
+		return nil, errors.New("user not authenticated")
+	}
+	if p.sshKeyManager == nil {
+		return nil, errors.New("SSH key manager unavailable")
+	}
+	respond := func(data any) (*message, error) {
+		response, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		msg.Response = response
+		return msg, nil
+	}
+	keyManager := keyManagerFacade{keyManager: p.sshKeyManager, user: p.user, modelUUID: p.modelUUID}
+
+	switch msg.Request {
+	case "ListKeys":
+		var request jujuparams.ListSSHKeys
+		if err := json.Unmarshal(msg.Params, &request); err != nil {
+			return nil, err
+		}
+		result, err := keyManager.ListKeys(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return respond(result)
+	case "AddKeys":
+		var request jujuparams.ModifyUserSSHKeys
+		if err := json.Unmarshal(msg.Params, &request); err != nil {
+			return nil, err
+		}
+		result, err := keyManager.AddKeys(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return respond(result)
+	case "DeleteKeys":
+		var request jujuparams.ModifyUserSSHKeys
+		if err := json.Unmarshal(msg.Params, &request); err != nil {
+			return nil, err
+		}
+		result, err := keyManager.DeleteKeys(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return respond(result)
+	case "ImportKeys":
+		return nil, errors.Codef(errors.CodeNotImplemented, "ImportKeys not implemented")
+	default:
+		return nil, errors.New("unknown key manager request")
+	}
+}
+
+// shouldInterceptKeyManager reports whether JIMM must handle the model-scoped
+// KeyManager facade. Juju 3 calls continue through the normal proxy path.
+func shouldInterceptKeyManager(controllerVersion string) (bool, error) {
+	controller, err := version.Parse(controllerVersion)
+	if err != nil {
+		return false, errors.Codef(errors.CodeNotSupported, "cannot determine KeyManager routing: controller version %q is invalid", controllerVersion)
+	}
+	switch {
+	case controller.Major == 3:
+		return false, nil
+	case controller.Major >= 4:
+		return true, nil
+	default:
+		return false, errors.Codef(errors.CodeNotSupported, "cannot determine KeyManager routing for Juju %s", controllerVersion)
 	}
 }
 

--- a/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_sshkeys_mock.go
@@ -12,11 +12,10 @@ import (
 )
 
 type SSHKeyManager struct {
-	AddUserPublicKey_           func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
-	ListUserPublicKeys_         func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
-	RemoveUserKeyByComment_     func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error
-	RemoveUserKeyByFingerprint_ func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error
-	VerifyPublicKey_            func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
+	AddUserPublicKey_   func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error
+	ListUserPublicKeys_ func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter) ([]sshkeys.PublicKey, error)
+	RemoveUserKeys_     func(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error
+	VerifyPublicKey_    func(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
 func (j *SSHKeyManager) AddUserPublicKey(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, publicKey sshkeys.PublicKey) error {
@@ -33,18 +32,11 @@ func (j *SSHKeyManager) ListUserPublicKeys(ctx context.Context, user *openfga.Us
 	return j.ListUserPublicKeys_(ctx, user, model)
 }
 
-func (j *SSHKeyManager) RemoveUserKeyByComment(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, comment string) error {
-	if j.RemoveUserKeyByComment_ == nil {
+func (j *SSHKeyManager) RemoveUserKeys(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, targets ...string) error {
+	if j.RemoveUserKeys_ == nil {
 		return errors.New("not implemented")
 	}
-	return j.RemoveUserKeyByComment_(ctx, user, model, comment)
-}
-
-func (j *SSHKeyManager) RemoveUserKeyByFingerprint(ctx context.Context, user *openfga.User, model db.SSHKeyModelFilter, fingerprint string) error {
-	if j.RemoveUserKeyByFingerprint_ == nil {
-		return errors.New("not implemented")
-	}
-	return j.RemoveUserKeyByFingerprint_(ctx, user, model, fingerprint)
+	return j.RemoveUserKeys_(ctx, user, model, targets...)
 }
 
 func (j *SSHKeyManager) VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error) {

--- a/testing/sshkeymanager_test.go
+++ b/testing/sshkeymanager_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Canonical.
+
+package testing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/juju/api/client/keymanager"
+	"github.com/juju/utils/v4/ssh"
+	"github.com/juju/version/v2"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/canonical/jimm/v3/internal/db"
+	"github.com/canonical/jimm/v3/internal/testutils/jimmtest"
+)
+
+// TestModelSSHKeys verifies that Juju 3 model key management is delegated to
+// the backing controller, while Juju 4 model key management is persisted in
+// JIMM's model-scoped SSH key database.
+func TestModelSSHKeys(t *testing.T) {
+	c := qt.New(t)
+	s := jimmtest.SetupJimmWithControllers(c)
+	model := s.CreateModelForBob(c)
+	controllerVersion := version.MustParse(model.Controller.AgentVersion)
+	keysAreStoredByJIMM := controllerVersion.Major >= 4
+
+	modelTag := model.ResourceTag()
+	conn := s.Open(c, nil, bobOwnerTag.Id(), &modelTag)
+	defer conn.Close()
+	client := keymanager.NewClient(conn)
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	c.Assert(err, qt.IsNil)
+	publicKey, err := gossh.NewPublicKey(privateKey.Public())
+	c.Assert(err, qt.IsNil)
+	authorizedKey := fmt.Sprintf("%s %s %s", publicKey.Type(), base64.StdEncoding.EncodeToString(publicKey.Marshal()), "model-ssh-key")
+	fingerprint := gossh.FingerprintLegacyMD5(publicKey)
+
+	addResults, err := client.AddKeys(c.Context(), "unused", authorizedKey)
+	c.Assert(err, qt.IsNil)
+	c.Check(addResults, qt.HasLen, 0)
+	keys, err := client.ListKeys(c.Context(), ssh.Fingerprints)
+	c.Assert(err, qt.IsNil)
+	c.Assert(keys, qt.HasLen, 1)
+	c.Check(keys[0].Error, qt.IsNil)
+	c.Check(keys[0].Result, qt.DeepEquals, []string{fmt.Sprintf("%s (%s)", fingerprint, "model-ssh-key")})
+	if keysAreStoredByJIMM {
+		dbKeys, err := s.JIMM.Database.ListSSHKeysForUser(c.Context(), bobOwnerTag.Id(), db.SSHKeyModelFilter{ModelUUID: model.UUID.String})
+		c.Assert(err, qt.IsNil)
+		c.Check(dbKeys, qt.HasLen, 1)
+	}
+
+	deleteResults, err := client.DeleteKeys(c.Context(), "unused", fingerprint)
+	c.Assert(err, qt.IsNil)
+	c.Check(deleteResults, qt.HasLen, 0)
+	if keysAreStoredByJIMM {
+		dbKeys, err := s.JIMM.Database.ListSSHKeysForUser(c.Context(), bobOwnerTag.Id(), db.SSHKeyModelFilter{ModelUUID: model.UUID.String})
+		c.Assert(err, qt.IsNil)
+		c.Check(dbKeys, qt.HasLen, 0)
+	}
+}

--- a/testing/sshkeymanager_test.go
+++ b/testing/sshkeymanager_test.go
@@ -40,13 +40,20 @@ func TestModelSSHKeys(t *testing.T) {
 	authorizedKey := fmt.Sprintf("%s %s %s", publicKey.Type(), base64.StdEncoding.EncodeToString(publicKey.Marshal()), "model-ssh-key")
 	fingerprint := gossh.FingerprintLegacyMD5(publicKey)
 
-	addResults, err := client.AddKeys(c.Context(), "unused", authorizedKey)
+	addResults, err := client.AddKeys(c.Context(), bobOwnerTag.Id(), authorizedKey)
 	c.Assert(err, qt.IsNil)
-	c.Check(addResults, qt.HasLen, 0)
-	keys, err := client.ListKeys(c.Context(), ssh.Fingerprints)
+	if keysAreStoredByJIMM {
+		// Juju 4 returns no per-key results when every key is added successfully.
+		c.Check(addResults, qt.HasLen, 0)
+	} else {
+		// Juju 3 returns one successful result for each requested key.
+		c.Check(addResults, qt.HasLen, 1)
+		c.Check(addResults[0].Error == nil, qt.IsTrue)
+	}
+	keys, err := client.ListKeys(c.Context(), ssh.Fingerprints, bobOwnerTag.Id())
 	c.Assert(err, qt.IsNil)
 	c.Assert(keys, qt.HasLen, 1)
-	c.Check(keys[0].Error, qt.IsNil)
+	c.Check(keys[0].Error == nil, qt.IsTrue)
 	c.Check(keys[0].Result, qt.DeepEquals, []string{fmt.Sprintf("%s (%s)", fingerprint, "model-ssh-key")})
 	if keysAreStoredByJIMM {
 		dbKeys, err := s.JIMM.Database.ListSSHKeysForUser(c.Context(), bobOwnerTag.Id(), db.SSHKeyModelFilter{ModelUUID: model.UUID.String})
@@ -54,9 +61,16 @@ func TestModelSSHKeys(t *testing.T) {
 		c.Check(dbKeys, qt.HasLen, 1)
 	}
 
-	deleteResults, err := client.DeleteKeys(c.Context(), "unused", fingerprint)
+	deleteResults, err := client.DeleteKeys(c.Context(), bobOwnerTag.Id(), fingerprint)
 	c.Assert(err, qt.IsNil)
-	c.Check(deleteResults, qt.HasLen, 0)
+	if keysAreStoredByJIMM {
+		// Juju 4 returns no per-key results when every key is deleted successfully.
+		c.Check(deleteResults, qt.HasLen, 0)
+	} else {
+		// Juju 3 returns one successful result for each requested key.
+		c.Check(deleteResults, qt.HasLen, 1)
+		c.Check(deleteResults[0].Error == nil, qt.IsTrue)
+	}
 	if keysAreStoredByJIMM {
 		dbKeys, err := s.JIMM.Database.ListSSHKeysForUser(c.Context(), bobOwnerTag.Id(), db.SSHKeyModelFilter{ModelUUID: model.UUID.String})
 		c.Assert(err, qt.IsNil)

--- a/tests/ssh/verify-ssh-server-running.sh
+++ b/tests/ssh/verify-ssh-server-running.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 
-# This script verifies that the SSH server is running on the JIMM controller.
+# This script verifies SSH access to a machine through JIMM's jump server.
 
-# TODO(simonedutto): improve this test when juju ssh controller is implemented.
-nc -zv localhost 17022
+set -euo pipefail
+
+key_path="$(mktemp -u "${TMPDIR:-/tmp}/jimm-ssh-test-key.XXXXXX")"
+model_name="ssh-test-$RANDOM"
+
+cleanup() {
+	rm -f "$key_path" "$key_path.pub"
+	juju destroy-model "$model_name" --force --no-prompt --destroy-all-models 2>/dev/null || true
+}
+trap cleanup EXIT
+
+ssh-keygen -q -t rsa -N "" -f "$key_path"
+juju add-ssh-key "$(cat "$key_path.pub")"
+
+juju add-model "$model_name"
+juju add-machine
+until [ "$(juju status 0 --format json | jq -r '.machines["0"]["juju-status"].current')" = "started" ]; do
+	sleep 5
+done
+juju ssh --jump 0 true

--- a/tests/ssh/verify-ssh-server-running.sh
+++ b/tests/ssh/verify-ssh-server-running.sh
@@ -5,8 +5,12 @@
 set -euo pipefail
 
 JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
+BACKING_CONTROLLER_NAME="${BACKING_CONTROLLER_NAME:-qa-lxd}"
 key_path="$(mktemp -u "${TMPDIR:-/tmp}/jimm-ssh-test-key.XXXXXX")"
 model_name="ssh-test-$RANDOM"
+
+# Source the `JAAS` variable for executing jaas commands.
+source "local/jimm/detect-jaas.sh"
 
 cleanup() {
 	rm -f "$key_path" "$key_path.pub"
@@ -18,7 +22,7 @@ trap cleanup EXIT
 # JIMM's controller, then create and select this test's model before executing
 # model-scoped commands.
 juju switch "$JIMM_CONTROLLER_NAME"
-juju add-model "$model_name" localhost
+$JAAS add-model "$model_name" localhost --target-controller "$BACKING_CONTROLLER_NAME"
 
 ssh-keygen -q -t rsa -N "" -f "$key_path"
 juju add-ssh-key "$(cat "$key_path.pub")"

--- a/tests/ssh/verify-ssh-server-running.sh
+++ b/tests/ssh/verify-ssh-server-running.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 
+JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
 key_path="$(mktemp -u "${TMPDIR:-/tmp}/jimm-ssh-test-key.XXXXXX")"
 model_name="ssh-test-$RANDOM"
 
@@ -13,12 +14,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Tests run sequentially and share Juju's current controller/model. Start on
+# JIMM's controller, then create and select this test's model before executing
+# model-scoped commands.
+juju switch "$JIMM_CONTROLLER_NAME"
+juju add-model "$model_name" localhost
+
 ssh-keygen -q -t rsa -N "" -f "$key_path"
 juju add-ssh-key "$(cat "$key_path.pub")"
-
-juju add-model "$model_name"
 juju add-machine
 until [ "$(juju status 0 --format json | jq -r '.machines["0"]["juju-status"].current')" = "started" ]; do
 	sleep 5
 done
-juju ssh --jump 0 true
+juju ssh 0 true

--- a/tests/ssh/verify-ssh-server-running.sh
+++ b/tests/ssh/verify-ssh-server-running.sh
@@ -6,14 +6,19 @@ set -euo pipefail
 
 JIMM_CONTROLLER_NAME="${JIMM_CONTROLLER_NAME:-jimm-dev}"
 BACKING_CONTROLLER_NAME="${BACKING_CONTROLLER_NAME:-qa-lxd}"
-key_path="$(mktemp -u "${TMPDIR:-/tmp}/jimm-ssh-test-key.XXXXXX")"
 model_name="ssh-test-$RANDOM"
+ssh_dir="$HOME/.ssh"
+ssh_private_key="$ssh_dir/id_rsa"
+ssh_public_key="$ssh_private_key.pub"
+generated_default_key=false
 
 # Source the `JAAS` variable for executing jaas commands.
 source "local/jimm/detect-jaas.sh"
 
 cleanup() {
-	rm -f "$key_path" "$key_path.pub"
+	if [[ "$generated_default_key" == true ]]; then
+		rm -f "$ssh_private_key" "$ssh_public_key"
+	fi
 	juju destroy-model "$model_name" --force --no-prompt --destroy-all-models 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -24,8 +29,12 @@ trap cleanup EXIT
 juju switch "$JIMM_CONTROLLER_NAME"
 $JAAS add-model "$model_name" localhost --target-controller "$BACKING_CONTROLLER_NAME"
 
-ssh-keygen -q -t rsa -N "" -f "$key_path"
-juju add-ssh-key "$(cat "$key_path.pub")"
+mkdir -p "$ssh_dir"
+if [[ ! -f "$ssh_public_key" || ! -f "$ssh_private_key" ]]; then
+	ssh-keygen -q -t rsa -N "" -f "$ssh_private_key"
+	generated_default_key=true
+fi
+juju add-ssh-key "$(cat "$ssh_public_key")"
 juju add-machine
 until [ "$(juju status 0 --format json | jq -r '.machines["0"]["juju-status"].current')" = "started" ]; do
 	sleep 5


### PR DESCRIPTION
## Description

Intercept keymanager to populate jimm's db.

- for juju 4 we intercept the call, and we don't proxy to the controller
- for juju 3 we just forward the call


## QA

`make qa-lxd`

```
juju add-model a
juju add-machine

juju ssh --jump 0
```