### PR TITLE
feat: ssh tunnel over http upgrade

### DIFF
--- a/internal/jimm/jujuauth/sshtokens.go
+++ b/internal/jimm/jujuauth/sshtokens.go
@@ -4,16 +4,11 @@ package jujuauth
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/names/v6"
 
 	"github.com/canonical/jimm/v3/internal/jimmjwx"
-)
-
-const (
-	sshPublicKeyClaim = "ssh_public_key"
 )
 
 // SSHTokenGenerator provides the ability to generate JWT tokens that
@@ -35,7 +30,6 @@ type SSHTokenArgs struct {
 	User           string
 	ControllerUUID string
 	ModelTag       names.Tag
-	PublicKey      []byte
 }
 
 // NewSSHToken generates a JWT token with the correct claims
@@ -48,9 +42,6 @@ func (s *SSHTokenGenerator) NewSSHToken(ctx context.Context, tokenArgs SSHTokenA
 		User:       tokenArgs.User,
 		Access: map[string]string{
 			tokenArgs.ModelTag.String(): string(permission.AdminAccess),
-		},
-		ExtraClaims: map[string]any{
-			sshPublicKeyClaim: base64.StdEncoding.EncodeToString(tokenArgs.PublicKey),
 		},
 	})
 	if err != nil {

--- a/internal/jimm/jujuauth/sshtokens_test.go
+++ b/internal/jimm/jujuauth/sshtokens_test.go
@@ -24,7 +24,6 @@ func TestNewSSHToken(t *testing.T) {
 		User:           "testuser",
 		ControllerUUID: "123",
 		ModelTag:       names.NewModelTag("testmodel"),
-		PublicKey:      []byte("testkey"),
 	}
 	sshToken, err := sshTokenGen.NewSSHToken(context.Background(), params)
 	c.Assert(err, qt.IsNil)
@@ -32,9 +31,7 @@ func TestNewSSHToken(t *testing.T) {
 
 	c.Assert(jwtSvc.params.User, qt.Equals, "testuser")
 	c.Assert(jwtSvc.params.Controller, qt.Equals, "123")
-	c.Assert(jwtSvc.params.ExtraClaims, qt.DeepEquals, map[string]any{
-		"ssh_public_key": "dGVzdGtleQ==", // base64.StdEncoding.EncodeToString([]byte("testkey"))
-	})
+	c.Assert(jwtSvc.params.ExtraClaims, qt.IsNil)
 	c.Assert(jwtSvc.params.Access, qt.DeepEquals, map[string]string{
 		"model-testmodel": string(permission.AdminAccess),
 	})

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -3,17 +3,21 @@
 package ssh
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	goerr "errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gliderlabs/ssh"
-	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/zaputil/zapctx"
-	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
 	"github.com/canonical/jimm/v3/internal/errors"
@@ -22,16 +26,28 @@ import (
 	"github.com/canonical/jimm/v3/internal/rpc"
 )
 
-// DialInfo is the struct holding the infomation
-// to dial a controller via SSH.
+// relayUpgradeToken is the custom HTTP upgrade token the controller's
+// relay endpoint requires. A bare "ssh" token is not used because
+// authentication already happened at the HTTP layer and any SSH client
+// could otherwise negotiate the upgrade.
+const relayUpgradeToken = "juju-ssh-relay"
+
+// relayDialTimeout bounds each attempt to dial a controller's relay
+// endpoint.
+const relayDialTimeout = 5 * time.Second
+
+// DialInfo is the struct holding the information
+// to dial a controller's SSH relay endpoint.
 type DialInfo struct {
-	// addresses to dial the controller
+	// Addresses to dial the controller's API server, each as host:port.
 	Addresses []string
 
-	// Port to establish the SSH connection
-	Port int
+	// TLSConfig authenticates the controller. It must pin ALPN to
+	// http/1.1: HTTP/2 disallows the upgrade mechanism.
+	TLSConfig *tls.Config
 
-	// JWT to authenticate to the controller
+	// JWT is the base64-encoded bearer token authenticating JIMM to the
+	// controller.
 	JWT string
 }
 
@@ -43,7 +59,6 @@ type IdentityManager interface {
 // JujuManager provides a means to fetch a model from the model service.
 type JujuManager interface {
 	GetModel(ctx context.Context, uuid string) (dbmodel.Model, error)
-	ControllerConfig(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error)
 }
 
 // SSHKeyManager provides a means to manage ssh keys within JIMM.
@@ -51,17 +66,77 @@ type SSHKeyManager interface {
 	VerifyPublicKey(ctx context.Context, claimUser string, publicKey []byte) (bool, error)
 }
 
-// SSHDialer provides a means to establish an SSH connection.
+// SSHDialer provides a means to establish an upgraded connection to a
+// controller's SSH relay endpoint.
 type SSHDialer interface {
-	Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error)
+	// DialRelay dials the controller at addr (host:port of its API server)
+	// and performs the HTTP upgrade handshake for the given virtual
+	// hostname, returning the raw upgraded connection that carries the
+	// user's SSH session bytes.
+	DialRelay(ctx context.Context, addr string, tlsConfig *tls.Config, virtualHostname, bearerToken string) (net.Conn, error)
 }
 
-// BasicDialer is a wrapper around the default Go x/crypto/ssh
-// dialer for cases where no changes are needed.
+// BasicDialer is a wrapper around the default TLS dialer for cases where
+// no changes are needed.
 type BasicDialer struct{}
 
-func (d *BasicDialer) Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error) {
-	return gossh.Dial(network, addr, config)
+// DialRelay implements SSHDialer. It dials the controller's API server
+// over TLS, sends the upgrade request, and returns the raw connection
+// after a 101 Switching Protocols response.
+func (d *BasicDialer) DialRelay(ctx context.Context, addr string, tlsConfig *tls.Config, virtualHostname, bearerToken string) (net.Conn, error) {
+	// ALPN must be pinned to http/1.1: HTTP/2 disallows the upgrade
+	// mechanism and Hijack returns ErrNotSupported on an h2 connection.
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	tlsConfig.NextProtos = []string{"http/1.1"}
+
+	dialer := &tls.Dialer{
+		Config: tlsConfig,
+		NetDialer: &net.Dialer{
+			Timeout: relayDialTimeout,
+		},
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("dialing controller %s: %w", addr, err)
+	}
+
+	target := &url.URL{
+		Scheme: "https",
+		Host:   addr,
+		Path:  "/ssh-relay/" + virtualHostname,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("building relay upgrade request: %w", err)
+	}
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", relayUpgradeToken)
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+
+	if err := req.Write(conn); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("writing relay upgrade request: %w", err)
+	}
+	// Read the response head with a bounded reader; the connection is
+	// handed over raw afterwards so no buffered bytes may be lost.
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("reading relay upgrade response: %w", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		_ = conn.Close()
+		return nil, fmt.Errorf("relay upgrade rejected: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	_ = resp.Body.Close()
+	return conn, nil
 }
 
 // SSHManagerParams contains the dependencies
@@ -133,8 +208,8 @@ func (s *SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 
 // DialInfo resolves the address of the controller to contact given the
 // model UUID and returns a struct with parameters to connect and authenticate
-// to the controller. The context should contain the public key the user
-// used to authenticate.
+// to the controller's SSH relay endpoint. The context should contain the
+// public key the user used to authenticate.
 func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (DialInfo, error) {
 	zapctx.Info(ctx, "SSHDialInfo")
 	model, err := s.jujuManager.GetModel(ctx, modelUUID)
@@ -142,26 +217,9 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 		return DialInfo{}, fmt.Errorf("cannot find model: %v", err)
 	}
 
-	controllerConfig, err := s.jujuManager.ControllerConfig(ctx, user, model.Controller.Name)
-	if err != nil {
-		return DialInfo{}, fmt.Errorf("cannot get controller config: %w", err)
-	}
-
-	addrs, _ := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
+	addrs, tlsConfig := rpc.GetAddressesAndTLSConfig(ctx, &model.Controller)
 	if len(addrs) == 0 {
-		return DialInfo{}, fmt.Errorf("cannot find addresses for model's controller: %v", err)
-	}
-
-	addrsNoPort := make([]string, len(addrs))
-	for i, addr := range addrs {
-		hostNoPort, _, err := net.SplitHostPort(addr)
-		// If there was an error we will assume there is no port since
-		// SplitHostPort doesn't expose const error types for checking.
-		if err != nil {
-			addrsNoPort[i] = addr
-		} else {
-			addrsNoPort[i] = hostNoPort
-		}
+		return DialInfo{}, errors.New("cannot find addresses for model's controller")
 	}
 
 	publicKey, _ := ctx.Value(ssh.ContextKeyPublicKey).(ssh.PublicKey)
@@ -182,41 +240,33 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 	}
 
 	return DialInfo{
-		Addresses: addrsNoPort,
-		Port:      controllerConfig.SSHServerPort(),
-		JWT:       base64.StdEncoding.EncodeToString(token),
+		Addresses: addrs,
+		TLSConfig: tlsConfig,
+		JWT:      base64.StdEncoding.EncodeToString(token),
 	}, nil
 }
 
-// DialController dials a controller's SSH
-// server and returns an SSH connection.
-func (s *SSHManager) DialController(ctx context.Context, dialInfo DialInfo, user *openfga.User) (*gossh.Client, error) {
-	var client *gossh.Client
+// DialController dials a controller's SSH relay endpoint over an HTTP
+// upgrade connection and returns the raw connection carrying the user's
+// relayed SSH session bytes. The virtual hostname identifies the
+// destination within the controller.
+func (s *SSHManager) DialController(ctx context.Context, dialInfo DialInfo, virtualHostname string) (net.Conn, error) {
+	var conn net.Conn
 	var err error
 	var errs []error
 
 	for _, addr := range dialInfo.Addresses {
-		dest := net.JoinHostPort(addr, fmt.Sprint(dialInfo.Port))
-		client, err = s.dialer.Dial("tcp", dest, &gossh.ClientConfig{
-			User: "external-auth",
-			//nolint:gosec // this will be removed once we handle hostkeys
-			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
-			Auth: []gossh.AuthMethod{
-				gossh.PasswordCallback(func() (secret string, err error) {
-					return dialInfo.JWT, nil
-				}),
-			},
-			Timeout: 5 * time.Second,
-		})
+		conn, err = s.dialer.DialRelay(ctx, addr, dialInfo.TLSConfig, virtualHostname, dialInfo.JWT)
 		if err != nil {
+			conn = nil
 			errs = append(errs, err)
 		} else {
 			break
 		}
 	}
 
-	if client == nil {
+	if conn == nil {
 		return nil, fmt.Errorf("failed to dial controller: %v", goerr.Join(errs...))
 	}
-	return client, nil
+	return conn, nil
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -268,7 +268,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 	}
 
 	tokenArgs := jujuauth.SSHTokenArgs{
-		User:           user.Name,
+		User:           user.Tag().String(),
 		ControllerUUID: model.Controller.UUID,
 		ModelTag:       model.Tag(),
 		PublicKey:      publicKey.Marshal(),

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -169,6 +169,16 @@ func (c *prefixConn) Read(p []byte) (int, error) {
 	return c.Conn.Read(p)
 }
 
+// CloseWrite delegates to the underlying connection if it supports
+// half-close, so the relay pipe can signal EOF per direction through
+// the wrapper.
+func (c *prefixConn) CloseWrite() error {
+	if hc, ok := c.Conn.(interface{ CloseWrite() error }); ok {
+		return hc.CloseWrite()
+	}
+	return nil
+}
+
 // SSHManagerParams contains the dependencies
 // needed to create the SSHManager service.
 type SSHManagerParams struct {

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/zaputil/zapctx"
 
 	"github.com/canonical/jimm/v3/internal/dbmodel"
@@ -248,8 +247,7 @@ func (s *SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key
 
 // DialInfo resolves the address of the controller to contact given the
 // model UUID and returns a struct with parameters to connect and authenticate
-// to the controller's SSH relay endpoint. The context should contain the
-// public key the user used to authenticate.
+// to the controller's SSH relay endpoint.
 func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (DialInfo, error) {
 	zapctx.Info(ctx, "SSHDialInfo")
 	model, err := s.jujuManager.GetModel(ctx, modelUUID)
@@ -262,16 +260,10 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 		return DialInfo{}, errors.New("cannot find addresses for model's controller")
 	}
 
-	publicKey, _ := ctx.Value(ssh.ContextKeyPublicKey).(ssh.PublicKey)
-	if publicKey == nil {
-		return DialInfo{}, errors.New("cannot find user's public key")
-	}
-
 	tokenArgs := jujuauth.SSHTokenArgs{
 		User:           user.Tag().String(),
 		ControllerUUID: model.Controller.UUID,
 		ModelTag:       model.Tag(),
-		PublicKey:      publicKey.Marshal(),
 	}
 	jwtGenerator := s.jwtFactory.NewSSHGenerator()
 	token, err := jwtGenerator.NewSSHToken(ctx, tokenArgs)

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -291,22 +291,15 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 // relayed SSH session bytes. The virtual hostname identifies the
 // destination within the controller.
 func (s *SSHManager) DialController(ctx context.Context, dialInfo DialInfo, virtualHostname string) (net.Conn, error) {
-	var conn net.Conn
-	var err error
 	var errs []error
 
 	for _, addr := range dialInfo.Addresses {
-		conn, err = s.dialer.DialRelay(ctx, addr, dialInfo.TLSConfig, virtualHostname, dialInfo.JWT)
-		if err != nil {
-			conn = nil
-			errs = append(errs, err)
-		} else {
-			break
+		conn, err := s.dialer.DialRelay(ctx, addr, dialInfo.TLSConfig, virtualHostname, dialInfo.JWT)
+		if err == nil {
+			return conn, nil
 		}
+		errs = append(errs, err)
 	}
 
-	if conn == nil {
-		return nil, fmt.Errorf("failed to dial controller: %v", goerr.Join(errs...))
-	}
-	return conn, nil
+	return nil, fmt.Errorf("failed to dial controller: %v", goerr.Join(errs...))
 }

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -107,7 +107,7 @@ func (d *BasicDialer) DialRelay(ctx context.Context, addr string, tlsConfig *tls
 	target := &url.URL{
 		Scheme: "https",
 		Host:   addr,
-		Path:  "/ssh-relay/" + virtualHostname,
+		Path:   "/ssh-relay/" + virtualHostname,
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openf
 	return DialInfo{
 		Addresses: addrs,
 		TLSConfig: tlsConfig,
-		JWT:      base64.StdEncoding.EncodeToString(token),
+		JWT:       base64.StdEncoding.EncodeToString(token),
 	}, nil
 }
 

--- a/internal/jimm/ssh/ssh.go
+++ b/internal/jimm/ssh/ssh.go
@@ -122,9 +122,11 @@ func (d *BasicDialer) DialRelay(ctx context.Context, addr string, tlsConfig *tls
 		_ = conn.Close()
 		return nil, fmt.Errorf("writing relay upgrade request: %w", err)
 	}
-	// Read the response head with a bounded reader; the connection is
-	// handed over raw afterwards so no buffered bytes may be lost.
-	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	// Read the response head with a bounded reader. The connection is
+	// handed over raw afterwards, so any bytes the reader buffered past
+	// the response head must be preserved.
+	reader := bufio.NewReaderSize(conn, 4096)
+	resp, err := http.ReadResponse(reader, req)
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("reading relay upgrade response: %w", err)
@@ -136,7 +138,35 @@ func (d *BasicDialer) DialRelay(ctx context.Context, addr string, tlsConfig *tls
 		return nil, fmt.Errorf("relay upgrade rejected: %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	_ = resp.Body.Close()
+	// If the reader buffered bytes past the response head (e.g. the
+	// controller's SSH banner), prepend them to the returned connection.
+	if buffered := reader.Buffered(); buffered > 0 {
+		prefix, err := reader.Peek(buffered)
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("reading buffered bytes: %w", err)
+		}
+		return &prefixConn{Conn: conn, prefix: append([]byte(nil), prefix...)}, nil
+	}
 	return conn, nil
+}
+
+// prefixConn wraps a net.Conn, serving a prefix of already-read bytes
+// before reading from the underlying connection. This preserves bytes
+// a bufio.Reader consumed past an HTTP response head.
+type prefixConn struct {
+	net.Conn
+	prefix []byte
+}
+
+// Read first drains the prefix, then reads from the underlying connection.
+func (c *prefixConn) Read(p []byte) (int, error) {
+	if len(c.prefix) > 0 {
+		n := copy(p, c.prefix)
+		c.prefix = c.prefix[n:]
+		return n, nil
+	}
+	return c.Conn.Read(p)
 }
 
 // SSHManagerParams contains the dependencies

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -6,16 +6,17 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"database/sql"
 	"encoding/base64"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
 	gliderssh "github.com/gliderlabs/ssh"
-	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/names/v6"
 	gossh "golang.org/x/crypto/ssh"
 
@@ -110,21 +111,8 @@ func (s *sshManagerSuite) Init(c *qt.C) {
 			return m, err
 		},
 	}
-	attrs := map[string]any{
-		"ssh-server-port": "17023",
-	}
-	certPEM, _, err := jimmtest.GenerateTestCACert()
-	c.Assert(err, qt.IsNil)
-	cfg, err := jujucontroller.NewConfig(uuid, certPEM, attrs)
-	c.Assert(err, qt.IsNil)
-	controllerService := mocks.ControllerService{
-		ControllerConfig_: func(ctx context.Context, user *openfga.User, controllerName string) (jujucontroller.Config, error) {
-			return cfg, nil
-		},
-	}
 	jujuManager := mocks.JujuManager{
-		ModelManager:      modelManager,
-		ControllerService: controllerService,
+		ModelManager: modelManager,
 	}
 	permissionManager, err := permissions.NewManager(s.database, ofgaClient, uuid, jimmTag)
 	c.Assert(err, qt.IsNil)
@@ -205,9 +193,8 @@ func (s *sshManagerSuite) TestDialInfo(c *qt.C) {
 	connInfo, err := s.sshManager.DialInfo(ctx, s.allowedModelUUID, s.userWithAccess)
 	c.Assert(err, qt.IsNil)
 	c.Assert(connInfo.Addresses, qt.HasLen, 1)
-	c.Assert(connInfo.Addresses[0], qt.Equals, "localhost")
+	c.Assert(connInfo.Addresses[0], qt.Equals, "localhost:1234")
 	c.Assert(connInfo.JWT, qt.Not(qt.HasLen), 0)
-	c.Assert(connInfo.Port, qt.Equals, 17023)
 	_, err = base64.StdEncoding.DecodeString(connInfo.JWT)
 	c.Assert(err, qt.IsNil)
 
@@ -221,10 +208,10 @@ type mockDialer struct {
 	callCount    int
 }
 
-func (d *mockDialer) Dial(network string, addr string, config *gossh.ClientConfig) (*gossh.Client, error) {
+func (d *mockDialer) DialRelay(ctx context.Context, addr string, tlsConfig *tls.Config, virtualHostname, bearerToken string) (net.Conn, error) {
 	d.callCount++
 	if addr == d.validAddress {
-		return &gossh.Client{}, nil
+		return &net.TCPConn{}, nil
 	}
 	return nil, errors.New("dial error")
 }
@@ -233,18 +220,17 @@ func (s *sshManagerSuite) TestDialAllAddresses(c *qt.C) {
 	ctx := context.Background()
 
 	dialInfo := ssh.DialInfo{
-		Addresses: []string{"10.1.2.3", "10.1.2.4"},
-		Port:      1234,
+		Addresses: []string{"10.1.2.3:17070", "10.1.2.4:17070"},
 		JWT:       "fake-jwt",
 	}
 
-	_, err := s.sshManager.DialController(ctx, dialInfo, s.userWithAccess)
+	_, err := s.sshManager.DialController(ctx, dialInfo, "1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local")
 	c.Assert(err, qt.ErrorMatches, "failed to dial controller: dial error\ndial error")
 	c.Assert(s.mockDialer.callCount, qt.Equals, 2)
 
-	s.mockDialer.validAddress = "10.1.2.4:1234"
+	s.mockDialer.validAddress = "10.1.2.4:17070"
 	// Test that DialController works when there are multiple addresses.
-	_, err = s.sshManager.DialController(ctx, dialInfo, s.userWithAccess)
+	_, err = s.sshManager.DialController(ctx, dialInfo, "1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local")
 	c.Assert(err, qt.IsNil)
 	c.Assert(s.mockDialer.callCount, qt.Equals, 4)
 }

--- a/internal/jimm/ssh/ssh_test.go
+++ b/internal/jimm/ssh/ssh_test.go
@@ -16,7 +16,6 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
-	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/juju/names/v6"
 	gossh "golang.org/x/crypto/ssh"
 
@@ -182,12 +181,6 @@ func (s *sshManagerSuite) TestDialInfo(c *qt.C) {
 	err := s.database.GetController(ctx, &ctrl)
 	c.Assert(err, qt.IsNil)
 	c.Assert(ctrl.PublicAddress, qt.Equals, "localhost:1234")
-
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	c.Assert(err, qt.IsNil)
-	pubKey, err := gossh.NewPublicKey(&key.PublicKey)
-	c.Assert(err, qt.IsNil)
-	ctx = context.WithValue(ctx, gliderssh.ContextKeyPublicKey, pubKey)
 
 	// Test that the DialInfo returns the correct controller address and user when the model UUID is valid.
 	connInfo, err := s.sshManager.DialInfo(ctx, s.allowedModelUUID, s.userWithAccess)

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -38,8 +38,10 @@ type SSHManager interface {
 	// returns a struct with parameters to connect and authenticate to the controller.
 	DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (jimmssh.DialInfo, error)
 
-	// DialController dials a controller's SSH server using the provided info.
-	DialController(ctx context.Context, dialInfo jimmssh.DialInfo, user *openfga.User) (*gossh.Client, error)
+	// DialController dials a controller's SSH relay endpoint using the
+	// provided info and virtual hostname, returning the raw upgraded
+	// connection.
+	DialController(ctx context.Context, dialInfo jimmssh.DialInfo, virtualHostname string) (net.Conn, error)
 }
 
 // forwardMessage is the struct holding the information about the jump message received by the ssh client.
@@ -160,18 +162,14 @@ func directTCPIPHandler(sshManager SSHManager) func(srv *ssh.Server, conn *gossh
 			return
 		}
 
-		client, err := sshManager.DialController(ctx, dialInfo, user)
+		// The virtual hostname identifies the destination within the
+		// controller; the relay upgrade request carries it in its URL path.
+		controllerConn, err := sshManager.DialController(ctx, dialInfo, d.DestAddr)
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to dial controller", err)
 			return
 		}
 
-		// The port below is arbitrary as the controller ignores it.
-		controllerConn, err := client.Dial("tcp", fmt.Sprintf("%s:22", d.DestAddr))
-		if err != nil {
-			rejectConnectionAndLogError(ctx, newChan, "failed to create tunnel to controller", err)
-			return
-		}
 		clientConn, reqs, err := newChan.Accept()
 		if err != nil {
 			rejectConnectionAndLogError(ctx, newChan, "failed to accept channel creation request", err)

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -3,12 +3,14 @@
 package ssh_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -73,27 +75,22 @@ func (s *sshSuite) Init(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	userWithoutAccess := openfga.NewUser(i2, ofgaClient)
 
-	// setup destination server
+	// setup destination server. This simulates the controller's embedded
+	// terminating SSH server: the jump server relays the user's session
+	// bytes to it over the upgraded relay connection.
 	s.received = make(chan bool)
 	destinationServerListener := bufconn.Listen(1 * 1024)
 
 	s.destinationJujuSSHServer = &gliderssh.Server{
-		ChannelHandlers: map[string]gliderssh.ChannelHandler{
-			"direct-tcpip": func(srv *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
-				d := ssh.ForwardMessage{}
-				if err := gossh.Unmarshal(newChan.ExtraData(), &d); err != nil {
-					err := newChan.Reject(gossh.ConnectionFailed, "Failed to parse channel data")
-					c.Check(err, qt.IsNil)
-					return
-				}
-				_, _, err := newChan.Accept()
-				c.Check(err, qt.IsNil)
-				s.testInDestinationServerF(d)
-				s.received <- true
-			},
+		// The destination server terminates the user's SSH session relayed
+		// by the jump server over the upgraded connection.
+		PublicKeyHandler: func(ctx gliderssh.Context, key gliderssh.PublicKey) bool {
+			return true
 		},
-		PasswordHandler: func(ctx gliderssh.Context, password string) bool {
-			return password == "valid-jwt"
+		Handler: func(sess gliderssh.Session) {
+			_, _ = sess.Write([]byte("session established\n"))
+			_ = sess.Exit(0)
+			s.received <- true
 		},
 	}
 	go func() {
@@ -133,24 +130,11 @@ func (s *sshSuite) Init(c *qt.C) {
 				}
 				return jimmssh.DialInfo{}, nil
 			},
-			DialController_: func(ctx context.Context, ctrlInfo jimmssh.DialInfo, user *openfga.User) (*gossh.Client, error) {
-				conn, err := destinationServerListener.Dial()
-				if err != nil {
-					return nil, err
-				}
-				sshConn, newChan, reqs, err := gossh.NewClientConn(conn, "", &gossh.ClientConfig{
-					//nolint:gosec
-					HostKeyCallback: gossh.InsecureIgnoreHostKey(),
-					Auth: []gossh.AuthMethod{
-						gossh.Password("valid-jwt"),
-					},
-					User: user.Name,
-				})
-				if err != nil {
-					return nil, err
-				}
-
-				return gossh.NewClient(sshConn, newChan, reqs), nil
+			DialController_: func(ctx context.Context, ctrlInfo jimmssh.DialInfo, virtualHostname string) (net.Conn, error) {
+				// Simulate the upgraded relay connection: a raw pipe to the
+				// destination server. The user's SSH session bytes are relayed
+				// over it and terminated by the destination server.
+				return destinationServerListener.Dial()
 			},
 		})
 	c.Assert(err, qt.IsNil)
@@ -192,13 +176,36 @@ func (s *sshSuite) TestSSHJump(c *qt.C) {
 	})
 	defer client.Close()
 
-	// send forward message
-	s.testInDestinationServerF = func(fm ssh.ForwardMessage) {
-		c.Check(fm.DestAddr, qt.Equals, s.virtualHostname.String())
-	}
-	conn, err := client.Dial("tcp", fmt.Sprintf("%s:22", s.virtualHostname))
+	// Open a tunnel to the virtual hostname, then establish the
+	// terminating SSH session over it. The session bytes are relayed by
+	// the jump server over the upgraded connection and terminated by the
+	// destination server.
+	tunnel, err := client.Dial("tcp", fmt.Sprintf("%s:22", s.virtualHostname))
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer tunnel.Close()
+
+	sshConn, newChan, reqs, err := gossh.NewClientConn(tunnel, "", &gossh.ClientConfig{
+		//nolint:gosec // test host key
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Auth: []gossh.AuthMethod{
+			gossh.PublicKeys(s.privateKey),
+		},
+		User: "alice",
+	})
+	c.Assert(err, qt.IsNil)
+	terminatingClient := gossh.NewClient(sshConn, newChan, reqs)
+	defer terminatingClient.Close()
+
+	session, err := terminatingClient.NewSession()
+	c.Assert(err, qt.IsNil)
+	defer session.Close()
+
+	var output bytes.Buffer
+	session.Stdout = &output
+	err = session.Run("")
+	c.Assert(err, qt.IsNil)
+	c.Check(output.String(), qt.Equals, "session established\n")
+
 	select {
 	case <-s.received:
 	case <-time.After(100 * time.Millisecond):

--- a/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
+++ b/internal/testutils/jimmtest/mocks/jimm_ssh_mock.go
@@ -4,8 +4,7 @@ package mocks
 
 import (
 	"context"
-
-	gossh "golang.org/x/crypto/ssh"
+	"net"
 
 	"github.com/canonical/jimm/v3/internal/errors"
 	"github.com/canonical/jimm/v3/internal/jimm/ssh"
@@ -15,7 +14,7 @@ import (
 // SSHManager is an implementation of the SshManager interface.
 type SSHManager struct {
 	PublicKeyHandler_ func(ctx context.Context, claimUser string, key []byte) (*openfga.User, error)
-	DialController_   func(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error)
+	DialController_   func(ctx context.Context, ctrlInfo ssh.DialInfo, virtualHostname string) (net.Conn, error)
 	DialInfo_         func(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error)
 }
 
@@ -26,11 +25,11 @@ func (j SSHManager) PublicKeyHandler(ctx context.Context, claimUser string, key 
 	return j.PublicKeyHandler_(ctx, claimUser, key)
 }
 
-func (j SSHManager) DialController(ctx context.Context, ctrlInfo ssh.DialInfo, user *openfga.User) (*gossh.Client, error) {
+func (j SSHManager) DialController(ctx context.Context, ctrlInfo ssh.DialInfo, virtualHostname string) (net.Conn, error) {
 	if j.DialController_ == nil {
 		return nil, errors.New("not implemented")
 	}
-	return j.DialController_(ctx, ctrlInfo, user)
+	return j.DialController_(ctx, ctrlInfo, virtualHostname)
 }
 
 func (j SSHManager) DialInfo(ctx context.Context, modelUUID string, user *openfga.User) (ssh.DialInfo, error) {


### PR DESCRIPTION
# Description

Replaces the SSH-plus-JWT-password dial to the controller with an HTTP upgrade request to `GET /ssh-relay/:virtualHostname`. JIMM authenticates with a bearer JWT. The controller hijacks the connection after `101` and terminates the user's SSH session in an embedded server. JIMM blind-relays the bytes and holds no key.

## Key changes

- `internal/jimm/ssh`: `DialController` performs an HTTPS upgrade with a bearer JWT and returns the raw `net.Conn`. `BasicDialer.DialRelay` dials the controller's API port over TLS (replacing `InsecureIgnoreHostKey`). `DialInfo` drops `Port`, gains `TLSConfig`. `prefixConn` preserves buffered bytes past the 101 and forwards `CloseWrite`.
- `internal/ssh`: `DialController` takes a virtual hostname instead of a user and returns `net.Conn` instead of `*gossh.Client`. `directTCPIPHandler` passes the hostname through to the relay request.

## Checklist

- [x] Code style
- [x] Comments saying why
- [x] Go unit tests
- ~Integration tests~
- ~doc.go~

## QA steps

TODO

### Bootstrap

```
make dev-env
juju unregister jimm-dev
juju login jimm.localhost -c jimm-dev
./local/jimm/setup-controller.sh
./local/jimm/add-controller.sh
```

### JIMM relay

```
juju add-model test
juju deploy ubuntu
juju add-unit ubuntu -n 1
juju add-ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
juju ssh 0
juju scp ./foo.txt <machine>:/tmp/foo.txt
juju ssh <machine> cat /tmp/foo.txt
```

## Links

Requires https://github.com/juju/juju/pull/23228