### PR TITLE
refactor: rename dial methods

### DIFF
--- a/internal/jimm/jimm.go
+++ b/internal/jimm/jimm.go
@@ -370,18 +370,18 @@ func NewDialerAdapter(dialer *jujuclient.Dialer) *DialerAdapter {
 	}
 }
 
-// DialModel implements the juju.Dialer interface for the DialerAdapter.
+// DialModelAsSuperuser implements the juju.Dialer interface for the DialerAdapter.
 // It uses the underlying jujuclient.Dialer to establish a model-scoped
 // connection to the Juju controller and returns a juju.API connection.
-func (d *DialerAdapter) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
-	return d.dialer.DialModel(ctx, user, ctl, modelTag)
+func (d *DialerAdapter) DialModelAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	return d.dialer.DialModelAsSuperuser(ctx, user, ctl, modelTag)
 }
 
-// DialController implements the juju.Dialer interface for the DialerAdapter.
+// DialControllerAsSuperuser implements the juju.Dialer interface for the DialerAdapter.
 // It dials the controller with a controller-scoped connection on behalf
-// of the given user.
-func (d *DialerAdapter) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
-	return d.dialer.DialController(ctx, user, ctl, resourceTags...)
+// of the given user, forcing superuser permissions.
+func (d *DialerAdapter) DialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.dialer.DialControllerAsSuperuser(ctx, user, ctl, resourceTags...)
 }
 
 // DialModelAsService implements the juju.Dialer interface for the

