### PR TITLE
refactor: split dialer methods by purpose

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -370,9 +370,28 @@ func NewDialerAdapter(dialer *jujuclient.Dialer) *DialerAdapter {
 	}
 }
 
-// Dial implements the juju.Dialer interface for the DialerAdapter.
-// It uses the underlying jujuclient.Dialer to establish a connection
-// to the Juju controller and returns a juju.API connection.
-func (d *DialerAdapter) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (juju.API, error) {
-	return d.dialer.Dial(ctx, ctl, modelTag, user)
+// DialModel implements the juju.Dialer interface for the DialerAdapter.
+// It uses the underlying jujuclient.Dialer to establish a model-scoped
+// connection to the Juju controller and returns a juju.API connection.
+func (d *DialerAdapter) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	return d.dialer.DialModel(ctx, user, ctl, modelTag)
+}
+
+// DialController implements the juju.Dialer interface for the DialerAdapter.
+// It dials the controller with a controller-scoped connection on behalf
+// of the given user.
+func (d *DialerAdapter) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.dialer.DialController(ctx, user, ctl, resourceTags...)
+}
+
+// DialModelAsService implements the juju.Dialer interface for the
+// DialerAdapter. It dials the model using JIMM's own service identity.
+func (d *DialerAdapter) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	return d.dialer.DialModelAsService(ctx, ctl, modelTag)
+}
+
+// DialControllerAsService implements the juju.Dialer interface for the
+// DialerAdapter. It dials the controller using JIMM's own service identity.
+func (d *DialerAdapter) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	return d.dialer.DialControllerAsService(ctx, ctl)
 }

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -76,7 +76,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	if err == nil {
 		// The offer exists in JIMM's database, check against the Juju controller
 		// It's possible for an offer record in JIMM to dangle
-		checkAPI, dialErr := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
+		checkAPI, dialErr := j.dialController(ctx, user, &model.Controller)
 		if dialErr != nil {
 			return dialErr
 		}
@@ -100,7 +100,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return err
 	}
 
-	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &model.Controller)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		return errors.Codef(errors.CodeNotFound, "not found")
 	}
 
-	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// controller. The all-watcher events do not include enough
 	// information to reasonably keep the local database up-to-date,
 	// and it would be non-trivial to make it do so.
-	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 			// Return early if a single controller has an error
 			// to avoid misleading clients about what exists which
 			// could cause unneeded reconciliation.
-			api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
+			api, err := j.dialController(ctx, user, ctl)
 			if err != nil {
 				return err
 			}
@@ -614,7 +614,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	// add offer admin claim
-	api, err := j.dial(ctx, &offer.Model.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -344,7 +344,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 // the controller. No error will be returned if the cloud already exists on
 // the controller or the user already has access to the cloud.
 func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
-	api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, ctl)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		}
 		return fmt.Errorf("cloud administration not available for %s", ct.Id())
 	}
-	api, err := j.dial(ctx, &c.Regions[0].Controllers[0].Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &c.Regions[0].Controllers[0].Controller)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 		return errors.Codef(errors.CodeNotFound, "cloud not hosted by controller")
 	}
 
-	api, err := j.dial(ctx, &controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -515,7 +515,7 @@ func (j *JujuManager) recoverCredential(ctx context.Context, credential *dbmodel
 		}
 		seen[ctl.ID] = true
 
-		api, dialErr := j.dialController(ctx, &ctl, ownerUser)
+		api, dialErr := j.dialController(ctx, ownerUser, &ctl)
 		if dialErr != nil {
 			lastErr = dialErr
 			continue

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -244,7 +244,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 		}
 	}
 
-	api, err := j.dialController(ctx, ctl, user)
+	api, err := j.dialController(ctx, user, ctl)
 	if err != nil {
 		return fmt.Errorf("failed to dial the controller: %v", err)
 	}
@@ -393,7 +393,7 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, 
 		return err
 	}
 
-	api, err := m.jimm.dialController(ctx, controller, user)
+	api, err := m.jimm.dialController(ctx, user, controller)
 	if err != nil {
 		return fmt.Errorf("failed to dial the controller: %w", err)
 	}
@@ -632,7 +632,7 @@ func (j *JujuManager) UpdateMigratedModel(ctx context.Context, user *openfga.Use
 	}
 
 	// check the model is known to the controller
-	api, err := j.dial(ctx, &targetController, names.ModelTag{}, nil)
+	api, err := j.dialControllerAsService(ctx, &targetController)
 	if err != nil {
 		return err
 	}
@@ -731,7 +731,7 @@ func (j *JujuManager) initiateMigration(ctx context.Context, user *openfga.User,
 		}
 	}
 
-	api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, nil)
+	api, err := j.dialControllerAsService(ctx, &model.Controller)
 	if err != nil {
 		rollbackMigrationMode()
 		return result, fmt.Errorf("failed to dial the controller: %w", err)
@@ -766,7 +766,7 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, user *openfga.User, 
 		return jujucontroller.Config{}, err
 	}
 
-	api, err := j.dialController(ctx, controller, user)
+	api, err := j.dialController(ctx, user, controller)
 	if err != nil {
 		return jujucontroller.Config{}, err
 	}

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -22,15 +22,51 @@ import (
 	"github.com/canonical/jimm/v3/internal/openfga"
 )
 
-// A Dialer provides a connection to a controller.
+// A Dialer provides a connection to a controller. The four methods are
+// organised along two axes: connection scope (model vs controller) and
+// identity (real user vs JIMM's own service identity). After successfully
+// dialing the controller the UUID, AgentVersion and HostPorts fields in the
+// given controller should be updated to the values provided by the
+// controller.
+//
+// When to use which method:
+//
+//   - DialModel / DialController: dial on behalf of a real user. Prefer
+//     these wherever possible.
+//
+//   - DialModelAsService / DialControllerAsService: dial as JIMM's
+//     service identity. Use only for internal housekeeping with no real
+//     user. Every AsService call is a potential gap to close in Juju's
+//     permission model.
 type Dialer interface {
-	// Dial creates an API connection to a controller. If the given
-	// model-tag is non-zero the connection will be to that model,
-	// otherwise the connection is to the controller. After successfully
-	// dialing the controller the UUID, AgentVersion and HostPorts fields
-	// in the given controller should be updated to the values provided
-	// by the controller.
-	Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error)
+	// DialModel creates a model-scoped API connection on behalf of a real
+	// user. The user and modelTag must not be zero-valued.
+	DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error)
+
+	// DialController creates a controller-scoped API connection on behalf
+	// of a real user. This is used for operations that call
+	// controller-level facades (e.g. ModelManager) with a model UUID
+	// argument, or offer-related operations tied to a single offer: the
+	// connection must be controller-scoped, but the Juju permission
+	// check requires the user's access to the relevant resource(s).
+	//
+	// resourceTags is a generalisation of DialModel's modelTag: pass any
+	// mix of model and application-offer tags the operation is tied to.
+	// Pass no resourceTags when the operation is not tied to a specific
+	// resource (e.g. cloud or controller-level calls).
+	DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error)
+
+	// DialModelAsService creates a model-scoped API connection using
+	// JIMM's own service identity (no user). It is intended solely for
+	// internal housekeeping operations (e.g. model-status polling) that
+	// are not initiated by a real user.
+	DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error)
+
+	// DialControllerAsService creates a controller-scoped API connection
+	// using JIMM's own service identity (no user). It is intended solely
+	// for internal housekeeping operations (watcher, upgrade, controller
+	// administration, etc.) that are not initiated by a real user.
+	DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (API, error)
 }
 
 // An API is the interface JIMM uses to access the API on a controller.