--- a/internal/jimm/juju/applicationoffer.go
+++ b/internal/jimm/juju/applicationoffer.go
@@ -76,7 +76,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 	if err == nil {
 		// The offer exists in JIMM's database, check against the Juju controller
 		// It's possible for an offer record in JIMM to dangle
-		checkAPI, dialErr := j.dialController(ctx, user, &model.Controller)
+		checkAPI, dialErr := j.dialControllerAsSuperuser(ctx, user, &model.Controller)
 		if dialErr != nil {
 			return dialErr
 		}
@@ -100,7 +100,7 @@ func (j *JujuManager) Offer(ctx context.Context, user *openfga.User, offer AddAp
 		return err
 	}
 
-	api, err := j.dialController(ctx, user, &model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &model.Controller)
 	if err != nil {
 		return err
 	}
@@ -227,7 +227,7 @@ func (j *JujuManager) GetApplicationOfferConsumeDetails(ctx context.Context, use
 		return errors.Codef(errors.CodeNotFound, "not found")
 	}
 
-	api, err := j.dialController(ctx, user, &offer.Model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (j *JujuManager) GetApplicationOffer(ctx context.Context, user *openfga.Use
 	// controller. The all-watcher events do not include enough
 	// information to reasonably keep the local database up-to-date,
 	// and it would be non-trivial to make it do so.
-	api, err := j.dialController(ctx, user, &offer.Model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (j *JujuManager) queryControllersForOffers(ctx context.Context, user *openf
 			// Return early if a single controller has an error
 			// to avoid misleading clients about what exists which
 			// could cause unneeded reconciliation.
-			api, err := j.dialController(ctx, user, ctl)
+			api, err := j.dialControllerAsSuperuser(ctx, user, ctl)
 			if err != nil {
 				return err
 			}
@@ -614,7 +614,7 @@ func (j *JujuManager) doApplicationOfferAdmin(ctx context.Context, user *openfga
 		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 	// add offer admin claim
-	api, err := j.dialController(ctx, user, &offer.Model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &offer.Model.Controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/cloud.go
+++ b/internal/jimm/juju/cloud.go
@@ -344,7 +344,7 @@ func (j *JujuManager) AddHostedCloud(ctx context.Context, user *openfga.User, ta
 // the controller. No error will be returned if the cloud already exists on
 // the controller or the user already has access to the cloud.
 func (j *JujuManager) addControllerCloud(ctx context.Context, ctl *dbmodel.Controller, user *openfga.User, tag names.CloudTag, cloud jujucloud.Cloud, force bool) (*jujucloud.Cloud, error) {
-	api, err := j.dialController(ctx, user, ctl)
+	api, err := j.dialControllerAsSuperuser(ctx, user, ctl)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (j *JujuManager) doCloudAdmin(ctx context.Context, user *openfga.User, ct n
 		}
 		return fmt.Errorf("cloud administration not available for %s", ct.Id())
 	}
-	api, err := j.dialController(ctx, user, &c.Regions[0].Controllers[0].Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &c.Regions[0].Controllers[0].Controller)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func (j *JujuManager) RemoveCloudFromController(ctx context.Context, user *openf
 		return errors.Codef(errors.CodeNotFound, "cloud not hosted by controller")
 	}
 
-	api, err := j.dialController(ctx, user, &controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/cloudcredential.go
+++ b/internal/jimm/juju/cloudcredential.go
@@ -515,7 +515,7 @@ func (j *JujuManager) recoverCredential(ctx context.Context, credential *dbmodel
 		}
 		seen[ctl.ID] = true
 
-		api, dialErr := j.dialController(ctx, ownerUser, &ctl)
+		api, dialErr := j.dialControllerAsSuperuser(ctx, ownerUser, &ctl)
 		if dialErr != nil {
 			lastErr = dialErr
 			continue

--- a/internal/jimm/juju/controller.go
+++ b/internal/jimm/juju/controller.go
@@ -244,7 +244,7 @@ func (j *JujuManager) AddController(ctx context.Context, user *openfga.User, ctl
 		}
 	}
 
-	api, err := j.dialController(ctx, user, ctl)
+	api, err := j.dialControllerAsSuperuser(ctx, user, ctl)
 	if err != nil {
 		return fmt.Errorf("failed to dial the controller: %v", err)
 	}
@@ -393,7 +393,7 @@ func (m *modelImporter) fetchModelInfo(ctx context.Context, user *openfga.User, 
 		return err
 	}
 
-	api, err := m.jimm.dialController(ctx, user, controller)
+	api, err := m.jimm.dialControllerAsSuperuser(ctx, user, controller)
 	if err != nil {
 		return fmt.Errorf("failed to dial the controller: %w", err)
 	}
@@ -766,7 +766,7 @@ func (j *JujuManager) ControllerConfig(ctx context.Context, user *openfga.User, 
 		return jujucontroller.Config{}, err
 	}
 
-	api, err := j.dialController(ctx, user, controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, controller)
 	if err != nil {
 		return jujucontroller.Config{}, err
 	}

--- a/internal/jimm/juju/interface.go
+++ b/internal/jimm/juju/interface.go
@@ -31,7 +31,7 @@ import (
 //
 // When to use which method:
 //
-//   - DialModel / DialController: dial on behalf of a real user. Prefer
+//   - DialModelAsSuperuser / DialControllerAsSuperuser: dial on behalf of a real user. Prefer
 //     these wherever possible.
 //
 //   - DialModelAsService / DialControllerAsService: dial as JIMM's
@@ -39,11 +39,11 @@ import (
 //     user. Every AsService call is a potential gap to close in Juju's
 //     permission model.
 type Dialer interface {
-	// DialModel creates a model-scoped API connection on behalf of a real
+	// DialModelAsSuperuser creates a model-scoped API connection on behalf of a real
 	// user. The user and modelTag must not be zero-valued.
-	DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error)
+	DialModelAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (API, error)
 
-	// DialController creates a controller-scoped API connection on behalf
+	// DialControllerAsSuperuser creates a controller-scoped API connection on behalf
 	// of a real user. This is used for operations that call
 	// controller-level facades (e.g. ModelManager) with a model UUID
 	// argument, or offer-related operations tied to a single offer: the
@@ -54,7 +54,7 @@ type Dialer interface {
 	// mix of model and application-offer tags the operation is tied to.
 	// Pass no resourceTags when the operation is not tied to a specific
 	// resource (e.g. cloud or controller-level calls).
-	DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error)
+	DialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error)
 
 	// DialModelAsService creates a model-scoped API connection using
 	// JIMM's own service identity (no user). It is intended solely for

--- a/internal/jimm/juju/juju.go
+++ b/internal/jimm/juju/juju.go
@@ -77,16 +77,14 @@ func NewJujuManager(
 	}, nil
 }
 
-// dialController dials the controller with a controller-scoped
-// connection on behalf of the given user. Use this for operations that
-// call controller-level facades (e.g. ModelManager) with a model UUID
-// argument, or offer-related operations tied to a single offer.
-func (j *JujuManager) dialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error) {
+// dialControllerAsSuperuser dials the controller on behalf of the given
+// user with forced superuser permissions.
+func (j *JujuManager) dialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (API, error) {
 	if j == nil || j.Dialer == nil {
 		return nil, errors.Codef(errors.CodeConnectionFailed, "no dialer configured")
 	}
 
-	return j.Dialer.DialController(ctx, user, ctl, resourceTags...)
+	return j.Dialer.DialControllerAsSuperuser(ctx, user, ctl, resourceTags...)
 }
 
 // dialModelAsService dials the model using JIMM's own service identity.

--- a/internal/jimm/juju/migrationtarget.go
+++ b/internal/jimm/juju/migrationtarget.go
@@ -47,7 +47,7 @@ func (j *JujuManager) AbortMigration(ctx context.Context, user *openfga.User, mo
 		return fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -100,7 +100,7 @@ func (j *JujuManager) CheckMachines(ctx context.Context, user *openfga.User, mod
 		return nil, fmt.Errorf("failed to get model migration %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -188,7 +188,7 @@ func (j *JujuManager) Prechecks(ctx context.Context, user *openfga.User, model M
 		return err
 	}
 
-	api, err := j.dialController(ctx, user, &incomingModel.TargetController)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &incomingModel.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -266,7 +266,7 @@ func (j *JujuManager) AdoptResources(ctx context.Context, user *openfga.User, mo
 		return fmt.Errorf("failed to get model migration for model %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, user, &model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &model.Controller)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -370,7 +370,7 @@ func (j *JujuManager) LatestLogTime(ctx context.Context, user *openfga.User, mod
 		return time.Time{}, fmt.Errorf("failed to get model %q: %w", modelUUID, err)
 	}
 
-	api, err := j.dialController(ctx, user, &model.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &model.Controller)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -397,7 +397,7 @@ func (j *JujuManager) Activate(ctx context.Context, user *openfga.User, modelTag
 	if err != nil {
 		return fmt.Errorf("failed to get model migration for model %q: %w", modelTag.Id(), err)
 	}
-	api, err := j.dialController(ctx, user, &modelMigration.TargetController)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &modelMigration.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}
@@ -531,7 +531,7 @@ func (j *JujuManager) Import(ctx context.Context, user *openfga.User, serialized
 	}
 
 	// Call the import method on the target controller to import the model.
-	api, err := j.dialController(ctx, user, &incomingMigration.TargetController)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &incomingMigration.TargetController)
 	if err != nil {
 		return fmt.Errorf("failed to dial controller: %w", err)
 	}

--- a/internal/jimm/juju/model.go
+++ b/internal/jimm/juju/model.go
@@ -216,7 +216,7 @@ func (j *JujuManager) ModelInfo(ctx context.Context, user *openfga.User, mt name
 		return jujuclient.ModelInfo{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dialController(ctx, user, &m.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &m.Controller)
 	if err != nil {
 		return jujuclient.ModelInfo{}, err
 	}
@@ -263,7 +263,7 @@ func (j *JujuManager) reactToModelInfoError(ctx context.Context, user *openfga.U
 		if err := j.Database.GetModel(ctx, model); err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
-		api, err := j.dialController(ctx, user, &model.Controller)
+		api, err := j.dialControllerAsSuperuser(ctx, user, &model.Controller)
 		if err != nil {
 			return jujuclient.ModelInfo{}, err
 		}
@@ -491,7 +491,7 @@ func (j *JujuManager) ModelStatus(ctx context.Context, user *openfga.User, mt na
 		return base.ModelStatus{}, errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dialController(ctx, user, &m.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &m.Controller)
 	if err != nil {
 		return base.ModelStatus{}, err
 	}
@@ -708,7 +708,7 @@ func (j *JujuManager) UpgradeController(ctx context.Context, user *openfga.User,
 		return version.Number{}, err
 	}
 
-	api, err := j.dialController(ctx, user, controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, controller)
 	if err != nil {
 		return version.Number{}, err
 	}
@@ -792,7 +792,7 @@ func (j *JujuManager) doModel(ctx context.Context, user *openfga.User, mt names.
 		return errors.Codef(errors.CodeUnauthorized, "unauthorized")
 	}
 
-	api, err := j.dialController(ctx, user, &m.Controller)
+	api, err := j.dialControllerAsSuperuser(ctx, user, &m.Controller)
 	if err != nil {
 		return err
 	}

--- a/internal/jimm/juju/model_poller_test.go
+++ b/internal/jimm/juju/model_poller_test.go
@@ -44,7 +44,7 @@ func newPerControllerDialer(api juju.API) *perControllerDialer {
 	}
 }
 
-func (d *perControllerDialer) DialModel(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
+func (d *perControllerDialer) DialModelAsSuperuser(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
 	name := ctl.Name
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -59,25 +59,25 @@ func (d *perControllerDialer) DialModel(_ context.Context, _ *openfga.User, ctl 
 	}, nil
 }
 
-// DialController implements juju.Dialer. It delegates to DialModel since the
+// DialControllerAsSuperuser implements juju.Dialer. It delegates to DialModelAsSuperuser since the
 // perControllerDialer test double does not distinguish connection scope,
 // resource tags, or user vs service identity for JWT minting.
-func (d *perControllerDialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
-	return d.DialModel(ctx, user, ctl, names.ModelTag{})
+func (d *perControllerDialer) DialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.DialModelAsSuperuser(ctx, user, ctl, names.ModelTag{})
 }
 
-// DialModelAsService implements juju.Dialer. It delegates to DialModel since
+// DialModelAsService implements juju.Dialer. It delegates to DialModelAsSuperuser since
 // the perControllerDialer test double does not distinguish user vs service
 // identity for JWT minting.
 func (d *perControllerDialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
-	return d.DialModel(ctx, nil, ctl, mt)
+	return d.DialModelAsSuperuser(ctx, nil, ctl, mt)
 }
 
-// DialControllerAsService implements juju.Dialer. It delegates to DialModel
+// DialControllerAsService implements juju.Dialer. It delegates to DialModelAsSuperuser
 // since the perControllerDialer test double does not distinguish connection
 // scope or user vs service identity for JWT minting.
 func (d *perControllerDialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
-	return d.DialModel(ctx, nil, ctl, names.ModelTag{})
+	return d.DialModelAsSuperuser(ctx, nil, ctl, names.ModelTag{})
 }
 
 // openedCounts returns a snapshot of the dial counts per controller.

--- a/internal/jimm/juju/modelbuilder.go
+++ b/internal/jimm/juju/modelbuilder.go
@@ -540,7 +540,7 @@ func (b *modelBuilder) CreateControllerModel() *modelBuilder {
 		return b
 	}
 
-	api, err := b.jujuManager.dialController(b.ctx, b.ofgaUser, b.controller)
+	api, err := b.jujuManager.dialControllerAsSuperuser(b.ctx, b.ofgaUser, b.controller)
 	if err != nil {
 		b.err = err
 		return b

--- a/internal/jimm/upgrade/mocks/dialer.go
+++ b/internal/jimm/upgrade/mocks/dialer.go
@@ -44,50 +44,6 @@ func (m *MockDialer) EXPECT() *MockDialerMockRecorder {
 	return m.recorder
 }
 
-// DialController mocks base method.
-func (m *MockDialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{ctx, user, ctl}
-	for _, a := range resourceTags {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DialController", varargs...)
-	ret0, _ := ret[0].(juju.API)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DialController indicates an expected call of DialController.
-func (mr *MockDialerMockRecorder) DialController(ctx, user, ctl any, resourceTags ...any) *MockDialerDialControllerCall {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, user, ctl}, resourceTags...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialController", reflect.TypeOf((*MockDialer)(nil).DialController), varargs...)
-	return &MockDialerDialControllerCall{Call: call}
-}
-
-// MockDialerDialControllerCall wrap *gomock.Call
-type MockDialerDialControllerCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockDialerDialControllerCall) Return(arg0 juju.API, arg1 error) *MockDialerDialControllerCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockDialerDialControllerCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDialerDialControllerCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DialControllerAsService mocks base method.
 func (m *MockDialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
 	m.ctrl.T.Helper()
@@ -127,41 +83,46 @@ func (c *MockDialerDialControllerAsServiceCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// DialModel mocks base method.
-func (m *MockDialer) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+// DialControllerAsSuperuser mocks base method.
+func (m *MockDialer) DialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DialModel", ctx, user, ctl, modelTag)
+	varargs := []any{ctx, user, ctl}
+	for _, a := range resourceTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DialControllerAsSuperuser", varargs...)
 	ret0, _ := ret[0].(juju.API)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DialModel indicates an expected call of DialModel.
-func (mr *MockDialerMockRecorder) DialModel(ctx, user, ctl, modelTag any) *MockDialerDialModelCall {
+// DialControllerAsSuperuser indicates an expected call of DialControllerAsSuperuser.
+func (mr *MockDialerMockRecorder) DialControllerAsSuperuser(ctx, user, ctl any, resourceTags ...any) *MockDialerDialControllerAsSuperuserCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialModel", reflect.TypeOf((*MockDialer)(nil).DialModel), ctx, user, ctl, modelTag)
-	return &MockDialerDialModelCall{Call: call}
+	varargs := append([]any{ctx, user, ctl}, resourceTags...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialControllerAsSuperuser", reflect.TypeOf((*MockDialer)(nil).DialControllerAsSuperuser), varargs...)
+	return &MockDialerDialControllerAsSuperuserCall{Call: call}
 }
 
-// MockDialerDialModelCall wrap *gomock.Call
-type MockDialerDialModelCall struct {
+// MockDialerDialControllerAsSuperuserCall wrap *gomock.Call
+type MockDialerDialControllerAsSuperuserCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockDialerDialModelCall) Return(arg0 juju.API, arg1 error) *MockDialerDialModelCall {
+func (c *MockDialerDialControllerAsSuperuserCall) Return(arg0 juju.API, arg1 error) *MockDialerDialControllerAsSuperuserCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDialerDialModelCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelCall {
+func (c *MockDialerDialControllerAsSuperuserCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerAsSuperuserCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDialerDialModelCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelCall {
+func (c *MockDialerDialControllerAsSuperuserCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, ...names.Tag) (juju.API, error)) *MockDialerDialControllerAsSuperuserCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -201,6 +162,45 @@ func (c *MockDialerDialModelAsServiceCall) Do(f func(context.Context, *dbmodel.C
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockDialerDialModelAsServiceCall) DoAndReturn(f func(context.Context, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelAsServiceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DialModelAsSuperuser mocks base method.
+func (m *MockDialer) DialModelAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (juju.API, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialModelAsSuperuser", ctx, user, ctl, modelTag)
+	ret0, _ := ret[0].(juju.API)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DialModelAsSuperuser indicates an expected call of DialModelAsSuperuser.
+func (mr *MockDialerMockRecorder) DialModelAsSuperuser(ctx, user, ctl, modelTag any) *MockDialerDialModelAsSuperuserCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialModelAsSuperuser", reflect.TypeOf((*MockDialer)(nil).DialModelAsSuperuser), ctx, user, ctl, modelTag)
+	return &MockDialerDialModelAsSuperuserCall{Call: call}
+}
+
+// MockDialerDialModelAsSuperuserCall wrap *gomock.Call
+type MockDialerDialModelAsSuperuserCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDialerDialModelAsSuperuserCall) Return(arg0 juju.API, arg1 error) *MockDialerDialModelAsSuperuserCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDialerDialModelAsSuperuserCall) Do(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelAsSuperuserCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDialerDialModelAsSuperuserCall) DoAndReturn(f func(context.Context, *openfga.User, *dbmodel.Controller, names.ModelTag) (juju.API, error)) *MockDialerDialModelAsSuperuserCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/jujuapi/streamcontrollerproxy.go
+++ b/internal/jujuapi/streamcontrollerproxy.go
@@ -92,7 +92,7 @@ func (s streamControllerProxier) ServeWS(ctx context.Context, clientConn *websoc
 		return
 	}
 
-	api, err := s.jimm.Dialer.DialController(ctx, user, &model.Controller)
+	api, err := s.jimm.Dialer.DialControllerAsSuperuser(ctx, user, &model.Controller)
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuapi/streammodelproxy.go
+++ b/internal/jujuapi/streammodelproxy.go
@@ -88,7 +88,7 @@ func (s streamModelProxier) ServeWS(ctx context.Context, clientConn *websocket.C
 		return
 	}
 
-	api, err := s.jimm.Dialer.DialModel(ctx, user, &model.Controller, model.ResourceTag())
+	api, err := s.jimm.Dialer.DialModelAsSuperuser(ctx, user, &model.Controller, model.ResourceTag())
 	if err != nil {
 		zapctx.Error(ctx, "failed to dial controller", zap.Error(err))
 		writeError(fmt.Sprintf("failed to dial controller: %s", err.Error()), errors.CodeConnectionFailed)

--- a/internal/jujuclient/dial.go
+++ b/internal/jujuclient/dial.go
@@ -87,13 +87,13 @@ func (d *Dialer) createLoginRequest(ctx context.Context, ctl *dbmodel.Controller
 	}, nil
 }
 
-// DialModel implements jimm.Dialer. It creates a model-scoped
-// connection on behalf of a real user. The user must be non-nil; use
-// DialModelAsService for JIMM's own internal operations that have no
-// associated user.
-func (d *Dialer) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (*Connection, error) {
+// DialModelAsSuperuser implements jimm.Dialer. It creates a model-scoped
+// connection on behalf of a real user, forcing superuser permissions.
+// The user must be non-nil; use DialModelAsService for JIMM's own
+// internal operations that have no associated user.
+func (d *Dialer) DialModelAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, modelTag names.ModelTag) (*Connection, error) {
 	if user == nil {
-		return nil, errors.New("DialModel requires a non-nil user")
+		return nil, errors.New("DialModelAsSuperuser requires a non-nil user")
 	}
 	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, user)
 	if err != nil {
@@ -102,14 +102,14 @@ func (d *Dialer) DialModel(ctx context.Context, user *openfga.User, ctl *dbmodel
 	return d.dial(ctx, ctl, modelTag, user, loginRequest)
 }
 
-// DialController implements jimm.Dialer. It creates a controller-scoped
-// connection (so controller-level facades are available) on behalf of a
-// real user. The user must be non-nil; use DialControllerAsService for
-// JIMM's own internal operations that have no associated user.
-// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
-func (d *Dialer) DialController(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (*Connection, error) {
+// DialControllerAsSuperuser implements jimm.Dialer. It creates a
+// controller-scoped connection (so controller-level facades are
+// available) on behalf of a real user, forcing superuser permissions.
+// The user must be non-nil; use DialControllerAsService for JIMM's own
+// internal operations that have no associated user.
+func (d *Dialer) DialControllerAsSuperuser(ctx context.Context, user *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (*Connection, error) {
 	if user == nil {
-		return nil, errors.New("DialController requires a non-nil user")
+		return nil, errors.New("DialControllerAsSuperuser requires a non-nil user")
 	}
 	modelTag := names.ModelTag{}
 	loginRequest, err := d.createLoginRequest(ctx, ctl, modelTag, user)

--- a/internal/testutils/jimmtest/api.go
+++ b/internal/testutils/jimmtest/api.go
@@ -55,8 +55,8 @@ type Dialer struct {
 	open int64
 }
 
-// DialModel implements juju.Dialer.
-func (d *Dialer) DialModel(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
+// DialModelAsSuperuser implements juju.Dialer.
+func (d *Dialer) DialModelAsSuperuser(_ context.Context, _ *openfga.User, ctl *dbmodel.Controller, _ names.ModelTag) (juju.API, error) {
 	if d.Err != nil {
 		return nil, d.Err
 	}
@@ -79,24 +79,23 @@ func (d *Dialer) DialModel(_ context.Context, _ *openfga.User, ctl *dbmodel.Cont
 	}, nil
 }
 
-// DialController implements juju.Dialer. The test double does not
+// DialControllerAsSuperuser implements juju.Dialer. The test double does not
 // distinguish connection scope or resource tags; it delegates to
-// DialModel with no model tag.
-// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
-func (d *Dialer) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
-	return d.DialModel(ctx, u, ctl, names.ModelTag{})
+// DialModelAsSuperuser with no model tag.
+func (d *Dialer) DialControllerAsSuperuser(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+	return d.DialModelAsSuperuser(ctx, u, ctl, names.ModelTag{})
 }
 
 // DialModelAsService implements juju.Dialer. It dials as JIMM's service identity.
 func (d *Dialer) DialModelAsService(ctx context.Context, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
-	// Delegate to DialModel with a nil user since the Dialer test double
+	// Delegate to DialModelAsSuperuser with a nil user since the Dialer test double
 	// does not distinguish user vs service identity for JWT minting.
-	return d.DialModel(ctx, nil, ctl, mt)
+	return d.DialModelAsSuperuser(ctx, nil, ctl, mt)
 }
 
 // DialControllerAsService implements juju.Dialer. It dials as JIMM's service identity.
 func (d *Dialer) DialControllerAsService(ctx context.Context, ctl *dbmodel.Controller) (juju.API, error) {
-	return d.DialModel(ctx, nil, ctl, names.ModelTag{})
+	return d.DialModelAsSuperuser(ctx, nil, ctl, names.ModelTag{})
 }
 
 // IsClosed returns true if all opened connections have been closed.
@@ -120,19 +119,18 @@ func (w apiWrapper) Close() error {
 // it is designed such that should you need to query multiple models, you can.
 type ModelDialerMap map[string]juju.Dialer
 
-// DialModel implements juju.Dialer.
-func (m ModelDialerMap) DialModel(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+// DialModelAsSuperuser implements juju.Dialer.
+func (m ModelDialerMap) DialModelAsSuperuser(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
 	if d, ok := m[mt.Id()]; ok {
-		return d.DialModel(ctx, u, ctl, mt)
+		return d.DialModelAsSuperuser(ctx, u, ctl, mt)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
 
-// DialController implements juju.Dialer.
-// TODO(luci1900): refactor to pass in resource tags for scoped JWT minting.
-func (m ModelDialerMap) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+// DialControllerAsSuperuser implements juju.Dialer.
+func (m ModelDialerMap) DialControllerAsSuperuser(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
 	if d, ok := m[""]; ok {
-		return d.DialController(ctx, u, ctl, resourceTags...)
+		return d.DialControllerAsSuperuser(ctx, u, ctl, resourceTags...)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
@@ -157,18 +155,18 @@ func (m ModelDialerMap) DialControllerAsService(ctx context.Context, ctl *dbmode
 // each controller. The DialerMap is keyed by controller name.
 type DialerMap map[string]juju.Dialer
 
-// DialModel implements juju.Dialer.
-func (m DialerMap) DialModel(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
+// DialModelAsSuperuser implements juju.Dialer.
+func (m DialerMap) DialModelAsSuperuser(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, mt names.ModelTag) (juju.API, error) {
 	if d, ok := m[ctl.Name]; ok {
-		return d.DialModel(ctx, u, ctl, mt)
+		return d.DialModelAsSuperuser(ctx, u, ctl, mt)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }
 
-// DialController implements juju.Dialer.
-func (m DialerMap) DialController(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
+// DialControllerAsSuperuser implements juju.Dialer.
+func (m DialerMap) DialControllerAsSuperuser(ctx context.Context, u *openfga.User, ctl *dbmodel.Controller, resourceTags ...names.Tag) (juju.API, error) {
 	if d, ok := m[ctl.Name]; ok {
-		return d.DialController(ctx, u, ctl, resourceTags...)
+		return d.DialControllerAsSuperuser(ctx, u, ctl, resourceTags...)
 	}
 	return nil, fmt.Errorf("dialer not configured for controller %s", ctl.Name)
 }


### PR DESCRIPTION
## Description
The method names now make it clear what permissions the dial actually sets.

This is to make it possible to later introduce methods that dial with fewer permissions than this.

## Engineering checklist
- [ ] Documentation updated
- [x] Covered by unit tests
- [x] Covered by integration tests