--- a/internal/jimm/juju/jimm.go
+++ b/internal/jimm/juju/jimm.go
@@ -44,7 +44,7 @@ func (j *JujuManager) forEachController(ctx context.Context, controllers []dbmod
 	eg := new(errgroup.Group)
 	for i := range controllers {
 		eg.Go(func() error {
-			api, err := j.dial(ctx, &controllers[i], names.ModelTag{}, nil)
+			api, err := j.dialControllerAsService(ctx, &controllers[i])
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func (j *JujuManager) FullModelStatus(ctx context.Context, user *openfga.User, m
 		return nil, err
 	}
 
-	api, err := j.dial(ctx, &model.Controller, modelTag, nil)
+	api, err := j.dialModelAsService(ctx, &model.Controller, modelTag)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -77,15 +77,37 @@ func NewJujuManager(
 	}, nil
 }
 
-// dial dials the controller and model specified by the given Controller
-// and ModelTag. If no Dialer has been configured then an error with a
-// code of CodeConnectionFailed will be returned.
-func (j *JujuManager) dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (API, error) {
+// dialController dials the controller with a controller-scoped
+// connection on behalf of the given user. Use this for operations that
+// call controller-level facades (e.g. ModelManager) with a model UUID
+// argument, or offer-related operations tied to a single offer.
+func (j *JujuManager) dialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error) {
 	if j == nil || j.Dialer == nil {
 		return nil, errors.Codef(errors.CodeConnectionFailed, "no dialer configured")
 	}
 
-	return j.Dialer.Dial(ctx, ctl, modelTag, user)
+	return j.Dialer.DialController(ctx, user, ctl, resourceTags...)
+}
+
+// dialModelAsService dials the model using JIMM's own service identity.
+// Use this for internal housekeeping that has no associated user.
+func (j *JujuManager) dialModelAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error) {
+	if j == nil || j.Dialer == nil {
+		return nil, errors.Codef(errors.CodeConnectionFailed, "no dialer configured")
+	}
+
+	return j.Dialer.DialModelAsService(ctx, ctl, modelTag)
+}
+
+// dialControllerAsService dials the controller using JIMM's own service
+// identity. Use this for internal housekeeping that has no associated
+// user.
+func (j *JujuManager) dialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (API, error) {
+	if j == nil || j.Dialer == nil {
+		return nil, errors.Codef(errors.CodeConnectionFailed, "no dialer configured")
+	}
+
+	return j.Dialer.DialControllerAsService(ctx, ctl)
 }
 
 // ResourceTag returns JIMM's controller tag stating its UUID.

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -47,7 +47,7 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 		return fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
+	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -100,7 +100,7 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 		return nil, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
+	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -188,7 +188,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 		return err
 	}
 
-	api, err := j.dialController(ctx, &incomingModel.TargetController, user)
+	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -266,7 +266,7 @@ func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, mo
 		return fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, &model.Controller, user)
+	api, err := j.dialController(ctx, user, &model.Controller)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -370,7 +370,7 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, user *openfga.User, mod
 		return time.Time{}, fmt.Errorf("failed to get model %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, &model.Controller, user)
+	api, err := j.dialController(ctx, user, &model.Controller)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -397,7 +397,7 @@ func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag
 	if err != nil {
 		return fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err)
 	}
-	api, err := j.dialController(ctx, &modelMigration.TargetController, user)
+	api, err := j.dialController(ctx, user, &modelMigration.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -531,7 +531,7 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	}
 
 	// Call the import method on the target controller to import the model.
-	api, err := j.dialController(ctx, &incomingMigration.TargetController, user)
+	api, err := j.dialController(ctx, user, &incomingMigration.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -216,7 +216,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 		return jujuclient.ModelInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &m.Controller)
 	if err != nil {
 		return jujuclient.ModelInfo{}, err
 	}
@@ -263,7 +263,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.U
 		if err := j.Database.GetModel(ctx, model); err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
-		api, err := j.dial(ctx, &model.Controller, names.ModelTag{}, user)
+		api, err := j.dialController(ctx, user, &model.Controller)
 		if err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
@@ -491,7 +491,7 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 		return base.ModelStatus{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &m.Controller)
 	if err != nil {
 		return base.ModelStatus{}, err
 	}
@@ -708,7 +708,7 @@ func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User,
 		return version.Number{}, err
 	}
 
-	api, err := j.dialController(ctx, controller, user)
+	api, err := j.dialController(ctx, user, controller)
 	if err != nil {
 		return version.Number{}, err
 	}
@@ -792,7 +792,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dial(ctx, &m.Controller, names.ModelTag{}, user)
+	api, err := j.dialController(ctx, user, &m.Controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/model_poller.go
+++ b/internal/jimm/juju/model_poller.go
@@ -23,7 +23,7 @@ func (j *JujuManager) pollModels(ctx context.Context, models []*dbmodel.Model) e
 
 	ctrl := models[0].Controller
 
-	api, err := j.dialController(ctx, &ctrl, nil)
+	api, err := j.dialControllerAsService(ctx, &ctrl)
 	if err != nil {
 		zapctx.Error(ctx, "cannot dial controller", zap.String("controller", ctrl.UUID), zap.Error(err))
 		return nil

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -44,7 +44,7 @@ func newPerControllerDialer(api juju.API) *perControllerDialer {
 	}
 }
 
-func (d *perControllerDialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelTag, _ *openfga.User) (juju.API, error) {
+func (d *perControllerDialer) DialModel(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
 	name := ctl.Name
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -57,6 +57,27 @@ func (d *perControllerDialer) Dial(_ context.Context, ctl *dbmodel.Controller, _
 			d.closed[name]++
 		},
 	}, nil
+}
+
+// DialController implements juju.Dialer. It delegates to DialModel since the
+// perControllerDialer test double does not distinguish connection scope,
+// resource tags, or user vs service identity for JWT minting.
+func (d *perControllerDialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.DialModel(ctx, user, ctl, names.ModelTag{})
+}
+
+// DialModelAsService implements juju.Dialer. It delegates to DialModel since
+// the perControllerDialer test double does not distinguish user vs service
+// identity for JWT minting.
+func (d *perControllerDialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+	return d.DialModel(ctx, nil, ctl, mt)
+}
+
+// DialControllerAsService implements juju.Dialer. It delegates to DialModel
+// since the perControllerDialer test double does not distinguish connection
+// scope or user vs service identity for JWT minting.
+func (d *perControllerDialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	return d.DialModel(ctx, nil, ctl, names.ModelTag{})
 }
 
 // openedCounts returns a snapshot of the dial counts per controller.

--- a/internal/jimm/juju/model_status_parser.go
+++ b/internal/jimm/juju/model_status_parser.go
@@ -190,7 +190,7 @@ func (f *formatterParamsRetriever) dialModel(ctx context.Context) error {
 	if !ok {
 		return errors.New("failed to parse model tag")
 	}
-	api, err := f.jujuManager.dial(ctx, &f.model.Controller, modelTag, nil)
+	api, err := f.jujuManager.dialModelAsService(ctx, &f.model.Controller, modelTag)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller for model", zap.String("controller-uuid", f.model.Controller.UUID), zap.String("model-uuid", f.model.UUID.String), zap.Error(err))
 	}

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -540,7 +540,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 		return b
 	}
 
-	api, err := b.jujuManager.dial(b.ctx, b.controller, names.ModelTag{}, b.ofgaUser)
+	api, err := b.jujuManager.dialController(b.ctx, b.ofgaUser, b.controller)
 	if err != nil {
 		b.err = err
 		return b

--- a/internal/jimm/juju/utils.go
+++ b/internal/jimm/juju/utils.go
@@ -5,10 +5,6 @@ package juju
 import (
 	"context"
 
-	"github.com/juju/names/v5"
-	"github.com/juju/zaputil"
-	"github.com/juju/zaputil/zapctx"
-
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/openfga"
@@ -58,14 +54,4 @@ func (j *JujuManager) getControllerByName(ctx context.Context, controllerName st
 		return nil, errors.Codef(errors.CodeNotFound, "controller not found")
 	}
 	return &controller, nil
-}
-
-// dialController dials a controller.
-func (j *JujuManager) dialController(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User) (API, error) {
-	api, err := j.dial(ctx, ctl, names.ModelTag{}, user)
-	if err != nil {
-		zapctx.Error(ctx, "failed to dial the controller", zaputil.Error(err))
-		return nil, err
-	}
-	return api, nil
 }

--- a/internal/jimm/juju/watcher.go
+++ b/internal/jimm/juju/watcher.go
@@ -107,7 +107,7 @@ func (w *Watcher) dialController(ctx context.Context, ctl *dbmodel.Controller) (
 	currentControllerVersion := ctl.AgentVersion
 
 	// connect to the controller
-	api, err = w.Dialer.Dial(ctx, ctl, names.ModelTag{}, nil)
+	api, err = w.Dialer.DialControllerAsService(ctx, ctl)
 	if err != nil {
 		ctl.UnavailableSince = db.Now()
 		updateController = true

--- a/internal/jimm/upgrade/mocks/dialer.go
+++ b/internal/jimm/upgrade/mocks/dialer.go
@@ -44,41 +44,163 @@ func (m *MockDialer) EXPECT() *MockDialerMockRecorder {
 	return m.recorder
 }
 
-// Dial mocks base method.
-func (m *MockDialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (juju.API, error) {
+// DialController mocks base method.
+func (m *MockDialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", ctx, ctl, modelTag, user)
+	varargs := []any{ctx, user, ctl}
+	for _, a := range resourceTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DialController", varargs...)
 	ret0, _ := ret[0].(juju.API)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Dial indicates an expected call of Dial.
-func (mr *MockDialerMockRecorder) Dial(ctx, ctl, modelTag, user any) *MockDialerDialCall {
+// DialController indicates an expected call of DialController.
+func (mr *MockDialerMockRecorder) DialController(ctx, user, ctl any, resourceTags ...any) *MockDialerDialControllerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockDialer)(nil).Dial), ctx, ctl, modelTag, user)
-	return &MockDialerDialCall{Call: call}
+	varargs := append([]any{ctx, user, ctl}, resourceTags...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialController", reflect.TypeOf((*MockDialer)(nil).DialController), varargs...)
+	return &MockDialerDialControllerCall{Call: call}
 }
 
-// MockDialerDialCall wrap *gomock.Call
-type MockDialerDialCall struct {
+// MockDialerDialControllerCall wrap *gomock.Call
+type MockDialerDialControllerCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockDialerDialCall) Return(arg0 juju.API, arg1 error) *MockDialerDialCall {
+func (c *MockDialerDialControllerCall) Return(arg0 juju.API, arg1 error) *MockDialerDialControllerCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDialerDialCall) Do(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User) (juju.API, error)) *MockDialerDialCall {
+func (c *MockDialerDialControllerCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDialerDialCall) DoAndReturn(f func(context.Context, *dbmodel.Controller, names.ModelTag, *openfga.User) (juju.API, error)) *MockDialerDialCall {
+func (c *MockDialerDialControllerCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DialControllerAsService mocks base method.
+func (m *MockDialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialControllerAsService", ctx, ctl)
+	ret0, _ := ret[0].(juju.API)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DialControllerAsService indicates an expected call of DialControllerAsService.
+func (mr *MockDialerMockRecorder) DialControllerAsService(ctx, ctl any) *MockDialerDialControllerAsServiceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialControllerAsService", reflect.TypeOf((*MockDialer)(nil).DialControllerAsService), ctx, ctl)
+	return &MockDialerDialControllerAsServiceCall{Call: call}
+}
+
+// MockDialerDialControllerAsServiceCall wrap *gomock.Call
+type MockDialerDialControllerAsServiceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDialerDialControllerAsServiceCall) Return(arg0 juju.API, arg1 error) *MockDialerDialControllerAsServiceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDialerDialControllerAsServiceCall) Do(f func(context.Context, *dbmodel.Controller) (juju.API, error)) *MockDialerDialControllerAsServiceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDialerDialControllerAsServiceCall) DoAndReturn(f func(context.Context, *dbmodel.Controller) (juju.API, error)) *MockDialerDialControllerAsServiceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DialModel mocks base method.
+func (m *MockDialer) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialModel", ctx, user, ctl, modelTag)
+	ret0, _ := ret[0].(juju.API)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DialModel indicates an expected call of DialModel.
+func (mr *MockDialerMockRecorder) DialModel(ctx, user, ctl, modelTag any) *MockDialerDialModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialModel", reflect.TypeOf((*MockDialer)(nil).DialModel), ctx, user, ctl, modelTag)
+	return &MockDialerDialModelCall{Call: call}
+}
+
+// MockDialerDialModelCall wrap *gomock.Call
+type MockDialerDialModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDialerDialModelCall) Return(arg0 juju.API, arg1 error) *MockDialerDialModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDialerDialModelCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDialerDialModelCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DialModelAsService mocks base method.
+func (m *MockDialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialModelAsService", ctx, ctl, modelTag)
+	ret0, _ := ret[0].(juju.API)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DialModelAsService indicates an expected call of DialModelAsService.
+func (mr *MockDialerMockRecorder) DialModelAsService(ctx, ctl, modelTag any) *MockDialerDialModelAsServiceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialModelAsService", reflect.TypeOf((*MockDialer)(nil).DialModelAsService), ctx, ctl, modelTag)
+	return &MockDialerDialModelAsServiceCall{Call: call}
+}
+
+// MockDialerDialModelAsServiceCall wrap *gomock.Call
+type MockDialerDialModelAsServiceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDialerDialModelAsServiceCall) Return(arg0 juju.API, arg1 error) *MockDialerDialModelAsServiceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDialerDialModelAsServiceCall) Do(f func(context.Context, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelAsServiceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDialerDialModelAsServiceCall) DoAndReturn(f func(context.Context, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelAsServiceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jimm/upgrade/upgrade.go
+++ b/internal/jimm/upgrade/upgrade.go
@@ -101,7 +101,7 @@ func (u *UpgradeManager) UpgradeModel(ctx context.Context, modelUUID string, tar
 		return errors.Codef(errors.CodeNotFound, "model not found: %w", err)
 	}
 
-	api, err := u.dialer.Dial(ctx, &model.Controller, names.ModelTag{}, nil)
+	api, err := u.dialer.DialControllerAsService(ctx, &model.Controller)
 	if err != nil {
 		return fmt.Errorf("failed to dial target controller: %w", err)
 	}

--- a/internal/jimm/upgrade/upgrade_test.go
+++ b/internal/jimm/upgrade/upgrade_test.go
@@ -429,7 +429,7 @@ func TestUpgradeModel_AlreadyAtTargetDoesNotCallUpgrade(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DialControllerAsService(gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	s.api.EXPECT().ModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, mt names.ModelTag) (jujuclient.ModelInfo, error) {
@@ -473,7 +473,7 @@ func TestUpgradeModel_RetriesUntilModelReportsTargetVersion(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DialControllerAsService(gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	modelInfoCalls := 0
@@ -531,7 +531,7 @@ func TestUpgradeModel_AlreadyUpgraded(t *testing.T) {
 	})
 
 	s.dialer.EXPECT().
-		Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DialControllerAsService(gomock.Any(), gomock.Any()).
 		Return(s.api, nil)
 
 	s.api.EXPECT().ModelInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, mt names.ModelTag) (jujuclient.ModelInfo, error) {

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	jujuparams "github.com/juju/juju/rpc/params"
-	"github.com/juju/names/v5"
 	"github.com/juju/zaputil/zapctx"
 	"go.uber.org/zap"
 
@@ -93,7 +92,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, names.ModelTag{}, user)
+	api, err := s.jimm.Dialer.DialController(ctx, user, &model.Controller)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -88,7 +88,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		return
 	}
 
-	api, err := s.jimm.Dialer.Dial(ctx, &model.Controller, model.ResourceTag(), user)
+	api, err := s.jimm.Dialer.DialModel(ctx, user, &model.Controller, model.ResourceTag())
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -87,10 +87,74 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 	}, nil
 }
 
-// Dial implements jimm.Dialer.
-func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag, user *openfga.User) (*Connection, error) {
+// DialModel implements jimm.Dialer. It creates a model-scoped
+// connection on behalf of a real user. The user must be non-nil; use
+// DialModelAsService for JIMM's own internal operations that have no
+// associated user.
+func (d *Dialer) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (*Connection, error) {
+	if user == nil {
+		return nil, errors.New("DialModel requires a non-nil user")
+	}
+	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, user)
+	if err != nil {
+		return nil, err
+	}
+	return d.dial(ctx, ctl, modelTag, user, loginRequest)
+}
 
-	conn, err := rpc.Dial(ctx, ctl, modelTag, "", nil, nil)
+// DialController implements jimm.Dialer. It creates a controller-scoped
+// connection (so controller-level facades are available) on behalf of a
+// real user. The user must be non-nil; use DialControllerAsService for
+// JIMM's own internal operations that have no associated user.
+// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
+func (d *Dialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (*Connection, error) {
+	if user == nil {
+		return nil, errors.New("DialController requires a non-nil user")
+	}
+	modelTag := names.ModelTag{}
+	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, user)
+	if err != nil {
+		return nil, err
+	}
+	return d.dial(ctx, ctl, modelTag, user, loginRequest)
+}
+
+// DialModelAsService implements jimm.Dialer. It dials the given model
+// on behalf of JIMM itself (no user), using JIMM's service identity
+// (jaas-<uuid>@external). Use this for internal housekeeping operations,
+// such as model-status polling, that are not initiated by a real user.
+func (d *Dialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (*Connection, error) {
+	return d.dialAsService(ctx, ctl, modelTag)
+}
+
+// DialControllerAsService implements jimm.Dialer. It dials the given
+// controller on behalf of JIMM itself (no user), using a
+// controller-scoped connection and JIMM's service identity
+// (jaas-<uuid>@external). Use this for internal housekeeping operations
+// such as the watcher, upgrade worker, and controller administration
+// tasks that are not initiated by a real user.
+func (d *Dialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (*Connection, error) {
+	return d.dialAsService(ctx, ctl, names.ModelTag{})
+}
+
+// dialAsService dials the given controller/model on behalf of JIMM
+// itself (no user), using JIMM's service identity.
+func (d *Dialer) dialAsService(ctx context.Context, ctl *dbmodel.Controller, modelTag names.ModelTag) (*Connection, error) {
+	user := &openfga.User{Identity: &dbmodel.Identity{Name: d.AdminUsername}}
+	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, user)
+	if err != nil {
+		return nil, err
+	}
+	return d.dial(ctx, ctl, modelTag, user, loginRequest)
+}
+
+// dial establishes a connection and logs in with the given login request.
+// The connModelTag scopes the connection (empty means controller-scoped)
+// and the user is recorded on the connection for later token minting
+// (e.g. authorization headers).
+func (d *Dialer) dial(ctx context.Context, ctl *dbmodel.Controller, connModelTag names.ModelTag, user *openfga.User, loginRequest *jujuparams.LoginRequest) (*Connection, error) {
+
+	conn, err := rpc.Dial(ctx, ctl, connModelTag, "", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -99,17 +163,6 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 	}
 
 	client := rpc.NewClient(conn)
-
-	if user == nil {
-		user = &openfga.User{Identity: &dbmodel.Identity{Name: d.AdminUsername}}
-	}
-
-	var loginRequest *jujuparams.LoginRequest
-	loginRequest, err = d.createLoginRequest(ctx, ctl, modelTag, user)
-	if err != nil {
-		client.Close()
-		return nil, err
-	}
 
 	var res jujuparams.LoginResult
 	if err := client.Call(ctx, "Admin", 3, "", "Login", loginRequest, &res); err != nil {
@@ -148,7 +201,7 @@ func (d *Dialer) Dial(ctx context.Context, ctl *dbmodel.Controller, modelTag nam
 		broken:             broken,
 		dialer:             d,
 		ctl:                ctl,
-		mt:                 modelTag,
+		mt:                 connModelTag,
 	}, nil
 }
 

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -55,8 +55,8 @@ type Dialer struct {
 	open int64
 }
 
-// Dialer implements juju.Dialer.
-func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelTag, _ *openfga.User) (juju.API, error) {
+// DialModel implements juju.Dialer.
+func (d *Dialer) DialModel(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
 	if d.Err != nil {
 		return nil, d.Err
 	}
@@ -77,6 +77,26 @@ func (d *Dialer) Dial(_ context.Context, ctl *dbmodel.Controller, _ names.ModelT
 		API:  d.API,
 		open: &d.open,
 	}, nil
+}
+
+// DialController implements juju.Dialer. The test double does not
+// distinguish connection scope or resource tags; it delegates to
+// DialModel with no model tag.
+// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
+func (d *Dialer) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.DialModel(ctx, u, ctl, names.ModelTag{})
+}
+
+// DialModelAsService implements juju.Dialer. It dials as JIMM's service identity.
+func (d *Dialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+	// Delegate to DialModel with a nil user since the Dialer test double
+	// does not distinguish user vs service identity for JWT minting.
+	return d.DialModel(ctx, nil, ctl, mt)
+}
+
+// DialControllerAsService implements juju.Dialer. It dials as JIMM's service identity.
+func (d *Dialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	return d.DialModel(ctx, nil, ctl, names.ModelTag{})
 }
 
 // IsClosed returns true if all opened connections have been closed.
@@ -100,10 +120,35 @@ func (w apiWrapper) Close() error {
 // it is designed such that should you need to query multiple models, you can.
 type ModelDialerMap map[string]juju.Dialer
 
-// Dial implements juju.Dialer.
-func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, u *openfga.User) (juju.API, error) {
+// DialModel implements juju.Dialer.
+func (m ModelDialerMap) DialModel(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
 	if d, ok := m[mt.Id()]; ok {
-		return d.Dial(ctx, ctl, mt, u)
+		return d.DialModel(ctx, u, ctl, mt)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialController implements juju.Dialer.
+// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
+func (m ModelDialerMap) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	if d, ok := m[""]; ok {
+		return d.DialController(ctx, u, ctl, resourceTags...)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialModelAsService implements juju.Dialer.
+func (m ModelDialerMap) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+	if d, ok := m[mt.Id()]; ok {
+		return d.DialModelAsService(ctx, ctl, mt)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialControllerAsService implements juju.Dialer.
+func (m ModelDialerMap) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	for _, d := range m {
+		return d.DialControllerAsService(ctx, ctl)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
@@ -112,10 +157,34 @@ func (m ModelDialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt na
 // each controller. The DialerMap is keyed by controller name.
 type DialerMap map[string]juju.Dialer
 
-// Dial implements juju.Dialer.
-func (m DialerMap) Dial(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag, u *openfga.User) (juju.API, error) {
+// DialModel implements juju.Dialer.
+func (m DialerMap) DialModel(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
 	if d, ok := m[ctl.Name]; ok {
-		return d.Dial(ctx, ctl, mt, u)
+		return d.DialModel(ctx, u, ctl, mt)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialController implements juju.Dialer.
+func (m DialerMap) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	if d, ok := m[ctl.Name]; ok {
+		return d.DialController(ctx, u, ctl, resourceTags...)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialModelAsService implements juju.Dialer.
+func (m DialerMap) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+	if d, ok := m[ctl.Name]; ok {
+		return d.DialModelAsService(ctx, ctl, mt)
+	}
+	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
+}
+
+// DialControllerAsService implements juju.Dialer.
+func (m DialerMap) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
+	if d, ok := m[ctl.Name]; ok {
+		return d.DialControllerAsService(ctx, ctl)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }

--- a/testing/dial_test.go
+++ b/testing/dial_test.go
@@ -31,7 +31,7 @@ func TestDial(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil)
+	api, err := s.JIMM.Dialer.DialControllerAsService(context.Background(), &ctl)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -69,7 +69,7 @@ func TestDialWithJWT(t *testing.T) {
 	}
 
 	// Check dial is OK
-	api, err := dialer.Dial(ctx, &ctl, names.ModelTag{}, nil)
+	api, err := dialer.DialControllerAsService(ctx, &ctl)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -98,7 +98,7 @@ func TestDialModelStatusMissingModel(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, names.ModelTag{}, nil)
+	api, err := s.JIMM.Dialer.DialControllerAsService(context.Background(), &ctl)
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 
@@ -125,7 +125,7 @@ func TestConnectStreams(t *testing.T) {
 		TLSHostname:   "juju-apiserver",
 	}
 
-	api, err := s.JIMM.Dialer.Dial(context.Background(), &ctl, model.ResourceTag(), nil)
+	api, err := s.JIMM.Dialer.DialModelAsService(context.Background(), &ctl, model.ResourceTag())
 	c.Assert(err, qt.Equals, nil)
 	defer api.Close()
 


### PR DESCRIPTION
## Description
Split the current `Dialer.Dial` into 4 methods, one for each separate purpose.

This is done for increased clarity and in preparation for https://github.com/canonical/jimm/pull/2080. The TODOs about `resourceTag` will be removed in this follow-up.

## Engineering checklist

- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
